### PR TITLE
Fixed card resizing when creating in edit mode

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -26,7 +26,7 @@ import {CardWrapper} from './ui/CardWrapper';
 const KoenigCardWrapperComponent = ({nodeKey, width, wrapperStyle, openInEditMode = false, children}) => {
     const [editor] = useLexicalComposerContext();
     const [isSelected, setSelected, clearSelected] = useLexicalNodeSelection(nodeKey);
-    const [isEditing, setEditing] = React.useState(false);
+    const [isEditing, setEditing] = React.useState(openInEditMode);
     const [selection, setSelection] = React.useState(null);
     const [cardType, setCardType] = React.useState(null);
     const [cardWidth, setCardWidth] = React.useState(width || 'regular');
@@ -279,23 +279,13 @@ const KoenigCardWrapperComponent = ({nodeKey, width, wrapperStyle, openInEditMod
         );
     }, [editor, isSelected, isEditing, setSelected, clearSelected, setEditing, nodeKey]);
 
-    // when openInEditMode is true the card node may have been created but not selected.
-    // make sure we reset the selection here
     React.useEffect(() => {
         if (openInEditMode) {
             editor.update(() => {
-                const nodeSelection = $createNodeSelection();
-                nodeSelection.add(nodeKey);
-                $setSelection(nodeSelection);
-
-                const node = $getNodeByKey(nodeKey);
-                node.clearOpenInEditMode();
+                $getNodeByKey(nodeKey).clearOpenInEditMode();
             });
-
-            setSelected(true);
-            setEditing(true);
         }
-    }, [editor, nodeKey, openInEditMode, setSelected, setEditing]);
+    }, [editor, nodeKey, openInEditMode]);
 
     return (
         <CardContext.Provider value={{

--- a/packages/koenig-lexical/src/components/ui/cards/MarkdownCard.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/MarkdownCard.stories.jsx
@@ -38,8 +38,7 @@ const story = {
                     Default: 'Default',
                     Selected: 'Selected',
                     Editing: 'Editing'
-                },
-                defaultValue: displayOptions.Default
+                }
             }
         }
     },

--- a/packages/koenig-lexical/src/nodes/ImageNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNode.jsx
@@ -58,7 +58,8 @@ export class ImageNode extends BaseImageNode {
     }
 
     getPreviewSrc() {
-        return this.__previewSrc;
+        const self = this.getLatest();
+        return self.__previewSrc;
     }
 
     setPreviewSrc(previewSrc) {

--- a/packages/koenig-lexical/src/plugins/MarkdownShortcutPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/MarkdownShortcutPlugin.jsx
@@ -10,6 +10,7 @@ import {MarkdownShortcutPlugin as LexicalMarkdownShortcutPlugin} from '@lexical/
 import {$createHorizontalRuleNode, $isHorizontalRuleNode, HorizontalRuleNode} from '../nodes/HorizontalRuleNode';
 import {$isCodeBlockNode, $createCodeBlockNode, CodeBlockNode} from '../nodes/CodeBlockNode';
 import {$isImageNode, $createImageNode, ImageNode} from '../nodes/ImageNode';
+import {$createNodeSelection, $setSelection} from 'lexical';
 
 export const HR = {
     dependencies: [HorizontalRuleNode],
@@ -51,7 +52,12 @@ export const CODE_BLOCK = {
     replace: (textNode, match, text) => {
         const language = text[1];
         const codeBlockNode = $createCodeBlockNode({language, _openInEditMode: true});
-        textNode.replace(codeBlockNode);
+        const replacementNode = textNode.replace(codeBlockNode);
+
+        // select node when replacing so it immediately renders in editing mode
+        const replacementSelection = $createNodeSelection();
+        replacementSelection.add(replacementNode.getKey());
+        $setSelection(replacementSelection);
     },
     type: 'element'
 };


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2493

When inserting code and markdown cards in edit mode there can be a flash of different sizing because the card initially renders with `isEditing: false` before immediately switching to `isEditing: true`.

- removed the effect that sets `isEditing` and makes the selection in favor of:
  - setting initial `isEditing` value to the `openInEditMode` prop value so the first render has the right mode
  - updating the shortcut plugin to select the code card immediately so `<KoenigCardWrapper>` doesn't (and no longer needs to) react to the selection changing
- kept an effect that resets the `__openInEditMode` value on the node after the first render
