### PR TITLE
Fixed Unsplash Card Positioning

### DIFF
--- a/packages/koenig-lexical/src/components/ui/UnsplashModal.jsx
+++ b/packages/koenig-lexical/src/components/ui/UnsplashModal.jsx
@@ -11,7 +11,7 @@ import {useMemo} from 'react';
 
 const API_URL = 'https://api.unsplash.com';
 
-const UnsplashModal = ({container, nodeKey, handleModalClose}) => {
+const UnsplashModal = ({nodeKey, handleModalClose}) => {
     const [editor] = useLexicalComposerContext();
     const {unsplashConf} = React.useContext(KoenigComposerContext);
     const UnsplashLib = useMemo(() => new UnsplashService({API_URL, HEADERS: unsplashConf}), [unsplashConf]);
@@ -34,7 +34,8 @@ const UnsplashModal = ({container, nodeKey, handleModalClose}) => {
         }
     }, [zoomedImg, scrollPos, lastScrollPos]);
 
-    const portalContainer = container || document.querySelector('.koenig-lexical');
+    // Add selector for consuming apps to render into
+    const portalContainer = document.querySelector('.koenig-lexical');
 
     const closeModalHandler = () => {
         // remove the image node from the editor
@@ -190,7 +191,7 @@ const UnsplashModal = ({container, nodeKey, handleModalClose}) => {
                 dataset={dataset}
                 selectImg={selectImg}
                 insertImage={insertImageToNode} 
-                error={UnsplashGallery.error}
+                error={UnsplashLib.error}
             />
         </UnsplashSelector>
         , portalContainer);

--- a/packages/koenig-lexical/src/components/ui/file-selectors/Unsplash/UnsplashSelector.jsx
+++ b/packages/koenig-lexical/src/components/ui/file-selectors/Unsplash/UnsplashSelector.jsx
@@ -7,8 +7,8 @@ import {ReactComponent as CloseIcon} from '../../../../assets/icons/kg-close.svg
 function UnsplashSelector({closeModal, handleSearch, children, galleryRef}) {
     return (
         <>
-            <div className="bg-black opacity-60 inset-0 h-[100vh]"></div>
-            <div data-kg-modal="unsplash" className="bg-white inset-8 rounded z-40 overflow-hidden absolute shadow-xl" ref={galleryRef}>
+            <div className="bg-black opacity-60 inset-0 h-[100vh] fixed"></div>
+            <div data-kg-modal="unsplash" className="z-100 not-kg-prose bg-white inset-8 rounded overflow-hidden fixed shadow-xl" ref={galleryRef}>
                 <button className="absolute top-6 right-6 cursor-pointer">
                     <CloseIcon 
                         data-kg-modal-close-button 

--- a/packages/koenig-lexical/src/plugins/ImagePlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/ImagePlugin.jsx
@@ -91,7 +91,6 @@ export const ImagePlugin = () => {
 
     if (showModal && selector) {
         return (<UnsplashModal
-            service={selector} 
             nodeKey={selectedKey}
             handleModalClose={setShowModal}
         />);


### PR DESCRIPTION
no issue

- the unsplash selector didn't render correctly inside Ghost admin, rendering into the width of the container instead of the viewport.
- Changed `Absolute` value of the selector to `fixed`.
- Cleaned up some old unused code.