### PR TITLE
Fixed missing color picker classes

### DIFF
--- a/packages/koenig-lexical/src/components/ui/ColorPicker.jsx
+++ b/packages/koenig-lexical/src/components/ui/ColorPicker.jsx
@@ -4,10 +4,10 @@ export function ColorPicker({buttons = [], selectedName, onClick}) {
     return (
         <div className="flex">
             <ul className="flex w-full items-center justify-between rounded font-sans text-md font-normal text-white">
-                {buttons.map(({label, name, color}) => (
+                {buttons.map(({label, name, colorClass}) => (
                     <ColorButton
                         key={`${name}-${label}`}
-                        color={color}
+                        colorClass={colorClass}
                         label={label}
                         name={name}
                         selectedName={selectedName}
@@ -19,7 +19,7 @@ export function ColorPicker({buttons = [], selectedName, onClick}) {
     );
 }
 
-export function ColorButton({onClick, label, name, color, selectedName}) {
+export function ColorButton({onClick, label, name, colorClass, selectedName}) {
     const isActive = name === selectedName;
     return (
         <li>
@@ -30,7 +30,7 @@ export function ColorButton({onClick, label, name, color, selectedName}) {
                 onClick={() => onClick(name)}
             >
                 <span
-                    className={`bg-${color} h-6 w-6 rounded-full border-2 border-black/5`}
+                    className={`${colorClass} h-6 w-6 rounded-full border-2 border-black/5`}
                 ></span>
             </button>
         </li>

--- a/packages/koenig-lexical/src/components/ui/ColorPicker.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/ColorPicker.stories.jsx
@@ -30,31 +30,38 @@ Default.args = {
     buttons: [
         {
             label: 'Grey',
-            color: 'grey'
+            name: 'grey',
+            colorClass: 'bg-grey'
         },
         {
             label: 'Blue',
-            color: 'blue'
+            name: 'blue',
+            colorClass: 'bg-blue'
         },
         {
             label: 'Green',
-            color: 'green'
+            name: 'green',
+            colorClass: 'bg-green'
         },
         {
             label: 'Yellow',
-            color: 'yellow'
+            name: 'yellow',
+            colorClass: 'bg-yellow'
         },
         {
             label: 'Red',
-            color: 'red'
+            name: 'red',
+            colorClass: 'bg-red'
         },
         {
             label: 'Pink',
-            color: 'pink'
+            name: 'pink',
+            colorClass: 'bg-pink'
         },
         {
             label: 'Purple',
-            color: 'purple'
+            name: 'purple',
+            colorClass: 'bg-purple'
         }
     ]
 };

--- a/packages/koenig-lexical/src/components/ui/SettingsPanel.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/SettingsPanel.stories.jsx
@@ -106,39 +106,48 @@ ButtonCard.args = {
 const calloutColorPicker = [
     {
         label: 'Grey',
-        color: 'grey-100'
+        name: 'grey',
+        colorClass: 'bg-grey-100'
     },
     {
         label: 'White',
-        color: 'white'
+        name: 'white',
+        colorClass: 'bg-white'
     },
     {
         label: 'Blue',
-        color: 'blue-100'
+        name: 'blue',
+        colorClass: 'bg-blue-100'
     },
     {
         label: 'Green',
-        color: 'green-100'
+        name: 'green',
+        colorClass: 'bg-green-100'
     },
     {
         label: 'Yellow',
-        color: 'yellow-100'
+        name: 'yellow',
+        colorClass: 'bg-yellow-100'
     },
     {
         label: 'Red',
-        color: 'red-100'
+        name: 'red',
+        colorClass: 'bg-red-100'
     },
     {
         label: 'Pink',
-        color: 'pink-100'
+        name: 'pink',
+        colorClass: 'bg-pink-100'
     },
     {
         label: 'Purple',
-        color: 'purple-100'
+        name: 'purple',
+        colorClass: 'bg-purple-100'
     },
     {
         label: 'Accent',
-        color: 'pink'
+        name: 'accent',
+        colorClass: 'bg-pink'
     }
 ];
 

--- a/packages/koenig-lexical/src/components/ui/cards/CalloutCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CalloutCard.jsx
@@ -18,47 +18,47 @@ export function CalloutCard({color, emoji, value, placeholder, isEditing}) {
         {
             label: 'Grey',
             name: 'grey',
-            color: 'grey-100'
+            colorClass: 'bg-grey-100'
         },
         {
             label: 'White',
             name: 'white',
-            color: 'white'
+            colorClass: 'bg-white'
         },
         {
             label: 'Blue',
             name: 'blue',
-            color: 'blue-100'
+            colorClass: 'bg-blue-100'
         },
         {
             label: 'Green',
             name: 'green',
-            color: 'green-100'
+            colorClass: 'bg-green-100'
         },
         {
             label: 'Yellow',
             name: 'yellow',
-            color: 'yellow-100'
+            colorClass: 'bg-yellow-100'
         },
         {
             label: 'Red',
             name: 'red',
-            color: 'red-100'
+            colorClass: 'bg-red-100'
         },
         {
             label: 'Pink',
             name: 'pink',
-            color: 'pink-100'
+            colorClass: 'bg-pink-100'
         },
         {
             label: 'Purple',
             name: 'purple',
-            color: 'purple-100'
+            colorClass: 'bg-purple-100'
         },
         {
             label: 'Accent',
             name: 'accent',
-            color: 'pink'
+            colorClass: 'bg-pink'
         }
     ];
 


### PR DESCRIPTION
no issue

- with Tailwind any classes need to exist as complete strings for them to be included in the build
- the `ColorButton` component was using a `color` prop to build a dynamic string like `bg-${color}` which meant classes weren't matchable and therefore not included in the build
- changed the prop to `colorClass` and updated all uses so that a full class name is passed through and can be picked up by Tailwind
