### PR TITLE
Fixed code nodes opening in edit mode when loading serialized content

### DIFF
--- a/packages/koenig-lexical/package.json
+++ b/packages/koenig-lexical/package.json
@@ -77,7 +77,6 @@
     "eslint-plugin-jest": "27.2.1",
     "eslint-plugin-tailwindcss": "3.8.0",
     "jsdom": "21.0.0",
-    "linkedom": "0.14.21",
     "playwright": "1.29.2",
     "postcss": "8.4.21",
     "postcss-import": "15.1.0",

--- a/packages/koenig-lexical/src/nodes/CodeBlockNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CodeBlockNode.jsx
@@ -41,9 +41,24 @@ function CodeBlockNodeComponent({nodeKey, caption, code, language}) {
 }
 
 export class CodeBlockNode extends BaseCodeBlockNode {
+    // transient properties used to control node behaviour
+    __openInEditMode = false;
+
+    constructor(dataset = {}, key) {
+        super(dataset, key);
+
+        const {_openInEditMode} = dataset;
+        this.__openInEditMode = _openInEditMode || false;
+    }
+
+    clearOpenInEditMode() {
+        const self = this.getWritable();
+        self.__openInEditMode = false;
+    }
+
     decorate() {
         return (
-            <KoenigCardWrapper nodeKey={this.getKey()} width={this.__cardWidth}>
+            <KoenigCardWrapper nodeKey={this.getKey()} width={this.__cardWidth} openInEditMode={this.__openInEditMode}>
                 <CodeBlockNodeComponent
                     nodeKey={this.getKey()}
                     caption={this.__caption}

--- a/packages/koenig-lexical/src/plugins/MarkdownShortcutPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/MarkdownShortcutPlugin.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     HEADING,
     ORDERED_LIST,
@@ -11,9 +10,6 @@ import {MarkdownShortcutPlugin as LexicalMarkdownShortcutPlugin} from '@lexical/
 import {$createHorizontalRuleNode, $isHorizontalRuleNode, HorizontalRuleNode} from '../nodes/HorizontalRuleNode';
 import {$isCodeBlockNode, $createCodeBlockNode, CodeBlockNode} from '../nodes/CodeBlockNode';
 import {$isImageNode, $createImageNode, ImageNode} from '../nodes/ImageNode';
-import {mergeRegister} from '@lexical/utils';
-import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {$createNodeSelection, $setSelection} from 'lexical';
 
 export const HR = {
     dependencies: [HorizontalRuleNode],
@@ -54,7 +50,7 @@ export const CODE_BLOCK = {
     regExp: /^```(\w{1,10})?\s/,
     replace: (textNode, match, text) => {
         const language = text[1];
-        const codeBlockNode = $createCodeBlockNode({language});
+        const codeBlockNode = $createCodeBlockNode({language, _openInEditMode: true});
         textNode.replace(codeBlockNode);
     },
     type: 'element'
@@ -100,25 +96,5 @@ export const DEFAULT_TRANSFORMERS = [
 ];
 
 export default function MarkdownShortcutPlugin({transformers = DEFAULT_TRANSFORMERS} = {}) {
-    const [editor] = useLexicalComposerContext();
-
-    React.useEffect(() => {
-        return mergeRegister(
-            editor.registerMutationListener(CodeBlockNode, (nodes) => {
-                // When a CodeBlockNode is created, the selection moves to the root node
-                // Here we update the selection to include the new CodeBlockNode
-                for (let [key, value] of nodes) {
-                    if (value === 'created') {
-                        editor.update(() => {
-                            const selection = $createNodeSelection();
-                            selection.add(key);
-                            $setSelection(selection);
-                        });
-                    }
-                }
-            })
-        );
-    });
-
     return LexicalMarkdownShortcutPlugin({transformers});
 }

--- a/packages/koenig-lexical/test/e2e/card-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/card-behaviour.test.js
@@ -108,10 +108,10 @@ describe('Card behaviour', async () => {
             await focusEditor(page);
             // TODO: Update this after setting to isEditing on creation
             await page.keyboard.type('```javascript ');
-    
+
             await page.click('div[data-kg-card="codeblock"]');
             await page.click('div[data-kg-card="codeblock"]');
-    
+
             expect (await page.$('[data-kg-card-editing="true"]')).not.toBeNull();
         });
 
@@ -123,7 +123,7 @@ describe('Card behaviour', async () => {
             await page.click('div[data-kg-card="codeblock"]');
             // Click to edit
             await page.click('div[data-kg-card="codeblock"]');
-    
+
             expect (await page.$('[data-kg-card-editing="true"]')).not.toBeNull();
         });
 
@@ -134,10 +134,10 @@ describe('Card behaviour', async () => {
             await page.keyboard.press('Enter');
             await page.keyboard.press('Enter');
             await page.keyboard.type('```javascript ');
-    
+
             await page.click('div[data-kg-card="codeblock"]');
             await page.click('div[data-kg-card="codeblock"]');
-    
+
             expect (await page.$('[data-kg-card-editing="true"]')).not.toBeNull();
 
             await page.click('p');
@@ -147,19 +147,24 @@ describe('Card behaviour', async () => {
         test('clicking on another card when a card is in edit mode selected new card and switches old card to display mode', async function () {
             await focusEditor(page);
             await page.keyboard.type('```python ');
+            await page.waitForSelector('[data-kg-card="codeblock"] [contenteditable="true"]');
+            await page.keyboard.press('Meta+Enter');
+            await page.waitForSelector('[data-kg-card="codeblock"][data-kg-card-selected="true"][data-kg-card-editing="false"]');
             await page.keyboard.press('Enter');
             await page.keyboard.type('```javascript ');
+            await page.waitForSelector('[data-kg-card="codeblock"] [contenteditable="true"]');
+            await page.keyboard.press('Meta+Enter');
+            await page.waitForSelector('[data-kg-card="codeblock"][data-kg-card-selected="true"][data-kg-card-editing="false"]');
 
             await assertHTML(page, html`
-                <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-selected="true" data-kg-card-editing="true" data-kg-card="codeblock">
-                    </div>
-                </div>
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="codeblock">
                     </div>
                 </div>
-                <div contenteditable="false" data-lexical-cursor="true"></div>
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="codeblock">
+                    </div>
+                </div>
             `, {ignoreCardContents: true});
 
             // Select the python card

--- a/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
@@ -41,7 +41,7 @@ describe('Code Block card', async () => {
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card-selected="true" data-kg-card-editing="true" data-kg-card="codeblock">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="codeblock">
                 </div>
             </div>
         `, {ignoreCardContents: true});
@@ -56,7 +56,6 @@ describe('Code Block card', async () => {
                 <div data-kg-card-selected="true" data-kg-card-editing="true" data-kg-card="codeblock">
                 </div>
             </div>
-            <div contenteditable="false" data-lexical-cursor="true"></div>
         `, {ignoreCardContents: true});
     });
 });

--- a/packages/koenig-lexical/test/e2e/cards/image-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/image-card.test.js
@@ -107,8 +107,8 @@ describe('Image card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="image">
-                    <figure>
-                        <img src="data:image/png;base64,BASE64DATA" alt="" />
+                    <figure data-kg-card-width="regular">
+                        <div><img src="data:image/png;base64,BASE64DATA" alt="upload in progress, 0 " /></div>
                         <figcaption>
                             <input placeholder="Type caption for image (optional)" value="" />
                             <button name="alt-toggle-button">Alt</button>
@@ -139,8 +139,8 @@ describe('Image card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="image">
-                    <figure>
-                        <img src="data:image/png;base64,BASE64DATA" alt="" />
+                    <figure data-kg-card-width="regular">
+                        <div><img src="data:image/png;base64,BASE64DATA" alt="upload in progress, 0 " /></div>
                         <figcaption>
                             <input placeholder="Type alt text for image (optional)" value=""/>
                             <button name="alt-toggle-button">Alt</button>
@@ -170,8 +170,8 @@ describe('Image card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="image">
-                    <figure>
-                        <img src="data:image/png;base64,BASE64DATA" alt="" />
+                    <figure data-kg-card-width="regular">
+                        <div><img src="data:image/png;base64,BASE64DATA" alt="upload in progress, 0 " /></div>
                         <figcaption>
                             <input placeholder="Type caption for image (optional)" value="This is a caption" />
                             <button name="alt-toggle-button">Alt</button>
@@ -319,8 +319,8 @@ describe('Image card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="image">
-                    <figure>
-                        <img src="data:image/jpeg;base64,BASE64DATA" alt="" />
+                    <figure data-kg-card-width="regular">
+                        <div><img src="data:image/jpeg;base64,BASE64DATA" alt="upload in progress, 0 " /></div>
                         <figcaption>
                             <input placeholder="Type caption for image (optional)" value="" />
                             <button name="alt-toggle-button">Alt</button>
@@ -459,27 +459,30 @@ describe('Image card', async () => {
         `);
     });
 
-    test('can insert unsplash image', async () => {
+    // TODO: Switch to mocked API. Currently uses real Unsplash API so the asserted test data isn't stable
+    test.skip('can insert unsplash image', async () => {
         await focusEditor(page);
         await page.click('[data-kg-plus-button]');
         await page.click('button[data-kg-card-menu-item="Unsplash"]');
         await page.click('[data-kg-unsplash-insert-button]');
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="unsplash">
+                <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="image">
                     <figure data-kg-card-width="regular">
                         <div>
                             <img
                                 src="https://images.unsplash.com/photo-1574948495680-f67aab1ec3ed?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxMTc3M3wwfDF8c2VhcmNofDMyMXx8c3VtbWVyfGVufDB8fHx8MTY2OTEwNDUwNw&ixlib=rb-4.0.3&q=80&w=1200"
-                                alt="" />
+                                alt="upload in progress, 0 " />
                         </div>
                         <figcaption>
-                            <input placeholder="Type caption for image (optional)" value="" />
+                            <input placeholder="Type caption for image (optional)" value="Photo by Mailchimp on Unsplash" />
                             <button name="alt-toggle-button">Alt</button>
                         </figcaption>
                     </figure>
+                    <div data-kg-card-toolbar="image"></div>
                 </div>
             </div>
+            <p><br /></p>
         `, {ignoreCardToolbarContents: true});
     });
 

--- a/packages/koenig-lexical/test/e2e/slash-menu.test.js
+++ b/packages/koenig-lexical/test/e2e/slash-menu.test.js
@@ -263,8 +263,10 @@ describe('Slash menu', async () => {
         it('has correct order when inserting after a card', async function () {
             await focusEditor(page);
             await page.keyboard.type('/hr');
+            await page.waitForSelector('li:first-child > [data-kg-card-menu-item="Divider"]');
             await page.keyboard.press('Enter');
             await page.keyboard.type('/img');
+            await page.waitForSelector('li:first-child > [data-kg-card-menu-item="Image"]');
             await page.keyboard.press('Enter');
 
             // image card retains focus after insert
@@ -275,7 +277,7 @@ describe('Slash menu', async () => {
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="image"></div>
                 </div>
-                <p dir="ltr"><br /></p>
+                <p><br /></p>
             `, {ignoreCardContents: true});
         });
 
@@ -288,7 +290,7 @@ describe('Slash menu', async () => {
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="image"></div>
                 </div>
-                <p dir="ltr"><br /></p>
+                <p><br /></p>
             `, {ignoreCardContents: true});
 
             expect(await page.evaluate(() => {

--- a/packages/koenig-lexical/test/e2e/text-transforms/code-block.test.js
+++ b/packages/koenig-lexical/test/e2e/text-transforms/code-block.test.js
@@ -17,7 +17,7 @@ describe('Renders code block node', async () => {
         await initialize({page});
     });
 
-    test('renders code block node', async function () {
+    test('renders code block node in edit mode', async function () {
         await focusEditor(page);
         await page.keyboard.type('```javascript ');
         await assertHTML(page, html`
@@ -25,7 +25,6 @@ describe('Renders code block node', async () => {
                 <div data-kg-card-selected="true" data-kg-card-editing="true" data-kg-card="codeblock">
                 </div>
             </div>
-            <div contenteditable="false" data-lexical-cursor="true"></div>
         `, {ignoreCardContents: true});
     });
 });

--- a/packages/koenig-lexical/test/utils/e2e.js
+++ b/packages/koenig-lexical/test/utils/e2e.js
@@ -1,8 +1,10 @@
 import {preview} from 'vite';
 import {expect} from 'vitest';
 import {chromium, webkit, firefox} from 'playwright';
-import {parseHTML} from 'linkedom';
+import jsdom from 'jsdom';
 import prettier from 'prettier';
+
+const {JSDOM} = jsdom;
 
 const BROWSER_NAME = process.env.browser || 'chromium';
 export const E2E_PORT = process.env.E2E_PORT || 3000;
@@ -103,7 +105,7 @@ export function prettifyHTML(string, options = {}) {
     output = output.replace(/"blob:(.*?)"/, '"blob:..."');
 
     if (options.ignoreCardContents || options.ignoreCardToolbarContents) {
-        const {document} = parseHTML(output);
+        const {document} = (new JSDOM(output)).window;
 
         const querySelectors = [];
         if (options.ignoreCardContents) {
@@ -114,10 +116,9 @@ export function prettifyHTML(string, options = {}) {
         }
 
         document.querySelectorAll(querySelectors.join(', ')).forEach((element) => {
-            for (const child of element.childNodes) {
-                child.remove();
-            }
+            element.innerHTML = '';
         });
+
         output = document.body.innerHTML;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6063,17 +6063,6 @@ css-select@^4.1.3, css-select@^4.3.0:
     domutils "^2.8.0"
     nth-check "^2.0.1"
 
-css-select@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
-  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
-  dependencies:
-    boolbase "^1.0.0"
-    css-what "^6.1.0"
-    domhandler "^5.0.2"
-    domutils "^3.0.1"
-    nth-check "^2.0.1"
-
 css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -6097,7 +6086,7 @@ css-what@2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
-css-what@^6.0.1, css-what@^6.1.0:
+css-what@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
   integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
@@ -6490,15 +6479,6 @@ dom-serializer@^1.0.1, dom-serializer@^1.3.2:
     domhandler "^4.2.0"
     entities "^2.0.0"
 
-dom-serializer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
-  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
-  dependencies:
-    domelementtype "^2.3.0"
-    domhandler "^5.0.2"
-    entities "^4.2.0"
-
 dom-serializer@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
@@ -6522,7 +6502,7 @@ domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
-domelementtype@^2.0.1, domelementtype@^2.2.0, domelementtype@^2.3.0:
+domelementtype@^2.0.1, domelementtype@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
@@ -6555,13 +6535,6 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
-domhandler@^5.0.1, domhandler@^5.0.2:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
-  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
-  dependencies:
-    domelementtype "^2.3.0"
-
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
@@ -6586,15 +6559,6 @@ domutils@^2.0.0, domutils@^2.4.2, domutils@^2.5.2, domutils@^2.8.0:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
-
-domutils@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.0.1.tgz#696b3875238338cb186b6c0612bd4901c89a4f1c"
-  integrity sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==
-  dependencies:
-    dom-serializer "^2.0.0"
-    domelementtype "^2.3.0"
-    domhandler "^5.0.1"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -6747,7 +6711,7 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
-entities@^4.2.0, entities@^4.3.0, entities@^4.4.0:
+entities@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
   integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
@@ -8988,11 +8952,6 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
-html-escaper@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-3.0.3.tgz#4d336674652beb1dcbc29ef6b6ba7f6be6fdfed6"
-  integrity sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==
-
 html-minifier-terser@^5.0.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#922e96f1f3bb60832c2634b79884096389b1f054"
@@ -9082,16 +9041,6 @@ htmlparser2@^6.1.0:
     domhandler "^4.0.0"
     domutils "^2.5.2"
     entities "^2.0.0"
-
-htmlparser2@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.1.tgz#abaa985474fcefe269bc761a779b544d7196d010"
-  integrity sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==
-  dependencies:
-    domelementtype "^2.3.0"
-    domhandler "^5.0.2"
-    domutils "^3.0.1"
-    entities "^4.3.0"
 
 http-errors@2.0.0:
   version "2.0.0"
@@ -10387,17 +10336,6 @@ lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
-
-linkedom@0.14.21:
-  version "0.14.21"
-  resolved "https://registry.yarnpkg.com/linkedom/-/linkedom-0.14.21.tgz#878e1e5e88028cb1d57bc6262f84484a41a37497"
-  integrity sha512-V+c0AAFMTVJA2iAhrdd+u44lL0TjL6hBenVB061VQ6BHqTAHtXw1v5F1/CHGKtwg0OHm+hrGbepb9ZSFJ7lJkg==
-  dependencies:
-    css-select "^5.1.0"
-    cssom "^0.5.0"
-    html-escaper "^3.0.3"
-    htmlparser2 "^8.0.1"
-    uhyphen "^0.1.0"
 
 linkify-it@^3.0.1:
   version "3.0.3"
@@ -14961,11 +14899,6 @@ uglify-js@^3.0.5, uglify-js@^3.1.4:
   version "3.17.4"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
   integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
-
-uhyphen@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/uhyphen/-/uhyphen-0.1.0.tgz#3cc22afa790daa802b9f6789f3583108d5b4a08c"
-  integrity sha512-o0QVGuFg24FK765Qdd5kk0zU/U4dEsCtN/GSiwNI9i8xsSVtjIAOdTaVhLwZ1nrbWxFVMxNDDl+9fednsOMsBw==
 
 umd@^3.0.0:
   version "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8615,14 +8615,16 @@ gulp-rename@*:
   resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-2.0.0.tgz#9bbc3962b0c0f52fc67cd5eaff6c223ec5b9cf6c"
   integrity sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ==
 
-gulp-uglify@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/gulp-uglify/-/gulp-uglify-3.0.1.tgz#8d3eee466521bea6b10fd75dff72adf8b7ea2d97"
-  integrity sha512-KVffbGY9d4Wv90bW/B1KZJyunLMyfHTBbilpDvmcrj5Go0/a1G3uVpt+1gRBWSw/11dqR3coJ1oWNTt1AiXuWQ==
+gulp-uglify@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/gulp-uglify/-/gulp-uglify-3.0.2.tgz#5f5b2e8337f879ca9dec971feb1b82a5a87850b0"
+  integrity sha512-gk1dhB74AkV2kzqPMQBLA3jPoIAPd/nlNzP2XMDSG8XZrqnlCiDGAqC+rZOumzFvB5zOphlFh6yr3lgcAb/OOg==
   dependencies:
+    array-each "^1.0.1"
+    extend-shallow "^3.0.2"
     gulplog "^1.0.0"
     has-gulplog "^0.1.0"
-    lodash "^4.13.1"
+    isobject "^3.0.1"
     make-error-cause "^1.1.1"
     safe-buffer "^5.1.2"
     through2 "^2.0.0"
@@ -10535,7 +10537,7 @@ lodash.upperfirst@4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@^4.13.1, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2451
refs https://github.com/TryGhost/Koenig/commit/27d735159c4901883c24ed9e6bb8f65092ea3267

The mutation listener approach worked when inserting a code card but had the unfortunate side effect of triggering when code cards were loaded from serialized content meaning if any loaded content contained a code card we'd immediately change the selection to the last instance and put it in edit mode.

- added `_openInEditMode` dataset property to `CodeBlockNode` that's passed through to `<KoenigCardWrapper>` as a prop
- added `clearOpenInEditMode()` method for resetting the dataset property
- added an effect to `<KoenigCardWrapper>` that runs when `openInEditMode` is true, it selects the node and puts it in edit mode then  calls `clearOpenInEditMode()` on the node
- removed the mutation listener as it's no longer required
