### PR TITLE
Added filtering in slash menu via /query

### DIFF
--- a/packages/koenig-lexical/src/nodes/HorizontalRuleNode.jsx
+++ b/packages/koenig-lexical/src/nodes/HorizontalRuleNode.jsx
@@ -23,7 +23,8 @@ export class HorizontalRuleNode extends DecoratorNode {
         label: 'Divider',
         desc: 'Insert a dividing line',
         Icon: DividerCardIcon,
-        insertCommand: INSERT_HORIZONTAL_RULE_COMMAND
+        insertCommand: INSERT_HORIZONTAL_RULE_COMMAND,
+        matches: ['divider', 'horizontal-rule', 'hr']
     };
 
     exportJSON() {

--- a/packages/koenig-lexical/src/nodes/ImageNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNode.jsx
@@ -32,7 +32,8 @@ export class ImageNode extends DecoratorNode {
         label: 'Image',
         desc: 'Upload, or embed with /image [url]',
         Icon: ImageCardIcon,
-        insertCommand: INSERT_IMAGE_COMMAND
+        insertCommand: INSERT_IMAGE_COMMAND,
+        matches: ['image', 'img']
     };
 
     static clone(node) {

--- a/packages/koenig-lexical/src/plugins/SlashCardMenuPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/SlashCardMenuPlugin.jsx
@@ -191,14 +191,14 @@ function useSlashCardMenu(editor) {
             closeMenu();
         };
         const cardNodes = getEditorCardNodes(editor);
-        setCardMenu(buildCardMenu(cardNodes, {insert}));
+        setCardMenu(buildCardMenu(cardNodes, {insert, query}));
     }, [editor, query, closeMenu]);
 
     const style = {
         top: `${topPosition}px`
     };
 
