### PR TITLE
Wired up card menu with insertion logic

### DIFF
--- a/packages/koenig-lexical/src/components/CardMenu/CardMenu.jsx
+++ b/packages/koenig-lexical/src/components/CardMenu/CardMenu.jsx
@@ -6,9 +6,9 @@ export const CardMenuSection = ({label, ...props}) => {
     );
 };
 
-export const CardMenuItem = ({label, desc, Icon, ...props}) => {
+export const CardMenuItem = ({label, desc, onClick, Icon, ...props}) => {
     return (
-        <div className="flex cursor-pointer flex-row items-center border border-transparent px-4 py-[1rem] text-grey-800 hover:bg-grey-100" {...props}>
+        <button className="flex w-full cursor-pointer flex-row items-center border border-transparent px-4 py-[1rem] text-left text-grey-800 hover:bg-grey-100" onClick={onClick} data-kg-card-menu-item={label} {...props}>
             <div className="flex items-center">
                 <Icon className="h-7 w-7" />
             </div>
@@ -16,7 +16,7 @@ export const CardMenuItem = ({label, desc, Icon, ...props}) => {
                 <div className="m-0 ml-4 truncate text-[1.3rem] font-normal leading-[1.6rem] tracking-[.02rem] text-grey-900">{label}</div>
                 <div className="m-0 ml-4 truncate text-xs font-normal leading-[1.6rem] tracking-[.02rem] text-grey">{desc}</div>
             </div>
-        </div>
+        </button>
     );
 };
 

--- a/packages/koenig-lexical/src/components/KoenigEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigEditor.jsx
@@ -9,6 +9,7 @@ import MarkdownShortcutPlugin from '../plugins/MarkdownShortcutPlugin';
 import PlusCardMenuPlugin from '../plugins/PlusCardMenuPlugin';
 import FloatingFormatToolbarPlugin from '../plugins/FloatingFormatToolbarPlugin';
 import ImagePlugin from '../plugins/ImagePlugin';
+import HorizontalRulePlugin from '../plugins/HorizontalRulePlugin';
 import '../styles/index.css';
 
 export let imageUploader;
@@ -51,6 +52,7 @@ const KoenigEditor = ({
             <PlusCardMenuPlugin />
             {floatingAnchorElem && (<FloatingFormatToolbarPlugin anchorElem={floatingAnchorElem} />)}
             <ImagePlugin />
+            <HorizontalRulePlugin />
         </div>
     );
 };

--- a/packages/koenig-lexical/src/nodes/HorizontalRuleNode.jsx
+++ b/packages/koenig-lexical/src/nodes/HorizontalRuleNode.jsx
@@ -27,7 +27,8 @@ export class HorizontalRuleNode extends DecoratorNode {
     static kgMenu = {
         label: 'Divider',
         desc: 'Insert a dividing line',
-        Icon: DividerCardIcon
+        Icon: DividerCardIcon,
+        insertCommand: INSERT_HORIZONTAL_RULE_COMMAND
     };
 
     exportJSON() {

--- a/packages/koenig-lexical/src/nodes/ImageNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNode.jsx
@@ -1,11 +1,13 @@
 import React, {useState, useRef, useEffect, useContext} from 'react';
-import {DecoratorNode, $getNodeByKey} from 'lexical';
+import {DecoratorNode, $getNodeByKey, createCommand} from 'lexical';
 import KoenigCardWrapper from '../components/KoenigCardWrapper';
 import {ReactComponent as ImgPlaceholderIcon} from '../assets/icons/kg-img-placeholder.svg';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {ReactComponent as ImageCardIcon} from '../assets/icons/kg-card-type-image.svg';
 import KoenigComposerContext from '../context/KoenigComposerContext';
 import CardContext from '../context/CardContext';
+
+export const INSERT_IMAGE_COMMAND = createCommand();
 
 function MediaCard({dataset, editor, nodeKey}) {
     const {payload, setPayload} = dataset;
@@ -158,7 +160,7 @@ function CaptionEditor({placeholder, nodeKey, toggleAltText, selected}) {
                     onChange={handleChange}
                     className="not-kg-prose w-full px-9 text-center font-sans text-sm font-normal leading-8 tracking-wide text-grey-900"
                     placeholder={placeholder}
-                    value={altText ? altTextValue : captionText}
+                    value={(altText ? altTextValue : captionText) || ''}
                 />
                 <button
                     name="alt-toggle-button"
@@ -207,7 +209,8 @@ export class ImageNode extends DecoratorNode {
     static kgMenu = {
         label: 'Image',
         desc: 'Upload, or embed with /image [url]',
-        Icon: ImageCardIcon
+        Icon: ImageCardIcon,
+        insertCommand: INSERT_IMAGE_COMMAND
     };
 
     exportDOM(){
@@ -304,7 +307,7 @@ export class ImageNode extends DecoratorNode {
     }
 }
 
-export const $createImageNode = ({src, caption, altText}) => {
+export const $createImageNode = ({src, caption, altText} = {}) => {
     const node = new ImageNode(src, caption, altText);
     return node;
 };

--- a/packages/koenig-lexical/src/plugins/HorizontalRulePlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/HorizontalRulePlugin.jsx
@@ -1,0 +1,51 @@
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {$getSelection, $isParagraphNode, $isRangeSelection, COMMAND_PRIORITY_EDITOR} from 'lexical';
+import {useEffect} from 'react';
+import {$createHorizontalRuleNode, INSERT_HORIZONTAL_RULE_COMMAND} from '../nodes/HorizontalRuleNode';
+
+export const HorizontalRulePlugin = () => {
+    const [editor] = useLexicalComposerContext();
+
+    useEffect(() => {
+        if (!editor.hasNodes([])) {
+            console.error('HorizontalRulePlugin: HorizontalRuleNode not registered'); // eslint-disable-line no-console
+            return;
+        }
+        return editor.registerCommand(
+            INSERT_HORIZONTAL_RULE_COMMAND,
+            () => {
+                const selection = $getSelection();
+
+                if (!$isRangeSelection(selection)) {
+                    return false;
+                }
+
+                const focusNode = selection.focus.getNode();
+
+                if (focusNode !== null) {
+                    const horizontalRuleNode = $createHorizontalRuleNode();
+
+                    // insert a paragraph unless we're already on a blank paragraph
+                    const selectedNode = selection.focus.getNode();
+                    if ($isParagraphNode(selectedNode) && selectedNode.getTextContent() !== '') {
+                        selection.insertParagraph();
+                    }
+
+                    // insert the horizontal rule before the current/inserted paragraph
+                    // so the cursor stays on the blank paragraph
+                    selection.focus
+                        .getNode()
+                        .getTopLevelElementOrThrow()
+                        .insertBefore(horizontalRuleNode);
+                }
+
+                return true;
+            },
+            COMMAND_PRIORITY_EDITOR
+        );
+    }, [editor]);
+
+    return null;
+};
+
+export default HorizontalRulePlugin;

--- a/packages/koenig-lexical/src/plugins/ImagePlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/ImagePlugin.jsx
@@ -5,17 +5,16 @@ import {
     DRAGSTART_COMMAND,
     DROP_COMMAND,
     COMMAND_PRIORITY_HIGH,
-    createCommand,
     $isRangeSelection,
-    $isRootNode,
-    LexicalEditor
+    LexicalEditor,
+    $createNodeSelection,
+    $setSelection,
+    $isParagraphNode
 } from 'lexical';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {mergeRegister} from '@lexical/utils';
 import KoenigComposerContext from '../context/KoenigComposerContext';
-import {$createImageNode, ImageNode} from '../nodes/ImageNode';
-
-export const INSERT_IMAGE_CMD = createCommand();
+import {$createImageNode, ImageNode, INSERT_IMAGE_COMMAND} from '../nodes/ImageNode';
 
 export const ImagePlugin = () => {
     const [editor] = useLexicalComposerContext();
@@ -24,29 +23,72 @@ export const ImagePlugin = () => {
     React.useEffect(() => {
         if (!editor.hasNodes([ImageNode])){
             console.error('ImagePlugin: ImageNode not registered'); // eslint-disable-line no-console
+            return;
         }
         return mergeRegister(
-            editor.registerCommand(INSERT_IMAGE_CMD, (dataset) => {
-                editor.update(() => {
+            editor.registerCommand(
+                INSERT_IMAGE_COMMAND,
+                (dataset) => {
                     const selection = $getSelection();
-                    if ($isRangeSelection) {
-                        if ($isRootNode(selection.anchor.getNode())){
+
+                    if (!$isRangeSelection(selection)) {
+                        return false;
+                    }
+
+                    const focusNode = selection.focus.getNode();
+
+                    if (focusNode !== null) {
+                        const imageNode = $createImageNode(dataset);
+
+                        // insert a paragraph if this will be the last card and
+                        // we're not already on a blank paragraph so we always
+                        // have a trailing paragraph in the doc
+                        const selectedNode = selection.focus.getNode();
+                        const selectedIsBlankParagraph = $isParagraphNode(selectedNode) && selectedNode.getTextContent() === '';
+                        const nextNode = selectedNode.getTopLevelElementOrThrow().getNextSibling();
+                        if (!selectedIsBlankParagraph && !nextNode) {
                             selection.insertParagraph();
                         }
-                        const imgNode = $createImageNode(dataset);
-                        selection.insertNodes([imgNode]);
+
+                        selection.focus
+                            .getNode()
+                            .getTopLevelElementOrThrow()
+                            .insertBefore(imageNode);
+
+                        // move the focus away from the paragraph to the inserted
+                        // decorator node
+                        const nodeSelection = $createNodeSelection();
+                        nodeSelection.add(imageNode.getKey());
+                        $setSelection(nodeSelection);
+
+                        // TODO: trigger file selector?
                     }
-                });
-            }, COMMAND_PRIORITY_HIGH),
-            editor.registerCommand(DRAGSTART_COMMAND, (event) => {
-                return onDragStart(event);
-            }, COMMAND_PRIORITY_HIGH),
-            editor.registerCommand(DRAGOVER_COMMAND, (event) => {
-                return onDragOver(event);
-            }, COMMAND_PRIORITY_HIGH),
-            editor.registerCommand(DROP_COMMAND, (event) => {
-                return onDragDrop(event, editor, imageUploader);
-            }, COMMAND_PRIORITY_HIGH),
+
+                    return true;
+                },
+                COMMAND_PRIORITY_HIGH
+            ),
+            editor.registerCommand(
+                DRAGSTART_COMMAND,
+                (event) => {
+                    return onDragStart(event);
+                },
+                COMMAND_PRIORITY_HIGH
+            ),
+            editor.registerCommand(
+                DRAGOVER_COMMAND,
+                (event) => {
+                    return onDragOver(event);
+                },
+                COMMAND_PRIORITY_HIGH
+            ),
+            editor.registerCommand(
+                DROP_COMMAND,
+                (event) => {
+                    return onDragDrop(event, editor, imageUploader);
+                },
+                COMMAND_PRIORITY_HIGH
+            ),
         );
     }, [editor, imageUploader]);
 
@@ -66,7 +108,7 @@ const onDragDrop = async (event, editor = LexicalEditor, imageUploader) => {
     const fls = event.dataTransfer.files;
     const files = await imageUploader.imageUploader(fls);
     if (files) {
-        editor.dispatchCommand(INSERT_IMAGE_CMD, files);
+        editor.dispatchCommand(INSERT_IMAGE_COMMAND, files);
     }
 };
 

--- a/packages/koenig-lexical/src/plugins/PlusCardMenuPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/PlusCardMenuPlugin.jsx
@@ -10,7 +10,7 @@ function usePlusCardMenu(editor) {
     const [isShowingMenu, setIsShowingMenu] = React.useState(false);
     const [topPosition, setTopPosition] = React.useState(0);
     const [cachedRange, setCachedRange] = React.useState(null);
-    const [cardMenu] = React.useState(buildCardMenu(editor));
+    const [cardMenu, setCardMenu] = React.useState([]);
     const containerRef = React.useRef(null);
 
     function getTopPosition(elem) {
@@ -213,6 +213,10 @@ function usePlusCardMenu(editor) {
             window.removeEventListener('keydown', handleKeydown);
         };
     });
+
+    React.useEffect(() => {
+        setCardMenu(buildCardMenu(editor, {afterInsert: closeMenu}));
+    }, [editor, closeMenu]);
 
     const style = {
         top: `${topPosition}px`

--- a/packages/koenig-lexical/src/utils/buildCardMenu.jsx
+++ b/packages/koenig-lexical/src/utils/buildCardMenu.jsx
@@ -4,7 +4,7 @@ import {
     CardMenuItem
 } from '../components/CardMenu';
 
-export function buildCardMenu(editor) {
+export function buildCardMenu(editor, {afterInsert} = {}) {
     const menu = new Map();
     menu.set('Primary', []);
 
@@ -33,10 +33,24 @@ export function buildCardMenu(editor) {
 
     const menuComponents = [];
 
+    // browsers will move focus on mouseDown but we don't want that because it
+    // removes focus from the editor meaning key commands don't work as
+    // expected after a card is inserted
+    const preventMouseDown = (event) => {
+        event.preventDefault();
+    };
+
     menu.forEach((items, section) => {
         menuComponents.push(<CardMenuSection key={section} label={section} />);
+
         items.forEach((item) => {
-            menuComponents.push(<CardMenuItem key={`${section}-${item.label}`} label={item.label} desc={item.desc} Icon={item.Icon} />);
+            const onClick = (event) => {
+                event.preventDefault();
+                editor.dispatchCommand(item.insertCommand);
+                afterInsert?.();
+            };
+
+            menuComponents.push(<CardMenuItem key={`${section}-${item.label}`} label={item.label} desc={item.desc} Icon={item.Icon} onMouseDown={preventMouseDown} onClick={onClick} />);
         });
     });
 

--- a/packages/koenig-lexical/test/e2e/plus-button.test.js
+++ b/packages/koenig-lexical/test/e2e/plus-button.test.js
@@ -307,5 +307,29 @@ describe('Plus button', async () => {
             const p1Box = await p1.boundingBox();
             await assertPosition(page, '[data-kg-plus-button]', {y: p1Box.y}, {threshold: 5});
         });
+
+        it('inserts card and closes menu when card item clicked', async function () {
+            await focusEditor(page);
+            await page.click('[data-kg-plus-button]');
+            await page.click('[data-kg-card-menu-item="Divider"]');
+
+            expect(await page.$('[data-kg-plus-menu]')).toBeNull();
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <p><br></p>
+            `);
+
+            await assertSelection(page, {
+                anchorOffset: 0,
+                anchorPath: [1],
+                focusOffset: 0,
+                focusPath: [1]
+            });
+        });
     });
 });


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2070

- adds `insertCommand` property to the `kgMenu` object defined on our card nodes
  - using a command allows for plugins to define the insertion behaviour such as what happens to selection after insert and for re-use across anything that can trigger a card insertion
- added `HorizontalRulePlugin` so it can register the `INSERT_HORIZONTAL_RULE_COMMAND` command
  - inserts the HR node and keeps selection on the blank paragraph so typing can continue
- updated `INSERT_IMAGE_COMMAND` handling in `ImagePlugin`
  - renamed from `CMD` to `COMMAND` for consistency
  - updated to insert/keep a paragraph after the inserted card only when the card is the last section in the document
- updated `buildCardMenu` to add an `onClick` handler to each `<CardMenuItem>` that dispatches the relevant command and calls an optionally passed-in `afterInsert` function for any other cleanup such as ensuring menus have closed
