### PR TITLE
Fixed alt text selection jumping in Image CardCaptionEditor

### DIFF
--- a/packages/koenig-lexical/src/components/ui/CardCaptionEditor.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardCaptionEditor.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
 function CaptionInput({value, placeholder, onChange, readOnly, dataTestId}) {
+    const [caption, setCaption] = React.useState(value);
     const handleOnChange = (e) => {
+        setCaption(e.target.value);
         onChange(e.target.value);
     };
 
@@ -10,7 +12,7 @@ function CaptionInput({value, placeholder, onChange, readOnly, dataTestId}) {
             onChange={handleOnChange}
             className="not-kg-prose w-full px-9 text-center font-sans text-sm font-normal leading-8 tracking-wide text-grey-900"
             placeholder={placeholder}
-            value={value}
+            value={caption}
             readOnly={readOnly}
             data-testid={dataTestId}
         />
@@ -18,7 +20,9 @@ function CaptionInput({value, placeholder, onChange, readOnly, dataTestId}) {
 }
 
 function AltTextInput({value, placeholder, onChange, readOnly, dataTestId}) {
+    const [altText, setAltText] = React.useState(value);
     const handleOnChange = (e) => {
+        setAltText(e.target.value);
         onChange(e.target.value);
     };
 
@@ -27,7 +31,7 @@ function AltTextInput({value, placeholder, onChange, readOnly, dataTestId}) {
             onChange={handleOnChange}
             className="not-kg-prose w-full px-9 text-center font-sans text-sm font-normal leading-8 tracking-wide text-grey-900"
             placeholder={placeholder}
-            value={value}
+            value={altText}
             readOnly={readOnly}
             data-testid={dataTestId}
         />

--- a/packages/koenig-lexical/src/components/ui/CardCaptionEditor.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardCaptionEditor.jsx
@@ -1,18 +1,13 @@
 import React from 'react';
+import {TextInput} from './TextInput';
 
 function CaptionInput({value, placeholder, onChange, readOnly, dataTestId}) {
-    const [caption, setCaption] = React.useState(value);
-    const handleOnChange = (e) => {
-        setCaption(e.target.value);
-        onChange(e.target.value);
-    };
-
     return (
-        <input
-            onChange={handleOnChange}
+        <TextInput
+            initialValue={value}
+            onChange={onChange}
             className="not-kg-prose w-full px-9 text-center font-sans text-sm font-normal leading-8 tracking-wide text-grey-900"
             placeholder={placeholder}
-            value={caption}
             readOnly={readOnly}
             data-testid={dataTestId}
         />
@@ -20,18 +15,12 @@ function CaptionInput({value, placeholder, onChange, readOnly, dataTestId}) {
 }
 
 function AltTextInput({value, placeholder, onChange, readOnly, dataTestId}) {
-    const [altText, setAltText] = React.useState(value);
-    const handleOnChange = (e) => {
-        setAltText(e.target.value);
-        onChange(e.target.value);
-    };
-
     return (
-        <input
-            onChange={handleOnChange}
+        <TextInput
+            onChange={onChange}
+            initialValue={value}
             className="not-kg-prose w-full px-9 text-center font-sans text-sm font-normal leading-8 tracking-wide text-grey-900"
             placeholder={placeholder}
-            value={altText}
             readOnly={readOnly}
             data-testid={dataTestId}
         />

--- a/packages/koenig-lexical/src/components/ui/TextInput.jsx
+++ b/packages/koenig-lexical/src/components/ui/TextInput.jsx
@@ -10,7 +10,6 @@ export function TextInput({initialValue, onChange, ...args}) {
     
     return (
         <input
-            type="text"
             value={value}
             onChange={handleOnChange}
             {...args}

--- a/packages/koenig-lexical/src/components/ui/TextInput.jsx
+++ b/packages/koenig-lexical/src/components/ui/TextInput.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export function TextInput({initialValue, onChange, ...args}) {
+    const [value, setValue] = React.useState(initialValue);
+
+    const handleOnChange = (e) => {
+        setValue(e.target.value);
+        onChange(e.target.value);
+    };
+    
+    return (
+        <input
+            type="text"
+            value={value}
+            onChange={handleOnChange}
+            {...args}
+        />
+    );
+}


### PR DESCRIPTION
refs TryGhost/Team#2587

- Added local state tracking for AltTextInput and CaptionInput in the ImageCard to prevent a complete rerender of the input components