### PR TITLE
Added tests for MarkdownCard

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/MarkdownCard/MarkdownHelpDialog.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/MarkdownCard/MarkdownHelpDialog.jsx
@@ -17,7 +17,7 @@ export function Td({value}) {
 export default function MarkdownHelpDialog(props) {
     return (
         <Modal {...props}>
-            <div className="p-8 text-left font-sans">
+            <div className="p-8 text-left font-sans" data-testid="markdown-help-dialog">
                 <header>
                     <h1 className="mr-6 text-2xl font-semibold leading-snug">
                         Markdown Help

--- a/packages/koenig-lexical/src/components/ui/cards/MarkdownCard/useMarkdownImageUploader.js
+++ b/packages/koenig-lexical/src/components/ui/cards/MarkdownCard/useMarkdownImageUploader.js
@@ -2,7 +2,7 @@ import {useRef} from 'react';
 
 export default function useMarkdownImageUploader(editor, imageUploader) {
     const imageInputRef = useRef(null);
-    const {progress, upload, errors, isLoading, filesNumber} = imageUploader();
+    const {progress, upload, errors, isLoading, filesNumber} = imageUploader('image');
 
     const uploadImages = async (event) => {
         const files = event.target.files;
@@ -41,9 +41,9 @@ export default function useMarkdownImageUploader(editor, imageUploader) {
 
                 return `![${alt}](${url})`;
 
-                // full url object, use attrs we're given
+            // full url object, use attrs we're given
             } else {
-                let image = `![${url.alt}](${url.url})`;
+                let image = `![${url.fileName}](${url.url})`;
 
                 if (url.credit) {
                     image += `\n${url.credit}`;

--- a/packages/koenig-lexical/test/e2e/cards/markdown-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/markdown-card.test.js
@@ -1,6 +1,7 @@
 import {afterAll, beforeAll, beforeEach, describe, test} from 'vitest';
 import {expect} from '@playwright/test';
-import {startApp, initialize, focusEditor, assertHTML, html, isMac} from '../../utils/e2e';
+import path from 'path';
+import {startApp, initialize, focusEditor, assertHTML, html, isMac, assertRootChildren} from '../../utils/e2e';
 
 describe('Markdown card', async () => {
     let app;
@@ -18,6 +19,37 @@ describe('Markdown card', async () => {
 
     beforeEach(async () => {
         await initialize({page});
+    });
+
+    test('can import serialized markdown card node', async function () {
+        await page.evaluate(() => {
+            const serializedState = JSON.stringify({
+                root: {
+                    children: [{
+                        type: 'markdown',
+                        version: 1,
+                        markdown: '# This is a heading'
+                    }],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            });
+            const editor = window.lexicalEditor;
+            const editorState = editor.parseEditorState(serializedState);
+            editor.setEditorState(editorState);
+        });
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div><svg></svg></div>
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="markdown">
+                    <div><h1 id="this-is-a-heading">This is a heading</h1></div>
+                </div>
+            </div>
+        `);
     });
 
     test('renders markdown card node', async function () {
@@ -96,6 +128,19 @@ describe('Markdown card', async () => {
         await fileChooserPromise;
     });
 
+    test('can display and close markdown help guide', async function () {
+        await focusEditor(page);
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.click('[data-kg-card="markdown"]');
+
+        await page.click('a[title="Markdown Guide"]');
+        await expect(await page.getByTestId('markdown-help-dialog')).toBeVisible();
+
+        await page.click('button[aria-label="Close dialog"]');
+        await expect(await page.getByTestId('markdown-help-dialog')).not.toBeVisible();
+    });
+
     test('adds extra paragraph when markdown is inserted at end of document', async function () {
         await focusEditor(page);
         await page.click('[data-kg-plus-button]');
@@ -131,5 +176,427 @@ describe('Markdown card', async () => {
             </div>
             <p dir="ltr"><span data-lexical-text="true">Testing</span></p>
         `, {ignoreCardContents: true});
+    });
+
+    test('can upload an image', async function () {
+        const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.png');
+        await focusEditor(page);
+        const fileChooserPromise = page.waitForEvent('filechooser');
+
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.keyboard.press(`${ctrlOrCmd}+Alt+I`);
+
+        const fileChooser = await fileChooserPromise;
+        await fileChooser.setFiles(filePath);
+
+        // wait for progress bar to be shown and subsequently hidden
+        await page.waitForSelector('[data-testid="progress-bar"]');
+        await expect(await page.getByTestId('progress-bar')).not.toBeVisible();
+
+        await assertRootChildren(page, JSON.stringify([
+            {
+                type: 'markdown',
+                version: 1,
+                markdown: '![large-image.png](blob:...)'
+            },
+            {
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'paragraph',
+                version: 1
+            }
+        ]));
+    });
+
+    test('can insert bold text', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.click('[data-kg-card="markdown"]');
+        await page.keyboard.press(`${ctrlOrCmd}+B`);
+        await page.keyboard.type('bold text');
+
+        await assertRootChildren(page, JSON.stringify([
+            {
+                type: 'markdown',
+                version: 1,
+                markdown: '**bold text**'
+            },
+            {
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'paragraph',
+                version: 1
+            }
+        ]));
+    });
+
+    test('can convert text to bold', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.click('[data-kg-card="markdown"]');
+        await page.keyboard.type('bold');
+        // select the text
+        await page.keyboard.down('Shift');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.up('Shift');
+        // make it bold
+        await page.keyboard.press(`${ctrlOrCmd}+B`);
+
+        await assertRootChildren(page, JSON.stringify([
+            {
+                type: 'markdown',
+                version: 1,
+                markdown: '**bold**'
+            },
+            {
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'paragraph',
+                version: 1
+            }
+        ]));
+    });
+
+    test('can insert italic text', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.click('[data-kg-card="markdown"]');
+        await page.keyboard.press(`${ctrlOrCmd}+I`);
+        await page.keyboard.type('italic text');
+
+        await assertRootChildren(page, JSON.stringify([
+            {
+                type: 'markdown',
+                version: 1,
+                markdown: '*italic text*'
+            },
+            {
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'paragraph',
+                version: 1
+            }
+        ]));
+    });
+
+    test('can convert text to italic', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.click('[data-kg-card="markdown"]');
+        await page.keyboard.type('italic');
+        // select the text
+        await page.keyboard.down('Shift');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.up('Shift');
+        // make it italic
+        await page.keyboard.press(`${ctrlOrCmd}+I`);
+
+        await assertRootChildren(page, JSON.stringify([
+            {
+                type: 'markdown',
+                version: 1,
+                markdown: '*italic*'
+            },
+            {
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'paragraph',
+                version: 1
+            }
+        ]));
+    });
+
+    test('can insert heading', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.click('[data-kg-card="markdown"]');
+        await page.keyboard.press(`${ctrlOrCmd}+H`);
+        await page.keyboard.type('Heading text');
+
+        await assertRootChildren(page, JSON.stringify([
+            {
+                type: 'markdown',
+                version: 1,
+                markdown: '# Heading text'
+            },
+            {
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'paragraph',
+                version: 1
+            }
+        ]));
+    });
+
+    test('can convert line to heading', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.click('[data-kg-card="markdown"]');
+        await page.keyboard.type('Heading');
+        await page.keyboard.press(`${ctrlOrCmd}+H`);
+
+        await assertRootChildren(page, JSON.stringify([
+            {
+                type: 'markdown',
+                version: 1,
+                markdown: '# Heading'
+            },
+            {
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'paragraph',
+                version: 1
+            }
+        ]));
+    });
+
+    test('can insert quote', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.click('[data-kg-card="markdown"]');
+        await page.keyboard.press(`${ctrlOrCmd}+'`);
+        await page.keyboard.type('quote');
+
+        await assertRootChildren(page, JSON.stringify([
+            {
+                type: 'markdown',
+                version: 1,
+                markdown: '> quote'
+            },
+            {
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'paragraph',
+                version: 1
+            }
+        ]));
+    });
+
+    test('can convert line to quote', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.click('[data-kg-card="markdown"]');
+        await page.keyboard.type('quote');
+        await page.keyboard.press(`${ctrlOrCmd}+'`);
+
+        await assertRootChildren(page, JSON.stringify([
+            {
+                type: 'markdown',
+                version: 1,
+                markdown: '> quote'
+            },
+            {
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'paragraph',
+                version: 1
+            }
+        ]));
+    });
+
+    test('can insert an unordered list', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.click('[data-kg-card="markdown"]');
+        await page.keyboard.press(`${ctrlOrCmd}+L`);
+        await page.keyboard.type('First list item');
+
+        await assertRootChildren(page, JSON.stringify([
+            {
+                type: 'markdown',
+                version: 1,
+                markdown: '* First list item'
+            },
+            {
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'paragraph',
+                version: 1
+            }
+        ]));
+    });
+
+    test('can convert line to unordered list', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.click('[data-kg-card="markdown"]');
+        await page.keyboard.type('A list item');
+        await page.keyboard.press(`${ctrlOrCmd}+L`);
+
+        await assertRootChildren(page, JSON.stringify([
+            {
+                type: 'markdown',
+                version: 1,
+                markdown: '* A list item'
+            },
+            {
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'paragraph',
+                version: 1
+            }
+        ]));
+    });
+
+    test('can insert an ordered list', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.click('[data-kg-card="markdown"]');
+        await page.keyboard.press(`${ctrlOrCmd}+Alt+L`);
+        await page.keyboard.type('First list item');
+
+        await assertRootChildren(page, JSON.stringify([
+            {
+                type: 'markdown',
+                version: 1,
+                markdown: '1. First list item'
+            },
+            {
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'paragraph',
+                version: 1
+            }
+        ]));
+    });
+
+    test('can convert line to ordered list', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.click('[data-kg-card="markdown"]');
+        await page.keyboard.type('A list item');
+        await page.keyboard.press(`${ctrlOrCmd}+Alt+L`);
+
+        await assertRootChildren(page, JSON.stringify([
+            {
+                type: 'markdown',
+                version: 1,
+                markdown: '1. A list item'
+            },
+            {
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'paragraph',
+                version: 1
+            }
+        ]));
+    });
+
+    test('can insert a link', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.click('[data-kg-card="markdown"]');
+        await page.keyboard.press(`${ctrlOrCmd}+K`);
+
+        await assertRootChildren(page, JSON.stringify([
+            {
+                type: 'markdown',
+                version: 1,
+                markdown: '[](http://)'
+            },
+            {
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'paragraph',
+                version: 1
+            }
+        ]));
+    });
+
+    test('can convert text to a link', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('/');
+        await page.click('[data-kg-card-menu-item="Markdown"]');
+        await page.click('[data-kg-card="markdown"]');
+        await page.keyboard.type('link');
+        // select the text
+        await page.keyboard.down('Shift');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.up('Shift');
+        // convert to link
+        await page.keyboard.press(`${ctrlOrCmd}+K`);
+
+        await assertRootChildren(page, JSON.stringify([
+            {
+                type: 'markdown',
+                version: 1,
+                markdown: '[link](http://)'
+            },
+            {
+                children: [],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'paragraph',
+                version: 1
+            }
+        ]));
     });
 });