-    if (isShowingMenu) {
+    if (isShowingMenu && cardMenu) {
         return (
             <div className="absolute" style={style} ref={containerRef} data-kg-slash-container>
                 <SlashMenu>{cardMenu}</SlashMenu>

--- a/packages/koenig-lexical/src/utils/buildCardMenu.jsx
+++ b/packages/koenig-lexical/src/utils/buildCardMenu.jsx
@@ -4,9 +4,11 @@ import {
     CardMenuItem
 } from '../components/ui/CardMenu';
 
-export function buildCardMenu(nodes, {insert} = {}) {
+export function buildCardMenu(nodes, {insert, query} = {}) {
     const menu = new Map();
     menu.set('Primary', []);
+
+    query = query?.toLowerCase();
 
     function addMenuItem(item) {
         const section = item.section || 'Primary';
@@ -39,6 +41,10 @@ export function buildCardMenu(nodes, {insert} = {}) {
         const itemComponents = [];
 
         items.forEach((item) => {
+            if (query && (!item.matches || !item.matches.find(m => m.startsWith(query)))) {
+                return;
+            }
+
             const onClick = (event) => {
                 event.preventDefault();
                 insert?.(item.insertCommand);
@@ -47,8 +53,14 @@ export function buildCardMenu(nodes, {insert} = {}) {
             itemComponents.push(<CardMenuItem key={`${section}-${item.label}`} label={item.label} desc={item.desc} Icon={item.Icon} onMouseDown={preventMouseDown} onClick={onClick} />);
         });
 
-        menuComponents.push(<CardMenuSection key={section} label={section}>{itemComponents}</CardMenuSection>);
+        if (itemComponents.length > 0) {
+            menuComponents.push(<CardMenuSection key={section} label={section}>{itemComponents}</CardMenuSection>);
+        }
     });
+
+    if (menuComponents.length === 0) {
+        return null;
+    }
 
     return (
         <CardMenu>

--- a/packages/koenig-lexical/test/e2e/slash-menu.test.js
+++ b/packages/koenig-lexical/test/e2e/slash-menu.test.js
@@ -149,4 +149,23 @@ describe('Slash menu', async () => {
             expect(await page.$('[data-kg-slash-menu]')).toBeNull();
         });
     });
+
+    describe('filtering', function () {
+        it('matches text after /', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('/img');
+
+            const $$menuitems = await page.$$('[data-kg-slash-menu] [role="menuitem"]');
+            expect($$menuitems).toHaveLength(1);
+
+            expect(await page.evaluate(el => el.innerText, $$menuitems[0])).toContain('Image');
+        });
+
+        it('shows no menu with no matches', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('/unknown');
+
+            expect(await page.$('[data-kg-slash-menu]')).toBeNull();
+        });
+    });
 });

--- a/packages/koenig-lexical/test/unit/buildCardMenu.test.jsx
+++ b/packages/koenig-lexical/test/unit/buildCardMenu.test.jsx
@@ -1,7 +1,8 @@
 import {describe, expect, it} from 'vitest';
 import {getAllByRole, render, screen} from '@testing-library/react';
 import {buildCardMenu} from '../../src/utils/buildCardMenu';
-import {ReactComponent as ImageCardIcon} from '../../src/assets/icons/kg-card-type-image.svg';
+
+const Icon = () => <svg title="icon" />;
 
 describe('buildCardMenu', function () {
     it('renders', async function () {
@@ -9,13 +10,13 @@ describe('buildCardMenu', function () {
             ['one', {kgMenu: {
                 label: 'One',
                 desc: 'Card test one',
-                Icon: ImageCardIcon,
+                Icon,
                 insertCommand: 'insert_card_one'
             }}],
             ['two', {kgMenu: {
                 label: 'Two',
                 desc: 'Card test two',
-                Icon: ImageCardIcon,
+                Icon,
                 insertCommand: 'insert_card_two'
             }}]
         ];
@@ -41,14 +42,14 @@ describe('buildCardMenu', function () {
             ['one', {kgMenu: {
                 label: 'One',
                 desc: 'Card test one',
-                Icon: ImageCardIcon,
+                Icon,
                 insertCommand: 'insert_card_one'
             }}],
             ['two', {kgMenu: {
                 label: 'Two',
                 desc: 'Card test two',
                 section: 'Secondary',
-                Icon: ImageCardIcon,
+                Icon,
                 insertCommand: 'insert_card_two'
             }}]
         ];
@@ -76,12 +77,12 @@ describe('buildCardMenu', function () {
             ['one', {kgMenu: [{
                 label: 'One',
                 desc: 'Card test one',
-                Icon: ImageCardIcon,
+                Icon,
                 insertCommand: 'insert_card_one'
             }, {
                 label: 'Two',
                 desc: 'Card test two',
-                Icon: ImageCardIcon,
+                Icon,
                 insertCommand: 'insert_card_two'
             }]}]
         ];
@@ -97,5 +98,184 @@ describe('buildCardMenu', function () {
         expect(menuitems).toHaveLength(2);
         expect(menuitems[0]).toHaveTextContent('One');
         expect(menuitems[1]).toHaveTextContent('Two');
+    });
+
+    describe('filtering', function () {
+        it('shows all items for blank query', async function () {
+            const nodes = [
+                ['one', {kgMenu: {
+                    label: 'One',
+                    desc: 'Card test one',
+                    Icon,
+                    insertCommand: 'insert_card_one',
+                    matches: ['one']
+                }}],
+                ['two', {kgMenu: {
+                    label: 'Two',
+                    desc: 'Card test two',
+                    Icon,
+                    insertCommand: 'insert_card_two',
+                    matches: ['two']
+                }}]
+            ];
+
+            const cardMenu = buildCardMenu(nodes, {query: ''});
+
+            render(<>{cardMenu}</>);
+
+            const sections = screen.getAllByRole('separator');
+            expect(sections).toHaveLength(1);
+
+            const menuitems = screen.getAllByRole('menuitem');
+            expect(menuitems).toHaveLength(2);
+        });
+
+        it('matches start of strings', async function () {
+            const nodes = [
+                ['one', {kgMenu: {
+                    label: 'One',
+                    desc: 'Card test one',
+                    Icon,
+                    insertCommand: 'insert_card_one',
+                    matches: ['one']
+                }}],
+                ['two', {kgMenu: {
+                    label: 'Two',
+                    desc: 'Card test two',
+                    Icon,
+                    insertCommand: 'insert_card_two',
+                    matches: ['two']
+                }}]
+            ];
+
+            const cardMenu = buildCardMenu(nodes, {query: 't'});
+
+            render(<>{cardMenu}</>);
+
+            const sections = screen.getAllByRole('separator');
+            expect(sections).toHaveLength(1);
+
+            const menuitems = screen.getAllByRole('menuitem');
+            expect(menuitems).toHaveLength(1);
+            expect(menuitems[0]).toHaveTextContent('Two');
+        });
+
+        it('can match against multiple strings', async function () {
+            const nodes = [
+                ['one', {kgMenu: {
+                    label: 'One',
+                    desc: 'Card test one',
+                    Icon,
+                    insertCommand: 'insert_card_one',
+                    matches: ['one']
+                }}],
+                ['two', {kgMenu: {
+                    label: 'Two',
+                    desc: 'Card test two',
+                    Icon,
+                    insertCommand: 'insert_card_two',
+                    matches: ['two', 'multiple']
+                }}]
+            ];
+
+            const cardMenu = buildCardMenu(nodes, {query: 'mul'});
+
+            render(<>{cardMenu}</>);
+
+            const sections = screen.getAllByRole('separator');
+            expect(sections).toHaveLength(1);
+
+            const menuitems = screen.getAllByRole('menuitem');
+            expect(menuitems).toHaveLength(1);
+            expect(menuitems[0]).toHaveTextContent('Two');
+        });
+
+        it('filters all sections', async function () {
+            const nodes = [
+                ['one', {kgMenu: {
+                    label: 'One',
+                    desc: 'Card test one',
+                    Icon,
+                    insertCommand: 'insert_card_one',
+                    matches: ['one']
+                }}],
+                ['two', {kgMenu: {
+                    label: 'Two',
+                    desc: 'Card test two',
+                    section: 'Secondary',
+                    Icon,
+                    insertCommand: 'insert_card_two',
+                    matches: ['two', 'multiple']
+                }}]
+            ];
+
+            const cardMenu = buildCardMenu(nodes, {query: 'mul'});
+
+            render(<>{cardMenu}</>);
+
+            const sections = screen.getAllByRole('separator');
+            expect(sections).toHaveLength(1);
+            expect(sections[0]).toHaveTextContent('Secondary');
+
+            const menuitems = screen.getAllByRole('menuitem');
+            expect(menuitems).toHaveLength(1);
+            expect(menuitems[0]).toHaveTextContent('Two');
+        });
+
+        it('renders nothing with no matches', async function () {
+            const nodes = [
+                ['one', {kgMenu: {
+                    label: 'One',
+                    desc: 'Card test one',
+                    Icon,
+                    insertCommand: 'insert_card_one',
+                    matches: ['one']
+                }}],
+                ['two', {kgMenu: {
+                    label: 'Two',
+                    desc: 'Card test two',
+                    section: 'Secondary',
+                    Icon,
+                    insertCommand: 'insert_card_two',
+                    matches: ['two', 'multiple']
+                }}]
+            ];
+
+            const cardMenu = buildCardMenu(nodes, {query: 'unknown'});
+
+            const {container} = render(<>{cardMenu}</>);
+
+            expect(container.innerHTML).toEqual('');
+        });
+
+        it('is case-insensitive', async function () {
+            const nodes = [
+                ['one', {kgMenu: {
+                    label: 'One',
+                    desc: 'Card test one',
+                    Icon,
+                    insertCommand: 'insert_card_one',
+                    matches: ['one']
+                }}],
+                ['two', {kgMenu: {
+                    label: 'Two',
+                    desc: 'Card test two',
+                    Icon,
+                    insertCommand: 'insert_card_two',
+                    matches: ['two']
+                }}]
+            ];
+
+            const cardMenu = buildCardMenu(nodes, {query: 'Tw'});
+
+            render(<>{cardMenu}</>);
+
+            const sections = screen.getAllByRole('separator');
+            expect(sections).toHaveLength(1);
+
+            const menuitems = screen.getAllByRole('menuitem');
+            expect(menuitems).toHaveLength(1);
+            expect(menuitems[0]).toHaveTextContent('Two');
+        });
     });
 });


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2121

- adds `query` option param to `buildCardMenu(nodes, {query})`
  - if query is present performs a match against each node's `kgMenu.matches` array and only adds the item if there's a match
  - skips adding sections with no items
  - skips rendering if there are no sections
- updated `SlashCardMenuPlugin` to pass the query through to `buildCardMenu()` and to not render anything if the menu is empty
