### PR TITLE
Added base lexical node for Audio card

### DIFF
--- a/packages/kg-default-nodes/lib/kg-default-nodes.js
+++ b/packages/kg-default-nodes/lib/kg-default-nodes.js
@@ -2,6 +2,7 @@ import * as image from './nodes/image/ImageNode';
 import * as codeblock from './nodes/codeblock/CodeBlockNode';
 import * as markdown from './nodes/markdown/MarkdownNode';
 import * as video from './nodes/video/VideoNode';
+import * as audio from './nodes/audio/AudioNode';
 
 // re-export everything for easier importing
 export * from './KoenigDecoratorNode';
@@ -10,11 +11,13 @@ export * from './nodes/image/ImageParser';
 export * from './nodes/codeblock/CodeBlockNode';
 export * from './nodes/markdown/MarkdownNode';
 export * from './nodes/video/VideoNode';
+export * from './nodes/audio/AudioNode';
 
 // export convenience objects for use elsewhere
 export const DEFAULT_NODES = [
     codeblock.CodeBlockNode,
     image.ImageNode,
     markdown.MarkdownNode,
-    video.VideoNode
+    video.VideoNode,
+    audio.AudioNode
 ];

--- a/packages/kg-default-nodes/lib/nodes/audio/AudioNode.js
+++ b/packages/kg-default-nodes/lib/nodes/audio/AudioNode.js
@@ -1,0 +1,173 @@
+import {createCommand} from 'lexical';
+import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
+import {AudioParser} from './AudioParser';
+import {renderAudioNodeToDOM} from './AudioRenderer';
+
+export const INSERT_AUDIO_COMMAND = createCommand();
+const NODE_TYPE = 'audio';
+
+export class AudioNode extends KoenigDecoratorNode {
+    // payload properties
+    __src;
+    __title;
+    __duration;
+    __mimeType;
+    __thumbnailSrc;
+
+    static getType() {
+        return NODE_TYPE;
+    }
+
+    static clone(node) {
+        return new this(
+            node.getDataset(),
+            node.__key
+        );
+    }
+
+    // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
+    static get urlTransformMap() {
+        return {
+            src: 'url'
+        };
+    }
+
+    getDataset() {
+        return {
+            src: this.__src,
+            title: this.__title,
+            duration: this.__duration,
+            mimeType: this.__mimeType,
+            thumbnailSrc: this.__thumbnailSrc
+        };
+    }
+
+    static extensionTypes = ['mp3', 'wav', 'ogg', 'm4a'];
+    static mimeTypes = ['audio/mp3', 'audio/mpeg', 'audio/ogg', 'audio/wav', 'audio/vnd.wav', 'audio/wave', 'audio/x-wav', 'audio/mp4', 'audio/x-m4a'];
+
+    constructor({src, title, duration, thumbnailSrc, mimeType} = {}, key) {
+        super(key);
+        this.__src = src || '';
+        this.__title = title || '';
+        this.__duration = duration || 0;
+        this.__mimeType = mimeType || null;
+        this.__thumbnailSrc = thumbnailSrc || '';
+    }
+
+    static importJSON(serializedNode) {
+        const {src, title, duration, mimeType, thumbnailSrc} = serializedNode;
+        const node = new this({
+            src,
+            title,
+            mimeType,
+            duration,
+            thumbnailSrc
+        });
+        return node;
+    }
+
+    exportJSON() {
+        // checks if src is a data string
+        const src = this.getSrc();
+        const isBlob = src.startsWith('data:');
+        const dataset = {
+            type: NODE_TYPE,
+            version: 1,
+            src: isBlob ? '<base64String>' : this.getSrc(),
+            title: this.getTitle(),
+            mimeType: this.getMimeType(),
+            duration: this.getDuration(),
+            thumbnailSrc: this.getThumbnailSrc()
+        };
+        return dataset;
+    }
+
+    static importDOM() {
+        const parser = new AudioParser(this);
+        return parser.DOMConversionMap;
+    }
+
+    exportDOM(options = {}) {
+        const element = renderAudioNodeToDOM(this, options);
+        return {element};
+    }
+
+    /* c8 ignore start */
+    createDOM() {
+        const element = document.createElement('div');
+        return element;
+    }
+
+    updateDOM() {
+        return false;
+    }
+
+    isInline() {
+        return false;
+    }
+    /* c8 ignore stop */
+
+    getSrc() {
+        const self = this.getLatest();
+        return self.__src;
+    }
+
+    setSrc(src) {
+        const writable = this.getWritable();
+        return writable.__src = src;
+    }
+
+    getTitle() {
+        const self = this.getLatest();
+        return self.__title;
+    }
+
+    setTitle(title) {
+        const writable = this.getWritable();
+        return writable.__title = title;
+    }
+
+    getDuration() {
+        const self = this.getLatest();
+        return self.__duration;
+    }
+
+    setDuration(duration) {
+        const writable = this.getWritable();
+        return writable.__duration = duration;
+    }
+
+    getMimeType() {
+        const self = this.getLatest();
+        return self.__mimeType;
+    }
+
+    setMimeType(mimeType) {
+        const writable = this.getWritable();
+        return writable.__mimeType = mimeType;
+    }
+
+    getThumbnailSrc() {
+        const self = this.getLatest();
+        return self.__thumbnailSrc;
+    }
+
+    setThumbnailSrc(thumbnailSrc) {
+        const writable = this.getWritable();
+        return writable.__thumbnailSrc = thumbnailSrc;
+    }
+
+    // should be overridden
+    /* c8 ignore next 3 */
+    decorate() {
+        return '';
+    }
+}
+
+export const $createAudioNode = (dataset) => {
+    return new AudioNode(dataset);
+};
+
+export function $isAudioNode(node) {
+    return node instanceof AudioNode;
+}

