### PR TITLE
Fixed callout editor selection

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigCalloutEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCalloutEditor.jsx
@@ -2,7 +2,7 @@
 
 import CardContext from '../context/CardContext.jsx';
 import React, {useCallback, useContext} from 'react';
-import {$createParagraphNode, $getNodeByKey, $setSelection, COMMAND_PRIORITY_LOW, FOCUS_COMMAND, KEY_ENTER_COMMAND} from 'lexical';
+import {$createParagraphNode, $getNodeByKey, COMMAND_PRIORITY_LOW, KEY_ENTER_COMMAND} from 'lexical';
 import {HtmlOutputPlugin, KoenigComposableEditor, KoenigComposer, MINIMAL_NODES, MINIMAL_TRANSFORMERS, RestrictContentPlugin} from '../index.js';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
@@ -21,13 +21,13 @@ function CalloutEditorPlugin({parentEditor}) {
 
     // focus on caption editor when something is typed while card is selected
     const handleKeyDown = useCallback((event) => {
-        // don't focus caption input if any other input or textarea is focused
+    // don't focus caption input if any other input or textarea is focused
         if (event.target.matches('input, textarea')) {
             return;
         }
-    
-        // only if key is printable key, focus on editor
-        if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+
+        // only trigger on Enter key
+        if (event.key === 'Enter') {
             editor.focus();
         }
     }, [editor]);
@@ -37,24 +37,11 @@ function CalloutEditorPlugin({parentEditor}) {
         return () => {
             document.removeEventListener('keydown', handleKeyDown);
         };
-    }, [handleKeyDown, editor]);
+    }, [handleKeyDown, editor, nodeKey]);
 
     React.useEffect(
         () => {
             return mergeRegister(
-                editor.registerCommand(
-                    FOCUS_COMMAND,
-                    () => {
-                        // focus on the parent node key
-                        parentEditor.update(() => {
-                            const cardNode = $getNodeByKey(nodeKey);
-                            $setSelection(cardNode);
-                        });
-
-                        return false;
-                    },
-                    COMMAND_PRIORITY_LOW
-                ),
                 editor.registerCommand(
                     KEY_ENTER_COMMAND,
                     (event) => {

--- a/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
+++ b/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
@@ -87,7 +87,7 @@ export function ButtonGroupSetting({label, onClick, selectedName, buttons}) {
 
 export function ColorPickerSetting({label, onClick, selectedName, buttons, layout, dataTestID}) {
     return (
-        <div className={`mt-2 flex w-full text-[1.3rem] first:mt-0 ${layout === 'stacked' ? 'flex-col' : 'items-center justify-between'}`} data-testID={dataTestID}>
+        <div className={`mt-2 flex w-full text-[1.3rem] first:mt-0 ${layout === 'stacked' ? 'flex-col' : 'items-center justify-between'}`} data-testid={dataTestID}>
             <div className="font-bold text-grey-900">{label}</div>
 
             <div className={`shrink-0 ${layout === 'stacked' ? '-mx-1 pt-1' : 'pl-2'}`}>


### PR DESCRIPTION
no issue

- there was a bug (currently similar experience with the photo / video captions) where editor doesn't stay focussed and updates the wrong node when there's multiple cards loaded with inner ComposableEditors