### PR TITLE
Fixed line breaks in toggle content

### DIFF
--- a/packages/koenig-lexical/src/nodes/ToggleNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ToggleNode.jsx
@@ -89,7 +89,8 @@ export class ToggleNode extends BaseToggleNode {
         if (this.__contentEditor) {
             this.__contentEditor.getEditorState().read(() => {
                 const html = $generateHtmlFromNodes(this.__contentEditor, null);
-                const cleanedHtml = cleanBasicHtml(html);
+                const cleanedHtml = cleanBasicHtml(html, {allowBr: true});
+
                 json.content = cleanedHtml;
             });
         }

--- a/packages/koenig-lexical/src/styles/components/kg-toggle.css
+++ b/packages/koenig-lexical/src/styles/components/kg-toggle.css
@@ -30,19 +30,4 @@
   .kg-toggle-header-text, .kg-toggle-content-text {
     @apply !whitespace-normal
   }
-
-  .kg-toggle-content-text .kg-prose :where(
-        p + p,
-        ul + p,
-        ol + p
-    ) {
-        @apply my-0
-    }
-
-    .kg-toggle-content-text .kg-prose :where(
-      p + ul,
-      p + ol,
-    ) {
-        @apply my-2
-    }
 }


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2992
- line breaks were being replaced by a space in the toggle content. This would prevent content from being saved properly in the database
- also aligned paragraphs styles in the toggle content with the main content (same vertical margins)