--- a/packages/koenig-lexical/test/utils/e2e.js
+++ b/packages/koenig-lexical/test/utils/e2e.js
@@ -141,6 +141,16 @@ export function prettifyHTML(string, options = {}) {
         .trim();
 }
 
+export function prettifyJSON(string) {
+    let output = string;
+
+    output = output.replace(/\(blob:http[^"]*\)/g, '(blob:...)');
+
+    return prettier.format(output, {
+        parser: 'json'
+    });
+}
+
 // This function does not suppose to do anything, it's only used as a trigger
 // for prettier auto-formatting (https://prettier.io/blog/2020/08/24/2.1.0.html#api)
 export function html(partials, ...params) {
@@ -216,6 +226,19 @@ export async function assertPosition(page, selector, expectedBox, {threshold = 0
             expect(assertedBox[boxProperty], boxProperty).toBeLessThanOrEqual(expectedBox[boxProperty] + threshold);
         }
     });
+}
+
+export async function assertRootChildren(page, expectedState) {
+    let actualState = await page.evaluate(() => {
+        const rootElement = document.querySelector('div[contenteditable="true"]');
+        const editor = rootElement.__lexicalEditor;
+        return JSON.stringify(editor.getEditorState().toJSON().root.children);
+    });
+
+    const actual = prettifyJSON(actualState);
+    const expected = prettifyJSON(expectedState);
+    
+    expect(actual).toEqual(expected);
 }
 
 export async function pasteText(page, text, mimeType = 'text/plain') {


### PR DESCRIPTION
refs TryGhost/Team#2537

- Added a bunch of tests to MarkdownCard
- Added assertRootChildren helper to e2e utils
    - assertHTML helper can be cumbersome with more complex cards, like the MarkdownCard