### PR TITLE
Deploy Demo only after CI test pass

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Wait for tests to succeed
         uses: lewagon/wait-on-check-action@master
         with:
-          ref: github.ref
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           check-name: 'Testing'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,6 +42,14 @@ jobs:
       contents: write
 
     steps:
+      - name: Wait for build to succeed
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-tests
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Test
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Wait for tests to succeed
         uses: lewagon/wait-on-check-action@master
         with:
-          ref: ${{ github.sha }}
+          ref: github.ref
           check-name: 'Testing'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Copy CNAME to build
         run: mkdir ./packages/koenig-lexical/public && cp ./.github/workflows/CNAME ./packages/koenig-lexical/public/CNAME
       
-      - name: Testing
-        run: cd ./packages/koenig-lexical && yarn && yarn test
-      
       - name: Build project
         run: cd ./packages/koenig-lexical && yarn && yarn build:demo
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,14 +42,13 @@ jobs:
       contents: write
 
     steps:
-      - name: Wait for test to succeed
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: wait-for-tests
+      - name: Wait for tests to succeed
+        uses: lewagon/wait-on-check-action@master
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: Testing
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          
+          ref: ${{ github.sha }}
+          check-name: 'Testing'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,10 @@ jobs:
 
       - name: Copy CNAME to build
         run: mkdir ./packages/koenig-lexical/public && cp ./.github/workflows/CNAME ./packages/koenig-lexical/public/CNAME
-
+      
+      - name: Testing
+        run: cd ./packages/koenig-lexical && yarn && yarn test
+      
       - name: Build project
         run: cd ./packages/koenig-lexical && yarn && yarn build:demo
 
@@ -42,12 +45,12 @@ jobs:
       contents: write
 
     steps:
-      - name: Wait for build to succeed
+      - name: Wait for test to succeed
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-tests
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: Test
+          checkName: Testing
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           
       - name: Download artifact

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,10 @@
 name: Deploy
 
 on:
-  push:
+  workflow_run:
+    workflows: [Test]
     branches: ["main", "lexical-demo"]
+    types: [ completed ]
 
 jobs:
   build:
@@ -12,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        
+      - uses: ahmadnassri/action-workflow-run-wait@v1
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -42,13 +46,6 @@ jobs:
       contents: write
 
     steps:
-      - name: Wait for tests to succeed
-        uses: lewagon/wait-on-check-action@master
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          check-name: 'Testing'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
       - 'renovate/*'
 jobs:
   test:
+    name: Testing
     uses: tryghost/actions/.github/workflows/test.yml@main
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,6 @@ on:
       - 'renovate/*'
 jobs:
   test:
-    with:
-      ref: ${{ github.sha }}
     name: Testing
     uses: tryghost/actions/.github/workflows/test.yml@main
     secrets:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
       - 'renovate/*'
 jobs:
   test:
+    with:
+      ref: ${{ github.sha }}
     name: Testing
     uses: tryghost/actions/.github/workflows/test.yml@main
     secrets:


### PR DESCRIPTION
no issue

- After quite a lot of trial and error (and trying multiple Github Action libraries), I think this is the cleanest setup to to ensure the Demo site only deploys after tests succeed.