### PR TITLE
Moved pass-through of koenig/mobiledoc editor instances in props to context

### DIFF
--- a/packages/koenig-react/src/KoenigEditor.js
+++ b/packages/koenig-react/src/KoenigEditor.js
@@ -54,7 +54,6 @@ class KoenigEditor {
                         isEditing: false, // shouldn't be used - our cards handle edit mode within their components
                         isSelected: false,
                         koenigOptions,
-                        mobiledocEditor: this.mobiledocEditor,
                         koenigEditor: this,
                         name,
                         options,

--- a/packages/koenig-react/src/components/Card.js
+++ b/packages/koenig-react/src/components/Card.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import koenigEditorContext from '../contexts/koenig-editor-context';
 
-const CardComponent = ({children, isSelected, isEditing, koenigOptions, selectCard, deselectCard, editCard, mobiledocEditor, ...props}) => {
+const CardComponent = ({children, isSelected, isEditing, koenigOptions, selectCard, deselectCard, editCard, ...props}) => {
+    const koenigEditor = React.useContext(koenigEditorContext);
     const [skipMouseUp, setSkipMouseUp] = React.useState(false);
     const elementRef = React.useRef(null);
 
@@ -38,7 +40,7 @@ const CardComponent = ({children, isSelected, isEditing, koenigOptions, selectCa
 
             // if an element in the editor is clicked then cursor placement will
             // deselect or keep this card selected as necessary
-            if (mobiledocEditor.element.contains(target)) {
+            if (koenigEditor.mobiledocEditor.element.contains(target)) {
                 return;
             }
 
@@ -52,7 +54,7 @@ const CardComponent = ({children, isSelected, isEditing, koenigOptions, selectCa
         return (() => {
             window.removeEventListener('click', handleWindowClick);
         });
-    }, [isSelected, deselectCard, mobiledocEditor]);
+    }, [isSelected, deselectCard, koenigEditor]);
 
     const handleMouseDown = (event) => {
         // if we perform an action we want to prevent the mousedown from

--- a/packages/koenig-react/src/components/CardMenuContent.js
+++ b/packages/koenig-react/src/components/CardMenuContent.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import koenigEditorContext from '../contexts/koenig-editor-context';
 
 const createItemMatcher = (query = '') => {
     // match everything before a space to a card. Keeps the relevant
@@ -133,7 +134,8 @@ const CardMenuItem = ({item, isSelected, itemWasClicked}) => {
     );
 };
 
-const CardMenuContent = ({koenigEditor, replacementRange, itemWasClicked, allowsKeyboardNav = false, query, ...props}) => {
+const CardMenuContent = ({replacementRange, itemWasClicked, allowsKeyboardNav = false, query, ...props}) => {
+    const koenigEditor = React.useContext(koenigEditorContext);
     const [state, dispatch] = React.useReducer(
         menuContentReducer,
         {
@@ -219,7 +221,6 @@ const CardMenuContent = ({koenigEditor, replacementRange, itemWasClicked, allows
                     group={group}
                     selectedItem={selectedItem}
                     itemWasClicked={insertItem}
-                    koenigEditor={koenigEditor}
                     key={group.title}
                     {...props}
                 />

--- a/packages/koenig-react/src/components/PlusMenu.js
+++ b/packages/koenig-react/src/components/PlusMenu.js
@@ -1,5 +1,6 @@
 import React, {useEffect} from 'react';
 import {v4 as uuidv4} from 'uuid';
+import koenigEditorContext from '../contexts/koenig-editor-context';
 import CardMenuContent from './CardMenuContent';
 import PlusIcon from '../icons/plus.svg';
 import rangeIsABlankParagraph from '../utils/range-is-blank-paragraph';
@@ -53,7 +54,8 @@ const PlusMenu = ({containerId, closeMenu, ...props}) => {
     );
 };
 
-const PlusMenuContainer = ({koenigEditor, selectedRange}) => {
+const PlusMenuContainer = ({selectedRange}) => {
+    const koenigEditor = React.useContext(koenigEditorContext);
     const containerId = React.useRef(`kg-plus-${uuidv4()}`);
     const containerEl = React.useRef();
     const lastSelectedRange = React.useRef(null); // used to trigger selectedRange prop change behavior
@@ -176,7 +178,7 @@ const PlusMenuContainer = ({koenigEditor, selectedRange}) => {
     return (
         <div id={containerId.current} data-kg="plus-menu" className="absolute" style={style} ref={containerEl}>
             {isShowingButton && <PlusButton onClick={handleButtonClick} />}
-            {isShowingMenu && <PlusMenu containerId={containerId.current} closeMenu={closeMenu} koenigEditor={koenigEditor} replacementRange={cachedRange} itemWasClicked={handleItemClick} />}
+            {isShowingMenu && <PlusMenu containerId={containerId.current} closeMenu={closeMenu} replacementRange={cachedRange} itemWasClicked={handleItemClick} />}
         </div>
     );
 };

--- a/packages/koenig-react/src/components/SlashMenu.js
+++ b/packages/koenig-react/src/components/SlashMenu.js
@@ -1,9 +1,11 @@
 import React, {useEffect} from 'react';
+import koenigEditorContext from '../contexts/koenig-editor-context';
 import CardMenuContent from './CardMenuContent';
 
 const Y_OFFSET = 16;
 
-const SlashMenu = ({closeMenu, containerId, koenigEditor, ...props}) => {
+const SlashMenu = ({closeMenu, containerId, ...props}) => {
+    const koenigEditor = React.useContext(koenigEditorContext);
     // watch the window for mousedown events so that we can close the
     // menu when we detect a click outside. This is preferable to
     // watching the range because the range will change and remove the
@@ -41,7 +43,8 @@ const SlashMenu = ({closeMenu, containerId, koenigEditor, ...props}) => {
     );
 };
 
-const SlashMenuContainer = ({selectedRange, koenigEditor}) => {
+const SlashMenuContainer = ({selectedRange}) => {
+    const koenigEditor = React.useContext(koenigEditorContext);
     const containerEl = React.useRef(null);
     const cachedRange = React.useRef(null);
     const lastSelectedRange = React.useRef(null);
@@ -131,7 +134,7 @@ const SlashMenuContainer = ({selectedRange, koenigEditor}) => {
 
     return (
         <div id="koenig-slash-menu" className="absolute" style={containerStyle} ref={containerEl}>
-            {isShowingMenu && <SlashMenu closeMenu={closeMenu} containerId={containerEl.current.id} query={query} replacementRange={cachedRange.current} koenigEditor={koenigEditor} /> }
+            {isShowingMenu && <SlashMenu closeMenu={closeMenu} containerId={containerEl.current.id} query={query} replacementRange={cachedRange.current} /> }
         </div>
     );
 };

--- a/packages/koenig-react/src/components/toolbar/Toolbar.js
+++ b/packages/koenig-react/src/components/toolbar/Toolbar.js
@@ -9,9 +9,10 @@ import QuoteIcon from './icons/kg-quote.svg';
 import LinkIcon from './icons/kg-link.svg';
 import LinkButton from './LinkButton';
 import UrlPromptInput from './UrlPromptInput';
+import koenigEditorContext from '../../contexts/koenig-editor-context';
 
-// Much of this file 
-// was extracted from https://github.com/TryGhost/Ghost/blob/main/ghost/admin/lib/koenig-editor/addon/components/koenig-toolbar.js 
+// Much of this file
+// was extracted from https://github.com/TryGhost/Ghost/blob/main/ghost/admin/lib/koenig-editor/addon/components/koenig-toolbar.js
 // and then modified to make it work with React.
 // Can certainly making a bit more "react-like" in future.
 
@@ -22,13 +23,13 @@ const DEFAULTSTYLES = {
 };
 
 export default function Toolbar({
-    editor,
     TOOLBAR_MARGIN = 15,
     // TICK_ADJUSTMENT = 8,
     activeMarkupTags,
     activeSectionTags,
     selectedRange
 }) {
+    const {mobiledocEditor: editor} = React.useContext(koenigEditorContext);
     const [showUrlPrompt, setShowUrlPrompt] = React.useState(false);
     const [urlAddress, setUrlAddress] = React.useState('');
     const toolbarRef = React.useRef();
@@ -141,11 +142,10 @@ export default function Toolbar({
     return (
         <React.Fragment>
             <UrlPromptInput
-                ref={urlPromptRef} 
-                showUrlPrompt={{showUrlPrompt, setShowUrlPrompt}} 
-                toolbarPosition={toolbarPosition} 
+                ref={urlPromptRef}
+                showUrlPrompt={{showUrlPrompt, setShowUrlPrompt}}
+                toolbarPosition={toolbarPosition}
                 urlAddress={{urlAddress, setUrlAddress}}
-                editor={editor}
                 cachedRange={cachedRange}
                 selectedRange={selectedRange}
             />

--- a/packages/koenig-react/src/contexts/koenig-editor-context.js
+++ b/packages/koenig-react/src/contexts/koenig-editor-context.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const koenigEditorContext = React.createContext({});
+
+export default koenigEditorContext;

--- a/packages/koenig-react/src/utils/create-component-card.js
+++ b/packages/koenig-react/src/utils/create-component-card.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {v4 as uuidv4} from 'uuid';
+import koenigEditorContext from '../contexts/koenig-editor-context';
 import {ADD_CARD_HOOK, REMOVE_CARD_HOOK} from './constants';
 
 const RENDER_TYPE = 'dom';
@@ -33,7 +34,7 @@ const createComponentCard = ({name, component: CardComponent, koenigOptions = {}
 
             didRender(() => {
                 const ComponentWithState = () => {
-                    const {isSelected: _isSelected, isEditing: _isEditing, ...props} = card.props;
+                    const {isSelected: _isSelected, isEditing: _isEditing, koenigEditor, ...props} = card.props;
                     const [isSelected, setIsSelected] = React.useState(_isSelected);
                     const [isEditing, setIsEditing] = React.useState(_isEditing);
                     // const [onChange, setOnChange] = React.useState(null);
@@ -46,7 +47,11 @@ const createComponentCard = ({name, component: CardComponent, koenigOptions = {}
                     card.setIsSelected = setIsSelected;
                     card.setIsEditing = setIsEditing;
 
-                    return <CardComponent isSelected={isSelected} isEditing={isEditing} {...props} />;
+                    return (
+                        <koenigEditorContext.Provider value={koenigEditor}>
+                            <CardComponent isSelected={isSelected} isEditing={isEditing} {...props} />
+                        </koenigEditorContext.Provider>
+                    );
                 };
 
                 // This is async, the component won't be rendered immediately


### PR DESCRIPTION
no issue

- the KoenigEditor instance and it's internal mobiledoc editor instance were passed down through most components as props as it's universally useful
- by moving the instance into a context we can make it available anywhere it's needed without being concerned about it getting passed through every component's props object correctly
- when cards are rendered they are rendered into a new React root so we have to set up a new context provider there so that behaviour is consistent across the app
