### PR TITLE
Added subscript & superscript rendering to markdown cards

### DIFF
--- a/packages/kg-markdown-html-renderer/lib/markdown-html-renderer.js
+++ b/packages/kg-markdown-html-renderer/lib/markdown-html-renderer.js
@@ -55,7 +55,9 @@ const selectRenderer = function (options) {
             .use(require('markdown-it-lazy-headers'))
             .use(require('markdown-it-mark'))
             .use(require('markdown-it-image-lazy-loading'))
-            .use(namedHeaders(options));
+            .use(namedHeaders(options))
+            .use(require('markdown-it-sub'))
+            .use(require('markdown-it-sup'));
 
         markdownIt.linkify.set({
             fuzzyLink: false
@@ -73,7 +75,9 @@ const selectRenderer = function (options) {
             .use(require('markdown-it-lazy-headers'))
             .use(require('markdown-it-mark'))
             .use(require('markdown-it-image-lazy-loading'))
-            .use(namedHeaders(options));
+            .use(namedHeaders(options))
+            .use(require('markdown-it-sub'))
+            .use(require('markdown-it-sup'));
 
         markdownIt.linkify.set({
             fuzzyLink: false

--- a/packages/kg-markdown-html-renderer/package.json
+++ b/packages/kg-markdown-html-renderer/package.json
@@ -34,6 +34,8 @@
     "markdown-it-image-lazy-loading": "^1.1.0",
     "markdown-it-lazy-headers": "^0.1.3",
     "markdown-it-mark": "^3.0.0",
+    "markdown-it-sub": "^1.0.0",
+    "markdown-it-sup": "^1.0.0",
     "semver": "^7.3.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9313,6 +9313,16 @@ markdown-it-mark@^3.0.0:
   resolved "https://registry.yarnpkg.com/markdown-it-mark/-/markdown-it-mark-3.0.1.tgz#51257db58787d78aaf46dc13418d99a9f3f0ebd3"
   integrity sha512-HyxjAu6BRsdt6Xcv6TKVQnkz/E70TdGXEFHRYBGLncRE9lBFwDNLVtFojKxjJWgJ+5XxUwLaHXy+2sGBbDn+4A==
 
+markdown-it-sub@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-sub/-/markdown-it-sub-1.0.0.tgz#375fd6026eae7ddcb012497f6411195ea1e3afe8"
+  integrity sha512-z2Rm/LzEE1wzwTSDrI+FlPEveAAbgdAdPhdWarq/ZGJrGW/uCQbKAnhoCsE4hAbc3SEym26+W2z/VQB0cQiA9Q==
+
+markdown-it-sup@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-sup/-/markdown-it-sup-1.0.0.tgz#cb9c9ff91a5255ac08f3fd3d63286e15df0a1fc3"
+  integrity sha512-E32m0nV9iyhRR7CrhnzL5msqic7rL1juWre6TQNxsnApg7Uf+F97JOKxUijg5YwXz86lZ0mqfOnutoryyNdntQ==
+
 markdown-it@^12.2.0:
   version "12.3.2"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz#bf92ac92283fe983fe4de8ff8abfb5ad72cd0c90"


### PR DESCRIPTION
[Ghost/#1763](https://github.com/TryGhost/Admin/pull/1763) added support for subscript and superscript within Markdown cards, but the HTML only renders in the editor and not in the published article. Copying the changes here so that the subscript and superscript HTML is rendered for published articles, too.