### PR TITLE
Allow russian letters in generated ids

### DIFF
--- a/packages/kg-mobiledoc-html-renderer/lib/mobiledoc-html-renderer.js
+++ b/packages/kg-mobiledoc-html-renderer/lib/mobiledoc-html-renderer.js
@@ -40,7 +40,7 @@ class DomModifier {
         let id = text
             .replace(/[<>&"?]/g, '')
             .trim()
-            .replace(/[^\wа-я]/g, '-')
+            .replace(/[^\wА-я]/g, '-')
             .replace(/-{2,}/g, '-')
             .toLowerCase();
 

--- a/packages/kg-mobiledoc-html-renderer/lib/mobiledoc-html-renderer.js
+++ b/packages/kg-mobiledoc-html-renderer/lib/mobiledoc-html-renderer.js
@@ -40,7 +40,7 @@ class DomModifier {
         let id = text
             .replace(/[<>&"?]/g, '')
             .trim()
-            .replace(/[^\w]/g, '-')
+            .replace(/[^\wа-я]/g, '-')
             .replace(/-{2,}/g, '-')
             .toLowerCase();
 


### PR DESCRIPTION
<img width="1680" alt="Screen Shot 2020-05-17 at 15 07 44" src="https://user-images.githubusercontent.com/1256834/82144882-34458b80-9850-11ea-924f-1501f43e7e3a.png">

Currently generated ids look like these. Not friendly.