### PR TITLE
Added display of card menu when typing `/` on empty paragraph

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigEditor.jsx
@@ -7,6 +7,7 @@ import {ListPlugin} from '@lexical/react/LexicalListPlugin';
 import KoenigBehaviourPlugin from '../plugins/KoenigBehaviourPlugin';
 import MarkdownShortcutPlugin from '../plugins/MarkdownShortcutPlugin';
 import PlusCardMenuPlugin from '../plugins/PlusCardMenuPlugin';
+import SlashCardMenuPlugin from '../plugins/SlashCardMenuPlugin';
 import FloatingFormatToolbarPlugin from '../plugins/FloatingFormatToolbarPlugin';
 import ImagePlugin from '../plugins/ImagePlugin';
 import HorizontalRulePlugin from '../plugins/HorizontalRulePlugin';
@@ -49,6 +50,7 @@ const KoenigEditor = ({
             <KoenigBehaviourPlugin containerElem={containerRef} />
             <MarkdownShortcutPlugin transformers={markdownTransformers} />
             <PlusCardMenuPlugin />
+            <SlashCardMenuPlugin />
             {floatingAnchorElem && (<FloatingFormatToolbarPlugin anchorElem={floatingAnchorElem} />)}
             <ImagePlugin />
             <HorizontalRulePlugin />

--- a/packages/koenig-lexical/src/components/ui/SlashMenu.jsx
+++ b/packages/koenig-lexical/src/components/ui/SlashMenu.jsx
@@ -1,0 +1,7 @@
+export function SlashMenu({children}) {
+    return (
+        <div data-kg-slash-menu>
+            {children}
+        </div>
+    );
+}

--- a/packages/koenig-lexical/src/plugins/SlashCardMenuPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/SlashCardMenuPlugin.jsx
@@ -1,7 +1,203 @@
+import React from 'react';
+import {$getSelection, $isParagraphNode, $isRangeSelection} from 'lexical';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {SlashMenu} from '../components/ui/SlashMenu';
+import {getSelectedNode} from '../utils/getSelectedNode';
+import {buildCardMenu} from '../utils/buildCardMenu';
 
 function useSlashCardMenu(editor) {
+    const [isShowingMenu, setIsShowingMenu] = React.useState(false);
+    const [topPosition, setTopPosition] = React.useState(0);
+    const [cardMenu, setCardMenu] = React.useState([]);
+    const cachedRange = React.useRef(null);
+    const containerRef = React.useRef(null);
 
+    function getTopPosition(elem) {
+        const elemRect = elem.getBoundingClientRect();
+        const containerRect = elem.parentNode.getBoundingClientRect();
+
+        return elemRect.bottom - containerRect.top;
+    }
+
+    function moveCursorToCachedRange() {
+        if (!cachedRange.current) {
+            return;
+        }
+        document.getSelection().removeAllRanges();
+        document.getSelection().addRange(cachedRange.current);
+    }
+
+    const openMenu = React.useCallback(() => {
+        setIsShowingMenu(true);
+    }, [setIsShowingMenu]);
+
+    const closeMenu = React.useCallback(({resetCursor = false} = {}) => {
+        if (resetCursor) {
+            moveCursorToCachedRange();
+        }
+        setIsShowingMenu(false);
+        cachedRange.current = null;
+    }, [setIsShowingMenu]);
+
+    // close menu if selection moves out of the slash command
+    // update the search query when typing
+    React.useEffect(() => {
+        return editor.registerUpdateListener(() => {
+            editor.getEditorState().read(() => {
+                // don't do anything when using IME input
+                if (editor.isComposing()) {
+                    return;
+                }
+
+                const selection = $getSelection();
+
+                if (!$isRangeSelection(selection) || !selection.type === 'text' || !selection.isCollapsed()) {
+                    closeMenu();
+                    return;
+                }
+
+                const node = getSelectedNode(selection).getTopLevelElement();
+
+                if (!node || !$isParagraphNode(node) || !node.getTextContent().startsWith('/')) {
+                    closeMenu();
+                    return;
+                }
+
+                const nativeSelection = window.getSelection();
+                const anchorNode = nativeSelection.anchorNode;
+                const rootElement = editor.getRootElement();
+
+                if (anchorNode?.nodeType !== Node.TEXT_NODE || !rootElement.contains(anchorNode)) {
+                    closeMenu();
+                    return;
+                }
+
+                // store the cached range so we can reset the cursor when Escape is pressed
+                // because that will _always_ blur the contenteditable which we don't want
+                cachedRange.current = nativeSelection.getRangeAt(0);
+
+                // TODO: adjust search query
+            });
+        });
+    }, [editor, closeMenu]);
+
+    // open the menu when / is pressed on a blank paragraph
+    React.useEffect(() => {
+        if (isShowingMenu) {
+            return;
+        }
+
+        const triggerMenu = (event) => {
+            const {key, isComposing, shiftKey, ctrlKey, metaKey, altKey} = event;
+
+            // we only care about / presses when not composing or pressed with modifiers
+            if (key !== '/' || isComposing || shiftKey || ctrlKey || metaKey || altKey) {
+                return;
+            }
+
+            // ignore if editor doesn't have focus
+            const rootElement = editor.getRootElement();
+            if (!rootElement.matches(':focus')) {
+                return;
+            }
+
+            // potentially valid / press
+            editor.getEditorState().read(() => {
+                const selection = $getSelection();
+                const node = getSelectedNode(selection).getTopLevelElement();
+
+                // ignore if selection is not on a top-level paragraph
+                if (!node || !$isParagraphNode(node)) {
+                    return;
+                }
+
+                const paragraphSize = node.getTextContentSize();
+                const isEmptyParagraph = selection.isCollapsed() && node.getTextContent() === '';
+                // if full paragraph is selected, pressing / will replace it so that's a valid press
+                const isFullParagraphSelection = !selection.isCollapsed() && (
+                    (selection.anchor.offset === 0 && selection.focus.offset === paragraphSize) ||
+                    (selection.anchor.offset === paragraphSize && selection.focus.offset === 0)
+                );
+
+                if (isEmptyParagraph || isFullParagraphSelection) {
+                    const nativeSelection = window.getSelection();
+                    let selectionElem;
+
+                    if (nativeSelection.anchorNode.nodeType === Node.TEXT_NODE) {
+                        selectionElem = nativeSelection.anchorNode.parentNode.closest('p');
+                    } else {
+                        selectionElem = nativeSelection.anchorNode;
+                    }
+
+                    setTopPosition(getTopPosition(selectionElem));
+                    openMenu();
+                }
+            });
+        };
+
+        window.addEventListener('keypress', triggerMenu);
+        return () => {
+            window.removeEventListener('keypress', triggerMenu);
+        };
+    }, [editor, isShowingMenu, setTopPosition, openMenu]);
+
+    // close the menu when Escape is pressed
+    React.useEffect(() => {
+        if (!isShowingMenu) {
+            return;
+        }
+
+        const handleEscape = (event) => {
+            if (event.key === 'Escape') {
+                closeMenu({resetCursor: true});
+                return;
+            }
+        };
+
+        window.addEventListener('keydown', handleEscape);
+        return () => {
+            window.removeEventListener('keydown', handleEscape);
+        };
+    }, [isShowingMenu, closeMenu]);
+
+    // close the menu on clicks outside the menu
+    React.useEffect(() => {
+        if (!isShowingMenu) {
+            return;
+        }
+
+        const handleMousedown = (event) => {
+            if (containerRef.current?.contains(event.target)) {
+                return;
+            }
+
+            closeMenu();
+        };
+
+        window.addEventListener('mousedown', handleMousedown);
+        return () => {
+            window.removeEventListener('mousedown', handleMousedown);
+        };
+    }, [isShowingMenu, closeMenu]);
+
+    // build up the card menu based on registered nodes and current search
+    React.useEffect(() => {
+        setCardMenu(buildCardMenu(editor, {afterInsert: closeMenu}));
+    }, [editor, closeMenu]);
+
+    const style = {
+        top: `${topPosition}px`
+    };
+
+    if (isShowingMenu) {
+        return (
+            <div className="absolute" style={style} ref={containerRef} data-kg-slash-container>
+                <SlashMenu>{cardMenu}</SlashMenu>
+            </div>
+        );
+    }
+
+    return null;
 }
 
 export default function SlashCardMenuPlugin() {

--- a/packages/koenig-lexical/test/e2e/slash-menu.test.js
+++ b/packages/koenig-lexical/test/e2e/slash-menu.test.js
@@ -1,0 +1,152 @@
+import {afterAll, beforeAll, beforeEach, describe, expect, it} from 'vitest';
+import {startApp, initialize, focusEditor, assertHTML, html, assertSelection} from '../utils/e2e';
+
+describe('Slash menu', async () => {
+    let app;
+    let page;
+
+    beforeAll(async () => {
+        ({app, page} = await startApp());
+    });
+
+    afterAll(async () => {
+        await app.stop();
+    });
+
+    beforeEach(async () => {
+        await initialize({page});
+    });
+
+    describe('open/close', function () {
+        it('opens with / on blank paragraph', async function () {
+            await focusEditor(page);
+            expect(await page.$('[data-kg-slash-menu]')).toBeNull();
+            await page.keyboard.type('/');
+            expect(await page.$('[data-kg-slash-menu]')).not.toBeNull();
+        });
+
+        it('opens with / on paragraph that is entirely selected', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('testing');
+
+            const paragraph = await page.$('[data-lexical-editor] > p');
+            await paragraph.click({clickCount: 3});
+
+            await assertSelection(page, {
+                anchorOffset: 0,
+                anchorPath: [0, 0, 0],
+                focusOffset: 7,
+                focusPath: [0, 0, 0]
+            });
+
+            await page.keyboard.type('/');
+
+            // sanity check that text was fully selected + replaced
+            await assertHTML(page, html`<p><span data-lexical-text="true">/</span></p>`);
+
+            expect(await page.$('[data-kg-slash-menu]')).not.toBeNull();
+        });
+
+        it('does not open with / on populated paragraph', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('testing');
+            await page.keyboard.type('/');
+
+            expect(await page.$('[data-kg-slash-menu]')).toBeNull();
+
+            await page.keyboard.press('Backspace');
+            for (let i = 0; i < 'testing'.length; i++) {
+                await page.keyboard.press('ArrowLeft');
+            }
+
+            await assertSelection(page, {
+                anchorOffset: 0,
+                anchorPath: [0, 0, 0],
+                focusOffset: 0,
+                focusPath: [0, 0, 0]
+            });
+
+            await page.keyboard.type('/');
+
+            expect(await page.$('[data-kg-slash-menu]')).toBeNull();
+        });
+
+        it('closes when / deleted', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('/');
+
+            expect(await page.$('[data-kg-slash-menu]')).not.toBeNull();
+
+            await page.keyboard.press('Backspace');
+
+            expect(await page.$('[data-kg-slash-menu]')).toBeNull();
+        });
+
+        it('closes on Escape', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('/');
+            await page.keyboard.press('Escape');
+
+            expect(await page.$('[data-kg-slash-menu]')).toBeNull();
+
+            await assertSelection(page, {
+                anchorOffset: 1,
+                anchorPath: [0, 0, 0],
+                focusOffset: 1,
+                focusPath: [0, 0, 0]
+            });
+        });
+
+        it('closes on click outside menu', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('/');
+            await page.click('body');
+
+            expect(await page.$('[data-kg-slash-menu]')).toBeNull();
+        });
+
+        it('does not close on click inside menu', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('/');
+            await page.click('[data-kg-slash-menu] > div > div'); // better selector for menu headings?
+
+            expect(await page.$('[data-kg-slash-menu]')).not.toBeNull();
+        });
+
+        it('closes on cursor movement to another section', async function () {
+            await focusEditor(page);
+            await page.keyboard.press('Enter');
+            await page.keyboard.type('/');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+
+            await assertSelection(page, {
+                anchorOffset: 0,
+                anchorPath: [0],
+                focusOffset: 0,
+                focusPath: [0]
+            });
+
+            expect(await page.$('[data-kg-slash-menu]')).toBeNull();
+        });
+
+        it('does not re-open when cursor placed back on /', async function () {
+            await focusEditor(page);
+            await page.keyboard.press('Enter');
+            await page.keyboard.type('/');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowRight');
+            await page.keyboard.press('ArrowRight');
+
+            await assertSelection(page, {
+                anchorOffset: 1,
+                anchorPath: [1, 0, 0],
+                focusOffset: 1,
+                focusPath: [1, 0, 0]
+            });
+
+            expect(await page.$('[data-kg-slash-menu]')).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2100

- adds `<SlashCardMenuPlugin>` which implements the `/` menu support
- when typing `/` on an empty paragraph the card menu is shown
  - deleting the `/` closes the menu
  - pressing <kbd>Escape</kbd> closes the menu and keeps cursor position
  - clicking anywhere outside of the menu closes the menu
  - any cursor movement that moves the cursor off the /-containing paragraph closes the menu
