### PR TITLE
Bugfix: Call "isCollapsed" to check return value

### DIFF
--- a/packages/koenig-lexical/src/plugins/FloatingFormatToolbarPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/FloatingFormatToolbarPlugin.jsx
@@ -123,7 +123,7 @@ function FloatingFormatToolbar({isText, editor, anchorElem, blockType, isBold, i
         if (
             selection !== null &&
             nativeSelection !== null &&
-            !nativeSelection.isCollapsed &&
+            !nativeSelection.isCollapsed() &&
             rootElement !== null &&
             rootElement.contains(nativeSelection.anchorNode)
         ) {

--- a/packages/koenig-lexical/src/plugins/FloatingFormatToolbarPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/FloatingFormatToolbarPlugin.jsx
@@ -123,7 +123,7 @@ function FloatingFormatToolbar({isText, editor, anchorElem, blockType, isBold, i
         if (
             selection !== null &&
             nativeSelection !== null &&
-            !nativeSelection.isCollapsed() &&
+            !nativeSelection.isCollapsed &&
             rootElement !== null &&
             rootElement.contains(nativeSelection.anchorNode)
         ) {

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -405,7 +405,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop}) {
                     }
 
                     if ($isRangeSelection(selection)) {
-                        if (selection.isCollapsed) {
+                        if (selection.isCollapsed()) {
                             const topLevelElement = selection.anchor.getNode().getTopLevelElement();
                             const nativeSelection = window.getSelection();
 
@@ -500,7 +500,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop}) {
                     }
 
                     if ($isRangeSelection(selection)) {
-                        if (selection.isCollapsed) {
+                        if (selection.isCollapsed()) {
                             const topLevelElement = selection.anchor.getNode().getTopLevelElement();
                             const nativeSelection = window.getSelection();
                             const nativeTopLevelElement = getTopLevelNativeElement(nativeSelection.anchorNode);
@@ -570,7 +570,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop}) {
                             }
                         }
 
-                        if (selection.isCollapsed && $isAtStartOfDocument(selection)) {
+                        if (selection.isCollapsed() && $isAtStartOfDocument(selection)) {
                             event.preventDefault();
                             cursorDidExitAtTop();
                             return true;
@@ -692,7 +692,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop}) {
                     const selection = $getSelection();
 
                     if ($isRangeSelection(selection)) {
-                        if (selection.isCollapsed) {
+                        if (selection.isCollapsed()) {
                             const anchor = selection.anchor;
                             const anchorNode = anchor.getNode();
                             const topLevelElement = anchorNode.getTopLevelElement();
@@ -764,7 +764,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop}) {
                     // handle card selection around card boundaries
                     const selection = $getSelection();
                     if ($isRangeSelection(selection)) {
-                        if (selection.isCollapsed) {
+                        if (selection.isCollapsed()) {
                             const anchor = selection.anchor;
                             const anchorNode = anchor.getNode();
                             const topLevelElement = anchorNode.getTopLevelElement();
@@ -823,7 +823,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop}) {
                         }
 
                         let nodes;
-                        if (selection.isCollapsed) {
+                        if (selection.isCollapsed()) {
                             const anchorNode = selection.anchor.getNode();
                             nodes = $isTextNode(anchorNode) ? [anchorNode.getParent()] : [anchorNode];
                         } else {


### PR DESCRIPTION
Fix a bug where the existence of `isCollapsed` was being checked instead of its return value. Previously, it would always resolve to `true`. Now, it will return the collapsed state of the selection.