### PR TITLE
Added callout card editor toggle

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/CalloutCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CalloutCard.jsx
@@ -77,7 +77,8 @@ export function CalloutCard({
     setText,
     nodeKey,
     toggleEmojiPicker,
-    showEmojiPicker
+    showEmojiPicker,
+    sanitizeHtml
 }) {
     const emojiButtonRef = React.useRef(null);
     const {darkMode} = React.useContext(KoenigComposerContext);
@@ -114,14 +115,19 @@ export function CalloutCard({
                     </>
                     }
                 </div>
-                <KoenigCalloutEditor
-                    className="my-0 w-full whitespace-normal bg-transparent font-serif text-xl font-normal text-black dark:text-grey-300"
-                    html={text}
-                    nodeKey={nodeKey}
-                    placeholderText={'Callout text...'}
-                    readOnly={isEditing}
-                    setHtml={setText}
-                />
+                {
+                    isEditing ?
+                        <KoenigCalloutEditor
+                            className="my-0 w-full whitespace-normal bg-transparent font-serif text-xl font-normal text-black dark:text-grey-300"
+                            html={text}
+                            nodeKey={nodeKey}
+                            placeholderText={'Callout text...'}
+                            readOnly={isEditing}
+                            setHtml={setText}
+                        />
+                        :
+                        <div dangerouslySetInnerHTML={{__html: sanitizeHtml(text)}} className="my-0 w-full whitespace-normal bg-transparent font-serif text-xl font-normal text-black dark:text-grey-300"/>
+                }
             </div>
             {
                 isEditing && (

--- a/packages/koenig-lexical/src/nodes/CalloutNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CalloutNode.jsx
@@ -7,6 +7,7 @@ import {CalloutNode as BaseCalloutNode, INSERT_CALLOUT_COMMAND} from '@tryghost/
 import {CalloutCard} from '../components/ui/cards/CalloutCard';
 import {ReactComponent as CalloutCardIcon} from '../assets/icons/kg-card-type-callout.svg';
 import {ToolbarMenu, ToolbarMenuItem, ToolbarMenuSeparator} from '../components/ui/ToolbarMenu.jsx';
+import {sanitizeHtml} from '../utils/sanitize-html';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
 // re-export here so we don't need to import from multiple places throughout the app
@@ -61,6 +62,14 @@ function CalloutNodeComponent({nodeKey, text, hasEmoji, backgroundColor, emojiVa
         setShowEmojiPicker(!showEmojiPicker);
     };
 
+    React.useEffect(() => {
+        if (!isEditing && isSelected) {
+            setEditing(true);
+        }
+        // only run on mount
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
     return (
         <>
             <CalloutCard
@@ -72,6 +81,7 @@ function CalloutNodeComponent({nodeKey, text, hasEmoji, backgroundColor, emojiVa
                 handleColorChange={handleColorChange}
                 isEditing={isEditing}
                 nodeKey={nodeKey}
+                sanitizeHtml={sanitizeHtml}
                 setShowEmojiPicker={setShowEmojiPicker}
                 setText={setText}
                 showEmojiPicker={showEmojiPicker}

--- a/packages/koenig-lexical/test/e2e/cards/callout-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/callout-card.test.js
@@ -57,7 +57,7 @@ describe('Callout Card', async () => {
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="callout">
+                <div data-kg-card-editing="true" data-kg-card-selected="true" data-kg-card="callout">
                 </div>
             </div>
             <p><br /></p>
@@ -68,9 +68,6 @@ describe('Callout Card', async () => {
         await focusEditor(page);
         await page.keyboard.type('/callout');
         await page.keyboard.press('Enter');
-
-        const editButton = await page.locator('[data-testid="edit-callout-card"]');
-        await editButton.click();
 
         // the settings panel consists of emoji-toggle and colour picker
         const emojiToggle = await page.locator('[data-testid="emoji-toggle"]');
@@ -95,10 +92,6 @@ describe('Callout Card', async () => {
         await page.keyboard.type('/callout');
         await page.keyboard.press('Enter');
 
-        // click <button data-testid="edit-callout-card"
-        const editButton = await page.locator('[data-testid="edit-callout-card"]');
-        await editButton.click();
-
         const toggle = await page.locator('[data-testid="emoji-toggle"]');
         await toggle.click();
         // click on data-kg-card="callout"
@@ -113,10 +106,6 @@ describe('Callout Card', async () => {
         await focusEditor(page);
         await page.keyboard.type('/callout');
         await page.keyboard.press('Enter');
-
-        // click <button data-testid="edit-callout-card"
-        const editButton = await page.locator('[data-testid="edit-callout-card"]');
-        await editButton.click();
         
         await page.getByRole('button', {name: '💡'}).click();
         const emojiPickerContainer = await page.locator('[data-testid="emoji-picker-container"]');
@@ -127,8 +116,6 @@ describe('Callout Card', async () => {
         await focusEditor(page);
         await page.keyboard.type('/callout');
         await page.keyboard.press('Enter');
-        const editButton = await page.locator('[data-testid="edit-callout-card"]');
-        await editButton.click();
 
         await Promise.all(calloutColorPicker.map(async (color) => {
             const colorPicker = await page.locator(`[data-test-id="color-picker-${color.name}"]`);
@@ -141,9 +128,6 @@ describe('Callout Card', async () => {
         await page.keyboard.type('/callout');
         await page.keyboard.press('Enter');
 
-        // click <button data-testid="edit-callout-card"
-        const editButton = await page.locator('[data-testid="edit-callout-card"]');
-        await editButton.click();
         const colorPicker = await page.locator(`[data-test-id="color-picker-green"]`);
         await colorPicker.click();
         
@@ -157,14 +141,44 @@ describe('Callout Card', async () => {
         await page.keyboard.type('/callout');
         await page.keyboard.press('Enter');
 
-        // click <button data-testid="edit-callout-card"
-        const editButton = await page.locator('[data-testid="edit-callout-card"]');
-        await editButton.click();
         await page.getByRole('button', {name: '💡'}).click();
         const lolEmoji = await page.locator('[aria-label="😂"]').nth(0); // nth(0) is required because there could two emojis with the same label (eg from frequently used)
         await lolEmoji.click();
         // await page.keyboard.type('Joke of the day');
         const calloutCard = await page.locator('[data-kg-card="callout"]');
         await expect(calloutCard).toContainText('😂');
+    });
+
+    it('has edit toolbar', async function () {
+        await focusEditor(page);
+        await page.keyboard.type('/callout');
+        await page.keyboard.press('Enter');
+        // press arrow down
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('ArrowDown'); // press twice to make sure card gets unselected
+
+        // press arrow up
+        await page.keyboard.press('ArrowUp');
+
+        const editButton = await page.locator('[data-testid="edit-callout-card"]');
+        await expect(editButton).toBeVisible();
+    });
+
+    it('can toggle edit', async function () {
+        await focusEditor(page);
+        await page.keyboard.type('/callout');
+        await page.keyboard.press('Enter');
+        // press arrow down
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('ArrowDown'); // press twice to make sure card gets unselected
+
+        // press arrow up
+        await page.keyboard.press('ArrowUp');
+
+        const editButton = await page.locator('[data-testid="edit-callout-card"]');
+        await editButton.click();
+
+        const calloutCard = await page.locator('[data-kg-card="callout"]');
+        await expect(calloutCard).toHaveAttribute('data-kg-card-editing', 'true');
     });
 });


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C04SRM01VB8/p1679674593963199

- avoid the nested editor from being used in display mode when.
- the nested editor is now only used when editing and then it gets switched to a div that outputs the HTML instead.