### PR TITLE
Updated Aside and HorizontalRule nodes to new pattern

### DIFF
--- a/packages/kg-default-nodes/lib/kg-default-nodes.js
+++ b/packages/kg-default-nodes/lib/kg-default-nodes.js
@@ -3,6 +3,7 @@ import * as codeblock from './nodes/codeblock/CodeBlockNode';
 import * as markdown from './nodes/markdown/MarkdownNode';
 import * as video from './nodes/video/VideoNode';
 import * as audio from './nodes/audio/AudioNode';
+import * as aside from './nodes/aside/AsideNode';
 
 // re-export everything for easier importing
 export * from './KoenigDecoratorNode';
@@ -12,6 +13,7 @@ export * from './nodes/codeblock/CodeBlockNode';
 export * from './nodes/markdown/MarkdownNode';
 export * from './nodes/video/VideoNode';
 export * from './nodes/audio/AudioNode';
+export * from './nodes/aside/AsideNode';
 
 // export convenience objects for use elsewhere
 export const DEFAULT_NODES = [
@@ -19,5 +21,6 @@ export const DEFAULT_NODES = [
     image.ImageNode,
     markdown.MarkdownNode,
     video.VideoNode,
-    audio.AudioNode
+    audio.AudioNode,
+    aside.AsideNode,
 ];

--- a/packages/kg-default-nodes/lib/kg-default-nodes.js
+++ b/packages/kg-default-nodes/lib/kg-default-nodes.js
@@ -4,6 +4,7 @@ import * as markdown from './nodes/markdown/MarkdownNode';
 import * as video from './nodes/video/VideoNode';
 import * as audio from './nodes/audio/AudioNode';
 import * as aside from './nodes/aside/AsideNode';
+import * as horizontalrule from './nodes/horizontalrule/HorizontalRuleNode';
 
 // re-export everything for easier importing
 export * from './KoenigDecoratorNode';
@@ -14,6 +15,7 @@ export * from './nodes/markdown/MarkdownNode';
 export * from './nodes/video/VideoNode';
 export * from './nodes/audio/AudioNode';
 export * from './nodes/aside/AsideNode';
+export * from './nodes/horizontalrule/HorizontalRuleNode';
 
 // export convenience objects for use elsewhere
 export const DEFAULT_NODES = [
@@ -23,4 +25,5 @@ export const DEFAULT_NODES = [
     video.VideoNode,
     audio.AudioNode,
     aside.AsideNode,
+    horizontalrule.HorizontalRuleNode
 ];

--- a/packages/kg-default-nodes/lib/nodes/aside/AsideNode.js
+++ b/packages/kg-default-nodes/lib/nodes/aside/AsideNode.js
@@ -1,0 +1,74 @@
+import {ElementNode} from 'lexical';
+import {AsideParser} from './AsideParser';
+import {renderAsideToDOM} from './AsideRenderer';
+
+export class AsideNode extends ElementNode {
+    static getType() {
+        return 'aside';
+    }
+
+    static clone(node) {
+        return new this(
+            node.__key
+        );
+    }
+
+    // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
+    static get urlTransformMap() {
+        return {};
+    }
+
+    constructor(key) {
+        super(key);
+    }
+
+    static importJSON(serializedNode) {
+        const node = new this();
+        node.setFormat(serializedNode.format);
+        node.setIndent(serializedNode.indent);
+        node.setDirection(serializedNode.direction);
+        return node;
+    }
+
+    exportJSON() {
+        const dataset = {
+            ...super.exportJSON(),
+            type: 'aside',
+            version: 1
+        };
+        return dataset;
+    }
+
+    static importDOM() {
+        const parser = new AsideParser(this);
+        return parser.DOMConversionMap;
+    }
+
+    exportDOM(options = {}) {
+        const element = renderAsideToDOM(this, options);
+        return {element};
+    }
+
+    /* c8 ignore start */
+    createDOM() {
+        const element = document.createElement('div');
+        return element;
+    }
+
+    updateDOM() {
+        return false;
+    }
+
+    isInline() {
+        return false;
+    }
+    /* c8 ignore stop */
+}
+
+export function $createAsideNode() {
+    return new AsideNode();
+}
+
+export function $isAsideNode(node) {
+    return node instanceof AsideNode;
+}

--- a/packages/kg-default-nodes/lib/nodes/aside/AsideParser.js
+++ b/packages/kg-default-nodes/lib/nodes/aside/AsideParser.js
@@ -1,0 +1,19 @@
+export class AsideParser {
+    constructor(NodeClass) {
+        this.NodeClass = NodeClass;
+    }
+
+    get DOMConversionMap() {
+        const self = this;
+
+        return {
+            aside: () => ({
+                conversion() {
+                    const node = new self.NodeClass();
+                    return {node};
+                },
+                priority: 0
+            })
+        };
+    }
+}

--- a/packages/kg-default-nodes/lib/nodes/aside/AsideRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/aside/AsideRenderer.js
@@ -1,0 +1,20 @@
+export function renderAsideToDOM(_, options = {}) {
+    /* c8 ignore start */
+    if (!options.createDocument) {
+        let document = typeof window !== 'undefined' && window.document;
+
+        if (!document) {
+            throw new Error('renderAsideToDOM() must be passed a `createDocument` function as an option when used in a non-browser environment'); // eslint-disable-line
+        }
+
+        options.createDocument = function () {
+            return document;
+        };
+    }
+    /* c8 ignore stop */
+
+    const document = options.createDocument();
+
+    const aside = document.createElement('aside');
+    return aside;
+}

--- a/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleNode.js
+++ b/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleNode.js
@@ -1,0 +1,77 @@
+import {createCommand} from 'lexical';
+import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
+import {renderHorizontalRuleToDOM} from './HorizontalRuleRenderer';
+
+export const INSERT_HORIZONTAL_RULE_COMMAND = createCommand();
+
+export class HorizontalRuleNode extends KoenigDecoratorNode {
+    static getType() {
+        return 'horizontalrule';
+    }
+
+    static clone(node) {
+        return new this(
+            node.__key
+        );
+    }
+
+    // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
+    static get urlTransformMap() {
+        return {};
+    }
+
+    constructor(key) {
+        super(key);
+    }
+
+    static importJSON() {
+        const node = new this({});
+        return node;
+    }
+
+    exportJSON() {
+        const dataset = {
+            type: 'horizontalrule',
+            version: 1
+        };
+        return dataset;
+    }
+
+    exportDOM(options = {}) {
+        const element = renderHorizontalRuleToDOM(this, options);
+        return {element};
+    }
+
+    getTextContent() {
+        return '\n';
+    }
+
+    /* c8 ignore start */
+    createDOM() {
+        const element = document.createElement('div');
+        return element;
+    }
+
+    updateDOM() {
+        return false;
+    }
+
+    isInline() {
+        return false;
+    }
+    /* c8 ignore stop */
+
+    // should be overridden
+    /* c8 ignore next 3 */
+    decorate() {
+        return '';
+    }
+}
+
+export function $createHorizontalRuleNode() {
+    return new HorizontalRuleNode();
+}
+
+export function $isHorizontalRuleNode(node) {
+    return node instanceof HorizontalRuleNode;
+}

--- a/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleNode.js
+++ b/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleNode.js
@@ -1,6 +1,7 @@
 import {createCommand} from 'lexical';
 import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
 import {renderHorizontalRuleToDOM} from './HorizontalRuleRenderer';
+import {HorizontalRuleParser} from './HorizontalRuleParser';
 
 export const INSERT_HORIZONTAL_RULE_COMMAND = createCommand();
 
@@ -35,6 +36,11 @@ export class HorizontalRuleNode extends KoenigDecoratorNode {
             version: 1
         };
         return dataset;
+    }
+
+    static importDOM() {
+        const parser = new HorizontalRuleParser(this);
+        return parser.DOMConversionMap;
     }
 
     exportDOM(options = {}) {

--- a/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleNode.js
+++ b/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleNode.js
@@ -25,7 +25,7 @@ export class HorizontalRuleNode extends KoenigDecoratorNode {
     }
 
     static importJSON() {
-        const node = new this({});
+        const node = new this();
         return node;
     }
 

--- a/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleParser.js
+++ b/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleParser.js
@@ -1,4 +1,4 @@
-export class AsideParser {
+export class HorizontalRuleParser {
     constructor(NodeClass) {
         this.NodeClass = NodeClass;
     }

--- a/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleParser.js
+++ b/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleParser.js
@@ -1,0 +1,19 @@
+export class AsideParser {
+    constructor(NodeClass) {
+        this.NodeClass = NodeClass;
+    }
+
+    get DOMConversionMap() {
+        const self = this;
+
+        return {
+            hr: () => ({
+                conversion() {
+                    const node = new self.NodeClass();
+                    return {node};
+                },
+                priority: 0
+            })
+        };
+    }
+}

--- a/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleRenderer.js
@@ -1,0 +1,20 @@
+export function renderHorizontalRuleToDOM(_, options = {}) {
+    /* c8 ignore start */
+    if (!options.createDocument) {
+        let document = typeof window !== 'undefined' && window.document;
+
+        if (!document) {
+            throw new Error('renderHorizontalRuleToDOM() must be passed a `createDocument` function as an option when used in a non-browser environment'); // eslint-disable-line
+        }
+
+        options.createDocument = function () {
+            return document;
+        };
+    }
+    /* c8 ignore stop */
+
+    const document = options.createDocument();
+
+    const hr = document.createElement('hr');
+    return hr;
+}

--- a/packages/kg-default-nodes/test/nodes/aside.test.js
+++ b/packages/kg-default-nodes/test/nodes/aside.test.js
@@ -1,0 +1,117 @@
+const {html} = require('../utils');
+const {$getRoot} = require('lexical');
+const {createHeadlessEditor} = require('@lexical/headless');
+const {$generateNodesFromDOM} = require('@lexical/html');
+const {JSDOM} = require('jsdom');
+const {AsideNode, $createAsideNode, $isAsideNode} = require('../../');
+
+const editorNodes = [AsideNode];
+
+describe('AsideNode', function () {
+    let editor;
+    let dataset;
+    let exportOptions;
+
+    // NOTE: all tests should use this function, without it you need manual
+    // try/catch and done handling to avoid assertion failures not triggering
+    // failed tests
+    const editorTest = testFn => function (done) {
+        editor.update(() => {
+            try {
+                testFn();
+                done();
+            } catch (e) {
+                done(e);
+            }
+        });
+    };
+
+    beforeEach(function () {
+        editor = createHeadlessEditor({nodes: editorNodes});
+
+        dataset = {};
+
+        exportOptions = {
+            createDocument() {
+                return (new JSDOM()).window.document;
+            }
+        };
+    });
+
+    it('matches node with $isAsideNode', editorTest(function () {
+        const asideNode = $createAsideNode();
+        $isAsideNode(asideNode).should.be.true;
+    }));
+
+    describe('exportDOM', function () {
+        it('creates aside element', editorTest(function () {
+            const asideNode = $createAsideNode();
+            const {element} = asideNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(html`
+                <aside></aside>
+            `);
+        }));
+    });
+
+    describe('importDOM', function () {
+        it('parses an aside element', editorTest(function () {
+            const dom = (new JSDOM(html`
+                <aside />
+            `)).window.document;
+            const nodes = $generateNodesFromDOM(editor, dom);
+
+            nodes.length.should.equal(1);
+            nodes[0].should.be.instanceof(AsideNode);
+        }));
+    });
+
+    describe('exportJSON', function () {
+        it('contains all data', editorTest(function () {
+            dataset.cardWidth = 'wide';
+
+            const asideNode = $createAsideNode(dataset);
+            const json = asideNode.exportJSON();
+
+            json.should.deepEqual({
+                type: 'aside',
+                version: 1,
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0
+            });
+        }));
+    });
+
+    describe('importJSON', function () {
+        it('imports all data', function (done) {
+            const serializedState = JSON.stringify({
+                root: {
+                    children: [{
+                        type: 'aside'
+                    }],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            });
+
+            const editorState = editor.parseEditorState(serializedState);
+            editor.setEditorState(editorState);
+
+            editor.getEditorState().read(() => {
+                try {
+                    const [asideNode] = $getRoot().getChildren();
+                    asideNode.should.be.instanceof(AsideNode);
+
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            });
+        });
+    });
+});

--- a/packages/kg-default-nodes/test/nodes/horizontalrule.test.js
+++ b/packages/kg-default-nodes/test/nodes/horizontalrule.test.js
@@ -1,0 +1,110 @@
+const {html} = require('../utils');
+const {$getRoot} = require('lexical');
+const {createHeadlessEditor} = require('@lexical/headless');
+const {$generateNodesFromDOM} = require('@lexical/html');
+const {JSDOM} = require('jsdom');
+const {HorizontalRuleNode, $createHorizontalRuleNode, $isHorizontalRuleNode} = require('../../');
+
+const editorNodes = [HorizontalRuleNode];
+
+describe('HorizontalNode', function () {
+    let editor;
+    let dataset;
+    let exportOptions;
+
+    // NOTE: all tests should use this function, without it you need manual
+    // try/catch and done handling to avoid assertion failures not triggering
+    // failed tests
+    const editorTest = testFn => function (done) {
+        editor.update(() => {
+            try {
+                testFn();
+                done();
+            } catch (e) {
+                done(e);
+            }
+        });
+    };
+
+    beforeEach(function () {
+        editor = createHeadlessEditor({nodes: editorNodes});
+
+        dataset = {};
+
+        exportOptions = {
+            createDocument() {
+                return (new JSDOM()).window.document;
+            }
+        };
+    });
+
+    it('matches node with $isHorizontalRuleNode', editorTest(function () {
+        const hrNode = $createHorizontalRuleNode();
+        $isHorizontalRuleNode(hrNode).should.be.true;
+    }));
+
+    describe('exportDOM', function () {
+        it('creates hr element', editorTest(function () {
+            const hrNode = $createHorizontalRuleNode();
+            const {element} = hrNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(html`
+                <hr />
+            `);
+        }));
+    });
+
+    describe('importDOM', function () {
+        it('parses an hr element', editorTest(function () {
+            const dom = (new JSDOM(html`
+                <hr />
+            `)).window.document;
+            const nodes = $generateNodesFromDOM(editor, dom);
+
+            nodes.length.should.equal(1);
+            nodes[0].should.be.instanceof(HorizontalRuleNode);
+        }));
+    });
+
+    describe('exportJSON', function () {
+        it('contains all data', editorTest(function () {
+            dataset.cardWidth = 'wide';
+
+            const asideNode = $createHorizontalRuleNode(dataset);
+            const json = asideNode.exportJSON();
+
+            json.should.deepEqual({
+                type: 'horizontalrule',
+                version: 1
+            });
+        }));
+    });
+
+    describe('importJSON', function () {
+        it('imports all data', function (done) {
+            const serializedState = JSON.stringify({
+                root: {
+                    children: [{
+                        type: 'horizontalrule'
+                    }],
+                    type: 'root',
+                    version: 1
+                }
+            });
+
+            const editorState = editor.parseEditorState(serializedState);
+            editor.setEditorState(editorState);
+
+            editor.getEditorState().read(() => {
+                try {
+                    const [hrNode] = $getRoot().getChildren();
+                    hrNode.should.be.instanceof(HorizontalRuleNode);
+
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            });
+        });
+    });
+});

--- a/packages/koenig-lexical/src/nodes/AsideNode.js
+++ b/packages/koenig-lexical/src/nodes/AsideNode.js
@@ -1,53 +1,16 @@
 import {
-    $createParagraphNode,
-    ElementNode
+    $createParagraphNode
 } from 'lexical';
+import {AsideNode as BaseAsideNode} from '@tryghost/kg-default-nodes';
 import {
     addClassNamesToElement
 } from '@lexical/utils';
 
-export class AsideNode extends ElementNode {
-    static getType() {
-        return 'aside';
-    }
-
-    static clone(node) {
-        return new AsideNode(node.__key);
-    }
-
-    // View
-
+export class AsideNode extends BaseAsideNode {
     createDOM(config) {
         const element = document.createElement('aside');
         addClassNamesToElement(element, config.theme.aside);
         return element;
-    }
-    updateDOM(prevNode, dom) {
-        return false;
-    }
-
-    static importDOM() {
-        return {
-            aside: node => ({
-                conversion: convertAsideElement,
-                priority: 0
-            })
-        };
-    }
-
-    static importJSON(serializedNode) {
-        const node = $createAsideNode();
-        node.setFormat(serializedNode.format);
-        node.setIndent(serializedNode.indent);
-        node.setDirection(serializedNode.direction);
-        return node;
-    }
-
-    exportJSON() {
-        return {
-            ...super.exportJSON(),
-            type: 'aside'
-        };
     }
 
     // Mutation
@@ -67,11 +30,6 @@ export class AsideNode extends ElementNode {
         this.replace(paragraph);
         return true;
     }
-}
-
-function convertAsideElement() {
-    const node = $createAsideNode;
-    return {node};
 }
 
 export function $createAsideNode() {

--- a/packages/koenig-lexical/src/nodes/HorizontalRuleNode.jsx
+++ b/packages/koenig-lexical/src/nodes/HorizontalRuleNode.jsx
@@ -1,24 +1,13 @@
 import * as React from 'react';
 import KoenigCardWrapper from '../components/KoenigCardWrapper';
-import {DecoratorNode, createCommand} from 'lexical';
+import {HorizontalRuleNode as BaseHorizontalRuleNode, INSERT_HORIZONTAL_RULE_COMMAND} from '@tryghost/kg-default-nodes';
 import {ReactComponent as DividerCardIcon} from '../assets/icons/kg-card-type-divider.svg';
 import {HorizontalRuleCard} from '../components/ui/cards/HorizontalRuleCard';
 
-export const INSERT_HORIZONTAL_RULE_COMMAND = createCommand();
+// re-export here so we don't need to import from multiple places throughout the app
+export {INSERT_HORIZONTAL_RULE_COMMAND} from '@tryghost/kg-default-nodes';
 
-export class HorizontalRuleNode extends DecoratorNode {
-    static getType() {
-        return 'horizontalrule';
-    }
-
-    static clone(node) {
-        return new HorizontalRuleNode(node.__key);
-    }
-
-    static importJSON(serializedNode) {
-        return $createHorizontalRuleNode();
-    }
-
+export class HorizontalRuleNode extends BaseHorizontalRuleNode {
     static kgMenu = {
         label: 'Divider',
         desc: 'Insert a dividing line',
@@ -31,28 +20,9 @@ export class HorizontalRuleNode extends DecoratorNode {
         return DividerCardIcon;
     }
 
-    exportJSON() {
-        return {
-            type: 'horizontalrule',
-            version: 1
-        };
-    }
-
     createDOM() {
         const div = document.createElement('div');
         return div;
-    }
-
-    getTextContent() {
-        return '\n';
-    }
-
-    isInline() {
-        return false;
-    }
-
-    updateDOM() {
-        return false;
     }
 
     decorate() {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2342

The kg-default-nodes package was added kater as a place for all of the core node behaviour to live in a node.js server-side compatible way. Some of the older nodes like Aside and HorizontalRule were still following the old patter, this change catches them up with new pattern.