--- a/packages/kg-default-nodes/lib/nodes/audio/AudioNode.js
+++ b/packages/kg-default-nodes/lib/nodes/audio/AudioNode.js
@@ -50,7 +50,7 @@ export class AudioNode extends KoenigDecoratorNode {
         this.__src = src || '';
         this.__title = title || '';
         this.__duration = duration || 0;
-        this.__mimeType = mimeType || null;
+        this.__mimeType = mimeType || '';
         this.__thumbnailSrc = thumbnailSrc || '';
     }
 
@@ -161,6 +161,14 @@ export class AudioNode extends KoenigDecoratorNode {
     /* c8 ignore next 3 */
     decorate() {
         return '';
+    }
+
+    hasEditMode() {
+        return true;
+    }
+
+    isEmpty() {
+        return !this.__src;
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/audio/AudioParser.js
+++ b/packages/kg-default-nodes/lib/nodes/audio/AudioParser.js
@@ -1,0 +1,25 @@
+// WIP
+export class AudioParser {
+    constructor(NodeClass) {
+        this.NodeClass = NodeClass;
+    }
+
+    get DOMConversionMap() {
+        const self = this;
+
+        return {
+            audio: () => ({
+                conversion(domNode) {
+                    if (domNode.tagName === 'AUDIO') {
+                        const {src} = domNode;
+                        const node = new self.NodeClass({src});
+                        return {node};
+                    }
+
+                    return null;
+                },
+                priority: 1
+            })
+        };
+    }
+}

--- a/packages/kg-default-nodes/lib/nodes/audio/AudioRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/audio/AudioRenderer.js
@@ -1,0 +1,27 @@
+// WIP
+export function renderAudioNodeToDOM(node, options = {}) {
+    /* c8 ignore start */
+    if (!options.createDocument) {
+        let document = typeof window !== 'undefined' && window.document;
+
+        if (!document) {
+            throw new Error('renderAudioNodeToDOM() must be passed a `createDocument` function as an option when used in a non-browser environment'); // eslint-disable-line
+        }
+
+        options.createDocument = function () {
+            return document;
+        };
+    }
+    /* c8 ignore stop */
+
+    const document = options.createDocument();
+
+    if (!node.getSrc() || node.getSrc().trim() === '') {
+        return document.createTextNode('');
+    }
+
+    const audio = document.createElement('audio');
+    audio.setAttribute('src', node.getSrc());
+
+    return audio;
+}

--- a/packages/kg-default-nodes/test/nodes/audio.test.js
+++ b/packages/kg-default-nodes/test/nodes/audio.test.js
@@ -1,0 +1,204 @@
+const {html} = require('../utils');
+const {$getRoot} = require('lexical');
+const {createHeadlessEditor} = require('@lexical/headless');
+const {JSDOM} = require('jsdom');
+
+const {AudioNode, $createAudioNode, $isAudioNode} = require('../../');
+
+const editorNodes = [AudioNode];
+
+describe('AudioNode', function () {
+    let editor;
+    let dataset;
+    let exportOptions;
+
+    // NOTE: all tests should use this function, without it you need manual
+    // try/catch and done handling to avoid assertion failures not triggering
+    // failed tests
+    const editorTest = testFn => function (done) {
+        editor.update(() => {
+            try {
+                testFn();
+                done();
+            } catch (e) {
+                done(e);
+            }
+        });
+    };
+
+    beforeEach(function () {
+        editor = createHeadlessEditor({nodes: editorNodes});
+
+        dataset = {
+            src: '/content/audio/2022/11/koenig-lexical.mp3',
+            title: 'Test Audio',
+            duration: 60,
+            mimeType: 'audio/mp3',
+            thumbnailSrc: '/content/images/2022/11/koenig-audio-lexical.jpg'
+        };
+
+        exportOptions = {
+            createDocument() {
+                return (new JSDOM()).window.document;
+            }
+        };
+    });
+
+    it('matches node with $isAudioNode', editorTest(function () {
+        const audioNode = $createAudioNode(dataset);
+        $isAudioNode(audioNode).should.be.true;
+    }));
+
+    describe('data access', function () {
+        it('has getters for all properties', editorTest(function () {
+            const audioNode = $createAudioNode(dataset);
+
+            audioNode.getSrc().should.equal(dataset.src);
+            audioNode.getTitle().should.equal(dataset.title);
+            audioNode.getDuration().should.equal(dataset.duration);
+            audioNode.getMimeType().should.equal(dataset.mimeType);
+            audioNode.getThumbnailSrc().should.equal(dataset.thumbnailSrc);
+        }));
+
+        it('has setters for all properties', editorTest(function () {
+            const audioNode = $createAudioNode();
+
+            audioNode.getSrc().should.equal('');
+            audioNode.setSrc('/content/audio/2022/12/koenig-lexical.mp3');
+            audioNode.getSrc().should.equal('/content/audio/2022/12/koenig-lexical.mp3');
+
+            audioNode.getTitle().should.equal('');
+            audioNode.setTitle('Test Audio');
+            audioNode.getTitle().should.equal('Test Audio');
+
+            audioNode.getDuration().should.equal(0);
+            audioNode.setDuration(70);
+            audioNode.getDuration().should.equal(70);
+
+            audioNode.getMimeType().should.equal('');
+            audioNode.setMimeType('audio/mp3');
+            audioNode.getMimeType().should.equal('audio/mp3');
+
+            audioNode.getThumbnailSrc().should.equal('');
+            audioNode.setThumbnailSrc('/content/images/2022/12/koenig-lexical.png');
+            audioNode.getThumbnailSrc().should.equal('/content/images/2022/12/koenig-lexical.png');
+        }));
+
+        it('has getDataset() convenience method', editorTest(function () {
+            const audioNode = $createAudioNode(dataset);
+            const audioNodeDataset = audioNode.getDataset();
+
+            audioNodeDataset.should.deepEqual({
+                ...dataset
+            });
+        }));
+
+        it('has isEmpty() convenience method', editorTest(function () {
+            const audioNode = $createAudioNode(dataset);
+
+            audioNode.isEmpty().should.be.false;
+            audioNode.setSrc('');
+            audioNode.isEmpty().should.be.true;
+        }));
+    });
+
+    describe('exportDOM', function () {
+        it('creates a audio card', editorTest(function () {
+            const audioNode = $createAudioNode(dataset);
+            const {element} = audioNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <audio src="${dataset.src}"></audio>
+            `);
+        }));
+
+        it('renders nothing with a missing src', editorTest(function () {
+            const audioNode = $createAudioNode();
+            const {element} = audioNode.exportDOM(exportOptions);
+
+            element.textContent.should.equal('');
+            should(element.outerHTML).be.undefined();
+        }));
+    });
+
+    describe('exportJSON', function () {
+        it('contains all data', editorTest(function () {
+            const audioNode = $createAudioNode(dataset);
+            const json = audioNode.exportJSON();
+
+            json.should.deepEqual({
+                type: 'audio',
+                version: 1,
+                src: dataset.src,
+                title: dataset.title,
+                duration: dataset.duration,
+                mimeType: dataset.mimeType,
+                thumbnailSrc: dataset.thumbnailSrc
+            });
+        }));
+    });
+
+    describe('importJSON', function () {
+        it('imports all data', function (done) {
+            const serializedState = JSON.stringify({
+                root: {
+                    children: [{
+                        type: 'audio',
+                        ...dataset
+                    }],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            });
+
+            const editorState = editor.parseEditorState(serializedState);
+            editor.setEditorState(editorState);
+
+            editor.getEditorState().read(() => {
+                try {
+                    const [audioNode] = $getRoot().getChildren();
+
+                    audioNode.getSrc().should.equal(dataset.src);
+                    audioNode.getTitle().should.equal(dataset.title);
+                    audioNode.getDuration().should.equal(dataset.duration);
+                    audioNode.getMimeType().should.equal(dataset.mimeType);
+                    audioNode.getThumbnailSrc().should.equal(dataset.thumbnailSrc);
+
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            });
+        });
+    });
+
+    describe('hasEditMode', function () {
+        it('returns true', editorTest(function () {
+            const audioNode = $createAudioNode(dataset);
+            audioNode.hasEditMode().should.be.true;
+        }));
+    });
+
+    describe('clone', function () {
+        it('clones the node', editorTest(function () {
+            const audioNode = $createAudioNode(dataset);
+            const clonedAudioNode = AudioNode.clone(audioNode);
+            $isAudioNode(clonedAudioNode).should.be.true;
+            clonedAudioNode.getSrc().should.equal(dataset.src);
+        }));
+    });
+
+    describe('static properties', function () {
+        it('getType', editorTest(function () {
+            AudioNode.getType().should.equal('audio');
+        }));
+
+        it('urlTransformMap', editorTest(function () {
+            AudioNode.urlTransformMap.should.deepEqual({
+                src: 'url'
+            });
+        }));
+    });
+});

--- a/packages/koenig-lexical/src/nodes/DefaultNodes.js
+++ b/packages/koenig-lexical/src/nodes/DefaultNodes.js
@@ -6,7 +6,6 @@ import {HorizontalRuleNode} from './HorizontalRuleNode';
 import {CodeBlockNode} from './CodeBlockNode';
 import {ImageNode} from './ImageNode';
 import {MarkdownNode} from './MarkdownNode';
-import {AudioNode} from './AudioNode';
 
 const DEFAULT_NODES = [
     HeadingNode,

--- a/packages/koenig-lexical/src/nodes/DefaultNodes.js
+++ b/packages/koenig-lexical/src/nodes/DefaultNodes.js
@@ -6,6 +6,7 @@ import {HorizontalRuleNode} from './HorizontalRuleNode';
 import {CodeBlockNode} from './CodeBlockNode';
 import {ImageNode} from './ImageNode';
 import {MarkdownNode} from './MarkdownNode';
+import {AudioNode} from './AudioNode';
 
 const DEFAULT_NODES = [
     HeadingNode,


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2497

- added `AudioNode` with dataset properties to `kg-default-nodes`
- added basic `AudioRenderer` for rendering audio card html
- added basic `AudioParser` for parsing audio card html
- added tests for the node's JSON (de)serialization and data access