### PR TITLE
Allow blockquotes w/ nested paragraphs to keep markup

### DIFF
--- a/packages/kg-parser-plugins/lib/parser-plugins.js
+++ b/packages/kg-parser-plugins/lib/parser-plugins.js
@@ -519,17 +519,22 @@ export function createParserPlugins(_options = {}) {
         }
 
         const html = [];
-
         const children = Array.from(node.children);
-        children.forEach((child, index) => {
-            if (index === children.length - 1) {
+
+        children.forEach((child) => {
+            let nextSibling = child.nextSibling;
+            let previousSibling = child.previousSibling;
+
+            // Only add a soft-break for two sequential paragraphs.
+            // Use the innerHTML only in that case, so Mobiledoc's default behaviour
+            // of creating separate blockquotes doesn't apply.
+            if (child.tagName === 'P' && (nextSibling && nextSibling.tagName === 'P')) {
+                html.push(`${child.innerHTML}<br><br>`);
+            } else if (child.tagName === 'P' && (previousSibling && previousSibling.tagName === 'P')) {
                 html.push(child.innerHTML);
-            } else if (child.tagName === 'P'){
-                html.push(`${child.innerHTML}<br>`);
             } else {
-                html.push(`${child.innerHTML} `);
+                html.push(child.outerHTML);
             }
-            child.remove();
         });
 
         node.innerHTML = html.join('').trim();


### PR DESCRIPTION
no issue

- blockquotes with nested paragraph children are valid HTML
- the current behaviour in Mobiledoc is to create a separate `<blockquote>` sections for each nested paragraph
- this behaviour is not desired when running migrations from other HTML sources, as it breaks the intended semantics
- this change will insert `soft-returns` between paragraph children and keep the `innerHtml` of those, so the default upstream logic doesn't grab
- only blockquotes with multiple children and sequential paragraphs (`p + p`) will be processed by this change
- this fix should probably be added into the upstream dependency and update the current behaviour which was created [here](https://github.com/bustle/mobiledoc-kit/issues/715)