### PR TITLE
Added full image card parsing to Lexical Image Card

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/image/ImageParser.js
+++ b/packages/kg-default-nodes/lib/nodes/image/ImageParser.js
@@ -1,5 +1,4 @@
 import cleanBasicHtml from '@tryghost/kg-clean-basic-html';
-import {JSDOM} from 'jsdom';
 
 function readImageAttributesFromNode(node) {
     const attrs = {};

--- a/packages/kg-default-nodes/lib/nodes/image/ImageParser.js
+++ b/packages/kg-default-nodes/lib/nodes/image/ImageParser.js
@@ -1,3 +1,62 @@
+import cleanBasicHtml from '@tryghost/kg-clean-basic-html';
+import {JSDOM} from 'jsdom';
+
+function readImageAttributesFromNode(node) {
+    const attrs = {};
+
+    if (node.src) {
+        attrs.src = node.src;
+    }
+
+    if (node.width) {
+        attrs.width = node.width;
+    } else if (node.dataset && node.dataset.width) {
+        attrs.width = parseInt(node.dataset.width, 10);
+    }
+
+    if (node.height) {
+        attrs.height = node.height;
+    } else if (node.dataset && node.dataset.height) {
+        attrs.height = parseInt(node.dataset.height, 10);
+    }
+
+    if ((!node.width && !node.height) && node.getAttribute('data-image-dimensions')) {
+        const [, width, height] = (/^(\d*)x(\d*)$/gi).exec(node.getAttribute('data-image-dimensions'));
+        attrs.width = parseInt(width, 10);
+        attrs.height = parseInt(height, 10);
+    }
+
+    if (node.alt) {
+        attrs.alt = node.alt;
+    }
+
+    if (node.title) {
+        attrs.title = node.title;
+    }
+
+    if (node.parentNode.tagName === 'A') {
+        const href = node.parentNode.href;
+
+        if (href !== attrs.src) {
+            attrs.href = href;
+        }
+    }
+
+    return attrs;
+}
+
+function addFigCaptionToPayload(node, payload, {selector = 'figcaption', options}) {
+    let figcaptions = Array.from(node.querySelectorAll(selector));
+
+    if (figcaptions.length) {
+        figcaptions.forEach((caption) => {
+            let cleanHtml = options?.cleanBasicHtml ? options.cleanBasicHtml(caption.innerHTML) : caption.innerHTML;
+            payload.caption = payload.caption ? `${payload.caption} / ${cleanHtml}` : cleanHtml;
+            caption.remove(); // cleanup this processed element
+        });
+    }
+}
+
 export class ImageParser {
     constructor(NodeClass) {
         this.NodeClass = NodeClass;
@@ -10,7 +69,8 @@ export class ImageParser {
             img: () => ({
                 conversion(domNode) {
                     if (domNode.tagName === 'IMG') {
-                        const {alt: altText, src, title, width, height} = domNode;
+                        const {src, width, height, alt: altText, title} = readImageAttributesFromNode(domNode);
+
                         const node = new self.NodeClass({altText, src, title, width, height});
                         return {node};
                     }
@@ -18,8 +78,47 @@ export class ImageParser {
                     return null;
                 },
                 priority: 1
-            })
-            // TODO: add <figure> and other handling from kg-parser-plugins
+            }),
+            figure: (node) => {
+                if (!node.querySelector('img')) {
+                    return null;
+                }
+                return {
+                    conversion(domNode) {
+                        const img = domNode.querySelector('img');
+                        const kgClass = domNode.className.match(/kg-width-(wide|full)/);
+                        const grafClass = domNode.className.match(/graf--layout(FillWidth|OutsetCenter)/);
+
+                        if (!img) {
+                            return null;
+                        }
+
+                        const payload = readImageAttributesFromNode(img);
+
+                        if (kgClass) {
+                            payload.cardWidth = kgClass[1];
+                        } else if (grafClass) {
+                            payload.cardWidth = grafClass[1] === 'FillWidth' ? 'full' : 'wide';
+                        }
+                        const options = {
+                            cleanBasicHtml: (html) => {
+                                const cleanedHtml = cleanBasicHtml(html, {
+                                    createDocument: (_html) => {
+                                        return (new JSDOM(_html)).window.document;
+                                    }
+                                });
+                                return cleanedHtml;
+                            }
+                        };
+                        addFigCaptionToPayload(domNode, payload, {options});
+
+                        const {src, width, height, alt: altText, title, caption, cardWidth} = payload;
+                        const node = new self.NodeClass({altText, src, title, width, height, caption, cardWidth});
+                        return {node};
+                    },
+                    priority: 1
+                };
+            }
         };
     }
 }

