### PR TITLE
Added mscorefonts install to CI test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,14 +7,52 @@ on:
       - 'renovate/*'
 jobs:
   test:
-    name: Testing
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    strategy:
+      matrix:
+        node: [ 14, 16 ]
+    env:
+      FORCE_COLOR: 1
+    name: Node ${{ matrix.node }}
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v2
+        env:
+          FORCE_COLOR: 0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: yarn
+
       - name: Install required fonts for consistent tests
         env:
           DEBIAN_FRONTEND: noninteractive
           DEBCONF_NONINTERACTIVE_SEEN: "true"
         run: echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
-      - uses: tryghost/actions/.github/workflows/test.yml@main
+
+      - name: "Check if repository is a Lerna monorepo"
+        id: check_files
+        uses: andstor/file-existence-action@87d74d4732ddb824259d80c8a508c0124bf1c673
+        with:
+          files: "lerna.json"
+
+      - run: yarn global add lerna@^4
+        if: steps.check_files.outputs.files_exists == 'true'
+
+      - run: yarn
+      - run: yarn test
+
+      - uses: codecov/codecov-action@v2
+
+      - uses: daniellockyer/action-slack-build@master
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,10 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
           DEBCONF_NONINTERACTIVE_SEEN: "true"
-        run: echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+        run: |
+          sudo apt-get update -yq
+          sudo sh -c "echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections"
+          sudo apt-get install msttcorefonts -qq
 
       - name: "Check if repository is a Lerna monorepo"
         id: check_files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     name: Testing
+    runs-on: ubuntu-latest
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,50 @@ on:
       - 'renovate/*'
 jobs:
   test:
-    name: Testing
     runs-on: ubuntu-latest
-    secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
+    strategy:
+      matrix:
+        node: [ 14, 16 ]
+    env:
+      FORCE_COLOR: 1
+    name: Node ${{ matrix.node }}
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v2
+        env:
+          FORCE_COLOR: 0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: yarn
+
       - name: Install required fonts for consistent tests
         env:
           DEBIAN_FRONTEND: noninteractive
           DEBCONF_NONINTERACTIVE_SEEN: "true"
         run: echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
-      - uses: tryghost/actions/.github/workflows/test.yml@main
+
+      - name: "Check if repository is a Lerna monorepo"
+        id: check_files
+        uses: andstor/file-existence-action@87d74d4732ddb824259d80c8a508c0124bf1c673
+        with:
+          files: "lerna.json"
+
+      - run: yarn global add lerna@^4
+        if: steps.check_files.outputs.files_exists == 'true'
+
+      - run: yarn
+      - run: yarn test
+
+      - uses: codecov/codecov-action@v2
+
+      - uses: daniellockyer/action-slack-build@master
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
           DEBCONF_NONINTERACTIVE_SEEN: "true"
-        run: echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
+        run: echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
 
       - name: "Check if repository is a Lerna monorepo"
         id: check_files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,52 +7,14 @@ on:
       - 'renovate/*'
 jobs:
   test:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
+    name: Testing
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-    strategy:
-      matrix:
-        node: [ 14, 16 ]
-    env:
-      FORCE_COLOR: 1
-    name: Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v2
-        env:
-          FORCE_COLOR: 0
-        with:
-          node-version: ${{ matrix.node }}
-          cache: yarn
-
       - name: Install required fonts for consistent tests
         env:
           DEBIAN_FRONTEND: noninteractive
           DEBCONF_NONINTERACTIVE_SEEN: "true"
         run: echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
-
-      - name: "Check if repository is a Lerna monorepo"
-        id: check_files
-        uses: andstor/file-existence-action@87d74d4732ddb824259d80c8a508c0124bf1c673
-        with:
-          files: "lerna.json"
-
-      - run: yarn global add lerna@^4
-        if: steps.check_files.outputs.files_exists == 'true'
-
-      - run: yarn
-      - run: yarn test
-
-      - uses: codecov/codecov-action@v2
-
-      - uses: daniellockyer/action-slack-build@master
-        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        with:
-          status: ${{ job.status }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - uses: tryghost/actions/.github/workflows/test.yml@main
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,13 @@ on:
 jobs:
   test:
     name: Testing
-    uses: tryghost/actions/.github/workflows/test.yml@main
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - name: Install required fonts for consistent tests
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          DEBCONF_NONINTERACTIVE_SEEN: "true"
+        run: echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
+      - uses: tryghost/actions/.github/workflows/test.yml@main
+


### PR DESCRIPTION
no issue

- some aspects of tests were inconsistent between local development testing and CI testing because the editor uses a font (Georgia) that isn't available by default on Linux machines meaning a different font is used making caret offsets vary
- updated test workflow to install mscorefonts before running tests
