### PR TITLE
Improved code in tests related to dataTransfer creation

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/VideoCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/VideoCard.jsx
@@ -51,7 +51,7 @@ function PopulatedVideoCard({
 
     return (
         <>
-            <div className="not-kg-prose relative">
+            <div className="not-kg-prose relative" data-testid="video-card-populated">
                 <div>
                     <img className="mx-auto" src={thumbnail} alt="Video thumbnail" />
                     {customThumbnail && <img className="absolute inset-0 h-full w-full object-cover" src={customThumbnail} alt="Video custom thumbnail" />}

--- a/packages/koenig-lexical/test/e2e/cards/audio-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/audio-card.test.js
@@ -109,7 +109,7 @@ describe('Audio card', async () => {
         await fileChooser.setFiles([]);
 
         // Create and dispatch data transfer
-        const dataTransfer = await createDataTransfer(page, {filePath, fileName: 'audio-sample.mp3', fileType: 'audio/mp3'});
+        const dataTransfer = await createDataTransfer(page, [{filePath, fileName: 'audio-sample.mp3', fileType: 'audio/mp3'}]);
         await page.getByTestId('media-placeholder').dispatchEvent('dragover', {dataTransfer});
 
         // Dragover text should be visible
@@ -152,7 +152,7 @@ describe('Audio card', async () => {
         await fileChooser.setFiles([]);
 
         // Create and dispatch data transfer
-        const dataTransfer = await createDataTransfer(page, {filePath, fileName: 'large-image.png', fileType: 'image/png'});
+        const dataTransfer = await createDataTransfer(page, [{filePath, fileName: 'large-image.png', fileType: 'image/png'}]);
         await page.getByTestId('media-placeholder').dispatchEvent('drop', {dataTransfer});
 
         // Errors should be visible
@@ -223,7 +223,7 @@ describe('Audio card', async () => {
         await expect(await page.getByTestId('media-duration')).toContainText('0:19');
 
         // Create and dispatch data transfer
-        const dataTransfer = await createDataTransfer(page, {filePath, fileName: 'large-image.png', fileType: 'image/png'});
+        const dataTransfer = await createDataTransfer(page, [{filePath, fileName: 'large-image.png', fileType: 'image/png'}]);
         await page.getByTestId('audio-card-populated').dispatchEvent('dragover', {dataTransfer});
 
         // Dragover text should be visible
@@ -248,7 +248,7 @@ describe('Audio card', async () => {
         await expect(await page.getByTestId('media-duration')).toContainText('0:19');
 
         // Create and dispatch data transfer
-        const dataTransfer = await createDataTransfer(page, {filePath, fileName: 'video.mp4', fileType: 'video/mp4'});
+        const dataTransfer = await createDataTransfer(page, [{filePath, fileName: 'video.mp4', fileType: 'video/mp4'}]);
         await page.getByTestId('audio-card-populated').dispatchEvent('drop', {dataTransfer});
 
         // Errors should be visible
@@ -319,7 +319,7 @@ describe('Audio card', async () => {
 
         const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.png');
         // Create and dispatch data transfer
-        const dataTransfer = await createDataTransfer(page, {filePath, fileName: 'large-image.png', fileType: 'image/png'});
+        const dataTransfer = await createDataTransfer(page, [{filePath, fileName: 'large-image.png', fileType: 'image/png'}]);
         await page.getByTestId('audio-card-populated').dispatchEvent('dragover', {dataTransfer});
 
         // Dragover text shouldn't be visible

--- a/packages/koenig-lexical/test/e2e/cards/image-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/image-card.test.js
@@ -457,23 +457,15 @@ describe('Image card', async () => {
         expect(imageCard).not.toBeNull();
 
         const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.png');
-        const dataTransfer = await createDataTransfer(page, {filePath, fileName: 'large-image.png', fileType: 'image/png'});
+        const dataTransfer = await createDataTransfer(page, [{filePath, fileName: 'large-image.png', fileType: 'image/png'}]);
 
-        await page.dispatchEvent(
-            '[data-kg-card="image"] [data-testid="media-placeholder"]',
-            'dragenter',
-            {dataTransfer}
-        );
+        await page.locator('[data-kg-card="image"] [data-testid="media-placeholder"]').dispatchEvent('dragenter', {dataTransfer});
 
-        expect(await page.$('[data-kg-card-drag-text="true"]')).not.toBeNull();
+        expect(await page.locator('[data-kg-card-drag-text="true"]')).not.toBeNull();
 
-        await page.dispatchEvent(
-            '[data-kg-card="image"] [data-testid="media-placeholder"]',
-            'dragleave',
-            {dataTransfer}
-        );
+        await page.locator('[data-kg-card="image"] [data-testid="media-placeholder"]').dispatchEvent('dragleave', {dataTransfer});
 
-        expect(await page.$('[data-kg-card-drag-text="true"]')).toBeNull();
+        await expect(await page.locator('[data-kg-card-drag-text="true"]')).toHaveCount(0);
     });
 
     test('can handle image drop', async function () {
@@ -481,22 +473,14 @@ describe('Image card', async () => {
         await page.keyboard.type('image! ');
 
         const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.png');
-        const dataTransfer = await createDataTransfer(page, {filePath, fileName: 'large-image.png', fileType: 'image/png'});
+        const dataTransfer = await createDataTransfer(page, [{filePath, fileName: 'large-image.png', fileType: 'image/png'}]);
 
-        await page.dispatchEvent(
-            '[data-kg-card="image"] [data-testid="media-placeholder"]',
-            'dragenter',
-            {dataTransfer}
-        );
+        await page.locator('[data-kg-card="image"] [data-testid="media-placeholder"]').dispatchEvent('dragenter', {dataTransfer});
 
         // Dragover text should be visible
         await expect(await page.locator('[data-kg-card-drag-text="true"]')).toBeVisible();
 
-        await page.dispatchEvent(
-            '[data-kg-card="image"] [data-testid="media-placeholder"]',
-            'drop',
-            {dataTransfer}
-        );
+        await page.locator('[data-kg-card="image"] [data-testid="media-placeholder"]').dispatchEvent('drop', {dataTransfer});
 
         // wait for upload to complete
         await expect(await page.getByTestId('progress-bar')).toBeVisible();

--- a/packages/koenig-lexical/test/e2e/cards/video-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/video-card.test.js
@@ -2,7 +2,7 @@ import {afterAll, beforeAll, beforeEach, describe, test} from 'vitest';
 import {expect} from '@playwright/test';
 import {startApp, initialize, focusEditor, assertHTML, html} from '../../utils/e2e';
 import path from 'path';
-import createDataTransfer from '../../utils/createDataTransfer.js';
+import createDataTransfer from '../../utils/createDataTransfer';
 
 describe('Video card', async () => {
     let app;
@@ -203,7 +203,7 @@ describe('Video card', async () => {
         await fileChooser.setFiles([]);
 
         // Create and dispatch data transfer
-        const dataTransfer = await createDataTransfer(page, {filePath, fileName: 'video.mp4', fileType: 'video/mp4'});
+        const dataTransfer = await createDataTransfer(page, [{filePath, fileName: 'video.mp4', fileType: 'video/mp4'}]);
         await page.getByTestId('media-placeholder').dispatchEvent('dragover', {dataTransfer});
 
         // Dragover text should be visible
@@ -233,7 +233,7 @@ describe('Video card', async () => {
         await fileChooser.setFiles([]);
 
         //  Drop file
-        const dataTransfer = await createDataTransfer(page, {filePath, fileName: 'large-image.png', fileType: 'image/png'});
+        const dataTransfer = await createDataTransfer(page, [{filePath, fileName: 'large-image.png', fileType: 'image/png'}]);
         await page.getByTestId('media-placeholder').dispatchEvent('dragover', {dataTransfer});
         await page.getByTestId('media-placeholder').dispatchEvent('drop', {dataTransfer});
 
@@ -251,7 +251,7 @@ describe('Video card', async () => {
         await page.waitForSelector('[data-testid="thumbnail-media-placeholder"]');
 
         // Create and dispatch data transfer
-        const dataTransfer = await createDataTransfer(page, {filePath, fileName: 'large-image.png', fileType: 'image/png'});
+        const dataTransfer = await createDataTransfer(page, [{filePath, fileName: 'large-image.png', fileType: 'image/png'}]);
         await page.getByTestId('thumbnail-media-placeholder').dispatchEvent('dragover', {dataTransfer});
 
         // Dragover text should be visible
@@ -277,7 +277,7 @@ describe('Video card', async () => {
         await page.waitForSelector('[data-testid="thumbnail-media-placeholder"]');
 
         // Create and dispatch data transfer
-        const dataTransfer = await createDataTransfer(page, {filePath, fileName: 'video.mp4', fileType: 'video/mp4'});
+        const dataTransfer = await createDataTransfer(page, [{filePath, fileName: 'video.mp4', fileType: 'video/mp4'}]);
         await page.getByTestId('thumbnail-media-placeholder').dispatchEvent('drop', {dataTransfer});
 
         // Errors should be visible

--- a/packages/koenig-lexical/test/e2e/plugins/DragDropPastePlugin.test.js
+++ b/packages/koenig-lexical/test/e2e/plugins/DragDropPastePlugin.test.js
@@ -1,7 +1,8 @@
 import {afterAll, beforeAll, beforeEach, describe, test} from 'vitest';
+import {expect} from '@playwright/test';
 import {startApp, initialize, focusEditor, assertHTML, html} from '../../utils/e2e';
 import path from 'path';
-import fs from 'fs';
+import createDataTransfer from '../../utils/createDataTransfer';
 
 describe('Drag Drop Paste Plugin', async function () {
     let app;
@@ -23,25 +24,17 @@ describe('Drag Drop Paste Plugin', async function () {
         await focusEditor(page);
 
         const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.png');
-        const buffer = fs.readFileSync(filePath);
+        const dataTransfer = await createDataTransfer(page, [{filePath, fileName: 'large-image.png', fileType: 'image/png'}]);
 
-        const dataTransfer = await page.evaluateHandle((data) => {
-            const dt = new DataTransfer();
-            const file = new File([data.toString('hex')], 'large-image.png', {type: 'image/png'});
-            dt.items.add(file);
-            return dt;
-        }, buffer);
+        await page.locator('.kg-prose').dispatchEvent('dragenter', {dataTransfer});
+        await page.locator('.kg-prose').dispatchEvent('drop', {dataTransfer});
 
-        await page.dispatchEvent(
-            '.kg-prose',
-            'dragenter',
-            {dataTransfer}
-        );
-        await page.dispatchEvent(
-            '.kg-prose',
-            'drop',
-            {dataTransfer}
-        );
+        // wait for upload to complete
+        await expect(await page.getByTestId('progress-bar')).toBeVisible();
+        await expect(await page.getByTestId('progress-bar')).toBeHidden();
+
+        // wait for card visibility
+        await expect(await page.getByTestId('image-card-populated')).toBeVisible();
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
@@ -58,35 +51,27 @@ describe('Drag Drop Paste Plugin', async function () {
                     </figure>
                 </div>
             </div>
-        `);
+        `, {ignoreCardToolbarContents: true, ignoreCardContents: true});
     });
 
     test('can drag and drop multiple images on the editor', async function () {
         await focusEditor(page);
         const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.png');
         const filePath2 = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.jpeg');
-        const buffer = fs.readFileSync(filePath);
-        const buffer2 = fs.readFileSync(filePath2);
+        const dataTransfer = await createDataTransfer(page, [
+            {filePath, fileName: 'large-image.png', fileType: 'image/png'},
+            {filePath: filePath2, fileName: 'large-image.jpeg', fileType: 'image/jpeg'}
+        ]);
 
-        const dataTransfer = await page.evaluateHandle((dataset) => {
-            const dt = new DataTransfer();
-            const file = new File([dataset.buffer.toString('hex')], 'large-image.png', {type: 'image/png'});
-            const file2 = new File([dataset.buffer2.toString('hex')], 'large-image.jpeg', {type: 'image/jpeg'});
-            dt.items.add(file);
-            dt.items.add(file2);
-            return dt;
-        }, {buffer, buffer2});
+        await page.locator('.kg-prose').dispatchEvent('dragenter', {dataTransfer});
+        await page.locator('.kg-prose').dispatchEvent('drop', {dataTransfer});
 
-        await page.dispatchEvent(
-            '.kg-prose',
-            'dragenter',
-            {dataTransfer}
-        );
-        await page.dispatchEvent(
-            '.kg-prose',
-            'drop',
-            {dataTransfer}
-        );
+        // wait for upload to complete
+        await expect(await page.getByTestId('progress-bar')).toHaveCount(2);
+        await expect(await page.getByTestId('progress-bar')).toHaveCount(0);
+
+        // wait for card visibility
+        await expect(await page.getByTestId('image-card-populated')).toHaveCount(2);
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
@@ -115,32 +100,17 @@ describe('Drag Drop Paste Plugin', async function () {
                     </figure>
                 </div>
             </div>
-        `);
+        `, {ignoreCardToolbarContents: true, ignoreCardContents: true});
     });
 
     test('can drag and drop an audio file on the editor', async function () {
         await focusEditor(page);
 
         const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/audio-sample.mp3');
-        const buffer = fs.readFileSync(filePath);
+        const dataTransfer = await createDataTransfer(page, [{filePath, fileName: 'audio-sample.mp3', fileType: 'audio/mp3'}]);
 
-        const dataTransfer = await page.evaluateHandle((data) => {
-            const dt = new DataTransfer();
-            const file = new File([data.toString('hex')], 'audio-sample.mp3', {type: 'audio/mp3'});
-            dt.items.add(file);
-            return dt;
-        }, buffer);
-
-        await page.dispatchEvent(
-            '.kg-prose',
-            'dragenter',
-            {dataTransfer}
-        );
-        await page.dispatchEvent(
-            '.kg-prose',
-            'drop',
-            {dataTransfer}
-        );
+        await page.locator('.kg-prose').dispatchEvent('dragenter', {dataTransfer});
+        await page.locator('.kg-prose').dispatchEvent('drop', {dataTransfer});
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
@@ -155,31 +125,17 @@ describe('Drag Drop Paste Plugin', async function () {
         await focusEditor(page);
         const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/audio-sample.mp3');
         const filePath2 = path.relative(process.cwd(), __dirname + '/../fixtures/audio-sample.mp3');
-        const buffer = fs.readFileSync(filePath);
-        const buffer2 = fs.readFileSync(filePath2);
 
-        const dataTransfer = await page.evaluateHandle((dataset) => {
-            const dt = new DataTransfer();
-            const file = new File([new Uint8Array(dataset.buffer)], 'audio-sample-1.mp3', {type: 'audio/mp3'});
-            const file2 = new File([new Uint8Array(dataset.buffer2)], 'audio-sample-2.mp3', {type: 'audio/mp3'});
-            dt.items.add(file);
-            dt.items.add(file2);
-            return dt;
-        }, {buffer: buffer.toJSON().data, buffer2: buffer2.toJSON().data});
+        const dataTransfer = await createDataTransfer(page, [
+            {filePath, fileName: 'audio-sample-1.mp3', fileType: 'audio/mp3'},
+            {filePath: filePath2, fileName: 'audio-sample-2.mp3', fileType: 'audio/mp3'}
+        ]);
 
-        await page.dispatchEvent(
-            '.kg-prose',
-            'dragenter',
-            {dataTransfer}
-        );
-        await page.dispatchEvent(
-            '.kg-prose',
-            'drop',
-            {dataTransfer}
-        );
+        await page.locator('.kg-prose').dispatchEvent('dragenter', {dataTransfer});
+        await page.locator('.kg-prose').dispatchEvent('drop', {dataTransfer});
 
-        await page.waitForSelector('input[value="Audio sample 1"]');
-        await page.waitForSelector('input[value="Audio sample 2"]');
+        await expect(await page.locator('input[value="Audio sample 1"]')).toBeVisible();
+        await expect(await page.locator('input[value="Audio sample 2"]')).toBeVisible();
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
@@ -188,130 +144,7 @@ describe('Drag Drop Paste Plugin', async function () {
             </div>
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="audio">
-                    
-                </div>
-            </div>
-        `, {ignoreCardContents: true, ignoreInnerSVG: false});
-    });
 
-    test('can drag and drop a video file on the editor', async function () {
-        await focusEditor(page);
-
-        const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/video.mp4');
-        const buffer = fs.readFileSync(filePath);
-
-        const dataTransfer = await page.evaluateHandle((data) => {
-            const dt = new DataTransfer();
-            const file = new File([data.toString('hex')], 'video.mp4', {type: 'video/mp4'});
-            dt.items.add(file);
-            return dt;
-        }, buffer);
-
-        await page.dispatchEvent(
-            '.kg-prose',
-            'dragenter',
-            {dataTransfer}
-        );
-        await page.dispatchEvent(
-            '.kg-prose',
-            'drop',
-            {dataTransfer}
-        );
-
-        await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="video">
-
-                </div>
-            </div>
-        `, {ignoreCardContents: true});
-    });
-
-    test('can drag and drop multiple video files on the editor', async function () {
-        await focusEditor(page);
-        const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/video.mp4');
-        const filePath2 = path.relative(process.cwd(), __dirname + '/../fixtures/video.mp4');
-        const buffer = fs.readFileSync(filePath);
-        const buffer2 = fs.readFileSync(filePath2);
-
-        const dataTransfer = await page.evaluateHandle((dataset) => {
-            const dt = new DataTransfer();
-            const file = new File([new Uint8Array(dataset.buffer)], 'video-1.mp4', {type: 'video/mp4'});
-            const file2 = new File([new Uint8Array(dataset.buffer2)], 'video-2.mp3', {type: 'video/mp4'});
-            dt.items.add(file);
-            dt.items.add(file2);
-            return dt;
-        }, {buffer: buffer.toJSON().data, buffer2: buffer2.toJSON().data});
-
-        await page.dispatchEvent(
-            '.kg-prose',
-            'dragenter',
-            {dataTransfer}
-        );
-        await page.dispatchEvent(
-            '.kg-prose',
-            'drop',
-            {dataTransfer}
-        );
-
-        await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="video">
-                </div>
-            </div>
-            <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="video">
-                </div>
-            </div>
-        `, {ignoreCardContents: true, ignoreInnerSVG: false});
-    });
-
-    test('can drag and drop multiple different types of files on the editor', async function () {
-        await focusEditor(page);
-        const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.png');
-        const filePath2 = path.relative(process.cwd(), __dirname + '/../fixtures/audio-sample.mp3');
-        const filePath3 = path.relative(process.cwd(), __dirname + '/../fixtures/video.mp4');
-        const buffer = fs.readFileSync(filePath);
-        const buffer2 = fs.readFileSync(filePath2);
-        const buffer3 = fs.readFileSync(filePath3);
-
-        const dataTransfer = await page.evaluateHandle((dataset) => {
-            const dt = new DataTransfer();
-            const file = new File([new Uint8Array(dataset.buffer)], 'large-image.png', {type: 'image/png'});
-            const file2 = new File([new Uint8Array(dataset.buffer2)], 'audio-sample.mp3', {type: 'audio/mp3'});
-            const file3 = new File([new Uint8Array(dataset.buffer3)], 'video.mp4', {type: 'video/mp4'});
-            dt.items.add(file);
-            dt.items.add(file2);
-            dt.items.add(file3);
-            return dt;
-        }, {buffer: buffer.toJSON().data, buffer2: buffer2.toJSON().data, buffer3: buffer3.toJSON().data});
-
-        await page.dispatchEvent(
-            '.kg-prose',
-            'dragenter',
-            {dataTransfer}
-        );
-        await page.dispatchEvent(
-            '.kg-prose',
-            'drop',
-            {dataTransfer}
-        );
-
-        // Wait for uploads to complete
-        await page.waitForSelector('input[value="Audio sample"]');
-        await page.waitForSelector('img[alt=""]');
-
-        await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="image">
-                </div>
-            </div>
-            <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="audio">
-                </div>
-            </div>
-            <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="video">
                 </div>
             </div>
         `, {ignoreCardContents: true, ignoreInnerSVG: false});

--- a/packages/koenig-lexical/test/e2e/plugins/DragDropPastePluginFirefox.test.js
+++ b/packages/koenig-lexical/test/e2e/plugins/DragDropPastePluginFirefox.test.js
@@ -1,0 +1,120 @@
+import {afterAll, beforeAll, beforeEach, describe, test} from 'vitest';
+import {expect} from '@playwright/test';
+import path from 'path';
+import {startApp, initialize, focusEditor, assertHTML, html} from '../../utils/e2e';
+import createDataTransfer from '../../utils/createDataTransfer';
+
+// Video card is tested in firefox
+// Need to get video thumbnail before uploading on the server; for this purpose, convert video to blob https://github.com/TryGhost/Koenig/blob/a04c59c2d81ddc783869c47653aa9d7adf093629/packages/koenig-lexical/src/utils/extractVideoMetadata.js#L45
+// The problem is that Chromium can't read video src as blob
+describe('Drag Drop Paste Plugin Firefox', async function () {
+    let app;
+    let page;
+
+    beforeAll(async function () {
+        ({app, page} = await startApp('firefox'));
+    });
+
+    afterAll(async function () {
+        await app.stop();
+    });
+
+    beforeEach(async function () {
+        await initialize({page});
+    });
+
+    test('can drag and drop a video file on the editor', async function () {
+        await focusEditor(page);
+
+        const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/video.mp4');
+        const dataTransfer = await createDataTransfer(page, [{filePath, fileName: 'video.mp4', fileType: 'video/mp4'}]);
+
+        await page.locator('.kg-prose').dispatchEvent('dragenter', {dataTransfer});
+        await page.locator('.kg-prose').dispatchEvent('drop', {dataTransfer});
+
+        // Check progress bar
+        await expect(await page.getByTestId('video-progress')).toBeVisible();
+
+        // Check that video file was uploaded
+        await expect(await page.getByTestId('media-duration')).toContainText('0:04');
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="video">
+                </div>
+                <figcaption>
+                    <input
+                        placeholder="Type caption for video (optional)"
+                        readonly=""
+                        value=""/>
+                </figcaption>
+            </div>
+        `, {ignoreCardContents: true});
+    });
+
+    test('can drag and drop multiple video files on the editor', async function () {
+        await focusEditor(page);
+        const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/video.mp4');
+        const filePath2 = path.relative(process.cwd(), __dirname + '/../fixtures/video.mp4');
+        const dataTransfer = await createDataTransfer(page, [
+            {filePath, fileName: 'video-1.mp4', fileType: 'video/mp4'},
+            {filePath: filePath2, fileName: 'video-2.mp4', fileType: 'video/mp4'}
+        ]);
+
+        await page.locator('.kg-prose').dispatchEvent('dragenter', {dataTransfer});
+        await page.locator('.kg-prose').dispatchEvent('drop', {dataTransfer});
+
+        // wait for upload to complete
+        await expect(await page.getByTestId('video-progress')).toHaveCount(2);
+        await expect(await page.getByTestId('video-progress')).toHaveCount(0);
+
+        // wait for card visibility
+        await expect(await page.getByTestId('media-duration')).toHaveCount(2);
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="video">
+                </div>
+            </div>
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="video">
+                </div>
+            </div>
+        `, {ignoreCardContents: true, ignoreInnerSVG: false});
+    });
+
+    test('can drag and drop multiple different types of files on the editor', async function () {
+        await focusEditor(page);
+        const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.png');
+        const filePath2 = path.relative(process.cwd(), __dirname + '/../fixtures/audio-sample.mp3');
+        const filePath3 = path.relative(process.cwd(), __dirname + '/../fixtures/video.mp4');
+        const dataTransfer = await createDataTransfer(page, [
+            {filePath, fileName: 'large-image.png', fileType: 'image/png'},
+            {filePath: filePath2, fileName: 'audio-sample.mp3', fileType: 'audio/mp3'},
+            {filePath: filePath3, fileName: 'video.mp4', fileType: 'video/mp4'}
+        ]);
+
+        await page.locator('.kg-prose').dispatchEvent('dragenter', {dataTransfer});
+        await page.locator('.kg-prose').dispatchEvent('drop', {dataTransfer});
+
+        // Wait for uploads to complete
+        await expect(await page.locator('input[value="Audio sample"]')).toBeVisible();
+        await expect(await page.getByTestId('image-card-populated')).toBeVisible();
+        await expect(await page.locator('[data-testid="video-card-populated"] [data-testid="media-duration"]')).toContainText('0:04');
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="image">
+                </div>
+            </div>
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="audio">
+                </div>
+            </div>
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="true" data-kg-card-editing="false" data-kg-card="video">
+                </div>
+            </div>
+        `, {ignoreCardContents: true, ignoreInnerSVG: false});
+    });
+});


### PR DESCRIPTION
no issue
- Added ability to pass few files to `createDataTransfer` helper
- Removed deprecated `page.dispatchEvent`
- Moved drag and drop plugin tests for video card to Firefox browser (they were false positive)