### PR TITLE
Added initial click-to-select behaviour

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$getSelection, $isNodeSelection, CLICK_COMMAND, COMMAND_PRIORITY_LOW} from 'lexical';
+import {$getSelection, $isNodeSelection, BLUR_COMMAND, CLICK_COMMAND, COMMAND_PRIORITY_LOW} from 'lexical';
 
 const KoenigCardWrapperComponent = ({nodeKey, children}) => {
     const [editor] = useLexicalComposerContext();
-    const [isSelected, setSelected] = useLexicalNodeSelection(nodeKey);
+    const [isSelected, setSelected, clearSelected] = useLexicalNodeSelection(nodeKey);
     const [selection, setSelection] = React.useState(null);
     const ref = React.useRef(null);
 
@@ -18,13 +18,28 @@ const KoenigCardWrapperComponent = ({nodeKey, children}) => {
             editor.registerCommand(
                 CLICK_COMMAND,
                 (event) => {
-                    setSelected(ref.current.contains(event.target));
+                    if (ref.current.contains(event.target)) {
+                        clearSelected();
+                        setSelected(true);
+                    } else if (isSelected) {
+                        clearSelected();
+                    }
+                    return false;
+                },
+                COMMAND_PRIORITY_LOW
+            ),
+            editor.registerCommand(
+                BLUR_COMMAND,
+                (event) => {
+                    if (isSelected && !ref.current.contains(event.relatedTarget)) {
+                        setSelected(false);
+                    }
                     return false;
                 },
                 COMMAND_PRIORITY_LOW
             )
         );
-    }, [editor, isSelected, setSelected, nodeKey]);
+    }, [editor, isSelected, setSelected, clearSelected, nodeKey]);
 
     const isFocused = $isNodeSelection(selection) && isSelected;
 

--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -1,8 +1,18 @@
 import React from 'react';
+import {
+    $createParagraphNode,
+    $getNodeByKey,
+    $getSelection,
+    $isNodeSelection,
+    BLUR_COMMAND,
+    CLICK_COMMAND,
+    COMMAND_PRIORITY_EDITOR,
+    COMMAND_PRIORITY_LOW,
+    KEY_ENTER_COMMAND
+} from 'lexical';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$createParagraphNode, $getNodeByKey, $getSelection, $isNodeSelection, BLUR_COMMAND, CLICK_COMMAND, COMMAND_PRIORITY_EDITOR, COMMAND_PRIORITY_LOW, INSERT_PARAGRAPH_COMMAND, KEY_ENTER_COMMAND} from 'lexical';
 
 const KoenigCardWrapperComponent = ({nodeKey, children}) => {
     const [editor] = useLexicalComposerContext();

--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -1,6 +1,40 @@
-const KoenigCardWrapperComponent = ({children}) => {
+import React from 'react';
+import {mergeRegister} from '@lexical/utils';
+import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {$getSelection, $isNodeSelection, CLICK_COMMAND, COMMAND_PRIORITY_LOW} from 'lexical';
+
+const KoenigCardWrapperComponent = ({nodeKey, children}) => {
+    const [editor] = useLexicalComposerContext();
+    const [isSelected, setSelected, clearSelection] = useLexicalNodeSelection(nodeKey);
+    const [selection, setSelection] = React.useState(null);
+    const ref = React.useRef(null);
+
+    React.useEffect(() => {
+        return mergeRegister(
+            editor.registerUpdateListener(({editorState}) => {
+                setSelection(editorState.read(() => $getSelection()));
+            }),
+            editor.registerCommand(
+                CLICK_COMMAND,
+                (event) => {
+                    console.log(event.target, ref.current, ref.current.contains(event.target));
+                    (ref.current.contains(event.target)) ? setSelected(true) : clearSelection();
+                    return true;
+                },
+                COMMAND_PRIORITY_LOW
+            )
+        );
+    }, [editor, isSelected, setSelected, clearSelection, nodeKey]);
+
+    const isFocused = $isNodeSelection(selection) && isSelected;
+
     return (
-        <div className="relative caret-grey-800 hover:shadow-[0_0_0_1px] hover:shadow-green" data-kg-card>
+        <div
+            className={`relative caret-grey-800 hover:shadow-[0_0_0_1px] hover:shadow-green ${isFocused ? 'shadow-[0_0_0_1px] shadow-green' : ''}`}
+            ref={ref}
+            data-kg-card
+        >
             {children}
         </div>
     );

--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -32,7 +32,7 @@ const KoenigCardWrapperComponent = ({nodeKey, children}) => {
                         clearSelected();
                         setSelected(true);
                     } else if (isSelected) {
-                        clearSelected();
+                        setSelected(false);
                     }
                     return false;
                 },
@@ -80,6 +80,7 @@ const KoenigCardWrapperComponent = ({nodeKey, children}) => {
             className={`relative caret-grey-800 hover:shadow-[0_0_0_1px] hover:shadow-green ${isFocused ? 'shadow-[0_0_0_1px] shadow-green' : ''}`}
             ref={ref}
             data-kg-card
+            data-kg-card-selected={isFocused}
         >
             {children}
         </div>

--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$getSelection, $isNodeSelection, BLUR_COMMAND, CLICK_COMMAND, COMMAND_PRIORITY_LOW} from 'lexical';
+import {$createParagraphNode, $getNodeByKey, $getSelection, $isNodeSelection, BLUR_COMMAND, CLICK_COMMAND, COMMAND_PRIORITY_EDITOR, COMMAND_PRIORITY_LOW, INSERT_PARAGRAPH_COMMAND, KEY_ENTER_COMMAND} from 'lexical';
 
 const KoenigCardWrapperComponent = ({nodeKey, children}) => {
     const [editor] = useLexicalComposerContext();
@@ -37,6 +37,28 @@ const KoenigCardWrapperComponent = ({nodeKey, children}) => {
                     return false;
                 },
                 COMMAND_PRIORITY_LOW
+            ),
+            editor.registerCommand(
+                KEY_ENTER_COMMAND,
+                (event) => {
+                    // TODO: test if this is needed when code card is working again
+                    // we don't want to insert paragraphs if Enter is pressed inside card's form element
+                    // if (event.target.matches('input textarea select option')) {
+                    //     return false;
+                    // }
+
+                    const latestSelection = $getSelection();
+                    if (isSelected && $isNodeSelection(latestSelection) && latestSelection.getNodes().length === 1) {
+                        event.preventDefault();
+                        const cardNode = $getNodeByKey(nodeKey);
+                        const paragraphNode = $createParagraphNode();
+                        cardNode.getTopLevelElementOrThrow().insertAfter(paragraphNode);
+                        paragraphNode.select();
+                        return true;
+                    }
+                    return false;
+                },
+                COMMAND_PRIORITY_EDITOR
             )
         );
     }, [editor, isSelected, setSelected, clearSelected, nodeKey]);

