### PR TITLE
✨ Added tableToHtmlCard

### DIFF
--- a/packages/kg-parser-plugins/lib/parser-plugins.js
+++ b/packages/kg-parser-plugins/lib/parser-plugins.js
@@ -466,6 +466,21 @@ export function createParserPlugins(_options = {}) {
         nodeFinished();
     }
 
+    function tableToHtmlCard(node, builder, {addSection, nodeFinished}) {
+        if (node.nodeType !== 1 || node.tagName !== 'TABLE') {
+            return;
+        }
+
+        if (node.parentNode.tagName === 'TABLE') {
+            return;
+        }
+
+        let payload = {html: node.outerHTML};
+        let cardSection = builder.createCardSection('html', payload);
+        addSection(cardSection);
+        nodeFinished();
+    }
+
     return [
         mixtapeEmbed,
         kgHtmlCardToCard,
@@ -481,6 +496,7 @@ export function createParserPlugins(_options = {}) {
         preCodeToCard,
         figureIframeToEmbedCard,
         iframeToEmbedCard, // Process iFrames without figures after ones with
-        figureScriptToHtmlCard
+        figureScriptToHtmlCard,
+        tableToHtmlCard
     ];
 }

--- a/packages/kg-parser-plugins/test/parser-plugins.test.js
+++ b/packages/kg-parser-plugins/test/parser-plugins.test.js
@@ -666,4 +666,25 @@ describe('parser-plugins', function () {
             });
         });
     });
+
+    describe('tableToHtmlCard', function () {
+        it('can parse a table as HTML card', function () {
+            const dom = buildDOM('<table style="float:right"><tr><th>Month</th><th>Savings</th></tr><tr><td>January</td><td>$100</td></tr><tr><td>February</td><td>$80</td></tr></table>');
+            const [section] = parser.parse(dom).sections.toArray();
+
+            section.type.should.equal('card-section');
+            section.name.should.equal('html');
+            section.payload.html.should.eql('<table style="float:right"><tbody><tr><th>Month</th><th>Savings</th></tr><tr><td>January</td><td>$100</td></tr><tr><td>February</td><td>$80</td></tr></tbody></table>');
+        });
+
+        it('can handle table nested in another table', function () {
+            const dom = buildDOM('<table id="table1"><tr><th>title1</th><th>title2</th><th>title3</th></tr><tr><td id="nested"><table id="table2"><tr><td>cell1</td><td>cell2</td><td>cell3</td></tr></table></td><td>cell2</td><td>cell3</td></tr><tr><td>cell4</td><td>cell5</td><td>cell6</td></tr></table>');
+            const [section] = parser.parse(dom).sections.toArray();
+
+            section.type.should.equal('card-section');
+            section.name.should.equal('html');
+            section.payload.html.should.eql('<table id="table1"><tbody><tr><th>title1</th><th>title2</th><th>title3</th></tr><tr><td id="nested"><table id="table2"><tbody><tr><td>cell1</td><td>cell2</td><td>cell3</td></tr></tbody></table></td><td>cell2</td><td>cell3</td></tr><tr><td>cell4</td><td>cell5</td><td>cell6</td></tr></tbody></table>');
+        });
+    });
 });
+


### PR DESCRIPTION
no issue

- A simple `<table>` markup is not support unless wrapped within an HTML card, or the table got created within the markdown card
- To migrate post content for migrations correctly, `<table>` markup should be recognised and parsed as HTML card
- Added tests