### PR TITLE
Added URL paste to link support

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -14,10 +14,6 @@ import {
     PASTE_COMMAND
 } from 'lexical';
 
-import {
-    $wrapNodes
-} from '@lexical/selection';
-
 import {$createLinkNode} from '@lexical/link';
 import {mergeRegister} from '@lexical/utils';
 

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -7,10 +7,18 @@ import {
     $isNodeSelection,
     $isRangeSelection,
     $setSelection,
+    $createTextNode,
     COMMAND_PRIORITY_HIGH,
     KEY_ARROW_DOWN_COMMAND,
-    KEY_ARROW_UP_COMMAND
+    KEY_ARROW_UP_COMMAND,
+    PASTE_COMMAND
 } from 'lexical';
+
+import {
+    $wrapNodes
+} from '@lexical/selection';
+
+import {$createLinkNode} from '@lexical/link';
 import {mergeRegister} from '@lexical/utils';
 
 const RANGE_TO_ELEMENT_BOUNDARY_THRESHOLD_PX = 10;
@@ -191,8 +199,29 @@ function useKoenigBehaviour({editor, containerElem}) {
                     return false;
                 },
                 COMMAND_PRIORITY_HIGH
-            )
-        );
+            ),
+            editor.registerCommand (
+                PASTE_COMMAND,
+                (clipboard) => {
+                    const clipboardDataset = clipboard?.clipboardData?.getData('text');
+                    const linkMatch = clipboardDataset?.match(/^(https?:\/\/[^\s]+)$/); // replace with better regex to include more protocols like mailto, ftp, etc
+                    const selection = $getSelection();
+                    const selectionContent = selection.getTextContent();
+                    if (linkMatch && selectionContent.length > 0) {
+                        const link = linkMatch[1];
+                        if ($isRangeSelection(selection)) {
+                            const textNode = selection.extract()[0];
+                            const linkNode = $createLinkNode(link);
+                            const linkTextNode = $createTextNode(selectionContent);
+                            linkTextNode.setFormat(textNode.getFormat());
+                            linkNode.append(linkTextNode);
+                            textNode.replace(linkNode);
+                        }
+                        return true;
+                    }
+                },
+                COMMAND_PRIORITY_HIGH
+            ));
     });
 
     return null;

--- a/packages/koenig-lexical/test/e2e/text-transforms/links.test.js
+++ b/packages/koenig-lexical/test/e2e/text-transforms/links.test.js
@@ -1,0 +1,38 @@
+import {afterAll, beforeAll, beforeEach, describe, test} from 'vitest';
+import {startApp, initialize, focusEditor, assertHTML, html, pasteText} from '../../utils/e2e';
+
+describe('Links', async () => {
+    let app;
+    let page;
+
+    beforeAll(async () => {
+        ({app, page} = await startApp());
+    });
+
+    afterAll(async () => {
+        await app.stop();
+    });
+
+    beforeEach(async () => {
+        await initialize({page});
+    });
+
+    test('converts selected text to link on url paste', async function () {
+        await focusEditor(page);
+        await page.keyboard.type('link');
+        await page.keyboard.down('Shift');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.up('Shift');
+        await pasteText(page, 'https://koenig.ghost.org');
+        await assertHTML(page, html`
+            <p dir="ltr">
+                <a href="https://koenig.ghost.org" dir="ltr">
+                <span data-lexical-text="true">link</span>
+                </a>
+            </p>
+        `);
+    });
+});

--- a/packages/koenig-lexical/test/e2e/text-transforms/links.test.js
+++ b/packages/koenig-lexical/test/e2e/text-transforms/links.test.js
@@ -35,4 +35,21 @@ describe('Links', async () => {
             </p>
         `);
     });
+
+    test('does not convert text to link if pasting a non-url', async function () {
+        await focusEditor(page);
+        await page.keyboard.type('link');
+        await page.keyboard.down('Shift');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.up('Shift');
+        await pasteText(page, 'Hello Koenig');
+        await assertHTML(page, html`
+            <p dir="ltr">
+                <span data-lexical-text="true">Hello Koenig</span>
+            </p>
+        `);
+    });
 });


### PR DESCRIPTION
ref https://github.com/TryGhost/Team/issues/2228

- Overrides the default lexical PASTE command.
- Checks if clipboard data is text and if it's a valid URL.
- Checks if we have text selected.
- Converts selected text into a new Link Node from the pasted URL.