### PR TITLE
Added auto-trigger of file dialog when inserting image from card menus

### DIFF
--- a/packages/koenig-lexical/src/components/ui/CardMenu.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardMenu.jsx
@@ -73,7 +73,7 @@ export const CardMenu = ({menu = new Map(), insert = () => {}, selectedItemIndex
             const isSelected = itemIndex === selectedItemIndex;
             const onClick = (event) => {
                 event.preventDefault();
-                insert?.(item.insertCommand);
+                insert?.(item.insertCommand, {insertParams: item.insertParams});
             };
 
             if (!item.type || item.type === 'card') {

--- a/packages/koenig-lexical/src/components/ui/cards/ImageCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/ImageCard.jsx
@@ -12,8 +12,14 @@ function PopulatedImageCard({src, alt}) {
     );
 }
 
-function EmptyImageCard({onFileChange}) {
+function EmptyImageCard({onFileChange, setFileInputRef}) {
     const fileInputRef = React.useRef(null);
+
+    const onFileInputRef = (element) => {
+        fileInputRef.current = element;
+        setFileInputRef(fileInputRef);
+    };
+
     return (
         <>
             <MediaPlaceholder
@@ -24,7 +30,7 @@ function EmptyImageCard({onFileChange}) {
             <ImageUploadForm
                 filePicker={() => openFileSelection({fileInputRef})}
                 onFileChange={onFileChange}
-                fileInputRef={fileInputRef}
+                fileInputRef={onFileInputRef}
             />
         </>
     );
@@ -38,7 +44,8 @@ export function ImageCard({
     setCaption,
     altText,
     setAltText,
-    setFigureRef
+    setFigureRef,
+    fileInputRef
 }) {
     const figureRef = React.useRef(null);
 
@@ -47,13 +54,19 @@ export function ImageCard({
             setFigureRef(figureRef);
         }
     }, [figureRef, setFigureRef]);
-    
+
+    const setFileInputRef = (ref) => {
+        if (fileInputRef) {
+            fileInputRef.current = ref.current;
+        }
+    };
+
     return (
         <>
             <figure ref={figureRef}>
                 {src
                     ? <PopulatedImageCard src={src} alt={altText} />
-                    : <EmptyImageCard onFileChange={onFileChange} />
+                    : <EmptyImageCard onFileChange={onFileChange} setFileInputRef={setFileInputRef} />
                 }
                 <CardCaptionEditor
                     altText={altText || ''}

--- a/packages/koenig-lexical/src/plugins/PlusCardMenuPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/PlusCardMenuPlugin.jsx
@@ -97,8 +97,9 @@ function usePlusCardMenu(editor) {
         });
     }, [editor, showButton, hideButton]);
 
-    const insert = React.useCallback((insertCommand) => {
-        editor.dispatchCommand(insertCommand);
+    const insert = React.useCallback((insertCommand, {insertParams = {}} = {}) => {
+        const commandParams = {...insertParams};
+        editor.dispatchCommand(insertCommand, commandParams);
         closeMenu();
     }, [editor, closeMenu]);
 

--- a/packages/koenig-lexical/src/plugins/SlashCardMenuPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/SlashCardMenuPlugin.jsx
@@ -45,12 +45,14 @@ function useSlashCardMenu(editor) {
         cachedRange.current = null;
     }, [setIsShowingMenu]);
 
-    const insert = React.useCallback((insertCommand) => {
+    const insert = React.useCallback((insertCommand, {insertParams = {}} = {}) => {
+        const commandParams = {...insertParams};
+
         editor.update(() => {
             const selection = $getSelection();
             selection.modify('extend', true, 'lineboundary');
             selection.deleteCharacter(true);
-            editor.dispatchCommand(insertCommand);
+            editor.dispatchCommand(insertCommand, commandParams);
         });
         closeMenu();
     }, [editor, closeMenu]);

--- a/packages/koenig-lexical/test/e2e/cards/image-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/image-card.test.js
@@ -285,4 +285,17 @@ describe('Image card', async () => {
 
         expect(await page.$('[data-kg-card-toolbar="image"]')).not.toBeNull();
     });
+
+    test('file input opens immediately when added via card menu', async function () {
+        await focusEditor(page);
+        await page.click('[data-kg-plus-button]');
+        const [fileChooser] = await Promise.all([
+            page.waitForFileChooser(),
+            page.click('[data-kg-card-menu-item="Image"]')
+        ]);
+
+        expect(fileChooser).not.toBeNull();
+
+        await fileChooser.cancel();
+    });
 });

--- a/packages/koenig-lexical/test/e2e/slash-menu.test.js
+++ b/packages/koenig-lexical/test/e2e/slash-menu.test.js
@@ -265,7 +265,11 @@ describe('Slash menu', async () => {
             await page.keyboard.type('/hr');
             await page.keyboard.press('Enter');
             await page.keyboard.type('/img');
-            await page.keyboard.press('Enter');
+            const [fileChooser] = await Promise.all([
+                page.waitForFileChooser(),
+                page.keyboard.press('Enter')
+            ]);
+            await fileChooser.cancel();
 
             // image card retains focus after insert
             await assertHTML(page, html`


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2155

- added `insertParams` object to the `kgMenu` objects used to define menu behaviour for nodes
  - the key/value properties on `insertParams` will be merged with any other params when dispatching the `insertCommand`
  - updated image node to pass a `triggerFileDialog: true` param that is used by the image card components later on
- updated ImageNode's `$createImageNode` and `constructor` to use a single object argument instead of ordered arguments
  - the number of arguments needed for creating an image node will be growing quite a bit and having an ordered list of args was troublesome, especially when some args are optional
  - allows for easier merging of `insertParams` (and later `queryParams`) when inserting from the card menus
- added `triggerFileDialog` "transient" property to ImageNode
  - does not get serialized as it's only use is to pass data from the editor through to the node's decorator component
- updated image card components to trigger file dialog on first render if `triggerFileDialog` is true
  - set up file input ref passing up from the empty card state up to the logic-containing `ImageNodeComponent`
  - added an effect on `ImageNodeComponent` that clicks the file input when `triggerFileDialog` prop is true, uses a 100ms timeout to avoid problems with React StrictMode rendering all components twice because the file dialog is blocking and will wait for you to select a file before the component is re-rendered and the file dialog is shown again
  - after clicking the file dialog resets the `__triggerFileDialog` property on the node to avoid any accidental opening of the dialog
