### PR TITLE
Added `ExternalControlPlugin` to let consumer apps handle tasks via a basic API

### DIFF
--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -17,7 +17,7 @@ const loadContent = () => {
 
 function useQuery() {
     const {search} = useLocation();
-  
+
     return React.useMemo(() => new URLSearchParams(search), [search]);
 }
 
@@ -27,6 +27,7 @@ function DemoApp() {
     const [sidebarView, setSidebarView] = useState('json');
     const [defaultContent] = useState(query.get('content') !== 'false' ? loadContent() : undefined);
     const [title, setTitle] = useState(defaultContent ? 'Meet the Koenig editor.' : '');
+    const [editorAPI, setEditorAPI] = useState(null);
 
     function openSidebar(view = 'json') {
         if (isSidebarOpen && sidebarView === view) {
@@ -35,10 +36,6 @@ function DemoApp() {
         setSidebarView(view);
         setIsSidebarOpen(true);
     }
-
-    const handleTitleInput = (e) => {
-        setTitle(e.target.value);
-    };
 
     return (
         <div className="koenig-lexical top">
@@ -51,9 +48,8 @@ function DemoApp() {
                     }
                     <div className="h-full overflow-auto">
                         <div className="mx-auto max-w-[740px] py-[15vmin]">
-                            <TitleTextBox handleTitleInput={handleTitleInput} title={title} />
-                            {/* <textarea onKeyDown={handleTitleKeyDown} ref={titleEl} onChange={handleTitleInput} value={title} className="w-full min-w-[auto] mb-3 pb-1 text-black font-sans text-5xl font-bold resize-none overflow-hidden focus-visible:outline-none" placeholder="Post title" /> */}
-                            <KoenigEditor />
+                            <TitleTextBox title={title} setTitle={setTitle} editorAPI={editorAPI} />
+                            <KoenigEditor registerAPI={setEditorAPI} />
                         </div>
                     </div>
                 </div>

--- a/packages/koenig-lexical/demo/components/TitleTextBox.jsx
+++ b/packages/koenig-lexical/demo/components/TitleTextBox.jsx
@@ -46,7 +46,8 @@ const TitleTextBox = ({title, setTitle, editorAPI}) => {
             onKeyDown={handleTitleKeyDown}
             value={title}
             className="w-full min-w-[auto] mb-3 pb-1 text-black font-sans text-5xl font-bold resize-none overflow-hidden focus-visible:outline-none"
-            placeholder="Post title" />
+            placeholder="Post title"
+            data-testid="post-title" />
     );
 };
 

--- a/packages/koenig-lexical/demo/components/TitleTextBox.jsx
+++ b/packages/koenig-lexical/demo/components/TitleTextBox.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const TitleTextBox = ({handleTitleInput, title}) => {
+const TitleTextBox = ({title, setTitle, editorAPI}) => {
     const titleEl = React.useRef(null);
     React.useEffect(() => {
         if (titleEl.current) {
@@ -9,21 +9,43 @@ const TitleTextBox = ({handleTitleInput, title}) => {
         }
     }, [title]);
 
-    // prevent default enter key behavior
+    const handleTitleInput = (e) => {
+        setTitle(e.target.value);
+    };
 
-    const handleTitleKeyDown = (e) => {
-        if (e.key === 'Enter') {
-            e.preventDefault();
+    // move cursor to the editor on
+    // - Tab
+    // - Arrow Down/Right when input is empty or caret at end of input
+    // - Enter, creating an empty paragraph when editor is not empty
+    const handleTitleKeyDown = (event) => {
+        if (!editorAPI) {
+            return;
+        }
+
+        const {key} = event;
+        const {value, selectionStart} = event.target;
+
+        const couldLeaveTitle = !value || selectionStart === value.length;
+        const arrowLeavingTitle = ['ArrowDown', 'ArrowRight'].includes(key) && couldLeaveTitle;
+
+        if (key === 'Enter' || key === 'Tab' || arrowLeavingTitle) {
+            event.preventDefault();
+
+            if (key === 'Enter' && !editorAPI.editorIsEmpty()) {
+                editorAPI.insertParagraphAtTop({focus: true});
+            } else {
+                editorAPI.focusEditor({position: 'top'});
+            }
         }
     };
-    
+
     return (
         <textarea
-            onKeyDown={handleTitleKeyDown}
-            ref={titleEl} 
+            ref={titleEl}
             onChange={handleTitleInput}
-            value={title} 
-            className="w-full min-w-[auto] mb-3 pb-1 text-black font-sans text-5xl font-bold resize-none overflow-hidden focus-visible:outline-none" 
+            onKeyDown={handleTitleKeyDown}
+            value={title}
+            className="w-full min-w-[auto] mb-3 pb-1 text-black font-sans text-5xl font-bold resize-none overflow-hidden focus-visible:outline-none"
             placeholder="Post title" />
     );
 };

--- a/packages/koenig-lexical/package.json
+++ b/packages/koenig-lexical/package.json
@@ -38,6 +38,7 @@
     "@lexical/list": "^0.6.0",
     "@lexical/react": "^0.6.0",
     "@lexical/selection": "^0.6.0",
+    "@lexical/text": "^0.6.0",
     "@lexical/utils": "^0.6.0",
     "@tryghost/kg-default-nodes": "^0.0.1",
     "lexical": "^0.6.0",

--- a/packages/koenig-lexical/src/components/KoenigEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigEditor.jsx
@@ -15,11 +15,13 @@ import ImagePlugin from '../plugins/ImagePlugin';
 import DragDropPastePlugin from '../plugins/DragDropPastePlugin';
 import HorizontalRulePlugin from '../plugins/HorizontalRulePlugin';
 import {EditorPlaceholder} from './ui/EditorPlaceholder';
+import {ExternalControlPlugin} from '../plugins/ExternalControlPlugin';
 import '../styles/index.css';
 
 const KoenigEditor = ({
     onChange,
-    markdownTransformers
+    markdownTransformers,
+    registerAPI
 }) => {
     const _onChange = React.useCallback((editorState) => {
         const json = editorState.toJSON();
@@ -58,6 +60,7 @@ const KoenigEditor = ({
             <ImagePlugin />
             <DragDropPastePlugin />
             <HorizontalRulePlugin />
+            <ExternalControlPlugin registerAPI={registerAPI} />
         </div>
     );
 };

--- a/packages/koenig-lexical/src/plugins/ExternalControlPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/ExternalControlPlugin.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {$createParagraphNode, $getRoot} from 'lexical';
+import {$canShowPlaceholder} from '@lexical/text';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+
+// used to register a minimal API for controlling the editor from the consuming app
+// designed to allow typical behaviours without the consuming app needing to bundle the lexical library
+export const ExternalControlPlugin = ({registerAPI}) => {
+    const [editor] = useLexicalComposerContext();
+
+    React.useEffect(() => {
+        if (!registerAPI) {
+            return;
+        }
+
+        const API = {
+            // give access to the editor instance so the Lexical API can be used directly if needed
+            editorInstance: editor,
+            // simplified API methods for typical consumer app actions
+            editorIsEmpty() {
+                let isEmpty;
+                editor.update(() => {
+                    isEmpty = $canShowPlaceholder(false, true);
+                });
+                return isEmpty;
+            },
+            focusEditor({position = 'bottom'} = {}) {
+                const editorFocusOptions = {
+                    defaultSelection: position === 'top' ? 'rootStart' : null
+                };
+
+                editor.focus(() => {}, editorFocusOptions);
+            },
+            blurEditor() {
+                editor.blur();
+            },
+            insertParagraphAtTop({focus = true} = {}) {
+                editor.update(() => {
+                    const paragraphNode = $createParagraphNode();
+                    const [firstChild] = $getRoot().getChildren();
+                    firstChild.insertBefore(paragraphNode);
+
+                    if (focus) {
+                        paragraphNode.selectStart();
+                    }
+                });
+            }
+        };
+
+        registerAPI(API);
+
+        return () => {
+            registerAPI?.(null);
+        };
+    }, [editor, registerAPI]);
+};

--- a/packages/koenig-lexical/test/e2e/title-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/title-behaviour.test.js
@@ -1,0 +1,163 @@
+import {afterAll, beforeAll, beforeEach, describe, expect, it} from 'vitest';
+import {startApp, initialize, focusEditor, assertHTML, html, assertSelection} from '../utils/e2e';
+
+describe('Title behaviour (ExternalControlPlugin)', async () => {
+    let app;
+    let page;
+
+    beforeAll(async () => {
+        ({app, page} = await startApp());
+    });
+
+    afterAll(async () => {
+        await app.stop();
+    });
+
+    beforeEach(async () => {
+        await initialize({page});
+    });
+
+    describe('ENTER', function () {
+        it('moves cursor to blank editor', async function () {
+            await page.getByTestId('post-title').click();
+            await page.keyboard.press('Enter');
+
+            // selection is on editor
+            await assertSelection(page, {
+                anchorOffset: 0,
+                anchorPath: [0],
+                focusOffset: 0,
+                focusPath: [0]
+            });
+
+            // no extra paragraph created
+            await assertHTML(page, html`
+                <p><br /></p>
+            `);
+        });
+
+        it('adds paragraph and moves cursor to populated editor', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('Populated editor');
+
+            await page.getByTestId('post-title').click();
+            await page.keyboard.press('Enter');
+
+            // selection is at start of editor
+            await assertSelection(page, {
+                anchorOffset: 0,
+                anchorPath: [0],
+                focusOffset: 0,
+                focusPath: [0]
+            });
+
+            // extra paragraph inserted
+            await assertHTML(page, html`
+                <p><br /></p>
+                <p dir="ltr"><span data-lexical-text="true">Populated editor</span></p>
+            `);
+        });
+    });
+
+    describe('TAB', function () {
+        it('moves cursor to blank editor', async function () {
+            await page.getByTestId('post-title').click();
+            await page.keyboard.press('Tab');
+
+            // selection is on editor
+            await assertSelection(page, {
+                anchorOffset: 0,
+                anchorPath: [0],
+                focusOffset: 0,
+                focusPath: [0]
+            });
+
+            // no extra paragraph created
+            await assertHTML(page, html`
+                <p><br /></p>
+            `);
+        });
+    });
+
+    describe('ARROW RIGHT', function () {
+        it('moves cursor to editor when title is blank', async function () {
+            await page.getByTestId('post-title').click();
+            await page.keyboard.press('ArrowRight');
+
+            // selection is on editor
+            await assertSelection(page, {
+                anchorOffset: 0,
+                anchorPath: [0],
+                focusOffset: 0,
+                focusPath: [0]
+            });
+
+            // no extra paragraph created
+            await assertHTML(page, html`
+                <p><br /></p>
+            `);
+        });
+
+        it('moves cursor to editor when cursor at end of title', async function () {
+            await page.getByTestId('post-title').click();
+            await page.keyboard.type('Populated title');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowRight');
+
+            const title = page.getByTestId('post-title');
+            let titleHasFocus = await title.evaluate(node => document.activeElement === node);
+            expect(titleHasFocus).toEqual(true);
+
+            await page.keyboard.press('ArrowRight');
+
+            await assertSelection(page, {
+                anchorOffset: 0,
+                anchorPath: [0],
+                focusOffset: 0,
+                focusPath: [0]
+            });
+
+            titleHasFocus = await title.evaluate(node => document.activeElement === node);
+            expect(titleHasFocus).toEqual(false);
+        });
+    });
+
+    describe('ARROW DOWN', function () {
+        it('moves cursor to editor when title is blank', async function () {
+            await page.getByTestId('post-title').click();
+            await page.keyboard.press('ArrowDown');
+
+            await assertSelection(page, {
+                anchorOffset: 0,
+                anchorPath: [0],
+                focusOffset: 0,
+                focusPath: [0]
+            });
+        });
+
+        it('moves cursor to editor when cursor at end of title', async function () {
+            await page.getByTestId('post-title').click();
+            await page.keyboard.type('Populated title');
+            await page.keyboard.press('ArrowLeft');
+            // moves cursor to end
+            await page.keyboard.press('ArrowDown');
+
+            const title = page.getByTestId('post-title');
+            let titleHasFocus = await title.evaluate(node => document.activeElement === node);
+            expect(titleHasFocus).toEqual(true);
+
+            // moves cursor to editor
+            await page.keyboard.press('ArrowDown');
+
+            await assertSelection(page, {
+                anchorOffset: 0,
+                anchorPath: [0],
+                focusOffset: 0,
+                focusPath: [0]
+            });
+
+            titleHasFocus = await title.evaluate(node => document.activeElement === node);
+            expect(titleHasFocus).toEqual(false);
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1598,6 +1598,11 @@
   resolved "https://registry.yarnpkg.com/@lexical/text/-/text-0.6.3.tgz#71eb9d69f008315f343ece8aab43d97a2d6574b2"
   integrity sha512-MoovOqr0ikT0vZoLfKQXfZQpF1qrf+xALtskmrjaO6h37jt2vOBDlkukpgg8ZUsUZaTKiaJlWAPnrgdji7L0tQ==
 
+"@lexical/text@^0.6.0":
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/@lexical/text/-/text-0.6.4.tgz#49267e7a9395720b6361ca12631e0370c118c03a"
+  integrity sha512-gCANONCi3J2zf+yxv2CPEj2rsxpUBgQuR4TymGjsoVFsHqjRc3qHF5lNlbpWjPL5bJDSHFJySwn4/P20GNWggg==
+
 "@lexical/utils@0.6.3", "@lexical/utils@^0.6.0":
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/@lexical/utils/-/utils-0.6.3.tgz#85276f9ef095d23634cb3f2d059f5781cee656ec"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2286

We want to enable consumer apps to streamline the cursor handling between other inputs and the editor canvas, the primary use-case being a title input that should move the cursor to the editor as if it was part of the editor canvas itself.

By exposing a simplified API for typical actions we allow consumer apps to use it without knowing the intricacies of the Lexical API. It also means when using Koenig as an externally loaded library, the consumer app doesn't need to pull in any of the Lexical utility functions to it's own code.

- adds a `registerAPI` prop to the `<KoenigEditor>` component that is called with an object containing a basic API with the necessary features needed for title input->editor behaviour
- updated demo app to use the new plugin in it's title component
  - <kbd>Tab</kbd> moves cursor to the editor
  - <kbd>Enter</kbd> moves cursor to the editor, inserting a blank paragraph at the top of the document if the editor already has content
  - <kbd>Arrow Down/Right</kbd> moves cursor to the editor only when the cursor is at the end of the title input, maintaining default browser/OS behaviour up until that point

TODO:
- [x] add test for the external API