### PR TITLE
Update Renovate Configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,10 +2,15 @@
   "extends": [
     "@tryghost:quietJS"
   ],
-  "prHourlyLimit": 0,
   "schedule": "at any time",
   "travis": { "enabled": true },
   "node": {
-    "supportPolicy": ["lts_latest"]
-   }
+    "supportPolicy": ["lts_active"]
+   },
+  "packageRules": [
+    {
+      "groupName": "rollup + plugins",
+      "packagePatterns": ["^rollup"]
+    }
+   ]
 }


### PR DESCRIPTION
- fixing support policy to active, rather than latest
- adding extra rules for rollup same as Ghost-SDK
- removing duplicate pr limit already handled by quietJS