### PR TITLE
Image Lazy Loading plugin for Markdown-it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,5 +68,4 @@ typings/
 # OSX
 .DS_Store
 
-# Koenig Custom
-packages/kg-markdown-html-renderer/package-lock.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,4 @@ typings/
 # OSX
 .DS_Store
 
-
+# Koenig Custom

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ typings/
 .DS_Store
 
 # Koenig Custom
+packages/kg-markdown-html-renderer/package-lock.json

--- a/packages/kg-markdown-html-renderer/lib/markdown-html-renderer.js
+++ b/packages/kg-markdown-html-renderer/lib/markdown-html-renderer.js
@@ -8,6 +8,7 @@ const markdownIt = new MarkdownIt({
     .use(require('markdown-it-footnote'))
     .use(require('markdown-it-lazy-headers'))
     .use(require('markdown-it-mark'))
+    .use(require('markdown-it-img-lazy'))
     .use(function namedHeaders(md) {
         // match legacy Showdown IDs
         const slugify = function (inputString, usedHeaders) {

--- a/packages/kg-markdown-html-renderer/package.json
+++ b/packages/kg-markdown-html-renderer/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "markdown-it": "^11.0.0",
     "markdown-it-footnote": "^3.0.2",
+    "markdown-it-img-lazy": "^1.0.2",
     "markdown-it-lazy-headers": "^0.1.3",
     "markdown-it-mark": "^3.0.0"
   }


### PR DESCRIPTION
Hi,

The lazy loading on images is now a **W3C standard** that can have a real benefits for posts with a lot of images.
https://forum.ghost.org/t/add-native-image-lazy-loading-support/8799

This attribute is now supported by most of the browsers on the Web.
https://caniuse.com/loading-lazy-attr

This pull request purposes to add the markdown-it-img-lazy plugin as a plugin for the Markdown-html-rederer.
https://www.npmjs.com/package/markdown-it-img-lazy

The markdown-it-img-lazy plugin has a "native" option by default to true.  By default the attribute loading="lazy" will be add to all images.

Regards,

Ludovic Toinel