### PR TITLE
Added async link autocomplete suggestions for ButtonNode

### DIFF
--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -31,7 +31,11 @@ const WEBSOCKET_ID = params.get('multiplayerId') || '0';
 const cardConfig = {
     unsplash: {defaultHeaders: defaultUnsplashHeaders},
     fetchEmbed: fetchEmbed,
-    tenor: tenorConfig
+    tenor: tenorConfig,
+    fetchAutocompleteLinks: () => Promise.resolve([
+        {label: 'Homepage', value: window.location.origin + '/'},
+        {label: 'Free signup', value: window.location.origin + '/#/portal/signup/free'}
+    ]),
 };
 
 function getDefaultContent({editorType}) {

--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -35,7 +35,7 @@ const cardConfig = {
     fetchAutocompleteLinks: () => Promise.resolve([
         {label: 'Homepage', value: window.location.origin + '/'},
         {label: 'Free signup', value: window.location.origin + '/#/portal/signup/free'}
-    ]),
+    ])
 };
 
 function getDefaultContent({editorType}) {

--- a/packages/koenig-lexical/src/components/ui/Input.jsx
+++ b/packages/koenig-lexical/src/components/ui/Input.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export function Input({dataTestId, list, listOptions, listVisibility, handleOptionClick, value, placeholder, onChange, onFocus}) {    
+export function Input({dataTestId, list, listOptions, listVisibility, handleOptionClick, value, placeholder, onChange, onFocus}) {
     return (
         <>
             <div className="relative">
@@ -13,7 +13,7 @@ export function Input({dataTestId, list, listOptions, listVisibility, handleOpti
                     onChange={onChange}
                     onFocus={onFocus}
                 />
-                {list && listOptions && listVisibility && <ul className="absolute mt-[-1px] max-h-[30vh] w-full overflow-y-auto rounded-b border border-grey-200 bg-white py-1 shadow dark:border-grey-800 dark:bg-grey-900">
+                {list && listOptions && !!listOptions.length && listVisibility && <ul className="absolute mt-[-1px] max-h-[30vh] w-full overflow-y-auto rounded-b border border-grey-200 bg-white py-1 shadow dark:border-grey-800 dark:bg-grey-900">
                     {listOptions.map((item) => {
                         return <li key={item.value} className="cursor-pointer px-4 py-2 text-left hover:bg-grey-100 dark:hover:bg-black" data-testid={`${dataTestId}-listOption`} onClick={event => handleOptionClick(event,item.caption)}>
                             <span className="block text-sm font-semibold leading-tight text-black dark:text-white" data-testid={`${dataTestId}-listOption-${item.value}`}>{item.value}</span>

--- a/packages/koenig-lexical/src/nodes/ButtonNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ButtonNode.jsx
@@ -19,15 +19,23 @@ function ButtonNodeComponent({alignment, buttonText, buttonUrl, nodeKey}) {
     const {isEditing, isSelected, setEditing} = React.useContext(CardContext);
     const {cardConfig} = React.useContext(KoenigComposerContext);
     const [showSnippetToolbar, setShowSnippetToolbar] = React.useState(false);
+    const [listOptions, setListOptions] = React.useState([]);
 
-    // TODO: this will need to be provided by the digesting code
-    const testListOptions = [
-        {value: 'Homepage', caption: window.location.origin + '/'},
-        {value: 'Free signup', caption: window.location.origin + '/#/portal/signup/free'}
-    ];
+    React.useEffect(() => {
+        if (cardConfig.fetchAutocompleteLinks) {
+            cardConfig.fetchAutocompleteLinks().then((links) => {
+                setListOptions(links.map((link) => {
+                    return {value: link.label, caption: link.value};
+                }));
+            });
+        }
+    }, [cardConfig]);
 
     const [suggestedUrlVisibility, setSuggestedUrlVisibility] = React.useState(false);
-    const [filteredSuggestedUrls, setFilteredSuggestedUrls] = React.useState(testListOptions);
+
+    const filteredSuggestedUrls = listOptions.filter((u) => {
+        return u.value.toLocaleLowerCase().includes(buttonUrl.toLocaleLowerCase());
+    });
 
     const handleToolbarEdit = (event) => {
         event.preventDefault();
@@ -46,13 +54,6 @@ function ButtonNodeComponent({alignment, buttonText, buttonUrl, nodeKey}) {
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
             node.setButtonUrl(event.target.value);
-            if (buttonUrl && event.target.value) {
-                setFilteredSuggestedUrls(testListOptions.filter((url) => {
-                    return url.value.includes(event.target.value);
-                }));
-            } else {
-                setFilteredSuggestedUrls(testListOptions);
-            }
         });
     };
 
@@ -72,7 +73,6 @@ function ButtonNodeComponent({alignment, buttonText, buttonUrl, nodeKey}) {
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
             node.setButtonUrl(value);
-            setFilteredSuggestedUrls(testListOptions);
             setSuggestedUrlVisibility(false);
         });
     };


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/3021

The new `fetchAutocompleteLinks` method in the cardConfig provides a way to fetch autocomplete suggestions. This is required because offers are needed as suggestions.

The demo app uses some fixed data.