### PR TITLE
Upgrade Lexical to 0.6

### DIFF
--- a/packages/koenig-lexical/package.json
+++ b/packages/koenig-lexical/package.json
@@ -35,11 +35,11 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@lexical/list": "^0.5.0",
-    "@lexical/react": "^0.5.0",
-    "@lexical/selection": "^0.5.0",
-    "@lexical/utils": "^0.5.0",
-    "lexical": "^0.5.0",
+    "@lexical/list": "^0.6.0",
+    "@lexical/react": "^0.6.0",
+    "@lexical/selection": "^0.6.0",
+    "@lexical/utils": "^0.6.0",
+    "lexical": "^0.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/koenig-lexical/src/components/KoenigEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigEditor.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {OnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
@@ -44,6 +45,7 @@ const KoenigEditor = ({
                     </div>
                 }
                 placeholder={<EditorPlaceholder />}
+                ErrorBoundary={LexicalErrorBoundary}
             />
             <OnChangePlugin onChange={_onChange} />
             <HistoryPlugin /> {/* adds undo/redo */}


### PR DESCRIPTION
no issue

- Lexical 0.6 introduces a mandantory `ErrorBoundary` to the RichTextPlugin, which is a breaking change.
- Also a bunch of new features with some that we'll be using in the coming weeks as we expand the editor. https://github.com/facebook/lexical/releases/tag/v0.6.0