### PR TITLE
Avoid deleting a card accidentally with CMD + backspace

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -35,7 +35,9 @@ import {
 import {$insertAndSelectNode} from '../utils/$insertAndSelectNode';
 import {
     $isAtStartOfDocument,
-    $selectDecoratorNode
+    $isAtTopOfNode,
+    $selectDecoratorNode,
+    getTopLevelNativeElement
 } from '../utils/';
 import {$isKoenigCard} from '@tryghost/kg-default-nodes';
 import {$isListItemNode, $isListNode, ListNode} from '@lexical/list';
@@ -50,15 +52,6 @@ export const EDIT_CARD_COMMAND = createCommand('EDIT_CARD_COMMAND');
 export const DELETE_CARD_COMMAND = createCommand('DELETE_CARD_COMMAND');
 
 const RANGE_TO_ELEMENT_BOUNDARY_THRESHOLD_PX = 10;
-
-function getTopLevelNativeElement(node) {
-    if (node.nodeType === Node.TEXT_NODE) {
-        node = node.parentNode;
-    }
-
-    const selector = '[data-lexical-editor] > *';
-    return node.closest(selector);
-}
 
 function $selectCard(editor, nodeKey, focusEditor = true) {
     const selection = $createNodeSelection();
@@ -461,25 +454,12 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                                     return true;
                                 }
                             } else {
-                                const range = nativeSelection.getRangeAt(0).cloneRange();
-                                const rects = range.getClientRects();
-
-                                if (rects.length > 0) {
-                                    // try second rect first because when the caret is at the beginning
-                                    // of a line the first rect will be positioned on line above breaking
-                                    // the top position check
-                                    const rangeRect = rects[1] || rects[0];
-                                    const nativeTopLevelElement = getTopLevelNativeElement(nativeSelection.anchorNode);
-                                    const elemRect = nativeTopLevelElement.getBoundingClientRect();
-
-                                    const atTopOfNode = Math.abs(rangeRect.top - elemRect.top) <= RANGE_TO_ELEMENT_BOUNDARY_THRESHOLD_PX;
-
-                                    if (atTopOfNode) {
-                                        const previousSibling = topLevelElement.getPreviousSibling();
-                                        if ($isDecoratorNode(previousSibling)) {
-                                            $selectDecoratorNode(previousSibling);
-                                            return true;
-                                        }
+                                const atTopOfNode = $isAtTopOfNode(nativeSelection, RANGE_TO_ELEMENT_BOUNDARY_THRESHOLD_PX);
+                                if (atTopOfNode) {
+                                    const previousSibling = topLevelElement.getPreviousSibling();
+                                    if ($isDecoratorNode(previousSibling)) {
+                                        $selectDecoratorNode(previousSibling);
+                                        return true;
                                     }
                                 }
                             }
@@ -843,8 +823,11 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                         return true;
                     }
 
+                    // Avoid deleting a card accidentally:
+                    // If a paragraph contains only one line and is next to a card, then by default CMD + Backspace deletes the line + the sibling card
+                    // In that case, we avoid using the default `selection.deleteLine()` from Lexical
+                    // Instead, we remove the topLevelElement and put the selection on the sibling card
                     const selection = $getSelection();
-
                     if ($isRangeSelection(selection)) {
                         if (selection.isCollapsed) {
                             const anchor = selection.anchor;
@@ -854,9 +837,12 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                             const nextSibling = topLevelElement.getNextSibling();
                             const sibling = isBackward ? previousSibling : nextSibling;
 
-                            // avoid deleting a card unintentionally
-                            if ($isDecoratorNode(sibling) && topLevelElement.getChildrenSize() === 1) {
-                                anchorNode.remove();
+                            // Find out if the paragraph contains only one line
+                            const nativeSelection = window.getSelection();
+                            const isFirstLine = $isAtTopOfNode(nativeSelection, RANGE_TO_ELEMENT_BOUNDARY_THRESHOLD_PX);
+
+                            if ($isDecoratorNode(sibling) && isFirstLine) {
+                                topLevelElement.remove();
                                 $selectDecoratorNode(sibling);
 
                                 return true;

--- a/packages/koenig-lexical/src/utils/$isAtTopOfNode.js
+++ b/packages/koenig-lexical/src/utils/$isAtTopOfNode.js
@@ -1,0 +1,22 @@
+import {getTopLevelNativeElement} from './getTopLevelNativeElement';
+
+/**
+ * 
+ * @param {Selection} nativeSelection (window.getSelection())
+ * @returns boolean
+ */
+export function $isAtTopOfNode(nativeSelection, thresold) {
+    const range = nativeSelection.getRangeAt(0).cloneRange();
+    const rects = range.getClientRects();
+
+    if (rects.length > 0) {
+        // try second rect first because when the caret is at the beginning
+        // of a line the first rect will be positioned on line above breaking
+        // the top position check
+        const rangeRect = rects[1] || rects[0];
+        const nativeTopLevelElement = getTopLevelNativeElement(nativeSelection.anchorNode);
+        const elemRect = nativeTopLevelElement.getBoundingClientRect();
+
+        return Math.abs(rangeRect.top - elemRect.top) <= thresold;
+    } 
+}

--- a/packages/koenig-lexical/src/utils/getTopLevelNativeElement.js
+++ b/packages/koenig-lexical/src/utils/getTopLevelNativeElement.js
@@ -1,0 +1,8 @@
+export function getTopLevelNativeElement(node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+        node = node.parentNode;
+    }
+
+    const selector = '[data-lexical-editor] > *';
+    return node.closest(selector);
+}

--- a/packages/koenig-lexical/src/utils/index.js
+++ b/packages/koenig-lexical/src/utils/index.js
@@ -1,3 +1,5 @@
 // publicly exported util functions
 export * from './$isAtStartOfDocument';
 export * from './$selectDecoratorNode';
+export * from './$isAtTopOfNode';
+export * from './getTopLevelNativeElement';


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/3063

- Currently, if a paragraph contains only one line and is next to a card, then by default CMD + Backspace deletes the line + the sibling card
- In that case, we avoid using the default `selection.deleteLine()` from Lexical
- Instead, we delete the line by hand and put the selection on the sibling card
