### PR TITLE
Added `yarn test:headed` and `yarn test:slowmo`

### DIFF
--- a/packages/koenig-lexical/README.md
+++ b/packages/koenig-lexical/README.md
@@ -53,6 +53,8 @@ All imported files are processed/optimised via SVGO (see `svgo.config.js` for op
 Tests use [Vitest](https://vitest.dev) as the test runner, with [Puppeteer](https://pptr.dev) used for e2e testing.
 
 - `yarn test run` runs tests and exits
+- `yarn test:headed` runs tests in browser so you can watch the tests execute
+- `yarn test:slowmo` same as `yarn test:headed` but adds 100ms delay between instructions to make it easier to see what's happening (note that some tests may fail or timeout due to the added delays)
 - `yarn test:watch` runs tests and starts a test watcher that re-runs tests on file changes
 - `yarn test:watch --ui` same as `yarn test:watch` but also opens a browser UI for exploring and re-running tests
 

--- a/packages/koenig-lexical/package.json
+++ b/packages/koenig-lexical/package.json
@@ -25,6 +25,8 @@
     "preview": "vite preview",
     "pretest": "VITE_TEST=true yarn build --config vite.config.demo.js",
     "test": "vitest run",
+    "test:headed": "PLAYWRIGHT_HEADLESS=false vitest run",
+    "test:slowmo": "PLAYWRIGHT_SLOWMO=100 PLAYWRIGHT_HEADLESS=false vitest run",
     "pretest:watch": "yarn pretest",
     "test:watch": "vitest",
     "posttest": "yarn lint",

--- a/packages/koenig-lexical/test/utils/e2e.js
+++ b/packages/koenig-lexical/test/utils/e2e.js
@@ -9,7 +9,12 @@ const {JSDOM} = jsdom;
 const BROWSER_NAME = process.env.browser || 'chromium';
 
 export async function startApp(browserName = BROWSER_NAME) {
-    const browser = await {chromium, webkit, firefox}[browserName].launch();
+    const headless = process.env.PLAYWRIGHT_HEADLESS === 'false' ? false : true;
+    const slowMo = parseInt(process.env.PLAYWRIGHT_SLOWMO) || 0;
+    const browser = await {chromium, webkit, firefox}[browserName].launch({
+        headless: headless,
+        slowMo: slowMo
+    });
     const page = await browser.newPage();
 
     return {


### PR DESCRIPTION
- Set environment variable PLAYWRIGHT_HEADLESS=false to run tests in headed mode so you can watch tests execute in your browser
- Set environment variable PLAYWRIGHT_SLOWMO={milliseconds} (eg PLAYWRIGHT_SLOWMO=500) to slow down tests so you can watch them execute in your browser more easily
- `yarn test` still defaults to headless mode with slowmo disabled
- Added `yarn test:headed` and `yarn test:slowmo` scripts to `package.json` for convenience
- Added new commands to testing section of README