--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -6,7 +6,7 @@ import {$getSelection, $isNodeSelection, CLICK_COMMAND, COMMAND_PRIORITY_LOW} fr
 
 const KoenigCardWrapperComponent = ({nodeKey, children}) => {
     const [editor] = useLexicalComposerContext();
-    const [isSelected, setSelected, clearSelection] = useLexicalNodeSelection(nodeKey);
+    const [isSelected, setSelected] = useLexicalNodeSelection(nodeKey);
     const [selection, setSelection] = React.useState(null);
     const ref = React.useRef(null);
 
@@ -18,14 +18,13 @@ const KoenigCardWrapperComponent = ({nodeKey, children}) => {
             editor.registerCommand(
                 CLICK_COMMAND,
                 (event) => {
-                    console.log(event.target, ref.current, ref.current.contains(event.target));
-                    (ref.current.contains(event.target)) ? setSelected(true) : clearSelection();
-                    return true;
+                    setSelected(ref.current.contains(event.target));
+                    return false;
                 },
                 COMMAND_PRIORITY_LOW
             )
         );
-    }, [editor, isSelected, setSelected, clearSelection, nodeKey]);
+    }, [editor, isSelected, setSelected, nodeKey]);
 
     const isFocused = $isNodeSelection(selection) && isSelected;
 

