### PR TITLE
Reduced upload hook delay to 0

### DIFF
--- a/packages/koenig-lexical/demo/utils/useFileUpload.js
+++ b/packages/koenig-lexical/demo/utils/useFileUpload.js
@@ -80,7 +80,7 @@ export function useFileUpload(type = '') {
         let stepDelay = 200;
         // adjust when testing to speed up tests
         if (import.meta.env.VITE_TEST === 'true') {
-            stepDelay = 30;
+            stepDelay = 0;
         }
 
         setProgress(30);

--- a/packages/koenig-lexical/src/components/ui/cards/ImageCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/ImageCard.jsx
@@ -19,7 +19,7 @@ function PopulatedImageCard({src, alt, previewSrc, imageUploader}) {
                 className={`mx-auto block ${previewSrc ? 'opacity-40' : ''}`}
                 src={previewSrc ? previewSrc : src}
                 alt={alt ? alt : progressAlt}
-                data-testid="image-card-populated"
+                data-testid={imageUploader.isLoading ? 'image-card-loading' : 'image-card-populated'}
             />
             {imageUploader.isLoading ?
                 <div className="absolute inset-0 flex min-w-full items-center justify-center overflow-hidden bg-white/50" data-testid="upload-progress">

--- a/packages/koenig-lexical/test/e2e/cards/audio-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/audio-card.test.js
@@ -78,10 +78,6 @@ describe('Audio card', async () => {
         await focusEditor(page);
         await uploadAudio(page);
 
-        // Check that the progress bar is displayed
-        await page.waitForSelector('[data-testid="progress-bar"]');
-        expect(await page.getByTestId('progress-bar')).toBeVisible();
-
         // Check that audio file was uploaded
         await expect(await page.getByTestId('audio-caption')).toBeVisible();
         expect(await page.getByTestId('audio-caption').inputValue()).toEqual('Audio sample');
@@ -118,9 +114,6 @@ describe('Audio card', async () => {
         // Drop file
         await page.getByTestId('media-placeholder').dispatchEvent('drop', {dataTransfer});
 
-        // Check progress bar
-        await expect(await page.getByTestId('progress-bar')).toBeVisible();
-
         // Check that audio file was uploaded
         await expect(await page.getByTestId('media-duration')).toContainText('0:19');
     });
@@ -128,10 +121,6 @@ describe('Audio card', async () => {
     test('shows errors on failed audio upload', async function () {
         await focusEditor(page);
         await uploadAudio(page, 'audio-sample-fail.mp3');
-
-        // Check that the progress bar is displayed
-        await page.waitForSelector('[data-testid="progress-bar"]');
-        expect(await page.getByTestId('progress-bar')).toBeVisible();
 
         // Check that errors are displayed
         await page.waitForSelector('[data-testid="audio-upload-errors"]');
@@ -231,9 +220,6 @@ describe('Audio card', async () => {
 
         // Drop file
         await page.getByTestId('audio-card-populated').dispatchEvent('drop', {dataTransfer});
-
-        // Check progress bar
-        await expect(await page.getByTestId('progress-bar')).toBeVisible();
 
         // Check that audio file was uploaded
         await expect (await page.getByTestId('audio-thumbnail')).toBeVisible();

--- a/packages/koenig-lexical/test/e2e/cards/image-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/image-card.test.js
@@ -90,12 +90,6 @@ describe('Image card', async () => {
         ]);
         await fileChooser.setFiles([filePath]);
 
-        // Check progress bar
-        await expect(await page.getByTestId('upload-progress')).toBeVisible();
-
-        // wait for upload to complete
-        await expect(await page.getByTestId('upload-progress')).not.toBeVisible();
-
         await expect(await page.getByTestId('image-card-populated')).toBeVisible();
     });
 
@@ -113,9 +107,11 @@ describe('Image card', async () => {
         ]);
         await fileChooser.setFiles([filePath]);
 
+        // placeholder is replaced with uploading image
+        await expect(await page.getByTestId('image-card-populated')).toBeVisible();
+
         // wait for upload to complete
-        await page.waitForSelector('[data-testid="upload-progress"]');
-        await expect(await page.getByTestId('upload-progress')).not.toBeVisible();
+        await expect(await page.getByTestId('progress-bar')).toBeHidden();
 
         await page.click('button[name="alt-toggle-button"]');
 
@@ -147,9 +143,11 @@ describe('Image card', async () => {
         ]);
         await fileChooser.setFiles([filePath]);
 
+        // placeholder is replaced with uploading image
+        await expect(await page.getByTestId('image-card-populated')).toBeVisible();
+
         // wait for upload to complete
-        await page.waitForSelector('[data-testid="upload-progress"]');
-        await expect(await page.getByTestId('upload-progress')).not.toBeVisible();
+        await expect(await page.getByTestId('progress-bar')).toBeHidden();
 
         await page.click('[data-testid="image-caption-editor"]');
         await page.keyboard.type('This is a caption');
@@ -168,10 +166,7 @@ describe('Image card', async () => {
         ]);
         await fileChooser.setFiles([filePath]);
 
-        // wait for upload to complete
-        await page.waitForSelector('[data-testid="upload-progress"]');
-        await expect(await page.getByTestId('upload-progress')).toBeHidden();
-
+        await page.waitForSelector('[data-testid="image-caption-editor"]');
         await page.click('[data-testid="image-caption-editor"]');
         await pasteText(page, 'This is link <a href="https://ghost.org/changelog/markdown/">ghost.org/changelog/markdown/</a>', 'text/html');
 
@@ -220,10 +215,6 @@ describe('Image card', async () => {
         await fileChooser.setFiles([filePath]);
         await page.click('[data-kg-card="image"]');
 
-        // wait for upload to complete
-        await page.waitForSelector('[data-testid="upload-progress"]');
-        await expect(await page.getByTestId('upload-progress')).not.toBeVisible();
-
         expect(await page.$('[data-kg-card-toolbar="image"]')).not.toBeNull();
     });
 
@@ -239,10 +230,6 @@ describe('Image card', async () => {
         ]);
         await fileChooser.setFiles([filePath]);
         await page.click('[data-kg-card="image"]');
-
-        // wait for upload to complete
-        await page.waitForSelector('[data-testid="upload-progress"]');
-        await expect(await page.getByTestId('upload-progress')).not.toBeVisible();
 
         expect(await page.$('[data-kg-card-toolbar="image"] button[aria-label="Regular"]')).not.toBeNull();
     });
@@ -260,10 +247,6 @@ describe('Image card', async () => {
         await fileChooser.setFiles([filePath]);
         await page.click('[data-kg-card="image"]');
 
-        // wait for upload to complete
-        await page.waitForSelector('[data-testid="upload-progress"]');
-        await expect(await page.getByTestId('upload-progress')).not.toBeVisible();
-
         expect(await page.$('[data-kg-card-toolbar="image"] button[aria-label="Wide"]')).not.toBeNull();
     });
 
@@ -279,10 +262,6 @@ describe('Image card', async () => {
         ]);
         await fileChooser.setFiles([filePath]);
         await page.click('[data-kg-card="image"]');
-
-        // wait for upload to complete
-        await page.waitForSelector('[data-testid="upload-progress"]');
-        await expect(await page.getByTestId('upload-progress')).not.toBeVisible();
 
         expect(await page.$('[data-kg-card-toolbar="image"] button[aria-label="Full"]')).not.toBeNull();
     });
@@ -300,10 +279,6 @@ describe('Image card', async () => {
         await fileChooser.setFiles([filePath]);
         await page.click('[data-kg-card="image"]');
 
-        // wait for upload to complete
-        await page.waitForSelector('[data-testid="upload-progress"]');
-        await expect(await page.getByTestId('upload-progress')).not.toBeVisible();
-
         expect(await page.$('[data-kg-card-toolbar="image"] button[aria-label="Link"]')).not.toBeNull();
     });
 
@@ -319,10 +294,6 @@ describe('Image card', async () => {
         ]);
         await fileChooser.setFiles([filePath]);
         await page.click('[data-kg-card="image"]');
-
-        // wait for upload to complete
-        await page.waitForSelector('[data-testid="upload-progress"]');
-        await expect(await page.getByTestId('upload-progress')).not.toBeVisible();
 
         expect(await page.$('[data-kg-card-toolbar="image"] button[aria-label="Replace"]')).not.toBeNull();
     });
@@ -340,10 +311,6 @@ describe('Image card', async () => {
         await fileChooser.setFiles([filePath]);
         await page.click('[data-kg-card="image"]');
 
-        // wait for upload to complete
-        await page.waitForSelector('[data-testid="upload-progress"]');
-        await expect(await page.getByTestId('upload-progress')).not.toBeVisible();
-
         expect(await page.$('[data-kg-card-toolbar="image"] button[aria-label="Snippet"]')).not.toBeNull();
     });
 
@@ -360,10 +327,6 @@ describe('Image card', async () => {
         ]);
         await fileChooser.setFiles([filePath]);
 
-        // wait for upload to complete
-        await page.waitForSelector('[data-testid="upload-progress"]');
-        await expect(await page.getByTestId('upload-progress')).not.toBeVisible();
-
         await page.click('[data-kg-card="image"]');
 
         expect(await page.locator('[data-kg-card-toolbar="image"]')).not.toBeNull();
@@ -374,9 +337,11 @@ describe('Image card', async () => {
         ]);
         await replacefileChooser.setFiles([filePath2]);
 
+        // placeholder is replaced with uploading image
+        await expect(await page.getByTestId('image-card-populated')).toBeVisible();
+
         // wait for upload to complete
-        await page.waitForSelector('[data-testid="upload-progress"]');
-        await expect(await page.getByTestId('upload-progress')).not.toBeVisible();
+        await expect(await page.getByTestId('progress-bar')).toBeHidden();
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
@@ -418,9 +383,11 @@ describe('Image card', async () => {
         ]);
         await fileChooser.setFiles([filePath]);
 
+        // placeholder is replaced with uploading image
+        await expect(await page.getByTestId('image-card-populated')).toBeVisible();
+
         // wait for upload to complete
-        await page.waitForSelector('[data-testid="upload-progress"]');
-        await expect(await page.getByTestId('upload-progress')).not.toBeVisible();
+        await expect(await page.getByTestId('progress-bar')).toBeHidden();
 
         await page.click('[data-kg-card="image"]');
 
@@ -448,9 +415,11 @@ describe('Image card', async () => {
         ]);
         await fileChooser.setFiles([filePath]);
 
+        // placeholder is replaced with uploading image
+        await expect(await page.getByTestId('image-card-populated')).toBeVisible();
+
         // wait for upload to complete
-        await page.waitForSelector('[data-testid="upload-progress"]');
-        await expect(await page.getByTestId('upload-progress')).not.toBeVisible();
+        await expect(await page.getByTestId('progress-bar')).toBeHidden();
 
         await page.click('figure');
 
@@ -503,11 +472,11 @@ describe('Image card', async () => {
 
         await page.locator('[data-kg-card="image"] [data-testid="media-placeholder"]').dispatchEvent('drop', {dataTransfer});
 
-        // wait for upload to complete
-        await expect(await page.getByTestId('progress-bar')).toBeHidden();
-
         // placeholder is replaced with uploading image
         await expect(await page.getByTestId('image-card-populated')).toBeVisible();
+
+        // wait for upload to complete
+        await expect(await page.getByTestId('progress-bar')).toBeHidden();
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">

--- a/packages/koenig-lexical/test/e2e/cards/video-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/video-card.test.js
@@ -129,9 +129,6 @@ describe('Video card', async () => {
         const fileChooser = await fileChooserPromise;
         await fileChooser.setFiles([imagePath]);
 
-        // Progress bar should be visible
-        await expect(await page.getByTestId('custom-thumbnail-progress')).toBeVisible();
-
         // Thumbnail should be visible
         await expect(await page.getByTestId('custom-thumbnail-filled')).toBeVisible();
 
@@ -250,9 +247,6 @@ describe('Video card', async () => {
 
         // Drop file
         await page.getByTestId('thumbnail-media-placeholder').dispatchEvent('drop', {dataTransfer});
-
-        // Progress bar should be visible
-        await expect(await page.getByTestId('custom-thumbnail-progress')).toBeVisible();
 
         // Thumbnail should be visible
         await expect(await page.getByTestId('custom-thumbnail-filled')).toBeVisible();


### PR DESCRIPTION
refs TryGhost/Team#2556
- Removed all progress bar selectors from tests. The problem is that with a small delay for the upload hook, tests are unstable due to the fast pass in CI. Progress bar is not displaying, and tests are failing. They work fine with large delay, but in this case, tests took too much time to complete, and this is not what we want