### PR TITLE
Updated CalloutCard to use a stable nested editor instance

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigCalloutEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCalloutEditor.jsx
@@ -1,9 +1,9 @@
 // we can probably refactor this so that KoenigCaptionEditor can be replaced with this:
 
 import CardContext from '../context/CardContext.jsx';
-import React, {useCallback, useContext} from 'react';
-import {$createParagraphNode, $getNodeByKey, COMMAND_PRIORITY_LOW, KEY_ENTER_COMMAND} from 'lexical';
-import {HtmlOutputPlugin, KoenigComposableEditor, KoenigComposer, MINIMAL_NODES, MINIMAL_TRANSFORMERS, RestrictContentPlugin} from '../index.js';
+import React from 'react';
+import {COMMAND_PRIORITY_LOW, KEY_ENTER_COMMAND} from 'lexical';
+import {KoenigComposableEditor, KoenigNestedComposer, MINIMAL_NODES, MINIMAL_TRANSFORMERS, RestrictContentPlugin} from '../index.js';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
@@ -15,47 +15,52 @@ const Placeholder = ({text = 'Type here'}) => {
     );
 };
 
+// TODO: extract shared behaviour into a `KoenigNestedEditorPlugin` component
 function CalloutEditorPlugin({parentEditor}) {
     const [editor] = useLexicalComposerContext();
-    const {nodeKey} = useContext(CardContext);
+    const {nodeKey} = React.useContext(CardContext);
 
-    // focus on caption editor when something is typed while card is selected
-    const handleKeyDown = useCallback((event) => {
-    // don't focus caption input if any other input or textarea is focused
-        if (event.target.matches('input, textarea')) {
-            return;
-        }
-
-        // only trigger on Enter key
-        if (event.key === 'Enter') {
-            editor.focus();
-        }
-    }, [editor]);
+    // using state here because this component will get re-rendered after the
+    // editor's editable state changes so we need to re-focus on re-render
+    const [shouldFocus, setShouldFocus] = React.useState(false);
 
     React.useEffect(() => {
-        document.addEventListener('keydown', handleKeyDown);
-        return () => {
-            document.removeEventListener('keydown', handleKeyDown);
-        };
-    }, [handleKeyDown, editor, nodeKey]);
+        if (shouldFocus) {
+            editor.focus(() => {
+                editor.getRootElement().focus({preventScroll: true});
+            });
+        }
+    }, [shouldFocus, editor]);
 
     React.useEffect(
         () => {
             return mergeRegister(
+                // watch for editor becoming editable rather than relying on an `isEditing` prop
+                // because the prop will change before the contenteditable becomes editable, meaning
+                // we try to focus a non-editable editor which puts focus on the main editor instead
+                editor.registerEditableListener((isEditable) => {
+                    if (isEditable) {
+                        setShouldFocus(true);
+                    } else {
+                        setShouldFocus(false);
+                    }
+                }),
                 editor.registerCommand(
                     KEY_ENTER_COMMAND,
                     (event) => {
-                        // if hitting enter while holding shift, don't create a new paragraph
+                        // allow shift+enter to create a line break
                         if (event.shiftKey) {
                             return false;
                         }
-                        parentEditor.update(() => {
-                            const cardNode = $getNodeByKey(nodeKey);
-                            const paragraphNode = $createParagraphNode();
-                            cardNode.getTopLevelElementOrThrow().insertAfter(paragraphNode);
-                            paragraphNode.selectStart();
-                        });
-                        return false;
+
+                        // otherwise, let the parent editor handle the enter key
+                        // - with ctrl/cmd+enter toggles edit mode
+                        // - or creates paragraph after card and moves cursor
+                        event._fromNested = true;
+                        parentEditor.dispatchCommand(KEY_ENTER_COMMAND, event);
+
+                        // prevent normal/KoenigBehaviourPlugin enter key behaviour
+                        return true;
                     },
                     COMMAND_PRIORITY_LOW
                 )
@@ -66,23 +71,29 @@ function CalloutEditorPlugin({parentEditor}) {
     return null;
 }
 
-const KoenigCalloutEditor = ({paragraphs = 1, html, setHtml, placeholderText, readOnly, className, nodeKey}) => {
+const KoenigCalloutEditor = ({
+    className,
+    nodeKey,
+    paragraphs = 1,
+    placeholderText,
+    textEditor
+}) => {
     const [parentEditor] = useLexicalComposerContext();
+
     return (
-        <KoenigComposer
-            nodes={MINIMAL_NODES}
+        <KoenigNestedComposer
+            initialEditor={textEditor}
+            initialNodes={MINIMAL_NODES}
         >
             <KoenigComposableEditor
                 className={className}
                 markdownTransformers={MINIMAL_TRANSFORMERS}
                 placeholder={<Placeholder text={placeholderText} />}
-                readOnly={readOnly}
             >
                 <CalloutEditorPlugin parentEditor={parentEditor} parentNode={nodeKey} />
                 <RestrictContentPlugin paragraphs={paragraphs} />
-                <HtmlOutputPlugin html={html} setHtml={setHtml} />
             </KoenigComposableEditor>
-        </KoenigComposer>
+        </KoenigNestedComposer>
     );
 };
 

--- a/packages/koenig-lexical/src/components/KoenigComposableEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigComposableEditor.jsx
@@ -4,7 +4,7 @@ import DragDropReorderPlugin from '../plugins/DragDropReorderPlugin';
 import FloatingFormatToolbarPlugin from '../plugins/FloatingFormatToolbarPlugin';
 import KoenigBehaviourPlugin from '../plugins/KoenigBehaviourPlugin';
 import KoenigComposerContext from '../context/KoenigComposerContext';
-import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
+import KoenigErrorBoundary from './KoenigErrorBoundary';
 import MarkdownShortcutPlugin from '../plugins/MarkdownShortcutPlugin';
 import React from 'react';
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';
@@ -13,6 +13,8 @@ import {ExternalControlPlugin} from '../plugins/ExternalControlPlugin';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {OnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
 import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useSharedHistoryContext} from '../context/SharedHistoryContext';
 
 const KoenigComposableEditor = ({
     onChange,
@@ -26,39 +28,54 @@ const KoenigComposableEditor = ({
     isDragEnabled = true
 }) => {
     const _onChange = React.useCallback((editorState) => {
-        const json = editorState.toJSON();
-        onChange?.(json);
+        if (onChange) {
+            const json = editorState.toJSON();
+            onChange(json);
+        }
     }, [onChange]);
 
+    const {historyState} = useSharedHistoryContext();
+
+    const [editor] = useLexicalComposerContext();
     const {editorContainerRef, darkMode} = React.useContext(KoenigComposerContext);
+
+    const isNested = !!editor._parentEditor;
+    const isDragReorderEnabled = isDragEnabled && !readOnly && !isNested;
+
+    const onWrapperRef = (wrapperElem) => {
+        if (!isNested) {
+            editorContainerRef.current = wrapperElem;
+        }
+    };
+
     // we need an element reference for the container element that
     // any floating elements in plugins will be rendered inside
     const [floatingAnchorElem, setFloatingAnchorElem] = React.useState(null);
-    const onRef = (_floatingAnchorElem) => {
+    const onContentEditableRef = (_floatingAnchorElem) => {
         if (_floatingAnchorElem !== null) {
             setFloatingAnchorElem(_floatingAnchorElem);
         }
     };
 
     return (
-        <div ref={editorContainerRef} className={`koenig-lexical ${darkMode ? 'dark' : ''} ${className}`}>
+        <div ref={onWrapperRef} className={`koenig-lexical ${darkMode ? 'dark' : ''} ${className}`}>
             <RichTextPlugin
                 contentEditable={
-                    <div ref={onRef} data-kg="editor">
+                    <div ref={onContentEditableRef} data-kg="editor">
                         <ContentEditable className="kg-prose" readOnly={readOnly} />
                     </div>
                 }
-                ErrorBoundary={LexicalErrorBoundary}
+                ErrorBoundary={KoenigErrorBoundary}
                 placeholder={placeholder || <EditorPlaceholder />}
             />
             <OnChangePlugin ignoreSelectionChange={true} onChange={_onChange} />
-            <HistoryPlugin /> {/* adds undo/redo */}
-            <KoenigBehaviourPlugin containerElem={editorContainerRef} cursorDidExitAtTop={cursorDidExitAtTop} />
+            <HistoryPlugin externalHistoryState={historyState} /> {/* adds undo/redo */}
+            <KoenigBehaviourPlugin containerElem={editorContainerRef} cursorDidExitAtTop={cursorDidExitAtTop} isNested={isNested} />
             <MarkdownShortcutPlugin transformers={markdownTransformers} />
             {floatingAnchorElem && (<FloatingFormatToolbarPlugin anchorElem={floatingAnchorElem} />)}
-            {isDragEnabled && <DragDropPastePlugin />}
-            <ExternalControlPlugin registerAPI={registerAPI} />
-            {isDragEnabled && <DragDropReorderPlugin containerElem={editorContainerRef} />}
+            <DragDropPastePlugin />
+            {registerAPI ? <ExternalControlPlugin registerAPI={registerAPI} /> : null}
+            {isDragReorderEnabled && <DragDropReorderPlugin containerElem={editorContainerRef} />}
             {children}
         </div>
     );

--- a/packages/koenig-lexical/src/components/KoenigEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigEditor.jsx
@@ -2,16 +2,19 @@ import '../styles/index.css';
 import KoenigComposableEditor from './KoenigComposableEditor';
 import React from 'react';
 import {AllDefaultPlugins} from '../plugins/AllDefaultPlugins';
+import {SharedHistoryContext} from '../context/SharedHistoryContext';
 
 const KoenigEditor = ({
     children,
     ...props
 }) => {
     return (
-        <KoenigComposableEditor {...props}>
-            <AllDefaultPlugins />
-            {children}
-        </KoenigComposableEditor>
+        <SharedHistoryContext>
+            <KoenigComposableEditor {...props}>
+                <AllDefaultPlugins />
+                {children}
+            </KoenigComposableEditor>
+        </SharedHistoryContext>
     );
 };
 

--- a/packages/koenig-lexical/src/components/KoenigErrorBoundary.jsx
+++ b/packages/koenig-lexical/src/components/KoenigErrorBoundary.jsx
@@ -1,0 +1,16 @@
+import KoenigComposerContext from '../context/KoenigComposerContext';
+import React from 'react';
+import {ErrorBoundary as ReactErrorBoundary} from 'react-error-boundary';
+
+export default function KoenigErrorBoundary({children}) {
+    const {onError} = React.useContext(KoenigComposerContext);
+
+    return (
+        <ReactErrorBoundary
+            fallback={<div className="border border-red p-2">An error was thrown.</div>}
+            onError={onError}
+        >
+            {children}
+        </ReactErrorBoundary>
+    );
+}

--- a/packages/koenig-lexical/src/components/KoenigNestedComposer.jsx
+++ b/packages/koenig-lexical/src/components/KoenigNestedComposer.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import {LexicalNestedComposer} from '@lexical/react/LexicalNestedComposer';
+
+const KoenigNestedComposer = ({initialEditor, initialNodes, initialTheme, skipCollabChecks, children} = {}) => {
+    return (
+        <LexicalNestedComposer
+            initialEditor={initialEditor}
+            initialNodes={initialNodes}
+            initialTheme={initialTheme}
+            skipCollabChecks={skipCollabChecks}
+        >
+            {children}
+        </LexicalNestedComposer>
+    );
+};
+
+export default KoenigNestedComposer;

--- a/packages/koenig-lexical/src/components/ui/cards/CalloutCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CalloutCard.jsx
@@ -65,20 +65,18 @@ export const calloutColorPicker = [
 ];
 
 export function CalloutCard({
-    color, 
-    emoji, 
+    color,
+    emoji,
     isEditing,
     setShowEmojiPicker,
-    toggleEmoji, 
-    handleColorChange, 
+    toggleEmoji,
+    handleColorChange,
     changeEmoji,
     emojiValue,
-    text,
-    setText,
+    textEditor,
     nodeKey,
     toggleEmojiPicker,
-    showEmojiPicker,
-    sanitizeHtml
+    showEmojiPicker
 }) {
     const emojiButtonRef = React.useRef(null);
     const {darkMode} = React.useContext(KoenigComposerContext);
@@ -89,52 +87,44 @@ export function CalloutCard({
         }
     }, [isEditing, setShowEmojiPicker]);
 
+    React.useEffect(() => {
+        textEditor.setEditable(isEditing);
+    }, [isEditing, textEditor]);
+
     return (
         <>
-            <div>
-                <div className={`flex rounded border px-7 py-5 ${CALLOUT_COLORS[color]} `} data-testid={`callout-bg-${color}`}>
-                    <div>
-                        {emoji && 
-                        <>
-                            <button
-                                ref={emojiButtonRef}
-                                className={`mr-2 cursor-pointer rounded px-2 text-xl ${isEditing ? 'hover:bg-grey-500/20' : ''} ` }
-                                data-testid="emoji-picker-button" 
-                                type="button" 
-                                onClick={toggleEmojiPicker} 
-                            >
-                                {emojiValue}
-                            </button>
-                            {
-                                isEditing && showEmojiPicker && (
-                                    <EmojiPickerPortal
-                                        buttonRef={emojiButtonRef}
-                                        togglePortal={toggleEmojiPicker}
-                                        onEmojiClick={changeEmoji} />
-                                )
-                            }
-                        </>
+            <div className={`flex rounded border px-7 py-5 ${CALLOUT_COLORS[color]} `} data-testid={`callout-bg-${color}`}>
+                <div>
+                    {emoji &&
+                    <>
+                        <button
+                            ref={emojiButtonRef}
+                            className={`mr-2 cursor-pointer rounded px-2 text-xl ${isEditing ? 'hover:bg-grey-500/20' : ''} ` }
+                            data-testid="emoji-picker-button"
+                            type="button"
+                            onClick={toggleEmojiPicker}
+                        >
+                            {emojiValue}
+                        </button>
+                        {
+                            isEditing && showEmojiPicker && (
+                                <EmojiPickerPortal
+                                    buttonRef={emojiButtonRef}
+                                    togglePortal={toggleEmojiPicker}
+                                    onEmojiClick={changeEmoji} />
+                            )
                         }
-                    </div>
-                    {
-                        isEditing ?
-                            <KoenigCalloutEditor
-                                className="my-0 w-full whitespace-normal bg-transparent font-serif text-xl font-normal text-black dark:text-grey-300"
-                                html={text}
-                                nodeKey={nodeKey}
-                                placeholderText={'Callout text...'}
-                                readOnly={isEditing}
-                                setHtml={setText}
-                            />
-                            :
-                            <div dangerouslySetInnerHTML={{__html: sanitizeHtml(text)}} className="my-0 w-full whitespace-normal bg-transparent font-serif text-xl font-normal text-black dark:text-grey-300"/>
-                    }
+                    </>}
                 </div>
-                {!isEditing && <div className="absolute inset-0 z-50">
-                </div>}
+                <KoenigCalloutEditor
+                    className="my-0 w-full whitespace-normal bg-transparent font-serif text-xl font-normal text-black dark:text-grey-300"
+                    nodeKey={nodeKey}
+                    placeholderText={'Callout text...'}
+                    textEditor={textEditor}
+                />
             </div>
             {
-                isEditing && (
+                isEditing ? (
                     <SettingsPanel
                         darkMode={darkMode}
                     >
@@ -153,6 +143,8 @@ export function CalloutCard({
                             onClick={handleColorChange}
                         />
                     </SettingsPanel>
+                ) : (
+                    <div className="absolute top-0 z-10 m-0 h-full w-full cursor-default p-0"></div>
                 )
             }
         </>

--- a/packages/koenig-lexical/src/components/ui/cards/CalloutCard.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CalloutCard.stories.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {CalloutCard} from './CalloutCard';
 import {CardWrapper} from './../CardWrapper';
+import {createEditor} from 'lexical';
 
 const displayOptions = {
     Default: {isSelected: false, isEditing: false},
@@ -35,15 +36,19 @@ const story = {
 };
 export default story;
 
-const Template = ({display, ...args}) => (
-    <div className="kg-prose">
-        <div className="mx-auto my-8 min-w-[initial] max-w-[740px]">
-            <CardWrapper {...display} {...args}>
-                <CalloutCard {...display} {...args} />
-            </CardWrapper>
+const Template = ({display, ...args}) => {
+    const textEditor = createEditor();
+
+    return (
+        <div className="kg-prose">
+            <div className="mx-auto my-8 min-w-[initial] max-w-[740px]">
+                <CardWrapper {...display} {...args}>
+                    <CalloutCard {...display} {...args} textEditor={textEditor} />
+                </CardWrapper>
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 export const Empty = Template.bind({});
 Empty.args = {

--- a/packages/koenig-lexical/src/context/SharedHistoryContext.jsx
+++ b/packages/koenig-lexical/src/context/SharedHistoryContext.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import {createEmptyHistoryState} from '@lexical/react/LexicalHistoryPlugin';
+
+const Context = React.createContext({});
+
+export const SharedHistoryContext = ({children}) => {
+    const historyContext = React.useMemo(
+        () => ({historyState: createEmptyHistoryState()}),
+        []
+    );
+
+    return <Context.Provider value={historyContext}>{children}</Context.Provider>;
+};
+
+export const useSharedHistoryContext = () => React.useContext(Context);

--- a/packages/koenig-lexical/src/index.js
+++ b/packages/koenig-lexical/src/index.js
@@ -3,6 +3,7 @@ import DesignSandbox from './components/DesignSandbox';
 import KoenigComposableEditor from './components/KoenigComposableEditor';
 import KoenigComposer from './components/KoenigComposer';
 import KoenigEditor from './components/KoenigEditor';
+import KoenigNestedComposer from './components/KoenigNestedComposer';
 
 /* Plugins */
 import AudioPlugin from './plugins/AudioPlugin';
@@ -51,6 +52,7 @@ export {
     KoenigComposableEditor,
     KoenigComposer,
     KoenigEditor,
+    KoenigNestedComposer,
 
     AudioPlugin,
     CardMenuPlugin,

--- a/packages/koenig-lexical/src/nodes/CalloutNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CalloutNode.jsx
@@ -1,7 +1,11 @@
 import CardContext from '../context/CardContext';
 import KoenigCardWrapper from '../components/KoenigCardWrapper';
+import MINIMAL_NODES from './MinimalNodes';
 import React from 'react';
-import {$getNodeByKey} from 'lexical';
+import cleanBasicHtml from '@tryghost/kg-clean-basic-html';
+import populateNestedEditor from '../utils/populateNestedEditor';
+import {$generateHtmlFromNodes} from '@lexical/html';
+import {$getNodeByKey, createEditor} from 'lexical';
 import {ActionToolbar} from '../components/ui/ActionToolbar.jsx';
 import {CalloutNode as BaseCalloutNode, INSERT_CALLOUT_COMMAND} from '@tryghost/kg-default-nodes';
 import {CalloutCard} from '../components/ui/cards/CalloutCard';
@@ -13,18 +17,11 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 // re-export here so we don't need to import from multiple places throughout the app
 export {INSERT_CALLOUT_COMMAND} from '@tryghost/kg-default-nodes';
 
-function CalloutNodeComponent({nodeKey, text, hasEmoji, backgroundColor, emojiValue}) {
+function CalloutNodeComponent({nodeKey, textEditor, hasEmoji, backgroundColor, emojiValue}) {
     const [editor] = useLexicalComposerContext();
 
     const {isSelected, isEditing, setEditing} = React.useContext(CardContext);
     const [showEmojiPicker, setShowEmojiPicker] = React.useState(false);
-
-    const setText = (newText) => {
-        editor.update(() => {
-            const node = $getNodeByKey(nodeKey);
-            node.setText(newText);
-        });
-    };
 
     const toggleEmoji = (event) => {
         editor.update(() => {
@@ -32,14 +29,6 @@ function CalloutNodeComponent({nodeKey, text, hasEmoji, backgroundColor, emojiVa
             node.setHasEmoji(event.target.checked);
         });
     };
-
-    // const handleToolbarEdit = (event) => {
-    //     event.preventDefault();
-    //     event.stopPropagation();
-    //     console.log(isEditing);
-    //     setEditing(true);
-    //     console.log('after', isEditing);
-    // };
 
     const handleColorChange = (color) => {
         editor.update(() => {
@@ -64,6 +53,7 @@ function CalloutNodeComponent({nodeKey, text, hasEmoji, backgroundColor, emojiVa
         setShowEmojiPicker(!showEmojiPicker);
     };
 
+    // TODO: this should be handled by KoenigBehaviourPlugin when inserting card
     React.useEffect(() => {
         if (!isEditing && isSelected) {
             setEditing(true);
@@ -77,7 +67,6 @@ function CalloutNodeComponent({nodeKey, text, hasEmoji, backgroundColor, emojiVa
             <CalloutCard
                 changeEmoji={handleEmojiChange}
                 color={backgroundColor}
-                editor={editor}
                 emoji={hasEmoji}
                 emojiValue={emojiValue}
                 handleColorChange={handleColorChange}
@@ -85,9 +74,8 @@ function CalloutNodeComponent({nodeKey, text, hasEmoji, backgroundColor, emojiVa
                 nodeKey={nodeKey}
                 sanitizeHtml={sanitizeHtml}
                 setShowEmojiPicker={setShowEmojiPicker}
-                setText={setText}
                 showEmojiPicker={showEmojiPicker}
-                text={text}
+                textEditor={textEditor}
                 toggleEmoji={toggleEmoji}
                 toggleEmojiPicker={toggleEmojiPicker}
             />
@@ -120,6 +108,28 @@ export class CalloutNode extends BaseCalloutNode {
 
     constructor(dataset = {}, key) {
         super(dataset, key);
+
+        // set up and populate nested editor from the serialized HTML
+        this.__textEditor = dataset.textEditor || createEditor({nodes: MINIMAL_NODES});
+        if (!dataset.textEditor) {
+            populateNestedEditor({editor: this.__textEditor, initialHtml: dataset.text});
+        }
+    }
+
+    exportJSON() {
+        const json = super.exportJSON();
+
+        // convert nested editor instance back into HTML because `text` may not
+        // be automatically updated when the nested editor changes
+        if (this.__textEditor) {
+            this.__textEditor.getEditorState().read(() => {
+                const html = $generateHtmlFromNodes(this.__textEditor, null);
+                const cleanedHtml = cleanBasicHtml(html);
+                json.text = cleanedHtml;
+            });
+        }
+
+        return json;
     }
 
     createDOM() {
@@ -127,7 +137,13 @@ export class CalloutNode extends BaseCalloutNode {
     }
 
     getDataset() {
-        return super.getDataset();
+        const dataset = super.getDataset();
+
+        // client-side only data properties such as nested editors
+        const self = this.getLatest();
+        dataset.textEditor = self.__textEditor;
+
+        return dataset;
     }
 
     updateDOM() {
@@ -142,7 +158,7 @@ export class CalloutNode extends BaseCalloutNode {
                     emojiValue={this.__emojiValue}
                     hasEmoji={this.__hasEmoji}
                     nodeKey={this.getKey()}
-                    text={this.__text}
+                    textEditor={this.__textEditor}
                 />
             </KoenigCardWrapper>
         );

--- a/packages/koenig-lexical/src/plugins/DragDropPastePlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/DragDropPastePlugin.jsx
@@ -63,12 +63,16 @@ function DragDropPastePlugin() {
     const {fileUploader} = React.useContext(KoenigComposerContext);
 
     const handleFileUpload = React.useCallback(async (files) => {
+        if (!fileUploader) {
+            return;
+        }
+
         const {acceptableMimeTypes} = await getListOfAcceptableMimeTypes(editor, fileUploader.fileTypes);
         const {processed} = await mediaFileReader(files, acceptableMimeTypes);
         processed.forEach((item) => {
             editor.dispatchCommand(INSERT_MEDIA_COMMAND, item);
         });
-    }, [editor, fileUploader.fileTypes]);
+    }, [editor, fileUploader]);
 
     // override the default Lexical drop handler because we always want to insert
     // where the selection was left rather than where the drop happened (matches mobiledoc editor)

--- a/packages/koenig-lexical/src/utils/populateNestedEditor.js
+++ b/packages/koenig-lexical/src/utils/populateNestedEditor.js
@@ -1,0 +1,43 @@
+import {$createParagraphNode} from 'lexical';
+import {$generateNodesFromDOM} from '@lexical/html';
+import {$getRoot, $insertNodes} from 'lexical';
+
+export default function populateNestedEditor({editor, initialHtml}) {
+    if (initialHtml) {
+        // convert html in `text` to Lexical nodes and populate the editor
+        editor.update(() => {
+            const parser = new DOMParser();
+            const dom = parser.parseFromString(initialHtml, 'text/html');
+
+            const nodes = $generateNodesFromDOM(editor, dom);
+
+            let isEmpty = true;
+            nodes.forEach((n) => {
+                // There are few recent issues related to $generateNodesFromDOM
+                // https://github.com/facebook/lexical/issues/2807
+                // https://github.com/facebook/lexical/issues/3677
+                // As a temporary fix, checking node content to remove additional spaces and br
+                if (n.getTextContent().trim()) {
+                    isEmpty = false;
+                }
+            });
+
+            // Select the root
+            $getRoot().select();
+
+            if (isEmpty) {
+                $getRoot().clear();
+                return;
+            }
+
+            // Insert them at a selection.
+            $insertNodes(nodes);
+        });
+    } else {
+        // for empty initial values, create a paragraph because a completely empty
+        // root won't accept focus
+        editor.update(() => {
+            $getRoot().append($createParagraphNode());
+        });
+    }
+}


### PR DESCRIPTION
no issue

For consistent undo/redo and working sync in multiplayer mode, nested editors need to have a consistent instance available rather than creating a new editor instance on every render or when moving in/out of edit mode.

- updated `CalloutNode` to create an editor instance in it's constructor that lives on the editor node so that it's a stable instance
  - added `populateNestedEditor()` helper method that initializes the editor with the HTML value that is stored in the serialized version of the node
  - updated `exportJSON()` to serialize the nested editor instance to HTML
- added `<KoenigNestedComposer>`
  - wrapper around `<LexicalNestedComposer>` that sets up an editor instance with the correct `parentEditor` property
- updated `<CalloutCard>` to work with the nested editor
  - replaced `text` and `setText` props in `<CalloutCard>` with `textEditor` prop
  - added an effect to toggle the editable state of the nested editor when the card enters/leaves edit mode
  - swapped the static content display state for an always-shown editor instance
- updated `<KoenigCalloutEditor>` to work with the nested editor
  - swapped `KoenigComposer` for `KoenigNestedComposer`, initializing with the passed-through `textEditor` editor instance
  - removed use of `HtmlOutputPlugin` as html deserialization/serialization is now handled at the node level
  - updated `CalloutEditorPlugin` to properly handle autofocus and Enter key behaviour with the nested editor
- updated `<KoenigBehaviourPlugin>` to work with nested editors
  - the plugin is used in both the top-level editor and nested editors so it's behaviour needs to adapt accordingly
  - added a skip of selection update behaviour when the plugin is nested (determined by the `isNested` prop used in nested editors)
  - updated `Enter` key behaviour to allow the normal paragraph creation when triggered via an event with the `_fromNested` property to allow nested editors to trigger the command (typically key events won't bubble up from the nested editor to the parent editor but in some cases we want the nested editor to explicitly trigger parent editor behaviour)
  - switched all command priorities to `LOW` so that they are not prevented by default editor behaviour and can be more easily overridden by other plugins using `NORMAL` or `HIGH` priorities
- added `<SharedHistoryContext>`
  - creates a single history context that can be shared across the main and nested editors
  - provider created in `<KoenigEditor>`
  - `<KoenigComposableEditor>` updated to use the context when initializing the `<HistoryPlugin>` component which covers both the main and nested editors (they both use the composable editor component)
