### PR TITLE
Fixed "open in edit mode" cards not working in multiplayer

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/callout/CalloutNode.js
+++ b/packages/kg-default-nodes/lib/nodes/callout/CalloutNode.js
@@ -130,6 +130,10 @@ export class CalloutNode extends KoenigDecoratorNode {
     decorate() {
         return '';
     }
+
+    hasEditMode() {
+        return true;
+    }
 }
 
 export function $isCalloutNode(node) {

--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -1,59 +1,23 @@
 import CardContext from '../context/CardContext';
+import KoenigComposerContext from '../context/KoenigComposerContext';
 import React from 'react';
-import {
-    $createNodeSelection,
-    $createParagraphNode,
-    $getNodeByKey,
-    $getRoot,
-    $getSelection,
-    $isDecoratorNode,
-    $isNodeSelection,
-    $setSelection,
-    CLICK_COMMAND,
-    COMMAND_PRIORITY_EDITOR,
-    COMMAND_PRIORITY_LOW,
-    KEY_ARROW_DOWN_COMMAND,
-    KEY_BACKSPACE_COMMAND,
-    KEY_DELETE_COMMAND,
-    KEY_ENTER_COMMAND,
-    KEY_ESCAPE_COMMAND
-} from 'lexical';
-import {$selectDecoratorNode} from '../utils/$selectDecoratorNode';
+import {$getNodeByKey, CLICK_COMMAND, COMMAND_PRIORITY_LOW} from 'lexical';
 import {CardWrapper} from './ui/CardWrapper';
+import {EDIT_CARD_COMMAND, SELECT_CARD_COMMAND} from '../plugins/KoenigBehaviourPlugin';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-import {useLexicalNodeSelection} from '@lexical/react/useLexicalNodeSelection';
 
 const KoenigCardWrapperComponent = ({nodeKey, width, wrapperStyle, IndicatorIcon, openInEditMode = false, children}) => {
     const [editor] = useLexicalComposerContext();
-    const [isSelected, setSelected, clearSelected] = useLexicalNodeSelection(nodeKey);
-    const [isEditing, setEditing] = React.useState(openInEditMode);
-    const [selection, setSelection] = React.useState(null);
     const [cardType, setCardType] = React.useState(null);
     const [captionHasFocus, setCaptionHasFocus] = React.useState(null);
     const [cardWidth, setCardWidth] = React.useState(width || 'regular');
     const containerRef = React.useRef(null);
 
-    const $removeOrReplaceNodeWithParagraph = React.useCallback((node) => {
-        if ($getRoot().getLastChild().is(node)) {
-            const paragraph = $createParagraphNode();
-            $getRoot().append(paragraph);
-            paragraph.select();
-        } else {
-            const nextNode = node.getNextSibling();
-            if ($isDecoratorNode(nextNode)) {
-                $selectDecoratorNode(nextNode);
-                // selecting a decorator node does not change the
-                // window selection (there's no caret) so we need
-                // to manually move focus to the editor element
-                editor.getRootElement().focus();
-            } else {
-                nextNode.selectStart();
-            }
-        }
+    const {selectedCardKey, isEditingCard} = React.useContext(KoenigComposerContext);
 
-        node.remove();
-    }, [editor]);
+    const isSelected = selectedCardKey === nodeKey;
+    const isEditing = isSelected && isEditingCard;
 
     React.useLayoutEffect(() => {
         editor.getEditorState().read(() => {
@@ -66,251 +30,47 @@ const KoenigCardWrapperComponent = ({nodeKey, width, wrapperStyle, IndicatorIcon
     }, []);
 
     React.useEffect(() => {
-        function select() {
-            setSelected(true);
-        }
-
         return mergeRegister(
-            editor.registerUpdateListener(({editorState}) => {
-                const latestSelection = editorState.read(() => $getSelection());
-                setSelection(latestSelection);
-
-                const cardIsSelected = editorState.read(() => {
-                    return $isNodeSelection(latestSelection) &&
-                        latestSelection.getNodes().length === 1 &&
-                        latestSelection.getNodes()[0].getKey() === nodeKey;
-                });
-
-                // ensure edit mode is removed any time the card loses selection
-                if (isEditing && !cardIsSelected) {
-                    setEditing(false);
-
-                    editor.update(() => {
-                        const cardNode = $getNodeByKey(nodeKey);
-
-                        if (cardNode.isEmpty?.()) {
-                            $removeOrReplaceNodeWithParagraph(cardNode);
-                        }
-                    });
-                }
-            }),
+            // we register a click command at the editor level rather than the React level
+            // so that we can prevent the editor's default click behaviour without also
+            // preventing the click behaviour of other React components inside the card
             editor.registerCommand(
                 CLICK_COMMAND,
                 (event) => {
                     if (containerRef.current.contains(event.target)) {
-                        const cardNode = $getNodeByKey(nodeKey);
-                        if (cardNode.hasEditMode?.() && isSelected) {
-                            setEditing(true);
-                            clearSelected();
-                            select();
-                        } else {
-                            clearSelected();
-                            select();
+                        if (isSelected && !isEditing) {
+                            editor.dispatchCommand(EDIT_CARD_COMMAND, {cardKey: nodeKey});
+                        } else if (!isSelected) {
+                            editor.dispatchCommand(SELECT_CARD_COMMAND, {cardKey: nodeKey});
                         }
+
+                        return true;
                     }
+
                     return false;
                 },
                 COMMAND_PRIORITY_LOW
-            ),
-            editor.registerCommand(
-                KEY_ENTER_COMMAND,
-                (event) => {
-                    const latestSelection = $getSelection();
-
-                    if (event.metaKey || event.ctrlKey) {
-                        if (isSelected) {
-                            event.preventDefault();
-
-                            const cardNode = $getNodeByKey(nodeKey);
-
-                            if (cardNode.hasEditMode?.()) {
-                                setEditing(!isEditing);
-
-                                // when leaving edit mode, ensure focus moves back to the editor
-                                // otherwise focus can be left on removed elements preventing further key events
-                                if (isEditing) {
-                                    editor.getRootElement().focus({preventScroll: true});
-
-                                    if (cardNode.isEmpty?.()) {
-                                        if ($getRoot().getLastChild().is(cardNode)) {
-                                            const paragraph = $createParagraphNode();
-                                            $getRoot().append(paragraph);
-                                            paragraph.select();
-                                        } else {
-                                            // select the next paragraph or card
-                                            editor.dispatchCommand(KEY_ARROW_DOWN_COMMAND);
-                                        }
-
-                                        cardNode.remove();
-                                    } else {
-                                        // re-create the node selection because the focus will place the cursor at
-                                        // the beginning of the doc
-                                        const nodeSelection = $createNodeSelection();
-                                        nodeSelection.add(nodeKey);
-                                        $setSelection(nodeSelection);
-                                    }
-                                }
-                            }
-
-                            return true;
-                        }
-                    } else {
-                        // avoid processing card behaviours when an inner element has focus
-                        if (document.activeElement !== editor.getRootElement()) {
-                            return true;
-                        }
-                        if (isSelected && $isNodeSelection(latestSelection) && latestSelection.getNodes().length === 1) {
-                            event.preventDefault();
-                            const cardNode = $getNodeByKey(nodeKey);
-                            const paragraphNode = $createParagraphNode();
-                            cardNode.getTopLevelElementOrThrow().insertAfter(paragraphNode);
-                            paragraphNode.select();
-                            return true;
-                        }
-                    }
-
-                    return false;
-                },
-                COMMAND_PRIORITY_EDITOR
-            ),
-            editor.registerCommand(
-                KEY_BACKSPACE_COMMAND,
-                (event) => {
-                    // avoid processing card behaviours when an inner element has focus
-                    if (document.activeElement !== editor.getRootElement()) {
-                        return true;
-                    }
-
-                    const latestSelection = $getSelection();
-                    if (isSelected && $isNodeSelection(latestSelection) && latestSelection.getNodes().length === 1) {
-                        event.preventDefault();
-
-                        const cardNode = $getNodeByKey(nodeKey);
-                        const previousSibling = cardNode.getPreviousSibling();
-                        const nextSibling = cardNode.getNextSibling();
-
-                        if (previousSibling) {
-                            if (previousSibling.selectEnd) {
-                                previousSibling.selectEnd();
-                            } else if ($isDecoratorNode(previousSibling)) {
-                                const nodeSelection = $createNodeSelection();
-                                nodeSelection.add(previousSibling.getKey());
-                                $setSelection(nodeSelection);
-                            } else {
-                                cardNode.selectPrevious();
-                            }
-                        } else if (nextSibling) {
-                            if (nextSibling.selectStart) {
-                                nextSibling.selectStart();
-                            } else if ($isDecoratorNode(nextSibling)) {
-                                const nodeSelection = $createNodeSelection();
-                                nodeSelection.add(nextSibling.getKey());
-                                $setSelection(nodeSelection);
-                            } else {
-                                cardNode.selectNext();
-                            }
-                        } else {
-                            // ensure we still have a paragraph if the deleted card was the only node
-                            const paragraph = $createParagraphNode();
-                            $getRoot().append(paragraph);
-                            paragraph.select();
-                        }
-
-                        cardNode.remove();
-
-                        return true;
-                    }
-                    return false;
-                },
-                COMMAND_PRIORITY_EDITOR
-            ),
-            editor.registerCommand(
-                KEY_DELETE_COMMAND,
-                (event) => {
-                    // avoid processing card behaviours when an inner element has focus
-                    if (document.activeElement !== editor.getRootElement()) {
-                        return true;
-                    }
-
-                    const latestSelection = $getSelection();
-                    if (isSelected && $isNodeSelection(latestSelection) && latestSelection.getNodes().length === 1) {
-                        event.preventDefault();
-
-                        const cardNode = $getNodeByKey(nodeKey);
-                        const nextSibling = cardNode.getNextSibling();
-
-                        if (nextSibling) {
-                            if (nextSibling.selectStart) {
-                                nextSibling.selectStart();
-                            } else if ($isDecoratorNode(nextSibling)) {
-                                const nodeSelection = $createNodeSelection();
-                                nodeSelection.add(nextSibling.getKey());
-                                $setSelection(nodeSelection);
-                            } else {
-                                cardNode.selectNext();
-                            }
-                        } else {
-                            const paragraphNode = $createParagraphNode();
-                            cardNode.getTopLevelElementOrThrow().insertAfter(paragraphNode);
-                            paragraphNode.select();
-                        }
-
-                        cardNode.remove();
-
-                        return true;
-                    }
-                    return false;
-                },
-                COMMAND_PRIORITY_EDITOR
-            ),
-            editor.registerCommand(
-                KEY_ESCAPE_COMMAND,
-                (event) => {
-                    event.preventDefault();
-
-                    const cardNode = $getNodeByKey(nodeKey);
-
-                    if (cardNode.hasEditMode?.() && isEditing) {
-                        if (cardNode.isEmpty?.()) {
-                            $removeOrReplaceNodeWithParagraph(cardNode);
-                        } else {
-                            setEditing(false);
-                            editor.update(() => {
-                                $selectDecoratorNode(cardNode);
-                            });
-                            editor.getRootElement().focus({preventScroll: true});
-                        }
-                    }
-                    return false;
-                },
-                COMMAND_PRIORITY_EDITOR
             )
         );
-    }, [editor, isSelected, isEditing, setSelected, clearSelected, setEditing, nodeKey, $removeOrReplaceNodeWithParagraph]);
+    });
 
-    React.useEffect(() => {
-        if (openInEditMode) {
-            editor.update(() => {
-                $getNodeByKey(nodeKey).clearOpenInEditMode();
-            });
+    const setEditing = (shouldEdit) => {
+        if (shouldEdit) {
+            editor.dispatchCommand(EDIT_CARD_COMMAND, {cardKey: nodeKey});
+        } else if (!isSelected) {
+            editor.dispatchCommand(SELECT_CARD_COMMAND, {cardKey: nodeKey});
         }
-    }, [editor, nodeKey, openInEditMode]);
-
-    // isSelected will be true when the selection is a range covering a card
-    // but for our purposes we want to know if the card is the only thing selected
-    // for showing selected state, toolbars etc
-    const isFocused = $isNodeSelection(selection) && isSelected;
+    };
 
     return (
         <CardContext.Provider value={{
-            isSelected: isFocused,
+            isSelected,
             captionHasFocus,
             isEditing,
             cardWidth,
             setCardWidth,
             setCaptionHasFocus,
             setEditing,
-            selection,
             nodeKey,
             cardContainerRef: containerRef
         }}>
@@ -320,7 +80,7 @@ const KoenigCardWrapperComponent = ({nodeKey, width, wrapperStyle, IndicatorIcon
                 cardWidth={cardWidth}
                 IndicatorIcon={IndicatorIcon}
                 isEditing={isEditing}
-                isSelected={isFocused}
+                isSelected={isSelected}
                 wrapperStyle={wrapperStyle}
             >
                 {children}

--- a/packages/koenig-lexical/src/components/KoenigComposer.jsx
+++ b/packages/koenig-lexical/src/components/KoenigComposer.jsx
@@ -25,6 +25,9 @@ const KoenigComposer = ({
     darkMode = false,
     children
 }) => {
+    const [selectedCardKey, setSelectedCardKey] = React.useState(null);
+    const [isEditingCard, setIsEditingCard] = React.useState(false);
+
     const initialConfig = React.useMemo(() => {
         return Object.assign({}, defaultConfig, {
             nodes,
@@ -44,7 +47,16 @@ const KoenigComposer = ({
 
     return (
         <LexicalComposer initialConfig={initialConfig}>
-            <KoenigComposerContext.Provider value={{fileUploader, editorContainerRef, cardConfig, darkMode}}>
+            <KoenigComposerContext.Provider value={{
+                fileUploader,
+                editorContainerRef,
+                cardConfig,
+                darkMode,
+                selectedCardKey,
+                setSelectedCardKey,
+                isEditingCard,
+                setIsEditingCard
+            }}>
                 {children}
             </KoenigComposerContext.Provider>
         </LexicalComposer>

--- a/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export const CardWrapper = React.forwardRef(({isSelected, isEditing, cardWidth, cardType, wrapperStyle, IndicatorIcon, children, ...props}, ref) => {
+export const CardWrapper = React.forwardRef(({isSelected, isEditing, cardWidth, cardType, wrapperStyle, IndicatorIcon, onClick, children, ...props}, ref) => {
     return (
         <>
             {IndicatorIcon &&

--- a/packages/koenig-lexical/src/nodes/CalloutNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CalloutNode.jsx
@@ -72,7 +72,6 @@ function CalloutNodeComponent({nodeKey, text, hasEmoji, backgroundColor, emojiVa
                 handleColorChange={handleColorChange}
                 isEditing={isEditing}
                 nodeKey={nodeKey}
-                setEditing={setEditing}
                 setShowEmojiPicker={setShowEmojiPicker}
                 setText={setText}
                 showEmojiPicker={showEmojiPicker}

--- a/packages/koenig-lexical/src/nodes/CodeBlockNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CodeBlockNode.jsx
@@ -63,7 +63,7 @@ export class CodeBlockNode extends BaseCodeBlockNode {
 
     decorate() {
         return (
-            <KoenigCardWrapper nodeKey={this.getKey()} openInEditMode={this.__openInEditMode} width={this.__cardWidth} wrapperStyle="code-card">
+            <KoenigCardWrapper nodeKey={this.getKey()} width={this.__cardWidth} wrapperStyle="code-card">
                 <CodeBlockNodeComponent
                     caption={this.__caption}
                     code={this.__code}

--- a/packages/koenig-lexical/src/nodes/HtmlNode.jsx
+++ b/packages/koenig-lexical/src/nodes/HtmlNode.jsx
@@ -49,23 +49,8 @@ export class HtmlNode extends BaseHtmlNode {
         return 'html';
     }
 
-    // transient properties used to control node behaviour
-    __openInEditMode = false;
-
-    constructor(dataset = {}, key) {
-        super(dataset, key);
-
-        const {_openInEditMode} = dataset;
-        this.__openInEditMode = _openInEditMode || false;
-    }
-
     getIcon() {
         return HtmlCardIcon;
-    }
-
-    clearOpenInEditMode() {
-        const self = this.getWritable();
-        self.__openInEditMode = false;
     }
 
     decorate() {
@@ -73,7 +58,6 @@ export class HtmlNode extends BaseHtmlNode {
             <KoenigCardWrapper
                 IndicatorIcon={HtmlIndicatorIcon}
                 nodeKey={this.getKey()}
-                openInEditMode={this.__openInEditMode}
                 width={this.__cardWidth}
                 wrapperStyle="wide"
             >

--- a/packages/koenig-lexical/src/nodes/MarkdownNode.jsx
+++ b/packages/koenig-lexical/src/nodes/MarkdownNode.jsx
@@ -49,23 +49,8 @@ export class MarkdownNode extends BaseMarkdownNode {
         return 'markdown';
     }
 
-    // transient properties used to control node behaviour
-    __openInEditMode = false;
-
-    constructor(dataset = {}, key) {
-        super(dataset, key);
-
-        const {_openInEditMode} = dataset;
-        this.__openInEditMode = _openInEditMode || false;
-    }
-
     getIcon() {
         return MarkdownCardIcon;
-    }
-
-    clearOpenInEditMode() {
-        const self = this.getWritable();
-        self.__openInEditMode = false;
     }
 
     decorate() {
@@ -73,7 +58,6 @@ export class MarkdownNode extends BaseMarkdownNode {
             <KoenigCardWrapper
                 IndicatorIcon={MarkdownIndicatorIcon}
                 nodeKey={this.getKey()}
-                openInEditMode={this.__openInEditMode}
                 width={this.__cardWidth}
                 wrapperStyle="wide"
             >

--- a/packages/koenig-lexical/src/plugins/AudioPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/AudioPlugin.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import {$createAudioNode, AudioNode, INSERT_AUDIO_COMMAND} from '../nodes/AudioNode';
-import {
-    $getSelection,
-    $isNodeSelection,
-    $isRangeSelection,
-    COMMAND_PRIORITY_HIGH
-} from 'lexical';
-import {$insertAndSelectNode} from '../utils/$insertAndSelectNode';
+import {COMMAND_PRIORITY_HIGH, COMMAND_PRIORITY_LOW} from 'lexical';
+import {INSERT_CARD_COMMAND} from './KoenigBehaviourPlugin';
 import {INSERT_MEDIA_COMMAND} from './DragDropPastePlugin';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
@@ -23,25 +18,12 @@ export const AudioPlugin = () => {
             editor.registerCommand(
                 INSERT_AUDIO_COMMAND,
                 async (dataset) => {
-                    const selection = $getSelection();
-
-                    let focusNode;
-                    if ($isRangeSelection(selection)) {
-                        focusNode = selection.focus.getNode();
-                    } else if ($isNodeSelection(selection)) {
-                        focusNode = selection.getNodes()[0];
-                    } else {
-                        return false;
-                    }
-
-                    if (focusNode !== null) {
-                        const audioNode = $createAudioNode(dataset);
-                        $insertAndSelectNode({selectedNode: focusNode, newNode: audioNode});
-                    }
+                    const cardNode = $createAudioNode(dataset);
+                    editor.dispatchCommand(INSERT_CARD_COMMAND, {cardNode});
 
                     return true;
                 },
-                COMMAND_PRIORITY_HIGH
+                COMMAND_PRIORITY_LOW
             ),
             editor.registerCommand(
                 INSERT_MEDIA_COMMAND,

--- a/packages/koenig-lexical/src/plugins/CalloutPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/CalloutPlugin.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {$createCalloutNode, CalloutNode, INSERT_CALLOUT_COMMAND} from '../nodes/CalloutNode';
-import {$getSelection, $isNodeSelection, $isRangeSelection, COMMAND_PRIORITY_HIGH} from 'lexical';
-import {$insertAndSelectNode} from '../utils/$insertAndSelectNode';
+import {COMMAND_PRIORITY_LOW} from 'lexical';
+import {INSERT_CARD_COMMAND} from './KoenigBehaviourPlugin';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
@@ -17,24 +17,12 @@ export const CalloutPlugin = () => {
             editor.registerCommand(
                 INSERT_CALLOUT_COMMAND,
                 async (dataset) => {
-                    const selection = $getSelection();
-
-                    let focusNode;
-                    if ($isRangeSelection(selection)) {
-                        focusNode = selection.focus.getNode();
-                    } else if ($isNodeSelection(selection)) {
-                        focusNode = selection.getNodes()[0];
-                    } else {
-                        return false;
-                    }
-                    if (focusNode !== null) {
-                        const calloutNode = $createCalloutNode(dataset);
-                        $insertAndSelectNode({selectedNode: focusNode, newNode: calloutNode});
-                    }
+                    const cardNode = $createCalloutNode(dataset);
+                    editor.dispatchCommand(INSERT_CARD_COMMAND, {cardNode});
 
                     return true;
                 },
-                COMMAND_PRIORITY_HIGH
+                COMMAND_PRIORITY_LOW
             )
         );
     });

--- a/packages/koenig-lexical/src/plugins/HtmlPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/HtmlPlugin.jsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import {$createHtmlNode, HtmlNode, INSERT_HTML_COMMAND} from '../nodes/HtmlNode';
-import {
-    $getSelection,
-    $isRangeSelection,
-    COMMAND_PRIORITY_HIGH
-} from 'lexical';
-import {$insertAndSelectNode} from '../utils/$insertAndSelectNode';
+import {COMMAND_PRIORITY_LOW} from 'lexical';
+import {INSERT_CARD_COMMAND} from './KoenigBehaviourPlugin';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
@@ -21,22 +17,12 @@ export const HtmlPlugin = () => {
             editor.registerCommand(
                 INSERT_HTML_COMMAND,
                 async (dataset) => {
-                    const selection = $getSelection();
-
-                    if (!$isRangeSelection(selection)) {
-                        return false;
-                    }
-
-                    const focusNode = selection.focus.getNode();
-
-                    if (focusNode !== null) {
-                        const htmlNode = $createHtmlNode({...dataset, _openInEditMode: true});
-                        $insertAndSelectNode({selectedNode: focusNode, newNode: htmlNode});
-                    }
+                    const cardNode = $createHtmlNode(dataset);
+                    editor.dispatchCommand(INSERT_CARD_COMMAND, {cardNode, openInEditMode: true});
 
                     return true;
                 },
-                COMMAND_PRIORITY_HIGH
+                COMMAND_PRIORITY_LOW
             )
         );
     }, [editor]);

--- a/packages/koenig-lexical/src/plugins/MarkdownPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/MarkdownPlugin.jsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import {$createMarkdownNode, INSERT_MARKDOWN_COMMAND, MarkdownNode} from '../nodes/MarkdownNode';
-import {
-    $getSelection,
-    $isRangeSelection,
-    COMMAND_PRIORITY_HIGH
-} from 'lexical';
-import {$insertAndSelectNode} from '../utils/$insertAndSelectNode';
+import {COMMAND_PRIORITY_HIGH} from 'lexical';
+import {INSERT_CARD_COMMAND} from './KoenigBehaviourPlugin';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
@@ -21,18 +17,8 @@ export const MarkdownPlugin = () => {
             editor.registerCommand(
                 INSERT_MARKDOWN_COMMAND,
                 async (dataset) => {
-                    const selection = $getSelection();
-
-                    if (!$isRangeSelection(selection)) {
-                        return false;
-                    }
-
-                    const focusNode = selection.focus.getNode();
-
-                    if (focusNode !== null) {
-                        const markdownNode = $createMarkdownNode({...dataset, _openInEditMode: true});
-                        $insertAndSelectNode({selectedNode: focusNode, newNode: markdownNode});
-                    }
+                    const cardNode = $createMarkdownNode(dataset);
+                    editor.dispatchCommand(INSERT_CARD_COMMAND, {cardNode, openInEditMode: true});
 
                     return true;
                 },

--- a/packages/koenig-lexical/src/plugins/VideoPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/VideoPlugin.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import {$createVideoNode, INSERT_VIDEO_COMMAND, VideoNode} from '../nodes/VideoNode';
-import {
-    $getSelection,
-    $isNodeSelection,
-    $isRangeSelection,
-    COMMAND_PRIORITY_HIGH
-} from 'lexical';
-import {$insertAndSelectNode} from '../utils/$insertAndSelectNode';
+import {COMMAND_PRIORITY_HIGH, COMMAND_PRIORITY_LOW} from 'lexical';
+import {INSERT_CARD_COMMAND} from './KoenigBehaviourPlugin';
 import {INSERT_MEDIA_COMMAND} from './DragDropPastePlugin';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
@@ -23,25 +18,12 @@ export const VideoPlugin = () => {
             editor.registerCommand(
                 INSERT_VIDEO_COMMAND,
                 async (dataset) => {
-                    const selection = $getSelection();
-
-                    let focusNode;
-                    if ($isRangeSelection(selection)) {
-                        focusNode = selection.focus.getNode();
-                    } else if ($isNodeSelection(selection)) {
-                        focusNode = selection.getNodes()[0];
-                    } else {
-                        return false;
-                    }
-
-                    if (focusNode !== null) {
-                        const videoNode = $createVideoNode(dataset);
-                        $insertAndSelectNode({selectedNode: focusNode, newNode: videoNode});
-                    }
+                    const cardNode = $createVideoNode(dataset);
+                    editor.dispatchCommand(INSERT_CARD_COMMAND, {cardNode});
 
                     return true;
                 },
-                COMMAND_PRIORITY_HIGH
+                COMMAND_PRIORITY_LOW
             ),
             editor.registerCommand(
                 INSERT_MEDIA_COMMAND,

--- a/packages/koenig-lexical/src/utils/draggable/DragDropHandler.jsx
+++ b/packages/koenig-lexical/src/utils/draggable/DragDropHandler.jsx
@@ -119,7 +119,7 @@ export class DragDropHandler {
                 const container = this.containers.find(c => c.element === containerElement);
                 this.sourceContainer = container;
 
-                if (container.isDragEnabled) {
+                if (container?.isDragEnabled) {
                     this._waitForDragStart(event).then(() => {
                         // stop the drag creating a selection
                         window.getSelection().removeAllRanges();

--- a/packages/koenig-lexical/test/e2e/card-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/card-behaviour.test.js
@@ -1230,7 +1230,7 @@ describe('Card behaviour', async () => {
             expect(await page.$('[data-kg-card-selected="true"]')).not.toBeNull();
             expect(await page.$('[data-kg-card-editing="false"]')).not.toBeNull();
 
-            // card is still able to re-enter edit mode with CMD+ETNER
+            // card is still able to re-enter edit mode with CMD+ENTER
             await page.keyboard.press('Meta+Enter');
 
             expect(await page.$('[data-kg-card-selected="true"]')).not.toBeNull();

--- a/packages/koenig-lexical/test/e2e/plugins/DragDropPastePlugin.test.js
+++ b/packages/koenig-lexical/test/e2e/plugins/DragDropPastePlugin.test.js
@@ -69,28 +69,10 @@ describe('Drag Drop Paste Plugin', async function () {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="image">
-                    <figure data-kg-card-width="regular">
-                        <div>
-                            <img
-                                src="blob:..."
-                                alt="" />
-                        </div>
-                    </figure>
                 </div>
             </div>
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="image">
-                    <figure data-kg-card-width="regular">
-                        <div>
-                            <img
-                                src="blob:..."
-                                alt="" />
-                        </div>
-                        <figcaption>
-                            <input placeholder="Type caption for image (optional)" value="" />
-                            <button name="alt-toggle-button" type="button">Alt</button>
-                        </figcaption>
-                    </figure>
                 </div>
             </div>
             <p><br /></p>


### PR DESCRIPTION
no issue

Cards which opened in edit mode were causing problems with multiplayer due to the way the `KoenigCardWrapper` component was architected. In order for card selection to work we watch for selection state changes and update accordingly but we need to ignore collaboration-derived state changes so card selection behaviour stays relative to local changes. Unfortunately we were triggering updates inside `<KoenigCardWrapper>` when rendering via `useEffect` which resulted in _local_ state changes when another user created a card.

- re-architected card selection behaviour
  - moved majority of behaviour from `<KoenigCardWrapper>` component to our `KoenigBehaviourPlugin`
  - added `selectedCardKey` and `isEditingCard` properties to `KoenigComposerContext` so they can be re-used in `<KoenigCardWrapper>`
  - switched to using custom card-related commands for typical card behaviours like insert, select, edit, deselect, delete so they can be triggered from elsewhere in the app when needed
    - updated card insert behaviour in all of our card plugins
    - updated "open in edit mode" behaviour so it lives in the `INSERT_CARD` command and doesn't require transient properties on nodes and render-time manipulation
- fixed missing `hasEditMode()` method on `CalloutNode`
