### PR TITLE
Add prebuild step for linked packages

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/markdown/MarkdownRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/markdown/MarkdownRenderer.js
@@ -1,4 +1,4 @@
-const markdownHtmlRenderer = require('@tryghost/kg-markdown-html-renderer');
+import markdownHtmlRenderer from '@tryghost/kg-markdown-html-renderer';
 
 export function renderMarkdownNodeToDOM(node, options = {}) {
     /* c8 ignore start */

--- a/packages/koenig-lexical/vite.config.demo.js
+++ b/packages/koenig-lexical/vite.config.demo.js
@@ -10,7 +10,13 @@ export default defineConfig({
         react()
     ],
     base: '/',
+    optimizeDeps: {
+        include: ['@tryghost/kg-markdown-html-renderer', '@tryghost/kg-simplemde']
+    },
     build: {
+        commonjsOptions: {
+            include: [/packages/, /node_modules/],
+        },
         sourcemap: true,
         rollupOptions: {
             input: {

--- a/packages/koenig-lexical/vite.config.js
+++ b/packages/koenig-lexical/vite.config.js
@@ -16,6 +16,9 @@ export default defineConfig({
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         'process.env.VITEST_SEGFAULT_RETRY': 3
     },
+    optimizeDeps: {
+        include: ['@tryghost/kg-markdown-html-renderer', '@tryghost/kg-simplemde']
+    },
     build: {
         minify: true,
         sourcemap: true,
@@ -39,7 +42,10 @@ export default defineConfig({
                     'react-dom': 'ReactDOM'
                 }
             }
-        }
+        },
+        commonjsOptions: {
+            include: [/packages/, /node_modules/],
+        },
     },
     test: {
         globals: true, // required for @testing-library/jest-dom extensions


### PR DESCRIPTION
- Linked packages don't inside node_modules and are not pre-bundled. Due to this reason, commonjs modules doesn't work properly.