### PR TITLE
Fixed Left/Right arrows putting cursor between cards

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -14,7 +14,9 @@ import {
     KEY_BACKSPACE_COMMAND,
     KEY_DELETE_COMMAND,
     PASTE_COMMAND,
-    $isElementNode
+    $isElementNode,
+    KEY_ARROW_LEFT_COMMAND,
+    KEY_ARROW_RIGHT_COMMAND
 } from 'lexical';
 
 import {$createLinkNode} from '@lexical/link';
@@ -193,6 +195,53 @@ function useKoenigBehaviour({editor, containerElem}) {
                                 }
                             }
                         }
+                    }
+
+                    return false;
+                },
+                COMMAND_PRIORITY_HIGH
+            ),
+            editor.registerCommand(
+                KEY_ARROW_LEFT_COMMAND,
+                (event) => {
+                    const selection = $getSelection();
+
+                    if (!$isNodeSelection(selection)) {
+                        return false;
+                    }
+
+                    const firstNode = selection.getNodes()[0];
+                    const topLevelElement = firstNode.getTopLevelElement();
+                    const previousSibling = topLevelElement.getPreviousSibling();
+
+                    if ($isDecoratorNode(previousSibling)) {
+                        event.preventDefault();
+                        $selectDecoratorNode(previousSibling);
+                        return true;
+                    }
+
+                    return false;
+                },
+                COMMAND_PRIORITY_HIGH
+            ),
+            editor.registerCommand(
+                KEY_ARROW_RIGHT_COMMAND,
+                (event) => {
+                    const selection = $getSelection();
+
+                    if (!$isNodeSelection(selection)) {
+                        return false;
+                    }
+
+                    const selectedNodes = selection.getNodes();
+                    const lastNode = selectedNodes[selectedNodes.length - 1];
+                    const topLevelElement = lastNode.getTopLevelElement();
+                    const nextSibling = topLevelElement.getNextSibling();
+
+                    if ($isDecoratorNode(nextSibling)) {
+                        event.preventDefault();
+                        $selectDecoratorNode(nextSibling);
+                        return true;
                     }
 
                     return false;

--- a/packages/koenig-lexical/test/e2e/card-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/card-behaviour.test.js
@@ -147,7 +147,43 @@ describe('Card behaviour', async () => {
         });
 
         // moves selection to previous card
-        test.todo('when selected card after card');
+        test('when selected card is after card', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('--- ');
+            await page.keyboard.type('--- ');
+
+            await page.keyboard.press('ArrowLeft');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-selected="true" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <p><br></p>
+            `);
+
+            await page.keyboard.press('ArrowLeft');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-selected="true" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <p><br></p>
+            `);
+        });
 
         // triggers "caret left at top" prop fn
         test.todo('when selected card is first section');
@@ -184,6 +220,67 @@ describe('Card behaviour', async () => {
                 anchorPath: [1],
                 focusOffset: 0,
                 focusPath: [1]
+            });
+        });
+
+        // moves selection to previous card
+        test('when selected card is before card', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('--- ');
+            await page.keyboard.type('--- ');
+            await page.click('hr');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-selected="true" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <p><br></p>
+            `);
+
+            await page.keyboard.press('ArrowRight');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-selected="true" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <p><br></p>
+            `);
+
+            await page.keyboard.press('ArrowRight');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <p><br></p>
+            `);
+
+            await assertSelection(page, {
+                anchorOffset: 0,
+                anchorPath: [2],
+                focusOffset: 0,
+                focusPath: [2]
             });
         });
     });


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2224

- Lexical by default places an invisible cursor between decorator nodes, we don't want to do that because we display decorator nodes as selected and handle various key commands separately with such a selection
- instead we want the selection to move immediately from one decorator node to the next when pressing <kbd>Left/Right</kbd> arrows
