### PR TITLE
Added caption input keyboard handling

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigCaptionEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCaptionEditor.jsx
@@ -1,5 +1,9 @@
-import React from 'react';
+import React, {useCallback, useContext} from 'react';
 import {HtmlOutputPlugin, KoenigComposableEditor, KoenigComposer, MINIMAL_NODES, MINIMAL_TRANSFORMERS, RestrictContentPlugin} from '../index.js';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {$setSelection, BLUR_COMMAND, COMMAND_PRIORITY_LOW, FOCUS_COMMAND, KEY_ENTER_COMMAND} from 'lexical';
+import CardContext from '../context/CardContext.jsx';
+import {mergeRegister} from '@lexical/utils';
 
 const Placeholder = ({text = 'Type here'}) => {
     return (
@@ -9,7 +13,66 @@ const Placeholder = ({text = 'Type here'}) => {
     );
 };
 
+function CaptionPlugin({parentEditor}) {
+    const [editor] = useLexicalComposerContext();
+    const {setCaptionHasFocus, captionHasFocus} = useContext(CardContext);
+
+    // focus on caption editor when something is typed while card is selected
+    const handleKeyDown = useCallback((event) => {
+        // only if key is printable key, focus on editor
+        if (!captionHasFocus && event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+            editor.focus();
+        }
+    }, [editor, captionHasFocus]);
+
+    React.useEffect(() => {
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [handleKeyDown, editor]);
+
+    // handle focus/blur and enter key commands
+    React.useEffect(
+        () => {
+            return mergeRegister(
+                editor.registerCommand(
+                    FOCUS_COMMAND,
+                    () => {
+                        setCaptionHasFocus(true);
+                        return false;
+                    },
+                    COMMAND_PRIORITY_LOW
+                ),
+                editor.registerCommand(
+                    BLUR_COMMAND,
+                    () => {
+                        setCaptionHasFocus(false);
+                        editor.update(() => {
+                            $setSelection(null);
+                        });
+                        return false;
+                    },
+                    COMMAND_PRIORITY_LOW
+                ),
+                editor.registerCommand(
+                    KEY_ENTER_COMMAND,
+                    (event) => {
+                        parentEditor?.dispatchCommand(KEY_ENTER_COMMAND, event);
+                        return false;
+                    },
+                    COMMAND_PRIORITY_LOW
+                )
+            );
+        },
+        [editor, setCaptionHasFocus, mainEditor]
+    );
+
+    return null;
+}
+
 const KoenigCaptionEditor = ({paragraphs = 1, html, setHtml, placeholderText, readOnly}) => {
+    const [parentEditor] = useLexicalComposerContext();
     return (
         <KoenigComposer
             nodes={MINIMAL_NODES}
@@ -20,6 +83,7 @@ const KoenigCaptionEditor = ({paragraphs = 1, html, setHtml, placeholderText, re
                 placeholder={<Placeholder text={placeholderText} />}
                 readOnly={readOnly}
             >
+                <CaptionPlugin parentEditor={parentEditor} />
                 <RestrictContentPlugin paragraphs={paragraphs} />
                 <HtmlOutputPlugin html={html} setHtml={setHtml} />
             </KoenigComposableEditor>

--- a/packages/koenig-lexical/src/components/KoenigCaptionEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCaptionEditor.jsx
@@ -7,7 +7,7 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
 const Placeholder = ({text = 'Type here'}) => {
     return (
-        <div className="text-grey-500 pointer-events-none absolute top-0 left-0 m-0 min-w-full cursor-text font-sans text-sm font-normal tracking-wide ">
+        <div className="pointer-events-none absolute top-0 left-0 m-0 min-w-full cursor-text font-sans text-sm font-normal tracking-wide text-grey-500 ">
             {text}
         </div>
     );

--- a/packages/koenig-lexical/src/components/KoenigCaptionEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCaptionEditor.jsx
@@ -19,6 +19,11 @@ function CaptionPlugin({parentEditor}) {
 
     // focus on caption editor when something is typed while card is selected
     const handleKeyDown = useCallback((event) => {
+        // don't focus caption input if any other input or textarea is focused
+        if (event.target.matches('input, textarea')) {
+            return;
+        }
+
         // only if key is printable key, focus on editor
         if (!captionHasFocus && event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
             editor.focus();

--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -30,6 +30,7 @@ const KoenigCardWrapperComponent = ({nodeKey, width, wrapperStyle, IndicatorIcon
     const [isEditing, setEditing] = React.useState(openInEditMode);
     const [selection, setSelection] = React.useState(null);
     const [cardType, setCardType] = React.useState(null);
+    const [captionHasFocus, setCaptionHasFocus] = React.useState(null);
     const [cardWidth, setCardWidth] = React.useState(width || 'regular');
     const containerRef = React.useRef(null);
 
@@ -303,9 +304,11 @@ const KoenigCardWrapperComponent = ({nodeKey, width, wrapperStyle, IndicatorIcon
     return (
         <CardContext.Provider value={{
             isSelected: isFocused,
+            captionHasFocus,
             isEditing,
             cardWidth,
             setCardWidth,
+            setCaptionHasFocus,
             setEditing,
             selection,
             cardContainerRef: containerRef

--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -311,6 +311,7 @@ const KoenigCardWrapperComponent = ({nodeKey, width, wrapperStyle, IndicatorIcon
             setCaptionHasFocus,
             setEditing,
             selection,
+            nodeKey,
             cardContainerRef: containerRef
         }}>
             <CardWrapper

--- a/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
@@ -16,7 +16,7 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, caption,
     const [editor] = useLexicalComposerContext();
     const [showLink, setShowLink] = React.useState(false);
     const {fileUploader} = React.useContext(KoenigComposerContext);
-    const {isSelected, cardWidth, setCardWidth} = React.useContext(CardContext);
+    const {isSelected, cardWidth, setCardWidth, setCaptionHasFocus, captionHasFocus} = React.useContext(CardContext);
     const fileInputRef = React.useRef();
     const toolbarFileInputRef = React.useRef();
 
@@ -130,13 +130,14 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, caption,
                 previewSrc={previewSrc}
                 setAltText={setAltText}
                 setCaption={setCaption}
+                setCaptionHasFocus={setCaptionHasFocus}
                 src={src}
                 onFileChange={onFileChange}
             />
 
             <ActionToolbar
                 data-kg-card-toolbar="image"
-                isVisible={showLink}
+                isVisible={showLink && !captionHasFocus}
             >
                 <LinkInput
                     cancel={cancelLinkAndReselect}
@@ -150,7 +151,7 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, caption,
 
             <ActionToolbar
                 data-kg-card-toolbar="image"
-                isVisible={src && isSelected && !showLink}
+                isVisible={src && isSelected && !showLink && !captionHasFocus}
             >
                 <ImageUploadForm
                     fileInputRef={toolbarFileInputRef}

--- a/packages/koenig-lexical/test/e2e/cards/image-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/image-card.test.js
@@ -154,7 +154,7 @@ describe('Image card', async () => {
         await expect(await page.locator('text="This is a caption"')).toBeVisible();
     });
 
-    test('can past html to caption', async function () {
+    test('can paste html to caption', async function () {
         const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.png');
 
         await focusEditor(page);
@@ -196,7 +196,6 @@ describe('Image card', async () => {
                             <button name="alt-toggle-button" type="button">Alt</button>
                         </figcaption>
                     </figure>
-                    <div data-kg-card-toolbar="image"></div>
                 </div>
             </div>
         `, {ignoreCardToolbarContents: true});


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2059

- adds new plugin for caption editor to control its behavior based on certain commands
- on focus/blur on caption editor, sets the caption focus state to update behavior of the card
- passes up the enter command so a next paragraph can be added
- updates image node to handle toolbar items based on caption selection