### PR TITLE
Fixed copying text from editor after adding video card

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/video/VideoRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/video/VideoRenderer.js
@@ -28,10 +28,7 @@ export function renderVideoNodeToDOM(node, options = {}) {
     const element = document.createElement('div');
     element.innerHTML = htmlString.trim();
 
-    const videoNode = element.firstElementChild;
-    document.body.replaceChildren(videoNode);
-
-    return videoNode;
+    return element.firstElementChild;
 }
 
 export function cardTemplate({node, cardClasses}) {


### PR DESCRIPTION
refs TryGhost/Team#2600
- Copying text from editor after adding video card broke it due to error in video node renderer.