### PR TITLE
Added tests covering the DragDropReorderPlugin

### DIFF
--- a/packages/koenig-lexical/test/e2e/plugins/DragDropReorderPlugin.test.js
+++ b/packages/koenig-lexical/test/e2e/plugins/DragDropReorderPlugin.test.js
@@ -1,0 +1,219 @@
+import {afterAll, beforeAll, beforeEach, describe, test} from 'vitest';
+import {startApp, initialize, focusEditor, dragMouse, html, assertHTML} from '../../utils/e2e';
+import {expect} from '@playwright/test';
+import path from 'path';
+
+describe('Drag Drop Reorder Plugin', async function () {
+    let app;
+    let page;
+
+    beforeAll(async function () {
+        ({app, page} = await startApp());
+    });
+
+    afterAll(async function () {
+        await app.stop();
+    });
+
+    beforeEach(async function () {
+        await initialize({page});
+    });
+
+    test('can drag and drop a card between two other nodes', async function () {
+        const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.png');
+
+        await focusEditor(page);
+
+        const [fileChooser] = await Promise.all([
+            page.waitForEvent('filechooser'),
+            await page.keyboard.type('/image'),
+            await page.keyboard.press('Enter')
+        ]);
+        await fileChooser.setFiles([filePath]);
+
+        await page.keyboard.press('ArrowDown');
+
+        await page.keyboard.type('/divider');
+        await page.keyboard.press('Enter');
+
+        await page.keyboard.type('This is some text');
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="image"></div>
+            </div>
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="horizontalrule"></div>
+            </div>
+            <p dir="ltr"><span data-lexical-text="true">This is some text</span></p>        
+        `, {ignoreCardContents: true});
+
+        const imageBBox = await page.locator('[data-kg-card="image"]').boundingBox();
+        const paragraphBBox = await page.locator('p').boundingBox();
+
+        await dragMouse(page, imageBBox, paragraphBBox, 'start', 'start', true, 100, 100);
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="horizontalrule"></div>
+            </div>
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="image"></div>
+            </div>
+            <p dir="ltr"><span data-lexical-text="true">This is some text</span></p>        
+        `, {ignoreCardContents: true});
+    });
+
+    test('can drag and drop a card at the top of the editor', async function () {
+        const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.png');
+
+        await focusEditor(page);
+
+        await page.keyboard.type('/divider');
+        await page.keyboard.press('Enter');
+
+        await page.keyboard.type('This is some text');
+        await page.keyboard.press('Enter');
+
+        const [fileChooser] = await Promise.all([
+            page.waitForEvent('filechooser'),
+            await page.keyboard.type('/image'),
+            await page.keyboard.press('Enter')
+        ]);
+        await fileChooser.setFiles([filePath]);
+
+        await page.keyboard.press('ArrowDown');
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="horizontalrule"></div>
+            </div>
+            <p dir="ltr"><span data-lexical-text="true">This is some text</span></p>    
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="image"></div>
+            </div>
+            <p><br /></p>
+        `, {ignoreCardContents: true});
+
+        const imageBBox = await page.locator('[data-kg-card="image"]').boundingBox();
+        const dividerBBox = await page.locator('hr').boundingBox();
+
+        await dragMouse(page, imageBBox, dividerBBox, 'start', 'start', true, 100, 100);
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="image"></div>
+            </div>
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="horizontalrule"></div>
+            </div>
+            <p dir="ltr"><span data-lexical-text="true">This is some text</span></p>       
+            <p><br /></p> 
+        `, {ignoreCardContents: true});
+    });
+
+    test('can drag and drop a card at the bottom of the editor', async function () {
+        const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.png');
+
+        await focusEditor(page);
+
+        const [fileChooser] = await Promise.all([
+            page.waitForEvent('filechooser'),
+            await page.keyboard.type('/image'),
+            await page.keyboard.press('Enter')
+        ]);
+        await fileChooser.setFiles([filePath]);
+
+        await page.keyboard.press('ArrowDown');
+
+        await page.keyboard.type('/divider');
+        await page.keyboard.press('Enter');
+
+        await page.keyboard.type('This is some text');
+        
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="image"></div>
+            </div>
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="horizontalrule"></div>
+            </div>
+            <p dir="ltr"><span data-lexical-text="true">This is some text</span></p>    
+        `, {ignoreCardContents: true});
+
+        const imageBBox = await page.locator('[data-kg-card="image"]').boundingBox();
+        const paragraphBBox = await page.locator('p').boundingBox();
+        const toBBox = {
+            x: paragraphBBox.x,
+            y: paragraphBBox.y + paragraphBBox.height + 45,
+            width: paragraphBBox.width,
+            height: paragraphBBox.height
+        };
+
+        await dragMouse(page, imageBBox, toBBox, 'start', 'start', true, 100, 100);
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="horizontalrule"></div>
+            </div>
+            <p dir="ltr"><span data-lexical-text="true">This is some text</span></p>       
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="image"></div>
+            </div>
+        `, {ignoreCardContents: true});
+    });
+
+    test('can display placeholder element while hovering between nodes', async function () {
+        const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.png');
+
+        await focusEditor(page);
+
+        const [fileChooser] = await Promise.all([
+            page.waitForEvent('filechooser'),
+            await page.keyboard.type('/image'),
+            await page.keyboard.press('Enter')
+        ]);
+        await fileChooser.setFiles([filePath]);
+
+        await page.keyboard.press('ArrowDown');
+
+        await page.keyboard.type('/divider');
+        await page.keyboard.press('Enter');
+
+        await page.keyboard.type('This is some text');
+        
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="image"></div>
+            </div>
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="horizontalrule"></div>
+            </div>
+            <p dir="ltr"><span data-lexical-text="true">This is some text</span></p>    
+        `, {ignoreCardContents: true});
+
+        const imageBBox = await page.locator('[data-kg-card="image"]').boundingBox();
+        const paragraphBBox = await page.locator('p').boundingBox();
+        const toBBox = {
+            x: paragraphBBox.x,
+            y: paragraphBBox.y + paragraphBBox.height + 45,
+            width: paragraphBBox.width,
+            height: paragraphBBox.height
+        };
+
+        await dragMouse(page, imageBBox, toBBox, 'start', 'start', false, 100, 100);
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="image"></div>
+            </div>
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-selected="false" data-kg-card-editing="false" data-kg-card="horizontalrule"></div>
+            </div>
+            <p dir="ltr"><span data-lexical-text="true">This is some text</span></p>       
+        `, {ignoreCardContents: true});
+
+        const indicator = await page.locator('#koenig-drag-drop-indicator');
+        await expect(await indicator).toBeVisible();
+    });
+});

