### PR TITLE
Updated toggle card with stable nested editor instance pattern

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigToggleEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigToggleEditor.jsx
@@ -1,6 +1,69 @@
 import React from 'react';
-import {AutoFocusPlugin} from '@lexical/react/LexicalAutoFocusPlugin';
-import {BASIC_NODES, BASIC_TRANSFORMERS, HtmlOutputPlugin, KoenigComposableEditor, KoenigComposer, RestrictContentPlugin} from '../index.js';
+import {BASIC_NODES, BASIC_TRANSFORMERS, KoenigComposableEditor, KoenigNestedComposer, MINIMAL_NODES, MINIMAL_TRANSFORMERS, RestrictContentPlugin} from '../index.js';
+import {COMMAND_PRIORITY_LOW, KEY_ENTER_COMMAND} from 'lexical';
+import {mergeRegister} from '@lexical/utils';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext.js';
+
+// TODO: extract shared behaviour into a `KoenigNestedEditorPlugin` component
+function ToggleEditorPlugin({autoFocus, focusNext}) {
+    const [editor] = useLexicalComposerContext();
+
+    // using state here because this component can get re-rendered after the
+    // editor's editable state changes so we need to re-focus on re-render
+    const [shouldFocus, setShouldFocus] = React.useState(autoFocus);
+
+    React.useEffect(() => {
+        if (shouldFocus) {
+            editor.focus(() => {
+                editor.getRootElement().focus({preventScroll: true});
+            });
+        }
+    }, [shouldFocus, editor]);
+
+    React.useEffect(() => {
+        return mergeRegister(
+            // watch for editor becoming editable rather than relying on an `isEditing` prop
+            // because the prop will change before the contenteditable becomes editable, meaning
+            // we try to focus a non-editable editor which puts focus on the main editor instead
+            editor.registerEditableListener((isEditable) => {
+                if (!autoFocus) {
+                    return;
+                }
+
+                if (isEditable) {
+                    setShouldFocus(true);
+                } else {
+                    setShouldFocus(false);
+                }
+            }),
+            editor.registerCommand(
+                KEY_ENTER_COMMAND,
+                (event) => {
+                    // let the parent editor handle the edit mode toggle
+                    if (event.metaKey || event.ctrlKey) {
+                        event._fromNested = true;
+                        editor._parentEditor?.dispatchCommand(KEY_ENTER_COMMAND, event);
+                        return true;
+                    }
+
+                    // move focus to the next editor if it exists (e.g. from header to content editor)
+                    if (focusNext) {
+                        event.preventDefault();
+                        focusNext.focus(() => {
+                            focusNext.getRootElement().focus({preventScroll: true});
+                        });
+                        return true;
+                    }
+
+                    return false;
+                },
+                COMMAND_PRIORITY_LOW
+            )
+        );
+    }, [editor, autoFocus, focusNext]);
+
+    return null;
+}
 
 const Placeholder = ({text = 'Type here', className = ''}) => {
     return (
@@ -10,23 +73,33 @@ const Placeholder = ({text = 'Type here', className = ''}) => {
     );
 };
 
-const KoenigToggleEditor = ({text, setText, placeholderText, textClassName, placeholderClassName, readOnly, autoFocus = false, singleParagraph = false}) => {
+const KoenigToggleEditor = ({
+    initialEditor,
+    nodes = 'basic',
+    placeholderText,
+    textClassName,
+    placeholderClassName,
+    autoFocus = false,
+    focusNext,
+    singleParagraph = false
+}) => {
+    const initialNodes = nodes === 'minimal' ? MINIMAL_NODES : BASIC_NODES;
+    const markdownTransformers = nodes === 'minimal' ? MINIMAL_TRANSFORMERS : BASIC_TRANSFORMERS;
+
     return (
-        <KoenigComposer
-            nodes={BASIC_NODES}
+        <KoenigNestedComposer
+            initialEditor={initialEditor}
+            initialNodes={initialNodes}
         >
             <KoenigComposableEditor
                 className={textClassName}
-                isDragEnabled={false}
-                markdownTransformers={BASIC_TRANSFORMERS}
+                markdownTransformers={markdownTransformers}
                 placeholder={<Placeholder className={placeholderClassName} text={placeholderText} />}
-                readOnly={readOnly}
             >
                 {singleParagraph && <RestrictContentPlugin paragraphs={1} />}
-                {autoFocus && <AutoFocusPlugin />}
-                <HtmlOutputPlugin html={text} setHtml={setText} />
+                <ToggleEditorPlugin autoFocus={autoFocus} focusNext={focusNext} />
             </KoenigComposableEditor>
-        </KoenigComposer>
+        </KoenigNestedComposer>
     );
 };
 

--- a/packages/koenig-lexical/src/components/ui/cards/ToggleCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/ToggleCard.jsx
@@ -2,91 +2,62 @@ import KoenigToggleEditor from '../../KoenigToggleEditor';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {ReactComponent as ArrowDownIcon} from '../../../assets/icons/kg-toggle-arrow.svg';
-import {sanitizeHtml} from '../../../utils/sanitize-html';
 
 export function ToggleCard({
-    content,
+    contentEditor,
     contentPlaceholder,
-    focusOnContent,
-    focusOnHeader,
-    header,
+    headerEditor,
     headerPlaceholder,
-    isContentFocused,
     isContentVisible,
     isEditing,
-    isHeaderFocused,
-    setContent,
-    setHeader,
     toggleContent,
     toggleRef
 }) {
     return (
-        <div className='rounded border border-grey/40 py-4 px-6 dark:border-grey/30'>
-            <div className='flex cursor-text items-start justify-between'>
-                <div className="mr-2 w-full" onClick={focusOnHeader} onKeyDown={focusOnContent}>
-                    {
-                        isEditing ?
-                            <KoenigToggleEditor
-                                autoFocus={isHeaderFocused}
-                                placeholderClassName={'kg-toggle-header-placeholder'}
-                                placeholderText={headerPlaceholder}
-                                readOnly={!isEditing}
-                                setText={setHeader}
-                                singleParagraph={true}
-                                text={header}
-                                textClassName={'kg-toggle-header-text'}
-                            /> :
-                            <div dangerouslySetInnerHTML={{__html: sanitizeHtml(header)}} className='kg-toggle-header-text'></div>
-                    }
-
-                </div>
-                <div ref={toggleRef} className='ml-auto mt-[-1px] flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center' onClick={toggleContent}>
-                    <ArrowDownIcon className={`h-4 w-4 stroke-2 text-grey-400 dark:text-grey/30 ${isContentVisible ? 'rotate-180' : 'rotate-0'}`} />
-                </div>
-            </div>
-            <div className={`mt-2 w-full ${isContentVisible ? 'visible' : 'hidden'}`}>
-                {
-                    isEditing ?
+        <>
+            <div className='rounded border border-grey/40 py-4 px-6 dark:border-grey/30'>
+                <div className='flex cursor-text items-start justify-between'>
+                    <div className="mr-2 w-full">
                         <KoenigToggleEditor
-                            autoFocus={isContentFocused}
-                            placeholderClassName={'kg-toggle-content-placeholder'}
-                            placeholderText={contentPlaceholder}
-                            readOnly={!isEditing}
-                            setText={setContent}
-                            text={content}
-                            textClassName={'kg-toggle-content-text'}
-                        /> :
-                        <div dangerouslySetInnerHTML={{__html: sanitizeHtml(content)}} className='kg-toggle-content-text'></div>
-                }
+                            autoFocus={true}
+                            focusNext={contentEditor}
+                            initialEditor={headerEditor}
+                            nodes='minimal'
+                            placeholderClassName={'kg-toggle-header-placeholder'}
+                            placeholderText={headerPlaceholder}
+                            singleParagraph={true}
+                            textClassName={'kg-toggle-header-text'}
+                        />
+                    </div>
+                    <div ref={toggleRef} className='z-20 ml-auto mt-[-1px] flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center' onClick={toggleContent}>
+                        <ArrowDownIcon className={`h-4 w-4 stroke-2 text-grey-400 dark:text-grey/30 ${isContentVisible ? 'rotate-180' : 'rotate-0'}`} />
+                    </div>
+                </div>
+                <div className={`mt-2 w-full ${isContentVisible ? 'visible' : 'hidden'}`}>
+                    <KoenigToggleEditor
+                        initialEditor={contentEditor}
+                        placeholderClassName={'kg-toggle-content-placeholder'}
+                        placeholderText={contentPlaceholder}
+                        textClassName={'kg-toggle-content-text'}
+                    />
+                </div>
             </div>
-        </div>
+            {!isEditing && <div className="absolute top-0 z-10 m-0 h-full w-full cursor-default p-0"></div>}
+        </>
     );
 }
 
 ToggleCard.propTypes = {
-    content: PropTypes.string,
     contentPlaceholder: PropTypes.string,
-    focusOnContent: PropTypes.func,
-    focusOnHeader: PropTypes.func,
-    header: PropTypes.string,
     headerPlaceholder: PropTypes.string,
-    isContentFocused: PropTypes.bool,
     isContentVisible: PropTypes.bool,
     isEditing: PropTypes.bool,
-    isHeaderFocused: PropTypes.bool,
-    setContent: PropTypes.func,
-    setHeader: PropTypes.func,
-    toggleContent: PropTypes.func,
     toggleRef: PropTypes.object
 };
 
 ToggleCard.defaultProps = {
-    content: '',
     contentPlaceholder: 'Collapsible content',
-    header: '',
     headerPlaceholder: 'Toggle header',
-    isContentFocused: false,
-    isContentVisible: false,
-    isEditing: false,
-    isHeaderFocused: true
+    isContentVisible: true,
+    isEditing: false
 };

--- a/packages/koenig-lexical/src/components/ui/cards/ToggleCard.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/ToggleCard.stories.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
+import populateNestedEditor from '../../../utils/populateNestedEditor';
+import {BASIC_NODES, MINIMAL_NODES} from '../../../index.js';
 import {CardWrapper} from './../CardWrapper';
 import {ToggleCard} from './ToggleCard';
+import {createEditor} from 'lexical';
 
 const displayOptions = {
     Default: {isSelected: false, isEditing: false},
@@ -35,22 +38,30 @@ const story = {
 };
 export default story;
 
-const Template = ({display, ...args}) => (
-    <div className="kg-prose">
-        <div className="not-kg-prose mx-auto my-8 min-w-[initial] max-w-[740px] py-10">
-            <CardWrapper {...display} {...args}>
-                <ToggleCard {...display} {...args} />
-            </CardWrapper>
-        </div>
-        <div className="w-full bg-black py-10">
-            <div className="not-kg-prose dark mx-auto my-8 min-w-[initial] max-w-[740px]">
-                <CardWrapper {...display} {...args}>
-                    <ToggleCard {...display} {...args} />
+const Template = ({display, header, content, ...args}) => {
+    const headerEditor = createEditor({nodes: MINIMAL_NODES});
+    populateNestedEditor({editor: headerEditor, initialHtml: `<p>${header}</p>`});
+
+    const contentEditor = createEditor({nodes: BASIC_NODES});
+    populateNestedEditor({editor: contentEditor, initialHtml: `<p>${content}</p>`});
+
+    return (
+        <div className="kg-prose">
+            <div className="not-kg-prose mx-auto my-8 min-w-[initial] max-w-[740px] py-10">
+                <CardWrapper {...display}>
+                    <ToggleCard {...display} {...args} contentEditor={contentEditor} headerEditor={headerEditor} />
                 </CardWrapper>
             </div>
+            <div className="w-full bg-black py-10">
+                <div className="not-kg-prose dark mx-auto my-8 min-w-[initial] max-w-[740px]">
+                    <CardWrapper {...display}>
+                        <ToggleCard {...display} {...args} contentEditor={contentEditor} headerEditor={headerEditor} />
+                    </CardWrapper>
+                </div>
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 export const Empty = Template.bind({});
 Empty.args = {

--- a/packages/koenig-lexical/src/nodes/ToggleNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ToggleNode.jsx
@@ -1,5 +1,10 @@
-import KoenigCardWrapper from '../components/KoenigCardWrapper';
 import React from 'react';
+import cleanBasicHtml from '@tryghost/kg-clean-basic-html';
+import populateNestedEditor from '../utils/populateNestedEditor';
+import {$canShowPlaceholderCurry} from '@lexical/text';
+import {$generateHtmlFromNodes} from '@lexical/html';
+import {$getRoot, createEditor} from 'lexical';
+import {BASIC_NODES, KoenigCardWrapper, MINIMAL_NODES} from '../index.js';
 import {ToggleNode as BaseToggleNode, INSERT_TOGGLE_COMMAND} from '@tryghost/kg-default-nodes';
 import {ReactComponent as ToggleCardIcon} from '../assets/icons/kg-card-type-toggle.svg';
 import {ToggleNodeComponent} from './ToggleNodeComponent';
@@ -20,6 +25,65 @@ export class ToggleNode extends BaseToggleNode {
         return ToggleCardIcon;
     }
 
+    constructor(dataset = {}, key) {
+        super(dataset, key);
+
+        // set up and populate nested editors from the serialized HTML
+        this.__headerEditor = dataset.headerEditor || createEditor({nodes: MINIMAL_NODES});
+        if (!dataset.headerEditor) {
+            // wrap the header in a paragraph so it gets parsed correctly
+            // - we serialize with no wrapper so the renderer can decide how to wrap it
+            const initialHtml = dataset.header ? `<p>${dataset.header}</p>` : null;
+            populateNestedEditor({editor: this.__headerEditor, initialHtml});
+        }
+        this.__contentEditor = dataset.contentEditor || createEditor({nodes: BASIC_NODES});
+        if (!dataset.contentEditor) {
+            populateNestedEditor({editor: this.__contentEditor, initialHtml: dataset.content});
+        }
+    }
+
+    getDataset() {
+        const dataset = super.getDataset();
+
+        // client-side only data properties such as nested editors
+        const self = this.getLatest();
+        dataset.headerEditor = self.__headerEditor;
+        dataset.contentEditor = self.__contentEditor;
+
+        return dataset;
+    }
+
+    exportJSON() {
+        const json = super.exportJSON();
+
+        // convert nested editor instances back into HTML because their content may not
+        // be automatically updated when the nested editor changes
+        if (this.__headerEditor) {
+            this.__headerEditor.update(() => {
+                // for the header we don't want any wrapper element in the serialized data,
+                // just the first element's contents
+                const selection = $getRoot().getFirstChild()?.select();
+
+                if (selection) {
+                    const html = $generateHtmlFromNodes(this.__headerEditor, selection);
+                    const cleanedHtml = cleanBasicHtml(html);
+                    json.header = cleanedHtml;
+                } else {
+                    json.header = '';
+                }
+            });
+        }
+        if (this.__contentEditor) {
+            this.__contentEditor.getEditorState().read(() => {
+                const html = $generateHtmlFromNodes(this.__contentEditor, null);
+                const cleanedHtml = cleanBasicHtml(html);
+                json.text = cleanedHtml;
+            });
+        }
+
+        return json;
+    }
+
     createDOM() {
         return document.createElement('div');
     }
@@ -28,12 +92,21 @@ export class ToggleNode extends BaseToggleNode {
         return (
             <KoenigCardWrapper nodeKey={this.getKey()} width={this.__cardWidth}>
                 <ToggleNodeComponent
-                    content={this.__content}
-                    header={this.__header}
+                    contentEditor={this.__contentEditor}
+                    headerEditor={this.__headerEditor}
                     nodeKey={this.getKey()}
                 />
             </KoenigCardWrapper>
         );
+    }
+
+    // override the default `isEmpty` check because we need to check the nested editors
+    // rather than the data properties themselves
+    isEmpty() {
+        const isHeaderEmpty = this.__headerEditor.getEditorState().read($canShowPlaceholderCurry(false));
+        const isContentEmpty = this.__contentEditor.getEditorState().read($canShowPlaceholderCurry(false));
+
+        return isHeaderEmpty && isContentEmpty;
     }
 }
 

--- a/packages/koenig-lexical/src/nodes/ToggleNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ToggleNodeComponent.jsx
@@ -1,83 +1,52 @@
 import CardContext from '../context/CardContext';
-import React, {useEffect, useRef, useState} from 'react';
-import {$getNodeByKey} from 'lexical';
+import React from 'react';
 import {ActionToolbar} from '../components/ui/ActionToolbar';
+import {EDIT_CARD_COMMAND} from '../plugins/KoenigBehaviourPlugin';
 import {ToggleCard} from '../components/ui/cards/ToggleCard';
 import {ToolbarMenu, ToolbarMenuItem, ToolbarMenuSeparator} from '../components/ui/ToolbarMenu';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
-export function ToggleNodeComponent({nodeKey, content, header}) {
+export function ToggleNodeComponent({nodeKey, headerEditor, contentEditor}) {
     const [editor] = useLexicalComposerContext();
     const cardContext = React.useContext(CardContext);
-    const {isEditing, isSelected, setEditing} = cardContext;
+    const {isEditing, isSelected} = cardContext;
 
-    const [isContentVisible, setContentVisible] = useState(false);
-    const [isContentFocused, setFocusOnContent] = useState(false);
-    const [isHeaderFocused, setFocusOnHeader] = useState(true);
+    const [isContentVisible, setContentVisible] = React.useState(false);
 
-    const toggleRef = useRef(null);
+    const toggleRef = React.useRef(null);
 
-    useEffect(() => {
+    React.useEffect(() => {
         if (toggleRef && toggleRef.current) {
             toggleRef.current.click();
         }
     }, []);
 
-    const toggleContent = () => {
+    const toggleContent = (event) => {
+        event?.preventDefault();
+        event?.stopPropagation();
         setContentVisible(!isContentVisible);
-    };
-
-    const focusOnContent = (e) => {
-        if (e.key === 'Enter') {
-            setFocusOnHeader(false);
-            setFocusOnContent(true);
-
-            if (!isContentVisible && toggleRef && toggleRef.current) {
-                toggleRef.current.click();
-            }
-        }
-    };
-
-    const focusOnHeader = (e) => {
-        setFocusOnContent(false);
-        setFocusOnHeader(true);
-    };
-
-    const setHeader = (newHeader) => {
-        editor.update(() => {
-            const node = $getNodeByKey(nodeKey);
-            node.setHeader(newHeader);
-        });
-    };
-
-    const setContent = (newContent) => {
-        editor.update(() => {
-            const node = $getNodeByKey(nodeKey);
-            node.setContent(newContent);
-        });
     };
 
     const handleToolbarEdit = (event) => {
         event.preventDefault();
         event.stopPropagation();
-        setEditing(true);
+        editor.dispatchCommand(EDIT_CARD_COMMAND, {cardKey: nodeKey});
     };
+
+    React.useEffect(() => {
+        headerEditor.setEditable(isEditing);
+        contentEditor.setEditable(isEditing);
+    }, [isEditing, headerEditor, contentEditor]);
 
     return (
         <>
             <ToggleCard
-                content={content}
+                contentEditor={contentEditor}
                 contentPlaceholder={'Collapsible content'}
-                focusOnContent={focusOnContent}
-                focusOnHeader={focusOnHeader}
-                header={header}
+                headerEditor={headerEditor}
                 headerPlaceholder={'Toggle header'}
-                isContentFocused={isContentFocused}
                 isContentVisible={isContentVisible}
                 isEditing={isEditing}
-                isHeaderFocused={isHeaderFocused}
-                setContent={setContent}
-                setHeader={setHeader}
                 toggleContent={toggleContent}
                 toggleRef={toggleRef}
             />

--- a/packages/koenig-lexical/test/e2e/cards/toggle-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/toggle-card.test.js
@@ -31,7 +31,7 @@ describe('Toggle card', async () => {
                 root: {
                     children: [{
                         type: 'toggle',
-                        header: '<p dir="ltr"><span>Header</span></p>',
+                        header: '<span><em>Header</em></span>', // header shouldn't have wrapper element like <p> or <h4>
                         content: '<p dir="ltr"><span>Content</span></p>'
                     }],
                     direction: null,
@@ -48,12 +48,21 @@ describe('Toggle card', async () => {
 
         await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="toggle">
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="toggle">
                         <div class="rounded border border-grey/40 py-4 px-6 dark:border-grey/30">
                             <div class="flex cursor-text items-start justify-between">
                                 <div class="mr-2 w-full">
                                     <div class="kg-toggle-header-text">
-                                        <p><span>Header</span></p>
+                                        <div data-kg="editor">
+                                            <div
+                                                contenteditable="false"
+                                                spellcheck="true"
+                                                data-lexical-editor="true"
+                                                aria-autocomplete="none"
+                                            >
+                                                <p dir="ltr"><em data-lexical-text="true">Header</em></p>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                                 <div
@@ -63,11 +72,20 @@ describe('Toggle card', async () => {
                             </div>
                             <div class="mt-2 w-full visible">
                                 <div class="kg-toggle-content-text">
-                                    <p><span>Content</span></p>
+                                    <div data-kg="editor">
+                                        <div
+                                            contenteditable="false"
+                                            spellcheck="true"
+                                            data-lexical-editor="true"
+                                            aria-autocomplete="none"
+                                        >
+                                            <p dir="ltr"><span data-lexical-text="true">Content</span></p>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                        <div data-kg-card-toolbar="toggle"></div>
+                        <div></div>
                     </div>
                 </div>
             `, {ignoreCardToolbarContents: true, ignoreInnerSVG: true});
@@ -79,10 +97,49 @@ describe('Toggle card', async () => {
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card-editing="true" data-kg-card-selected="true" data-kg-card="toggle"></div>
+                <div data-kg-card-editing="true" data-kg-card-selected="true" data-kg-card="toggle">
+                    <div class="rounded border border-grey/40 py-4 px-6 dark:border-grey/30">
+                        <div class="flex cursor-text items-start justify-between">
+                            <div class="mr-2 w-full">
+                                <div class="kg-toggle-header-text">
+                                    <div data-kg="editor">
+                                        <div
+                                            contenteditable="true"
+                                            spellcheck="true"
+                                            data-lexical-editor="true"
+                                            role="textbox"
+                                        >
+                                            <p><br /></p>
+                                        </div>
+                                    </div>
+                                    <div>Toggle header</div>
+                                </div>
+                            </div>
+                            <div
+                                class="ml-auto mt-[-1px] flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center">
+                                <svg></svg>
+                            </div>
+                        </div>
+                        <div class="mt-2 w-full visible">
+                            <div class="kg-toggle-content-text">
+                                <div data-kg="editor">
+                                    <div
+                                        contenteditable="true"
+                                        spellcheck="true"
+                                        data-lexical-editor="true"
+                                        role="textbox"
+                                    >
+                                        <p><br /></p>
+                                    </div>
+                                </div>
+                                <div>Collapsible content</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
             <p><br /></p>
-        `, {ignoreCardContents: true});
+        `, {ignoreInnerSVG: true});
     });
 
     it('focuses on the header input when rendered', async function () {
@@ -139,9 +196,12 @@ describe('Toggle card', async () => {
         await expect(header).toContainText('Header');
     });
 
-    it.todo('renders in display mode when unfocused', async function () {
+    it('renders in display mode when unfocused', async function () {
         await focusEditor(page);
         await insertToggleCard(page);
+
+        // add some content to avoid auto-removal when leaving empty
+        await page.keyboard.type('Header');
 
         // Shift focus from header to content
         await page.keyboard.press('ArrowDown');
@@ -153,9 +213,12 @@ describe('Toggle card', async () => {
         await expect(toggleCard).toHaveAttribute('data-kg-card-editing', 'false');
     });
 
-    it.todo('renders an action toolbar', async function () {
+    it('renders an action toolbar', async function () {
         await focusEditor(page);
         await insertToggleCard(page);
+
+        // Add some content to avoid auto-removal
+        await page.keyboard.type('Header');
 
         // Shift focus from header to content
         await page.keyboard.press('ArrowDown');
@@ -168,5 +231,19 @@ describe('Toggle card', async () => {
 
         const editButton = page.locator('[data-kg-card-toolbar="toggle"]');
         await expect(editButton).toBeVisible();
+    });
+
+    it('is removed when left empty', async function () {
+        await focusEditor(page);
+        await insertToggleCard(page);
+
+        // Shift focus from header to content
+        await page.keyboard.press('ArrowDown');
+
+        // Shift focus from content to editor
+        await page.keyboard.press('ArrowDown');
+
+        const toggleCard = page.locator('[data-kg-card="toggle"]');
+        await expect(toggleCard).not.toBeVisible();
     });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Koenig/pull/568

- updated `ToggleNode` to store an editor instance for each nested editor (ensures the instance is stable for the life of the node, compared to creating a new editor instance on each render if created at the React level)
  - creates and populates editors in the `constructor`
  - adds nested editor instances to the dataset for use when node instance is re-created/cloned
  - overrides `exportJSON` to serialize the nested editor instance's contents
  - modifies `decorate` to pass through the editor instances rather than static content strings
  - overrides `isEmpty()` to check the nested editor contents in place of static content string data properties
- added effect to `ToggleNodeComponent` that modifies nested editor "editable" properties when `isEditing` changes
  - ensures when card is in it's display state that there are no live `contenteditable` regions that can interfere with cursor selection
- updated `KoenigToggleEditor`/`KoenigToggleEditorPlugin` to handle autofocus when the editor instance's editable state changes
  - allows for some flexibility in timing between React rendering and the `contenteditable` regions actually being editable, if we try to focus before the regions are editable then we end up moving focus to the top level editor's element instead
