### PR TITLE
Moved `imageUploader` into new `KoenigComposerContext`

### DIFF
--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -20,13 +20,11 @@ function DemoApp() {
 
     return (
         <div className="koenig-lexical top">
-            <KoenigComposer>
+            <KoenigComposer imageUploadFunction={imageUploader}>
                 <Watermark />
                 <div className="h-full grow overflow-auto">
                     <div className="mx-auto h-full max-w-[740px] pt-[15vmin]">
-                        <KoenigEditor
-                            imageUploadFunc={imageUploader}
-                        />
+                        <KoenigEditor />
                     </div>
                 </div>
                 <div className="flex h-full flex-col items-end">

--- a/packages/koenig-lexical/demo/utils/imageUploader.js
+++ b/packages/koenig-lexical/demo/utils/imageUploader.js
@@ -1,4 +1,4 @@
-async function imageUploader(files) {
+export async function imageUploader(files) {
     function convertToURL(file) {
         return new Promise((resolve, reject) => {
             const fileReader = new FileReader();
@@ -19,5 +19,3 @@ async function imageUploader(files) {
         };
     }
 }
-
-export {imageUploader};

--- a/packages/koenig-lexical/src/components/KoenigComposer.jsx
+++ b/packages/koenig-lexical/src/components/KoenigComposer.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {LexicalComposer} from '@lexical/react/LexicalComposer';
 import DEFAULT_NODES from '../nodes/DefaultNodes';
 import defaultTheme from '../themes/default';
+import KoenigComposerContext from '../context/KoenigComposerContext';
 
 // Catch any errors that occur during Lexical updates and log them
 // or throw them as needed. If you don't throw them, Lexical will
@@ -19,6 +20,7 @@ const KoenigComposer = ({
     initialEditorState,
     nodes = [...DEFAULT_NODES],
     onError = defaultOnError,
+    imageUploadFunction,
     children
 }) => {
     const initialConfig = React.useMemo(() => {
@@ -29,9 +31,16 @@ const KoenigComposer = ({
         });
     }, [initialEditorState, nodes, onError]);
 
+    const imageUploader = imageUploadFunction || function () {
+        console.error('requires imageUploadFunction to be passed to KoenigEditor'); // eslint-disable-line no-console
+        return;
+    };
+
     return (
         <LexicalComposer initialConfig={initialConfig}>
-            {children}
+            <KoenigComposerContext.Provider value={{imageUploader}}>
+                {children}
+            </KoenigComposerContext.Provider>
         </LexicalComposer>
     );
 };

--- a/packages/koenig-lexical/src/components/KoenigEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigEditor.jsx
@@ -8,15 +8,14 @@ import KoenigBehaviourPlugin from '../plugins/KoenigBehaviourPlugin';
 import MarkdownShortcutPlugin from '../plugins/MarkdownShortcutPlugin';
 import PlusCardMenuPlugin from '../plugins/PlusCardMenuPlugin';
 import FloatingFormatToolbarPlugin from '../plugins/FloatingFormatToolbarPlugin';
-import '../styles/index.css';
 import ImagePlugin from '../plugins/ImagePlugin';
+import '../styles/index.css';
 
 export let imageUploader;
 
 const KoenigEditor = ({
     onChange,
-    markdownTransformers,
-    imageUploadFunc
+    markdownTransformers
 }) => {
     const _onChange = React.useCallback((editorState) => {
         const json = editorState.toJSON();
@@ -24,10 +23,6 @@ const KoenigEditor = ({
     }, [onChange]);
 
     const containerRef = React.useRef(null);
-    imageUploader = imageUploadFunc || function () {
-        console.error('requires imageUploadFunction to be passed to KoenigEditor'); // eslint-disable-line no-console
-        return;
-    };
 
     // we need an element reference for the container element that
     // any floating elements in plugins will be rendered inside
@@ -52,12 +47,10 @@ const KoenigEditor = ({
             <HistoryPlugin /> {/* adds undo/redo */}
             <ListPlugin /> {/* adds indent/outdent/remove etc support */}
             <KoenigBehaviourPlugin containerElem={containerRef} />
-            <MarkdownShortcutPlugin transformers={markdownTransformers} imageUploadFunc={imageUploadFunc} />
+            <MarkdownShortcutPlugin transformers={markdownTransformers} />
             <PlusCardMenuPlugin />
             {floatingAnchorElem && (<FloatingFormatToolbarPlugin anchorElem={floatingAnchorElem} />)}
-            <ImagePlugin 
-                imageUploadFunc={imageUploadFunc}
-            />
+            <ImagePlugin />
         </div>
     );
 };

--- a/packages/koenig-lexical/src/context/KoenigComposerContext.jsx
+++ b/packages/koenig-lexical/src/context/KoenigComposerContext.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const KoenigComposerContext = React.createContext({});
+
+export default KoenigComposerContext;

--- a/packages/koenig-lexical/src/nodes/DefaultNodes.js
+++ b/packages/koenig-lexical/src/nodes/DefaultNodes.js
@@ -13,7 +13,7 @@ const DEFAULT_NODES = [
     QuoteNode,
     AsideNode,
     LinkNode,
-    CodeBlockNode, // TODO: replace with our own card
+    CodeBlockNode,
     HorizontalRuleNode,
     ImageNode
 ];

--- a/packages/koenig-lexical/src/nodes/ImageNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNode.jsx
@@ -3,12 +3,13 @@ import {DecoratorNode, $getNodeByKey} from 'lexical';
 import KoenigCardWrapper from '../components/KoenigCardWrapper';
 import {ReactComponent as ImgPlaceholderIcon} from '../assets/icons/kg-img-placeholder.svg';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {imageUploader} from '../components/KoenigEditor';
 import {ReactComponent as ImageCardIcon} from '../assets/icons/kg-card-type-image.svg';
+import KoenigComposerContext from '../context/KoenigComposerContext';
 import CardContext from '../context/CardContext';
 
 function MediaCard({dataset, editor, nodeKey}) {
     const {payload, setPayload} = dataset;
+    const {imageUploader} = React.useContext(KoenigComposerContext);
 
     const uploadRef = useRef(null);
     const onUploadChange = async (e) => {

--- a/packages/koenig-lexical/src/plugins/ImagePlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/ImagePlugin.jsx
@@ -1,23 +1,26 @@
 import React from 'react';
-import {$createImageNode, ImageNode} from '../nodes/ImageNode';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {
-    $getSelection, 
-    DRAGOVER_COMMAND, 
-    DRAGSTART_COMMAND, 
-    DROP_COMMAND, 
-    COMMAND_PRIORITY_HIGH, 
+    $getSelection,
+    DRAGOVER_COMMAND,
+    DRAGSTART_COMMAND,
+    DROP_COMMAND,
+    COMMAND_PRIORITY_HIGH,
     createCommand,
     $isRangeSelection,
     $isRootNode,
     LexicalEditor
 } from 'lexical';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
+import KoenigComposerContext from '../context/KoenigComposerContext';
+import {$createImageNode, ImageNode} from '../nodes/ImageNode';
 
 export const INSERT_IMAGE_CMD = createCommand();
 
-export const ImagePlugin = ({imageUploadFunc}) => {
+export const ImagePlugin = () => {
     const [editor] = useLexicalComposerContext();
+    const {imageUploader} = React.useContext(KoenigComposerContext);
+
     React.useEffect(() => {
         if (!editor.hasNodes([ImageNode])){
             console.error('ImagePlugin: ImageNode not registered'); // eslint-disable-line no-console
@@ -42,14 +45,14 @@ export const ImagePlugin = ({imageUploadFunc}) => {
                 return onDragOver(event);
             }, COMMAND_PRIORITY_HIGH),
             editor.registerCommand(DROP_COMMAND, (event) => {
-                return onDragDrop(event, editor, imageUploadFunc);
+                return onDragDrop(event, editor, imageUploader);
             }, COMMAND_PRIORITY_HIGH),
         );
-    }, [editor, imageUploadFunc]);
+    }, [editor, imageUploader]);
 
     return null;
 };
-  
+
 const onDragStart = (event) => {
     return true;
 };

--- a/packages/koenig-lexical/src/plugins/MarkdownShortcutPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/MarkdownShortcutPlugin.jsx
@@ -1,4 +1,3 @@
-import {MarkdownShortcutPlugin as LexicalMarkdownShortcutPlugin} from '@lexical/react/LexicalMarkdownShortcutPlugin';
 import {
     HEADING,
     ORDERED_LIST,
@@ -7,12 +6,13 @@ import {
     TEXT_FORMAT_TRANSFORMERS,
     TEXT_MATCH_TRANSFORMERS
 } from '@lexical/markdown';
-import {$createHorizontalRuleNode, $isHorizontalRuleNode} from '../nodes/HorizontalRuleNode';
+import {MarkdownShortcutPlugin as LexicalMarkdownShortcutPlugin} from '@lexical/react/LexicalMarkdownShortcutPlugin';
+import {$createHorizontalRuleNode, $isHorizontalRuleNode, HorizontalRuleNode} from '../nodes/HorizontalRuleNode';
 import {$isCodeBlockNode, $createCodeBlockNode, CodeBlockNode} from '../nodes/CodeBlockNode';
-import {$createImageNode, $isImageNode} from '../nodes/ImageNode';
+import {$isImageNode, $createImageNode, ImageNode} from '../nodes/ImageNode';
 
 export const HR = {
-    dependencies: [], // todo: docs a bit unclear regarding the usage of this property, but required as of 0.4.0 https://github.com/facebook/lexical/pull/2910
+    dependencies: [HorizontalRuleNode],
     export: (node) => {
         return $isHorizontalRuleNode(node) ? '---' : null;
     },
@@ -33,7 +33,7 @@ export const HR = {
 };
 
 export const CODE_BLOCK = {
-    dependencies: [CodeBlockNode], // todo: docs a bit unclear regarding the usage of this property, but required as of 0.4.0
+    dependencies: [CodeBlockNode],
     export: (node) => {
         if (!$isCodeBlockNode(node)) {
             return null;
@@ -61,7 +61,7 @@ export const CODE_BLOCK = {
 // regex that detects exactly the string 'image!'
 
 export const IMAGE = {
-    dependencies: [], // todo: docs a bit unclear regarding the usage of this property, but required as of 0.4.0
+    dependencies: [ImageNode],
     export: (node) => {
         if (!$isImageNode(node)){
             return null;


### PR DESCRIPTION
no issue

- the exported `let` that was later set to the passed in `imageUploadFunction` created a circular dependency that meant it wasn't possible to import the `ImageNode` class elsewhere
- added a `KoenigComposerContext` React context for housing functions that should be available in any child components without needing to have module variables that create odd dependency chains or use prop drilling
- moved `imageUploadFunction` prop from `<KoenigEditor>` to `<KoenigComposer>` so it's in passed in at the top-level along with other editor-setup related props
- added `ImageNode` as a dependency to the image markdown transform