--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -42,7 +42,7 @@ const KoenigCardWrapperComponent = ({nodeKey, children}) => {
                 BLUR_COMMAND,
                 (event) => {
                     if (isSelected && !ref.current.contains(event.relatedTarget)) {
-                        setSelected(false);
+                        clearSelected();
                     }
                     return false;
                 },

--- a/packages/koenig-lexical/src/components/KoenigEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigEditor.jsx
@@ -4,6 +4,7 @@ import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {OnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
 import {ListPlugin} from '@lexical/react/LexicalListPlugin';
+import KoenigBehaviourPlugin from '../plugins/KoenigBehaviourPlugin';
 import MarkdownShortcutPlugin from '../plugins/MarkdownShortcutPlugin';
 import FloatingFormatToolbarPlugin from '../plugins/FloatingFormatToolbar';
 import '../styles/index.css';
@@ -17,6 +18,8 @@ const KoenigEditor = ({
         onChange?.(json);
     }, [onChange]);
 
+    const containerRef = React.useRef(null);
+
     // we need an element reference for the container element that
     // any floating elements in plugins will be rendered inside
     const [floatingAnchorElem, setFloatingAnchorElem] = React.useState(null);
@@ -27,7 +30,7 @@ const KoenigEditor = ({
     };
 
     return (
-        <div className="koenig-lexical">
+        <div className="koenig-lexical" ref={containerRef}>
             <RichTextPlugin
                 contentEditable={
                     <div ref={onRef}>
@@ -39,6 +42,7 @@ const KoenigEditor = ({
             <OnChangePlugin onChange={_onChange} />
             <HistoryPlugin /> {/* adds undo/redo */}
             <ListPlugin /> {/* adds indent/outdent/remove etc support */}
+            <KoenigBehaviourPlugin containerElem={containerRef} />
             <MarkdownShortcutPlugin transformers={markdownTransformers} />
             {floatingAnchorElem && (<FloatingFormatToolbarPlugin anchorElem={floatingAnchorElem} />)}
         </div>

--- a/packages/koenig-lexical/src/nodes/HorizontalRuleNode.jsx
+++ b/packages/koenig-lexical/src/nodes/HorizontalRuleNode.jsx
@@ -4,10 +4,10 @@ import KoenigCardWrapper from '../components/KoenigCardWrapper';
 
 export const INSERT_HORIZONTAL_RULE_COMMAND = createCommand();
 
-function HorizontalRuleComponent() {
+function HorizontalRuleComponent({nodeKey}) {
     return (
         <div className="inline-block">
-            <KoenigCardWrapper>
+            <KoenigCardWrapper nodeKey={nodeKey}>
                 <hr className="block h-[1px] border-0 border-t border-grey-300" />
             </KoenigCardWrapper>
         </div>
@@ -52,7 +52,7 @@ export class HorizontalRuleNode extends DecoratorNode {
     }
 
     decorate() {
-        return <HorizontalRuleComponent />;
+        return <HorizontalRuleComponent nodeKey={this.getKey()} />;
     }
 }
 

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {$getSelection, $isNodeSelection, $setSelection} from 'lexical';
+
+function useKoenigBehaviour({editor, containerElem}) {
+    // deselect cards on mousedown outside of the editor container
+    React.useEffect(() => {
+        const onMousedown = (event) => {
+            if (!containerElem.current.contains(event.target)) {
+                editor.update(() => {
+                    const selection = $getSelection();
+
+                    if ($isNodeSelection(selection)) {
+                        $setSelection(null);
+                    }
+                });
+            }
+        };
+
+        window.addEventListener('mousedown', onMousedown);
+
+        return () => {
+            window.removeEventListener('mousedown', onMousedown);
+        };
+    }, [editor, containerElem]);
+
+    return null;
+}
+
+export default function KoenigBehaviourPlugin({containerElem = document.querySelector('.koenig-editor')}) {
+    const [editor] = useLexicalComposerContext();
+    return useKoenigBehaviour({editor, containerElem});
+}

--- a/packages/koenig-lexical/test/e2e/card-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/card-behaviour.test.js
@@ -1,0 +1,215 @@
+import {beforeAll, afterAll, beforeEach, describe, expect, test} from 'vitest';
+import {start, initialize, focusEditor, assertHTML, html} from '../utils/e2e';
+
+describe('Card behaviour', async () => {
+    let app;
+    let page;
+
+    beforeAll(async function () {
+        ({app, page} = await start());
+    });
+
+    afterAll(async function () {
+        await app.stop();
+    });
+
+    beforeEach(async function () {
+        await initialize({page});
+    });
+
+    test('click selects card', async function () {
+        await focusEditor(page);
+        await page.keyboard.type('--- ');
+        await page.keyboard.type('--- ');
+
+        // clicking first HR card makes it selected
+        await page.click('hr');
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div>
+                    <div data-kg-card="true" data-kg-card-selected="true">
+                        <hr>
+                    </div>
+                </div>
+            </div>
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div>
+                    <div data-kg-card="true" data-kg-card-selected="false">
+                        <hr>
+                    </div>
+                </div>
+            </div>
+            <p><br></p>
+        `);
+
+        // clicking second HR card deselects the first and selects the second
+        await page.click('[data-lexical-decorator]:nth-of-type(2) hr');
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div>
+                    <div data-kg-card="true" data-kg-card-selected="false">
+                        <hr>
+                    </div>
+                </div>
+            </div>
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div>
+                    <div data-kg-card="true" data-kg-card-selected="true">
+                        <hr>
+                    </div>
+                </div>
+            </div>
+            <p><br></p>
+        `);
+    });
+
+    describe('when selected', function () {
+        test('click keeps selection', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('--- ');
+            await page.click('hr');
+            await page.click('hr');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div>
+                        <div data-kg-card="true" data-kg-card-selected="true">
+                            <hr>
+                        </div>
+                    </div>
+                </div>
+                <p><br></p>
+            `);
+        });
+
+        test('click off deselects', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('--- ');
+            await page.click('hr');
+            await page.click('p');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div>
+                        <div data-kg-card="true" data-kg-card-selected="false">
+                            <hr>
+                        </div>
+                    </div>
+                </div>
+                <p><br></p>
+            `);
+        });
+
+        test('click outside editor deselects', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('--- ');
+            await page.click('hr');
+            await page.click('body');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div>
+                        <div data-kg-card="true" data-kg-card-selected="false">
+                            <hr>
+                        </div>
+                    </div>
+                </div>
+                <p><br></p>
+            `);
+        });
+
+        test('RIGHT onto paragraph deselects', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('--- ');
+            await page.click('hr');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div>
+                        <div data-kg-card="true" data-kg-card-selected="true">
+                            <hr>
+                        </div>
+                    </div>
+                </div>
+                <p><br></p>
+            `);
+
+            await page.keyboard.press('ArrowRight');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div>
+                        <div data-kg-card="true" data-kg-card-selected="false">
+                            <hr>
+                        </div>
+                    </div>
+                </div>
+                <p><br></p>
+            `);
+        });
+
+        test('LEFT onto paragraph deselects', async function () {
+            await focusEditor(page);
+            await page.keyboard.press('Enter');
+            await page.keyboard.type('--- ');
+            await page.click('hr');
+
+            await assertHTML(page, html`
+                <p><br></p>
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div>
+                        <div data-kg-card="true" data-kg-card-selected="true">
+                            <hr>
+                        </div>
+                    </div>
+                </div>
+                <p><br></p>
+            `);
+
+            await page.keyboard.press('ArrowLeft');
+
+            await assertHTML(page, html`
+                <p><br></p>
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div>
+                        <div data-kg-card="true" data-kg-card-selected="false">
+                            <hr>
+                        </div>
+                    </div>
+                </div>
+                <p><br></p>
+            `);
+        });
+
+        test('ENTER creates paragraph after and moves selection', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('--- ');
+            await page.click('hr');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div>
+                        <div data-kg-card="true" data-kg-card-selected="true">
+                            <hr>
+                        </div>
+                    </div>
+                </div>
+                <p><br></p>
+            `);
+
+            await page.keyboard.press('Enter');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div>
+                        <div data-kg-card="true" data-kg-card-selected="false">
+                            <hr>
+                        </div>
+                    </div>
+                </div>
+                <p><br></p>
+                <p><br></p>
+            `);
+        });
+    });
+});

--- a/packages/koenig-lexical/test/e2e/card-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/card-behaviour.test.js
@@ -1,4 +1,4 @@
-import {beforeAll, afterAll, beforeEach, describe, expect, test} from 'vitest';
+import {beforeAll, afterAll, beforeEach, describe, test} from 'vitest';
 import {start, initialize, focusEditor, assertHTML, html} from '../utils/e2e';
 
 describe('Card behaviour', async () => {

--- a/packages/koenig-lexical/test/e2e/text-transforms/code-block.test.js
+++ b/packages/koenig-lexical/test/e2e/text-transforms/code-block.test.js
@@ -22,7 +22,7 @@ describe('Renders code block node', async () => {
         await page.keyboard.type('```javascript ');
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card="true">
+                <div data-kg-card="true" data-kg-card-selected="false">
                     <code>
                         <textarea autocorrect="off" autocapitalize="off" spellcheck="false" tabindex="0">javascript</textarea>
                     </code>

--- a/packages/koenig-lexical/test/e2e/text-transforms/horizontal-line-rule.test.js
+++ b/packages/koenig-lexical/test/e2e/text-transforms/horizontal-line-rule.test.js
@@ -23,7 +23,7 @@ describe('Renders horizontal line rule', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div>
-                    <div data-kg-card="true">
+                    <div data-kg-card="true" data-kg-card-selected="false">
                         <hr>
                     </div>
                 </div>


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1971

Behaviour changes:
- clicking a card puts it into "selected" mode
- clicking a different card swaps selection
- clicking onto a content section clears selection
- clicking outside of the editor clears selection
- <kbd>Enter</kbd> when a card is selected inserts a paragraph after, moves caret to it, and deselects card

---

- adds per-card behaviour to `<KoenigCardWrapper>` component
  - registers a `CLICK_COMMAND` handler that updates the `isSelected` state to true when the component or any of it's children are clicked and clears the state selection if the click was outside of the card
  - registers a `BLUR_COMMAND` handler that clears the selected state when the editor loses focus
  - registers an `KEY_ENTER_COMMAND` handler that inserts a blank paragraph after the card and selects in when <kbd>Enter</kbd> is pressed whilst the card is selected
  - adds green border classes to the card when selected
- adds `<KoenigBehaviourPlugin>` plugin and uses it by default in `<KoenigEditor>`
  - registers a window event listener that clears the editor selection any time a mousedown event fires outside of the editor canvas. Useful when an element inside a decorator node has focus and the click outside of the editor causes focus to be lost without dispatching a `BLUR_COMMAND` event