### PR TITLE
Added image card toolbar visibility behaviour

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -59,9 +59,11 @@ const KoenigCardWrapperComponent = ({nodeKey, children}) => {
             editor.registerCommand(
                 BLUR_COMMAND,
                 (event) => {
-                    if (isSelected && !ref.current.contains(event.relatedTarget)) {
-                        clearSelected();
-                    }
+                    // commented out for now as it breaks the card toolbar's behaviour
+
+                    // if (isSelected && !ref.current.contains(event.relatedTarget)) {
+                    //     clearSelected();
+                    // }
                     return false;
                 },
                 COMMAND_PRIORITY_LOW

--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -7,7 +7,7 @@ import {
     $isDecoratorNode,
     $isNodeSelection,
     $setSelection,
-    BLUR_COMMAND,
+    // BLUR_COMMAND,
     CLICK_COMMAND,
     COMMAND_PRIORITY_EDITOR,
     COMMAND_PRIORITY_LOW,
@@ -56,18 +56,16 @@ const KoenigCardWrapperComponent = ({nodeKey, children}) => {
                 },
                 COMMAND_PRIORITY_LOW
             ),
-            editor.registerCommand(
-                BLUR_COMMAND,
-                (event) => {
-                    // commented out for now as it breaks the card toolbar's behaviour
-
-                    // if (isSelected && !ref.current.contains(event.relatedTarget)) {
-                    //     clearSelected();
-                    // }
-                    return false;
-                },
-                COMMAND_PRIORITY_LOW
-            ),
+            // editor.registerCommand(
+            //     BLUR_COMMAND,
+            //     (event) => {
+            //         if (isSelected && !ref.current.contains(event.relatedTarget)) {
+            //             clearSelected();
+            //         }
+            //         return false;
+            //     },
+            //     COMMAND_PRIORITY_LOW
+            // ),
             editor.registerCommand(
                 KEY_ENTER_COMMAND,
                 (event) => {
@@ -175,7 +173,7 @@ const KoenigCardWrapperComponent = ({nodeKey, children}) => {
     }, [editor, isSelected, setSelected, clearSelected, nodeKey]);
 
     return (
-        <WrapperContext.Provider value={{isSelected, selection, setSelected}}>
+        <WrapperContext.Provider value={{isSelected, selection}}>
             <CardWrapper
                 isSelected={isSelected}
                 cardType={cardType}

--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -173,7 +173,7 @@ const KoenigCardWrapperComponent = ({nodeKey, children}) => {
     }, [editor, isSelected, setSelected, clearSelected, nodeKey]);
 
     return (
-        <WrapperContext.Provider value={{isSelected, selection}}>
+        <WrapperContext.Provider value={{isSelected, selection, setSelected}}>
             <CardWrapper
                 isSelected={isSelected}
                 cardType={cardType}

--- a/packages/koenig-lexical/src/components/ui/ImageCardToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/ImageCardToolbar.jsx
@@ -2,44 +2,18 @@ import React from 'react';
 import {ToolbarMenu, ToolbarMenuItem} from './ToolbarMenu';
 import ImageUploadForm from './ImageUploadForm';
 import {createPortal} from 'react-dom';
-import CardContext from '../../context/CardContext';
 
 function ImageCardToolbar({isSelected, fileInputRef, onFileChange, filePicker, figureRef, src}) {
-    const {setSelected} = React.useContext(CardContext);
     const element = document.querySelector('#koenig') || document.body;
     const toolbarRef = React.useRef(null);
-    const [showToolbar, setShowToolbar] = React.useState(false);
     const [rect, setRect] = React.useState({
         top: 0,
         left: 0,
         right: 0
     });
     
-    const handleClickOnToolbar = React.useCallback((e) => {
-        e.stopPropagation();
-        if (isSelected) {
-            setShowToolbar(true);
-            return;
-        }
-        if ((toolbarRef.current && toolbarRef.current.contains(e.target) && !isSelected)) {
-            setSelected(true);
-            setShowToolbar(true);
-            return;
-        } else {
-            setShowToolbar(false);
-        }
-    }, [toolbarRef, setSelected, isSelected]);
-
-    React.useEffect(() => {
-        document.addEventListener('click', handleClickOnToolbar);
-        return () => {
-            document.removeEventListener('click', handleClickOnToolbar);
-        };
-    }, [handleClickOnToolbar]);
-    
     React.useEffect(() => {
         if (figureRef && isSelected) {
-            setShowToolbar(true);
             const figureRect = figureRef.current.getBoundingClientRect();
             const top = figureRect.top - element.getBoundingClientRect().top;
             setRect({
@@ -56,11 +30,10 @@ function ImageCardToolbar({isSelected, fileInputRef, onFileChange, filePicker, f
         left: (rect?.right - rect?.left) / 2,
         transform: 'translate(-50%, 0)',
         top: rect?.top - 44,
-        zIndex: 1000,
-        opacity: showToolbar ? 1 : 0 || isSelected ? 1 : 0
+        zIndex: 1000
     };
 
-    if (src) {
+    if (src && isSelected) {
         return createPortal(
             <div ref={toolbarRef} data-kg-card-toolbar="image" style={toolbarPosition}>
                 <ImageUploadForm 

--- a/packages/koenig-lexical/src/components/ui/ImageCardToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/ImageCardToolbar.jsx
@@ -1,18 +1,45 @@
 import React from 'react';
 import {ToolbarMenu, ToolbarMenuItem} from './ToolbarMenu';
-import {ImageUploadForm} from './cards/ImageCard';
+import ImageUploadForm from './ImageUploadForm';
 import {createPortal} from 'react-dom';
+import CardContext from '../../context/CardContext';
 
-function ImageCardToolbar({isSelected, fileInputRef, onFileChange, filePicker, figureRef}) {
-    const element = document.querySelector('#koenig');
+function ImageCardToolbar({isSelected, fileInputRef, onFileChange, filePicker, figureRef, src}) {
+    const {setSelected} = React.useContext(CardContext);
+    const element = document.querySelector('#koenig') || document.body;
+    const toolbarRef = React.useRef(null);
+    const [showToolbar, setShowToolbar] = React.useState(false);
     const [rect, setRect] = React.useState({
         top: 0,
         left: 0,
         right: 0
     });
+    
+    const handleClickOnToolbar = React.useCallback((e) => {
+        e.stopPropagation();
+        if (isSelected) {
+            setShowToolbar(true);
+            return;
+        }
+        if ((toolbarRef.current && toolbarRef.current.contains(e.target) && !isSelected)) {
+            setSelected(true);
+            setShowToolbar(true);
+            return;
+        } else {
+            setShowToolbar(false);
+        }
+    }, [toolbarRef, setSelected, isSelected]);
 
     React.useEffect(() => {
-        if (isSelected) {
+        document.addEventListener('click', handleClickOnToolbar);
+        return () => {
+            document.removeEventListener('click', handleClickOnToolbar);
+        };
+    }, [handleClickOnToolbar]);
+    
+    React.useEffect(() => {
+        if (figureRef && isSelected) {
+            setShowToolbar(true);
             const figureRect = figureRef.current.getBoundingClientRect();
             const top = figureRect.top - element.getBoundingClientRect().top;
             setRect({
@@ -26,23 +53,28 @@ function ImageCardToolbar({isSelected, fileInputRef, onFileChange, filePicker, f
     
     const toolbarPosition = {
         position: 'absolute',
-        left: (rect?.right - rect?.left) / 2 || 0,
+        left: (rect?.right - rect?.left) / 2,
         transform: 'translate(-50%, 0)',
-        top: rect?.top - 44 || 0,
+        top: rect?.top - 44,
         zIndex: 1000,
-        opacity: isSelected ? 1 : 0
+        opacity: showToolbar ? 1 : 0 || isSelected ? 1 : 0
     };
-    return createPortal(
-        <div data-kg-card-toolbar="image" style={toolbarPosition}>
-            <ImageUploadForm onFileChange={onFileChange} fileInputRef={fileInputRef} />
-            <ToolbarMenu>
-                <ToolbarMenuItem label="Regular" icon="imageRegular" isActive={true} />
-                <ToolbarMenuItem label="Wide" icon="imageWide" isActive={false} />
-                <ToolbarMenuItem label="Full" icon="imageRegular" isActive={false} />
-                <ToolbarMenuItem label="Replace" icon="imageReplace" isActive={false} onClick={filePicker} />
-            </ToolbarMenu>
-        </div>, element
-    );
+
+    if (src) {
+        return createPortal(
+            <div ref={toolbarRef} data-kg-card-toolbar="image" style={toolbarPosition}>
+                <ImageUploadForm 
+                    onFileChange={onFileChange}
+                    fileInputRef={fileInputRef} />
+                <ToolbarMenu>
+                    <ToolbarMenuItem label="Regular" icon="imageRegular" isActive={true} />
+                    <ToolbarMenuItem label="Wide" icon="imageWide" isActive={false} />
+                    <ToolbarMenuItem label="Full" icon="imageRegular" isActive={false} />
+                    <ToolbarMenuItem label="Replace" icon="imageReplace" isActive={false} onClick={filePicker} />
+                </ToolbarMenu>
+            </div>, element
+        );
+    }
 }
 
 export default ImageCardToolbar;

--- a/packages/koenig-lexical/src/components/ui/ImageUploadForm.jsx
+++ b/packages/koenig-lexical/src/components/ui/ImageUploadForm.jsx
@@ -1,0 +1,15 @@
+function ImageUploadForm({onFileChange, fileInputRef}) {
+    return (
+        <form onChange={onFileChange}>
+            <input
+                name="image-input"
+                type='file'
+                accept='image/*'
+                ref={fileInputRef}
+                hidden={true}
+            />
+        </form>
+    );
+}
+
+export default ImageUploadForm;

--- a/packages/koenig-lexical/src/components/ui/cards/ImageCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/ImageCard.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import {CardCaptionEditor} from '../CardCaptionEditor';
 import {MediaPlaceholder} from '../MediaPlaceholder';
 import {ReactComponent as ImgPlaceholderIcon} from '../../../assets/icons/kg-img-placeholder.svg';
-import ImageCardToolbar from '../ImageCardToolbar';
+import {openFileSelection} from '../../../utils/openFileSelection';
+import ImageUploadForm from '../ImageUploadForm';
 
 function PopulatedImageCard({src, alt}) {
     return (
@@ -11,36 +12,17 @@ function PopulatedImageCard({src, alt}) {
     );
 }
 
-function openFilePicker({fileInputRef}) {
-    fileInputRef.current.click();
-}
-
-export function ImageUploadForm({onFileChange, fileInputRef}) {
-    return (
-        <form onChange={onFileChange}>
-            <input
-                name="image-input"
-                type='file'
-                accept='image/*'
-                ref={fileInputRef}
-                hidden={true}
-            />
-        </form>
-    );
-}
-
 function EmptyImageCard({onFileChange}) {
     const fileInputRef = React.useRef(null);
-
     return (
         <>
             <MediaPlaceholder
-                filePicker={() => openFilePicker({fileInputRef})}
+                filePicker={() => openFileSelection({fileInputRef})}
                 desc="Click to select an image"
                 Icon={ImgPlaceholderIcon}
             />
             <ImageUploadForm
-                filePicker={() => openFilePicker({fileInputRef})}
+                filePicker={() => openFileSelection({fileInputRef})}
                 onFileChange={onFileChange}
                 fileInputRef={fileInputRef}
             />
@@ -55,25 +37,19 @@ export function ImageCard({
     caption,
     setCaption,
     altText,
-    setAltText
+    setAltText,
+    setFigureRef
 }) {
     const figureRef = React.useRef(null);
-    const fileInputRef = React.useRef(null);
 
+    React.useEffect(() => {
+        if (setFigureRef) {
+            setFigureRef(figureRef);
+        }
+    }, [figureRef, setFigureRef]);
+    
     return (
         <>
-            {
-                src ?
-                    <>
-                        <ImageCardToolbar
-                            figureRef={figureRef}
-                            filePicker={() => openFilePicker({fileInputRef})} 
-                            isSelected={isSelected} 
-                            fileInputRef={fileInputRef} 
-                            onFileChange={onFileChange} />
-                    </>
-                    : <></>
-            }
             <figure ref={figureRef}>
                 {src
                     ? <PopulatedImageCard src={src} alt={altText} />
@@ -95,7 +71,7 @@ export function ImageCard({
 
 ImageCard.propTypes = {
     isSelected: PropTypes.bool,
-    setAltText: PropTypes.bool,
+    setAltText: PropTypes.func,
     caption: PropTypes.string,
     altText: PropTypes.string
 };

--- a/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
@@ -4,21 +4,26 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import CardContext from '../context/CardContext';
 import KoenigComposerContext from '../context/KoenigComposerContext';
 import {ImageCard} from '../components/ui/cards/ImageCard';
+import ImageCardToolbar from '../components/ui/ImageCardToolbar';
+import {openFileSelection} from '../utils/openFileSelection';
 
 export function ImageNodeComponent({nodeKey, src, altText, caption}) {
     const [editor] = useLexicalComposerContext();
     const {isSelected} = React.useContext(CardContext);
     const {imageUploader} = React.useContext(KoenigComposerContext);
-    const [toolbarVisible, setToolbarVisible] = React.useState(false);
+    const [figureRef, setFigureRef] = React.useState(null);
+    const fileInputRef = React.useRef(null);
 
     const onFileChange = async (e) => {
         const fls = e.target.files;
         const files = await imageUploader.imageUploader(fls); // idea here is to have something like imageUploader.uploadProgressPercentage to pass to the progress bar.
 
-        editor.update(() => {
-            const node = $getNodeByKey(nodeKey);
-            node.setSrc(files.src);
-        });
+        if (files) {
+            editor.update(() => {
+                const node = $getNodeByKey(nodeKey);
+                node.setSrc(files.src);
+            });
+        }
     };
 
     const setCaption = (newCaption) => {
@@ -35,17 +40,10 @@ export function ImageNodeComponent({nodeKey, src, altText, caption}) {
         });
     };
 
-    React.useEffect(() => {
-        if (isSelected && src !== '') {
-            setToolbarVisible(true);
-        } else {
-            setToolbarVisible(false);
-        }
-    }, [isSelected, src]);
-
     return (
         <>  
             <ImageCard
+                setFigureRef={setFigureRef}
                 isSelected={isSelected}
                 onFileChange={onFileChange}
                 src={src}
@@ -53,7 +51,14 @@ export function ImageNodeComponent({nodeKey, src, altText, caption}) {
                 setAltText={setAltText}
                 caption={caption}
                 setCaption={setCaption}
-                toolbarVisible={toolbarVisible}
+            />
+            <ImageCardToolbar
+                figureRef={figureRef}
+                filePicker={() => openFileSelection({fileInputRef})} 
+                isSelected={isSelected} 
+                fileInputRef={fileInputRef} 
+                onFileChange={onFileChange}
+                src={src}
             />
         </>
     );

--- a/packages/koenig-lexical/src/utils/openFileSelection.js
+++ b/packages/koenig-lexical/src/utils/openFileSelection.js
@@ -1,0 +1,5 @@
+// Triggers the file selection dialog from a given referenced element
+
+export function openFileSelection({fileInputRef}) {
+    fileInputRef.current.click();
+}

--- a/packages/koenig-lexical/test/e2e/cards/image-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/image-card.test.js
@@ -176,4 +176,23 @@ describe('Image card', async () => {
             </div>
         `);
     });
+
+    test('toolbar does not disappear on click', async function () {
+        const filePath = path.relative(process.cwd(), __dirname + '/assets/large.png');
+
+        await focusEditor(page);
+        await page.keyboard.type('image! ');
+
+        const [fileChooser] = await Promise.all([
+            page.waitForFileChooser(),
+            await page.click('button[name="placeholder-button"]')
+        ]);
+        await fileChooser.accept([filePath]);
+
+        await page.click('figure');
+
+        await page.click('[data-kg-card-toolbar="image"] button[aria-label="Regular"]');
+
+        expect(await page.$('[data-kg-card-toolbar="image"]')).not.toBeNull();
+    });
 });


### PR DESCRIPTION
ref https://github.com/TryGhost/Team/issues/2109

- Commented out the `BLUR_COMMAND` ([here](https://github.com/TryGhost/Koenig/blob/eaec68735271b01e3cf0e5a735a83f443689e609/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx#L64)) as it appears to be breaking the selection behaviour, where it fires unexpectedly. This (temporarily) fixes the image card toolbar's behaviour.
- Moved ImageUploadForm to standalone component to make it easier to reuse.
- rearranged the toolbar component to be passed from the ImageNodeComponent, to avoid it interfering with Storybook
- Added tests