--- a/packages/kg-default-nodes/lib/nodes/image/ImageParser.js
+++ b/packages/kg-default-nodes/lib/nodes/image/ImageParser.js
@@ -1,4 +1,5 @@
 import cleanBasicHtml from '@tryghost/kg-clean-basic-html';
+import {JSDOM} from 'jsdom';
 
 function readImageAttributesFromNode(node) {
     const attrs = {};
@@ -103,9 +104,9 @@ export class ImageParser {
                             cleanBasicHtml: (html) => {
                                 const cleanedHtml = cleanBasicHtml(html, {
                                     createDocument: (_html) => {
-                                        const clonedNode = domNode.cloneNode();
-                                        clonedNode.ownerDocument.body.innerHTML = _html;
-                                        return clonedNode.ownerDocument;
+                                        const newDoc = domNode.ownerDocument.implementation.createHTMLDocument();
+                                        newDoc.body.innerHTML = _html;
+                                        return newDoc;
                                     }
                                 });
                                 return cleanedHtml;

--- a/packages/kg-default-nodes/lib/nodes/image/ImageParser.js
+++ b/packages/kg-default-nodes/lib/nodes/image/ImageParser.js
@@ -1,5 +1,4 @@
 import cleanBasicHtml from '@tryghost/kg-clean-basic-html';
-import {JSDOM} from 'jsdom';
 
 function readImageAttributesFromNode(node) {
     const attrs = {};
@@ -79,8 +78,8 @@ export class ImageParser {
                 },
                 priority: 1
             }),
-            figure: (node) => {
-                if (!node.querySelector('img')) {
+            figure: (nodeElem) => {
+                if (!nodeElem.querySelector('img')) {
                     return null;
                 }
                 return {
@@ -104,7 +103,9 @@ export class ImageParser {
                             cleanBasicHtml: (html) => {
                                 const cleanedHtml = cleanBasicHtml(html, {
                                     createDocument: (_html) => {
-                                        return (new JSDOM(_html)).window.document;
+                                        const clonedNode = domNode.cloneNode();
+                                        clonedNode.ownerDocument.body.innerHTML = _html;
+                                        return clonedNode.ownerDocument;
                                     }
                                 });
                                 return cleanedHtml;

--- a/packages/kg-default-nodes/package.json
+++ b/packages/kg-default-nodes/package.json
@@ -41,6 +41,7 @@
     "sinon": "15.0.1"
   },
   "dependencies": {
+    "@tryghost/kg-clean-basic-html": "^3.0.4",
     "@tryghost/kg-markdown-html-renderer": "^6.0.0",
     "jsdom": "^21.0.0",
     "lexical": "^0.7.0"

--- a/packages/kg-default-nodes/test/nodes/image.test.js
+++ b/packages/kg-default-nodes/test/nodes/image.test.js
@@ -290,6 +290,116 @@ describe('ImageNode', function () {
             nodes[0].getImgWidth().should.equal(3000);
             nodes[0].getImgHeight().should.equal(2000);
         }));
+
+        it('parses IMG inside FIGURE to image card without caption', editorTest(function () {
+            const dom = (new JSDOM(html`
+                <figure>
+                    <img src="http://example.com/test.png" alt="Alt test" title="Title test" />
+                </figure>
+            `)).window.document;
+            const nodes = $generateNodesFromDOM(editor, dom);
+
+            nodes.length.should.equal(1);
+            nodes[0].getSrc().should.equal('http://example.com/test.png');
+            nodes[0].getAltText().should.equal('Alt test');
+            nodes[0].getTitle().should.equal('Title test');
+        }));
+
+        it('parses IMG inside FIGURE to image card with caption', editorTest(function () {
+            const dom = (new JSDOM(html`
+                <figure>
+                    <img src="http://example.com/test.png">
+                    <figcaption>&nbsp; <strong>Caption test</strong></figcaption>
+                </figure>
+            `)).window.document;
+            const nodes = $generateNodesFromDOM(editor, dom);
+
+            nodes.length.should.equal(1);
+            nodes[0].getSrc().should.equal('http://example.com/test.png');
+            nodes[0].getCaption().should.equal('<strong>Caption test</strong>');
+        }));
+
+        it('extracts Koenig card widths', editorTest(function () {
+            const dom = (new JSDOM(html`
+                <figure class="kg-card kg-width-wide">
+                    <img src="http://example.com/test.png">
+                </figure>
+            `)).window.document;
+            const nodes = $generateNodesFromDOM(editor, dom);
+
+            nodes.length.should.equal(1);
+            nodes[0].getCardWidth().should.equal('wide');
+        }));
+
+        it('extracts Medium card widths', editorTest(function () {
+            const dom = (new JSDOM(html`
+                <figure class="graf--layoutFillWidth">
+                    <img src="http://example.com/test.png">
+                </figure>
+            `)).window.document;
+            const nodes = $generateNodesFromDOM(editor, dom);
+
+            nodes.length.should.equal(1);
+            nodes[0].getCardWidth().should.equal('full');
+        }));
+
+        it('extracts IMG dimensions from width/height attrs', editorTest(function () {
+            const dom = (new JSDOM(html`
+                <figure>
+                    <img src="http://example.com/test.png" width="640" height="480">
+                </figure>
+            `)).window.document;
+            const nodes = $generateNodesFromDOM(editor, dom);
+
+            nodes.length.should.equal(1);
+            nodes[0].getSrc().should.equal('http://example.com/test.png');
+            nodes[0].getImgWidth().should.equal(640);
+            nodes[0].getImgHeight().should.equal(480);
+        }));
+
+        it('extracts IMG dimensions from dataset', editorTest(function () {
+            const dom = (new JSDOM(html`
+                <figure>
+                    <img src="http://example.com/test.png" width="640" height="480">
+                </figure>
+            `)).window.document;
+            const nodes = $generateNodesFromDOM(editor, dom);
+
+            nodes.length.should.equal(1);
+            nodes[0].getSrc().should.equal('http://example.com/test.png');
+            nodes[0].getImgWidth().should.equal(640);
+            nodes[0].getImgHeight().should.equal(480);
+        }));
+
+        it('extracts IMG dimensions from data-image-dimensions', editorTest(function () {
+            const dom = (new JSDOM(html`
+                <figure>
+                    <img src="http://example.com/test.png" data-image-dimensions="640x480">
+                </figure>
+            `)).window.document;
+            const nodes = $generateNodesFromDOM(editor, dom);
+
+            nodes.length.should.equal(1);
+            nodes[0].getSrc().should.equal('http://example.com/test.png');
+            nodes[0].getImgWidth().should.equal(640);
+            nodes[0].getImgHeight().should.equal(480);
+        }));
+
+        it('extracts href when img wrapped in anchor tag', editorTest(function () {
+            const dom = (new JSDOM(html`
+                <figure>
+                    <a href="https://example.com/link">
+                        <img src="http://example.com/test.png">
+                    </a>
+                </figure>
+            `)).window.document;
+            const nodes = $generateNodesFromDOM(editor, dom);
+
+            nodes.length.should.equal(1);
+            nodes[0].getSrc().should.equal('http://example.com/test.png');
+            // TODO: Add href support to image card
+            // nodes[0].getHref().should.equal('https://example.com/link');
+        }));
     });
 
     describe('exportJSON', function () {


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2334

This change updates Lexical Image card parsing for copy/paste of html containing images to match the behaviour we expect in the mobiledoc editor.

- uses `clean-basic-html` lib to clean image caption when parsing html
- uses same tests as `kg-parser-plugin` for mobiledoc image card to test upgraded behavior
- missing `href` behavior as current ImageNode in Lexical doesn't support it