### PR TITLE
Updated mixtape embed to use bookmark card

### DIFF
--- a/packages/kg-parser-plugins/lib/parser-plugins.js
+++ b/packages/kg-parser-plugins/lib/parser-plugins.js
@@ -96,7 +96,7 @@ export function createParserPlugins(_options = {}) {
             title: title,
             description: desc,
             thumbnail: imgSrc
-        }
+        };
 
         let payload = {metadata, url: metadata.url, type: 'bookmark'};
         let cardSection = builder.createCardSection('bookmark', payload);

--- a/packages/kg-parser-plugins/lib/parser-plugins.js
+++ b/packages/kg-parser-plugins/lib/parser-plugins.js
@@ -73,7 +73,6 @@ export function createParserPlugins(_options = {}) {
 
     // PLUGINS -----------------------------------------------------------------
 
-    // @TODO: rework this once we have bookmark cards
     function mixtapeEmbed(node, builder, {addSection, nodeFinished}) {
         if (node.nodeType !== 1 || node.tagName !== 'DIV' || !node.className.match(/graf--mixtapeEmbed/)) {
             return;
@@ -92,18 +91,15 @@ export function createParserPlugins(_options = {}) {
         }
 
         // Format our preferred structure.
-        let html = `<figure class="mixtape">
-        <a href="${anchor}" class="mixtape-url">
-            <div class="mixtape-content">
-                ${title ? `<div class="mixtape-title"><strong>${title.innerHTML}</strong></div>` : ''}
-                ${desc ? `<div class="mixtape-description"><small>${desc.innerHTML}</small></div>` : ''}
-            </div>
-            ${imgSrc ? `<div class="mixtape-thumbnail"><img src="${imgSrc}" /></div>` : ''}
-        </a>
-        </figure>`;
+        let metadata = {
+            url: anchor,
+            title: title,
+            description: desc,
+            thumbnail: imgSrc
+        }
 
-        let payload = {html: html};
-        let cardSection = builder.createCardSection('html', payload);
+        let payload = {metadata, url: metadata.url, type: 'bookmark'};
+        let cardSection = builder.createCardSection('bookmark', payload);
         addSection(cardSection);
         nodeFinished();
     }


### PR DESCRIPTION
Mixtape embed was previously using HTML card as we didn't have Bookmark card structure in place. We now have a structure for bookmark card and PR updates mixtape embed to create a bookmark card with embed information.

Bookmark Card PR - https://github.com/TryGhost/Ghost/pull/11024