### PR TITLE
Added srcset and sizes output for images in HTML renderer (wip)

### DIFF
--- a/packages/kg-lexical-html-renderer/lib/nodes/ImageNode.js
+++ b/packages/kg-lexical-html-renderer/lib/nodes/ImageNode.js
@@ -1,12 +1,14 @@
 const {DecoratorNode} = require('lexical');
 
 class ImageNode extends DecoratorNode {
-    constructor({src, caption, altText,cardWidth}) {
+    constructor({src, caption, altText,cardWidth, width, height}) {
         super();
         this.src = src || '';
         this.caption = caption || '';
         this.altText = altText || '';
         this.cardWidth = cardWidth || 'regular';
+        this.width = width || null;
+        this.height = height || null;
     }
 
     static getType() {

--- a/packages/kg-lexical-html-renderer/lib/transformers/element/image.js
+++ b/packages/kg-lexical-html-renderer/lib/transformers/element/image.js
@@ -1,18 +1,94 @@
 const {$isImageNode} = require('../../nodes/ImageNode');
+const {getAvailableImageWidths} = require('../../utils/get-available-image-widths');
+const {isLocalContentImage} = require('../../utils/is-local-content-image');
+const {setSrcsetAttribute} = require('../../utils/srcset-attribute');
+const {resizeImage} = require('../../utils/resize-image');
 
 module.exports = {
-    export(node) {
+    export(node, options) {
         if (!$isImageNode(node)) {
             return null;
         }
+
         let figureClasses = 'kg-card kg-image-card';
         if (node.cardWidth !== 'regular') {
             figureClasses += ` kg-width-${node.cardWidth}`;
         }
 
+        let img = `<img src="${node.src}" alt="${node.altText}" loading="lazy" />`;
+
+        let imgDimensions = '';
+        let srcSet = '';
+
+        if (node.width && node.height) {
+            imgDimensions = `width="${node.width}" height="${node.height}"`;
+            // parse imgDimensions into img
+            img = img.replace('/>', `${imgDimensions} />`);
+        }
+
+        // images can be resized to max width, if that's the case output
+        // the resized width/height attrs to ensure 3rd party gallery plugins
+        // aren't affected by differing sizes
+        const {canTransformImage} = options;
+        const {defaultMaxWidth} = options.imageOptimization || {};
+        if (
+            defaultMaxWidth &&
+            node.width > defaultMaxWidth &&
+            isLocalContentImage(node.src, options.siteUrl) &&
+            canTransformImage &&
+            canTransformImage(node.src)
+        ) {
+            const {width, height} = resizeImage(node, {width: defaultMaxWidth});
+            img = img.replace(imgDimensions, `width="${width}" height="${height}"`);
+        }
+
+        if (options.target !== 'email') {
+            srcSet = setSrcsetAttribute(srcSet, node, options);
+            // parse srcSet into img
+            if (srcSet) {
+                img = img.replace('/>', `srcset="${srcSet}" />`);
+            }
+            if (srcSet && node.width && node.width >= 720) {
+                // standard size
+                if (!node.cardWidth) {
+                    let sizes = `sizes="(min-width: 720px) 720px"`;
+                    img = img.replace('/>', ` ${sizes} />`);
+                }
+
+                if (node.cardWidth === 'wide' && node.width >= 1200) {
+                    let sizes = `sizes="(min-width: 1200px) 1200px"`;
+                    img = img.replace('/>', ` ${sizes} />`);
+                }
+            }
+        }
+
+        if (options.target === 'email' && node.width && node.height) {
+            let imageDimensions = {
+                width: node.width,
+                height: node.height
+            };
+            if (node.width >= 600) {
+                imageDimensions = resizeImage(imageDimensions, {width: 600});
+            }
+            img = img.replace('>', ` width="${imageDimensions.width}" height="${imageDimensions.height}">`);
+            
+            if (isLocalContentImage(node.src, options.siteUrl) && options.canTransformImage && options.canTransformImage(node.src)) {
+                // find available image size next up from 2x600 so we can use it for the "retina" src
+                const availableImageWidths = getAvailableImageWidths(node, options.imageOptimization.contentImageSizes);
+                const srcWidth = availableImageWidths.find(width => width >= 1200);
+
+                if (!srcWidth || srcWidth === node.width) {
+                    // do nothing, width is smaller than retina or matches the original node src
+                } else {
+                    const [, imagesPath, filename] = node.src.match(/(.*\/content\/images)\/(.*)/);
+                    img = img.replace(node.src, `${imagesPath}/size/w${srcWidth}/${filename}`);
+                }
+            }
+        }
+
         return (`
         <figure class="${figureClasses}">
-            <img src="${node.src}" alt="${node.altText}" />
+            ${img}
                 <figcaption>
                 ${node.caption}
                 </figcaption>

--- a/packages/kg-lexical-html-renderer/lib/utils/get-available-image-widths.js
+++ b/packages/kg-lexical-html-renderer/lib/utils/get-available-image-widths.js
@@ -1,0 +1,22 @@
+const getAvailableImageWidths = function (image, imageSizes) {
+    // get a sorted list of the available responsive widths
+    const imageWidths = Object.values(imageSizes)
+        .map(({width}) => width)
+        .sort((a, b) => a - b);
+
+    // select responsive widths that are usable based on the image width
+    const availableImageWidths = imageWidths
+        .filter(width => width <= image.width);
+
+    // add the original image size to the responsive list if it's not captured by largest responsive size
+    // - we can't know the width/height of the original `src` image because we don't know if it was resized
+    //   or not. Adding the original image to the responsive list ensures we're not showing smaller sized
+    //   images than we need to be
+    if (image.width > availableImageWidths[availableImageWidths.length - 1] && image.width < imageWidths[imageWidths.length - 1]) {
+        availableImageWidths.push(image.width);
+    }
+
+    return availableImageWidths;
+};
+
+module.exports = {getAvailableImageWidths};

--- a/packages/kg-lexical-html-renderer/lib/utils/is-local-content-image.js
+++ b/packages/kg-lexical-html-renderer/lib/utils/is-local-content-image.js
@@ -1,0 +1,7 @@
+const isLocalContentImage = function (url, siteUrl = '') {
+    const normalizedSiteUrl = siteUrl.replace(/\/$/, '');
+    const imagePath = url.replace(normalizedSiteUrl, '');
+    return /^(\/.*|__GHOST_URL__)\/?content\/images\//.test(imagePath);
+};
+
+module.exports = {isLocalContentImage};

--- a/packages/kg-lexical-html-renderer/lib/utils/is-unsplash-image.js
+++ b/packages/kg-lexical-html-renderer/lib/utils/is-unsplash-image.js
@@ -1,0 +1,5 @@
+const isUnsplashImage = function (url) {
+    return /images\.unsplash\.com/.test(url);
+};
+
+module.exports = {isUnsplashImage};

--- a/packages/kg-lexical-html-renderer/lib/utils/resize-image.js
+++ b/packages/kg-lexical-html-renderer/lib/utils/resize-image.js
@@ -1,0 +1,24 @@
+const resizeImage = function (image, {width: desiredWidth, height: desiredHeight} = {}) {
+    const {width, height} = image;
+    const ratio = width / height;
+
+    if (desiredWidth) {
+        const resizedHeight = Math.round(desiredWidth / ratio);
+
+        return {
+            width: desiredWidth,
+            height: resizedHeight
+        };
+    }
+
+    if (desiredHeight) {
+        const resizedWidth = Math.round(desiredHeight * ratio);
+
+        return {
+            width: resizedWidth,
+            height: desiredHeight
+        };
+    }
+};
+
+module.exports = {resizeImage};

--- a/packages/kg-lexical-html-renderer/lib/utils/srcset-attribute.js
+++ b/packages/kg-lexical-html-renderer/lib/utils/srcset-attribute.js
@@ -1,0 +1,65 @@
+const {isLocalContentImage} = require('./is-local-content-image');
+const {getAvailableImageWidths} = require('./get-available-image-widths');
+const {isUnsplashImage} = require('./is-unsplash-image');
+
+// default content sizes: [600, 1000, 1600, 2400]
+
+const getSrcsetAttribute = function ({src, width, options}) {
+    if (!options.imageOptimization || options.imageOptimization.srcsets === false || !width || !options.imageOptimization.contentImageSizes) {
+        return;
+    }
+
+    if (isLocalContentImage(src, options.siteUrl) && options.canTransformImage && !options.canTransformImage(src)) {
+        return;
+    }
+
+    const srcsetWidths = getAvailableImageWidths({width}, options.imageOptimization.contentImageSizes);
+    // apply srcset if this is a relative image that matches Ghost's image url structure
+    if (isLocalContentImage(src, options.siteUrl)) {
+        const [, imagesPath, filename] = src.match(/(.*\/content\/images)\/(.*)/);
+        const srcs = [];
+
+        srcsetWidths.forEach((srcsetWidth) => {
+            if (srcsetWidth === width) {
+                // use original image path if width matches exactly (avoids 302s from size->original)
+                srcs.push(`${src} ${srcsetWidth}w`);
+            } else if (srcsetWidth <= width) {
+                // avoid creating srcset sizes larger than intrinsic image width
+                srcs.push(`${imagesPath}/size/w${srcsetWidth}/${filename} ${srcsetWidth}w`);
+            }
+        });
+        if (srcs.length) {
+            return srcs.join(', ');
+        }
+    }
+
+    // apply srcset if this is an Unsplash image
+    if (isUnsplashImage(src)) {
+        const unsplashUrl = new URL(src);
+        const srcs = [];
+
+        srcsetWidths.forEach((srcsetWidth) => {
+            unsplashUrl.searchParams.set('w', srcsetWidth);
+            srcs.push(`${unsplashUrl.href} ${srcsetWidth}w`);
+        });
+
+        return srcs.join(', ');
+    }
+};
+
+const setSrcsetAttribute = function (srcSet, image, options) {
+    // if (!elem || !['IMG', 'SOURCE'].includes(elem.tagName) || !elem.getAttribute('src') || !image) {
+    //     return;
+    // }
+    const {src, width} = image;
+    const srcset = getSrcsetAttribute({src, width, options});
+
+    if (srcset) {
+        return srcSet = srcset;
+    }
+};
+
+module.exports = {
+    getSrcsetAttribute,
+    setSrcsetAttribute
+};

--- a/packages/kg-lexical-html-renderer/test/image.test.js
+++ b/packages/kg-lexical-html-renderer/test/image.test.js
@@ -20,9 +20,12 @@ describe('Images', function () {
               "version": 1
             }
           }`,
+        options: `{
+            target: 'html'
+        }`,
         output: `
         <figure class="kg-card kg-image-card">
-            <img src="https://example.com/image.png" alt="This is Alt" />
+            <img src="https://example.com/image.png" alt="This is Alt" loading="lazy" />
                 <figcaption>
                 This is a caption
                 </figcaption>
@@ -50,7 +53,7 @@ describe('Images', function () {
           }`,
         output: `
         <figure class="kg-card kg-image-card kg-width-wide">
-            <img src="https://example.com/image.png" alt="This is Alt" />
+            <img src="https://example.com/image.png" alt="This is Alt" loading="lazy" />
                 <figcaption>
                 This is a caption
                 </figcaption>
@@ -79,7 +82,157 @@ describe('Images', function () {
         }`,
         output: `
         <figure class="kg-card kg-image-card kg-width-full">
-            <img src="https://example.com/image.png" alt="This is Alt" />
+            <img src="https://example.com/image.png" alt="This is Alt" loading="lazy" />
+                <figcaption>
+                This is a caption
+                </figcaption>
+        </figure>
+        `
+    }));
+
+    it('should render image dimensions', shouldRender({
+        input: `{
+        "root": {
+          "children": [
+            {
+              "altText": "This is Alt",
+              "caption": "This is a caption",
+              "src": "/content/images/2022/11/koenig-lexical.jpg",
+              "type": "image",
+              "cardWidth": "full",
+              "width": 100,
+              "height": 100
+            }
+          ],
+          "direction": null,
+          "format": "",
+          "indent": 0,
+          "type": "root",
+          "version": 1
+        }
+      }`,
+        output: `
+        <figure class="kg-card kg-image-card kg-width-full">
+            <img src="/content/images/2022/11/koenig-lexical.jpg" alt="This is Alt" loading="lazy" width="100" height="100" />
+                <figcaption>
+                This is a caption
+                </figcaption>
+        </figure>
+        `
+    }));
+
+    it('should render image with srcset', shouldRender({
+        input: `{
+      "root": {
+        "children": [
+          {
+            "altText": "This is Alt",
+            "caption": "This is a caption",
+            "src": "/content/images/2022/11/koenig-lexical.jpg",
+            "type": "image",
+            "cardWidth": "full",
+            "width": 3000,
+            "height": 6000
+          }
+        ],
+        "direction": null,
+        "format": "",
+        "indent": 0,
+        "type": "root",
+        "version": 1
+      }
+    }`,
+        options: {
+            imageOptimization: {
+                contentImageSizes: {
+                    w600: {width: 600},
+                    w1000: {width: 1000},
+                    w1600: {width: 1600},
+                    w2400: {width: 2400}
+                }
+            }
+        },
+        output: `
+        <figure class="kg-card kg-image-card kg-width-full">
+            <img src="/content/images/2022/11/koenig-lexical.jpg" alt="This is Alt" loading="lazy" width="3000" height="6000" srcset="/content/images/size/w600/2022/11/koenig-lexical.jpg 600w, /content/images/size/w1000/2022/11/koenig-lexical.jpg 1000w, /content/images/size/w1600/2022/11/koenig-lexical.jpg 1600w, /content/images/size/w2400/2022/11/koenig-lexical.jpg 2400w" />
+                <figcaption>
+                This is a caption
+                </figcaption>
+        </figure>
+        `
+    }));
+
+    it('should use resized width and height when theres max width', shouldRender({
+        input: `{
+      "root": {
+        "children": [
+          {
+            "altText": "This is Alt",
+            "caption": "This is a caption",
+            "src": "/content/images/2022/11/koenig-lexical.jpg",
+            "type": "image",
+            "cardWidth": "full",
+            "width": 3000,
+            "height": 6000
+          }
+        ],
+        "direction": null,
+        "format": "",
+        "indent": 0,
+        "type": "root",
+        "version": 1
+      }
+    }`,
+        options: {
+            imageOptimization: {
+                defaultMaxWidth: 2000
+            },
+            canTransformImage: () => true
+        },
+        output: `
+        <figure class="kg-card kg-image-card kg-width-full">
+            <img src="/content/images/2022/11/koenig-lexical.jpg" alt="This is Alt" loading="lazy" width="2000" height="4000" />
+                <figcaption>
+                This is a caption
+                </figcaption>
+        </figure>
+        `
+    }));
+
+    it('is included when src is an unsplash image', shouldRender({
+        input: `{
+    "root": {
+      "children": [
+        {
+          "altText": "This is Alt",
+          "caption": "This is a caption",
+          "src": "https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=2000&fit=max&ixid=eyJhcHBfaWQiOjExNzczfQ",
+          "type": "image",
+          "cardWidth": "full",
+          "width": 3000,
+          "height": 6000
+        }
+      ],
+      "direction": null,
+      "format": "",
+      "indent": 0,
+      "type": "root",
+      "version": 1
+    }
+  }`,
+        options: {
+            imageOptimization: {
+                contentImageSizes: {
+                    w600: {width: 600},
+                    w1000: {width: 1000},
+                    w1600: {width: 1600},
+                    w2400: {width: 2400}
+                }
+            }
+        },
+        output: `
+        <figure class="kg-card kg-image-card kg-width-full">
+            <img src="https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=2000&fit=max&ixid=eyJhcHBfaWQiOjExNzczfQ" alt="This is Alt" loading="lazy" width="3000" height="6000" srcset="https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=600&fit=max&ixid=eyJhcHBfaWQiOjExNzczfQ 600w, https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1000&fit=max&ixid=eyJhcHBfaWQiOjExNzczfQ 1000w, https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1600&fit=max&ixid=eyJhcHBfaWQiOjExNzczfQ 1600w, https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=2400&fit=max&ixid=eyJhcHBfaWQiOjExNzczfQ 2400w" />
                 <figcaption>
                 This is a caption
                 </figcaption>

--- a/packages/kg-lexical-html-renderer/test/utils/should-render.js
+++ b/packages/kg-lexical-html-renderer/test/utils/should-render.js
@@ -1,9 +1,9 @@
 const Renderer = require('../../');
 
-function shouldRender({input, output}) {
+function shouldRender({input, output, options}) {
     return function () {
         const renderer = new Renderer();
-        renderer.render(input).should.equal(output);
+        renderer.render(input, options).should.equal(output);
     };
 }
 


### PR DESCRIPTION
ref https://github.com/TryGhost/Team/issues/2229

- Extracted and modified the lexical to html converter to parse image meta data when rendering as html.