--- a/packages/koenig-lexical/test/utils/e2e.js
+++ b/packages/koenig-lexical/test/utils/e2e.js
@@ -150,7 +150,10 @@ export function prettifyHTML(string, options = {}) {
 export function prettifyJSON(string) {
     let output = string;
 
+    // replace urls inside markdown links
     output = output.replace(/\(blob:http[^"]*\)/g, '(blob:...)');
+    // replace any other urls
+    output = output.replace(/blob:http[^"]*/g, 'blob:...');
 
     return prettier.format(output, {
         parser: 'json'
@@ -280,6 +283,8 @@ export async function dragMouse(
     positionStart = 'middle',
     positionEnd = 'middle',
     mouseUp = true,
+    hover = 0,
+    steps = 1
 ) {
     let fromX = fromBoundingBox.x;
     let fromY = fromBoundingBox.y;
@@ -303,7 +308,11 @@ export async function dragMouse(
         toY += toBoundingBox.height;
     }
 
-    await page.mouse.move(toX, toY);
+    await page.mouse.move(toX, toY, {steps: steps});
+
+    if (hover > 0) {
+        await page.waitForTimeout(hover);
+    }
 
     if (mouseUp) {
         await page.mouse.up();


### PR DESCRIPTION
refs TryGhost/Team#2555

- Added tests for dragging already existing cards around the editor to reorder them