### PR TITLE
Signup card label picker

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
@@ -1,7 +1,7 @@
 import {createCommand} from 'lexical';
 import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
-import {renderSignupCardToDOM} from './SignupRenderer';
 import {SignupParser} from './SignupParser';
+import {renderSignupCardToDOM} from './SignupRenderer';
 
 export const INSERT_SIGNUP_COMMAND = createCommand();
 const NODE_TYPE = 'signup';
@@ -14,6 +14,7 @@ export class SignupNode extends KoenigDecoratorNode {
     __subheader;
     __disclaimer;
     __backgroundImageSrc;
+    __labels;
 
     static getType() {
         return NODE_TYPE;
@@ -43,7 +44,8 @@ export class SignupNode extends KoenigDecoratorNode {
             header: self.__header,
             subheader: self.__subheader,
             disclaimer: self.__disclaimer,
-            backgroundImageSrc: self.__backgroundImageSrc
+            backgroundImageSrc: self.__backgroundImageSrc,
+            labels: self.__labels
         };
     }
 
@@ -52,7 +54,8 @@ export class SignupNode extends KoenigDecoratorNode {
         header,
         subheader,
         disclaimer,
-        backgroundImageSrc} = {}, key) {
+        backgroundImageSrc,
+        labels} = {}, key) {
         super(key);
         this.__style = style || 'dark';
         this.__buttonText = buttonText || '';
@@ -60,6 +63,7 @@ export class SignupNode extends KoenigDecoratorNode {
         this.__subheader = subheader || '';
         this.__disclaimer = disclaimer || '';
         this.__backgroundImageSrc = backgroundImageSrc || '';
+        this.__labels = labels || [];
     }
 
     exportDOM(options = {}) {
@@ -71,14 +75,15 @@ export class SignupNode extends KoenigDecoratorNode {
     }
 
     static importJSON(serializedNode) {
-        const {style, buttonText, header, subheader, disclaimer, backgroundImageSrc} = serializedNode;
+        const {style, buttonText, header, subheader, disclaimer, backgroundImageSrc, labels} = serializedNode;
         const node = new this({
             style,
             buttonText,
             header,
             subheader,
             disclaimer,
-            backgroundImageSrc
+            backgroundImageSrc,
+            labels
         });
         return node;
     }
@@ -97,7 +102,8 @@ export class SignupNode extends KoenigDecoratorNode {
             header: this.getHeader(),
             subheader: this.getSubheader(),
             disclaimer: this.getDisclaimer(),
-            backgroundImageSrc: this.getBackgroundImageSrc()
+            backgroundImageSrc: this.getBackgroundImageSrc(),
+            labels: this.getLabels()
         };
         return dataset;
     }
@@ -173,6 +179,16 @@ export class SignupNode extends KoenigDecoratorNode {
     setBackgroundImageSrc(backgroundImageSrc) {
         const writable = this.getWritable();
         writable.__backgroundImageSrc = backgroundImageSrc;
+    }
+
+    getLabels() {
+        const self = this.getLatest();
+        return self.__labels;
+    }
+
+    setLabels(labels) {
+        const writable = this.getWritable();
+        writable.__labels = labels;
     }
 
     hasEditMode() {

--- a/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
@@ -187,8 +187,22 @@ export class SignupNode extends KoenigDecoratorNode {
     }
 
     setLabels(labels) {
+        if (!Array.isArray(labels) || !labels.every(item => typeof item === 'string')) {
+            throw new Error('Invalid argument: Expected an array of strings.'); // eslint-disable-line
+        }
+
         const writable = this.getWritable();
         writable.__labels = labels;
+    }
+
+    addLabel(label) {
+        const writable = this.getWritable();
+        writable.__labels.push(label);
+    }
+
+    removeLabel(label) {
+        const writable = this.getWritable();
+        writable.__labels = writable.__labels.filter(l => l !== label);
     }
 
     hasEditMode() {

--- a/packages/kg-default-nodes/test/nodes/signup.test.js
+++ b/packages/kg-default-nodes/test/nodes/signup.test.js
@@ -30,6 +30,7 @@ describe('SignupNode', function () {
         signupNode.getHeader().should.equal(data.header);
         signupNode.getSubheader().should.equal(data.subheader);
         signupNode.getStyle().should.equal(data.style);
+        signupNode.getLabels().should.deepEqual(data.labels);
     };
 
     beforeEach(function () {
@@ -41,7 +42,8 @@ describe('SignupNode', function () {
             disclaimer: 'Disclaimer',
             header: 'Header',
             subheader: 'Subheader',
-            style: 'image'
+            style: 'image',
+            labels: ['label 1', 'label 2']
         };
 
         exportOptions = {
@@ -93,7 +95,34 @@ describe('SignupNode', function () {
             node.getSubheader().should.equal('This is the new subheader');
             node.setStyle('light');
             node.getStyle().should.equal('light');
+            // Labels are tested in a separate block below
         }));
+
+        describe('labels', function () {
+            it('can set multiple labels at once', editorTest(function () {
+                const node = $createSignupNode(dataset);
+                node.setLabels(['new label 1', 'new label 2']);
+                node.getLabels().should.deepEqual(['new label 1', 'new label 2']);
+            }));
+
+            it('only accepts an array of strings for setLabels', editorTest(function () {
+                const node = $createSignupNode(dataset);
+                (() => node.setLabels('label')).should.throwError();
+                (() => node.setLabels(['label 1', 2])).should.throwError();
+            }));
+
+            it('can add one label to the existing array', editorTest(function () {
+                const node = $createSignupNode(dataset);
+                node.addLabel('new label 3');
+                node.getLabels().should.deepEqual(['label 1', 'label 2', 'new label 3']);
+            }));
+
+            it('can remove one label from the existing array', editorTest(function () {
+                const node = $createSignupNode(dataset);
+                node.removeLabel('label 2');
+                node.getLabels().should.deepEqual(['label 1']);
+            }));
+        });
 
         it('has getDataset() method', editorTest(function () {
             const signupNode = $createSignupNode(dataset);
@@ -155,7 +184,8 @@ describe('SignupNode', function () {
                 header: dataset.header,
                 subheader: dataset.subheader,
                 disclaimer: dataset.disclaimer,
-                buttonText: dataset.buttonText
+                buttonText: dataset.buttonText,
+                labels: dataset.labels
             });
         }));
     });

--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -36,6 +36,12 @@ const cardConfig = {
         {label: 'Homepage', value: window.location.origin + '/'},
         {label: 'Free signup', value: window.location.origin + '/#/portal/signup/free'}
     ]),
+    signup: {
+        fetchAvailableLabels: () => Promise.resolve([
+            {id: '1', name: 'Label 1'},
+            {id: '2', name: 'Label 2'}
+        ])
+    },
     feature: {
         signupCard: true
     }

--- a/packages/koenig-lexical/src/components/ui/LabelDropdown.jsx
+++ b/packages/koenig-lexical/src/components/ui/LabelDropdown.jsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import {ReactComponent as ArrowIcon} from '../../assets/icons/kg-arrow-down.svg';
+import {ReactComponent as CloseIcon} from '../../assets/icons/kg-close.svg';
+import {DropdownContainer} from './DropdownContainer';
+import {KeyboardSelection} from './KeyboardSelection';
+
+function Item({item, selected, onChange}) {
+    let selectionClass = '';
+
+    if (item.name && selected) {
+        selectionClass = 'bg-grey-100 hover:bg-grey-100 dark:hover:bg-grey-950';
+    }
+
+    // We use the capture phase of the mouse down event, otherwise the list option will be removed when blurring the input
+    // before calling the click event
+    const handleOptionMouseDown = (event, v) => {
+        // Prevent losing focus when clicking an option
+        event.preventDefault();
+        onChange(v);
+    };
+
+    return (
+        <li key={item.name} className={selectionClass}>
+            <button className="h-full w-full cursor-pointer px-3 py-1 text-left dark:text-white" type="button" onMouseDownCapture={event => handleOptionMouseDown(event, item.name)}>{item.label}</button>
+        </li>
+    );
+}
+
+export function LabelDropdown({value = [], labels, onChange}) {
+    const [open, setOpen] = React.useState(false);
+    const [filter, setFilter] = React.useState('');
+    const inputRef = React.useRef(null);
+
+    const handleOpen = (event) => {
+        setOpen(!open);
+
+        // For Safari, we need to manually focus the button (doesn't happen by default)
+        if (!open) {
+            event.target.focus();
+        }
+    };
+
+    const handleBlur = () => {
+        setOpen(false);
+    };
+
+    const handleSelect = (name) => {
+        if (!name || value?.includes(name)) {
+            return;
+        }
+
+        onChange(value.concat(name));
+        setFilter('');
+    };
+
+    const handleDeselect = (event, name) => {
+        // Prevent losing focus when clicking an option
+        event.preventDefault();
+
+        onChange(value.filter(selection => selection !== name));
+    };
+
+    const handleBackspace = (event) => {
+        if (event.key === 'Backspace' && !filter) {
+            onChange(value.slice(0, -1));
+        }
+    };
+
+    const getItem = (item, selected) => {
+        return (
+            <Item key={item.name} item={item} selected={selected} onChange={handleSelect}/>
+        );
+    };
+
+    const nonSelectedItems = labels.filter(label => !value?.includes(label)).map(label => ({name: label, label}));
+    const filteredItems = nonSelectedItems.filter(item => item.label.toLowerCase().includes(filter.toLowerCase()));
+    const emptyItem = filter && !value?.includes(filter)
+        ? [{name: filter, label: <>Add <strong>&quot;{filter}&quot;...</strong></>}]
+        : [{name: undefined, label: 'Type to search'}];
+
+    return (
+        <div className="relative font-sans text-sm font-normal">
+            <div
+                className={`border-grey-300 text-grey-900 dark:border-grey-900 dark:bg-grey-900 dark:placeholder:text-grey-800 relative flex w-full cursor-text flex-wrap gap-1 border py-2 pl-3 pr-5 text-left font-sans font-normal focus-visible:outline-none dark:text-white ${open ? 'rounded-t' : 'rounded'}`}
+                type="button"
+                onClick={() => inputRef.current.focus()}
+            >
+                {value.map(label => (
+                    <button
+                        key={label}
+                        className="bg-grey-900 dark:bg-grey-100 dark:text-grey-900 flex cursor-pointer items-center rounded-sm py-1 px-2 leading-none text-white"
+                        type="button"
+                        onMouseDownCapture={event => handleDeselect(event, label)}
+                    >
+                        {label}
+                        <CloseIcon className="ml-2 h-2 w-2" />
+                    </button>
+                ))}
+
+                <div className="flex-1">
+                    <input
+                        ref={inputRef}
+                        className="h-full w-full min-w-[5rem] appearance-none bg-transparent px-1 leading-none outline-none"
+                        placeholder=""
+                        value={filter}
+                        onBlur={handleBlur}
+                        onChange={event => setFilter(event.target.value)}
+                        onFocus={handleOpen}
+                        onKeyDown={handleBackspace}
+                    />
+                </div>
+
+                <ArrowIcon className={`text-grey-600 absolute right-2 top-4 h-2 w-2 ${open && 'rotate-180'}`} />
+            </div>
+            {open && (
+                <DropdownContainer>
+                    <KeyboardSelection
+                        getItem={getItem}
+                        items={filteredItems.length ? filteredItems : emptyItem}
+                        onSelect={item => handleSelect(item.name)}
+                    />
+                </DropdownContainer>
+            )}
+        </div>
+    );
+}

--- a/packages/koenig-lexical/src/components/ui/LabelDropdown.jsx
+++ b/packages/koenig-lexical/src/components/ui/LabelDropdown.jsx
@@ -98,14 +98,14 @@ export function LabelDropdown({value = [], menu, onChange, dataTestId}) {
     return (
         <div className="relative font-sans text-sm font-normal" data-testid={dataTestId}>
             <div
-                className={`border-grey-300 text-grey-900 dark:border-grey-900 dark:bg-grey-900 dark:placeholder:text-grey-800 relative flex w-full cursor-text flex-wrap gap-1 border py-2 pl-3 pr-5 text-left font-sans font-normal focus-visible:outline-none dark:text-white ${open ? 'rounded-t' : 'rounded'}`}
+                className={`relative flex w-full cursor-text flex-wrap gap-1 border border-grey-300 py-2 pl-3 pr-5 text-left font-sans font-normal text-grey-900 focus-visible:outline-none dark:border-grey-900 dark:bg-grey-900 dark:text-white dark:placeholder:text-grey-800 ${open ? 'rounded-t' : 'rounded'}`}
                 type="button"
                 onClick={() => inputRef.current.focus()}
             >
                 {selectedLabels.map(label => (
                     <button
                         key={label.id}
-                        className="bg-grey-900 dark:bg-grey-100 dark:text-grey-900 flex cursor-pointer items-center rounded-sm py-1 px-2 leading-none text-white"
+                        className="flex cursor-pointer items-center rounded-sm bg-grey-900 py-1 px-2 leading-none text-white dark:bg-grey-100 dark:text-grey-900"
                         data-testid="label-dropdown-selected"
                         type="button"
                         onMouseDownCapture={event => handleDeselect(event, label)}
@@ -128,7 +128,7 @@ export function LabelDropdown({value = [], menu, onChange, dataTestId}) {
                     />
                 </div>
 
-                <ArrowIcon className={`text-grey-600 absolute right-2 top-4 h-2 w-2 ${open && 'rotate-180'}`} />
+                <ArrowIcon className={`absolute right-2 top-4 h-2 w-2 text-grey-600 ${open && 'rotate-180'}`} />
             </div>
             {open && (
                 <DropdownContainer>

--- a/packages/koenig-lexical/src/components/ui/LabelDropdown.jsx
+++ b/packages/koenig-lexical/src/components/ui/LabelDropdown.jsx
@@ -27,7 +27,7 @@ function Item({item, selected, onChange}) {
     );
 }
 
-export function LabelDropdown({value = [], labels, onChange}) {
+export function LabelDropdown({value = [], menu, onChange}) {
     const [open, setOpen] = React.useState(false);
     const [filter, setFilter] = React.useState('');
     const [newLabels, setNewLabels] = React.useState([]);
@@ -81,7 +81,7 @@ export function LabelDropdown({value = [], labels, onChange}) {
         );
     };
 
-    const allLabels = labels.concat(newLabels).map(label => ({...label, label: label.name}));
+    const allLabels = menu.concat(newLabels).map(label => ({...label, label: label.name}));
     const [selectedLabels, nonSelectedLabels] = partition(allLabels, label => value?.includes(label.id));
     const filteredItems = nonSelectedLabels.filter(item => item.name.toLowerCase().includes(filter.toLowerCase()));
     const emptyItem = filter && !selectedLabels?.some(label => label.name === filter)

--- a/packages/koenig-lexical/src/components/ui/LabelDropdown.jsx
+++ b/packages/koenig-lexical/src/components/ui/LabelDropdown.jsx
@@ -22,12 +22,19 @@ function Item({item, selected, onChange}) {
 
     return (
         <li key={item.name} className={selectionClass}>
-            <button className="h-full w-full cursor-pointer px-3 py-1 text-left dark:text-white" type="button" onMouseDownCapture={handleOptionMouseDown}>{item.label}</button>
+            <button
+                className="h-full w-full cursor-pointer px-3 py-1 text-left dark:text-white"
+                data-testid="label-dropdown-item"
+                type="button"
+                onMouseDownCapture={handleOptionMouseDown}
+            >
+                {item.label}
+            </button>
         </li>
     );
 }
 
-export function LabelDropdown({value = [], menu, onChange}) {
+export function LabelDropdown({value = [], menu, onChange, dataTestId}) {
     const [open, setOpen] = React.useState(false);
     const [filter, setFilter] = React.useState('');
     const [newLabels, setNewLabels] = React.useState([]);
@@ -89,7 +96,7 @@ export function LabelDropdown({value = [], menu, onChange}) {
         : [{id: undefined, name: undefined, label: 'Type to search'}];
 
     return (
-        <div className="relative font-sans text-sm font-normal">
+        <div className="relative font-sans text-sm font-normal" data-testid={dataTestId}>
             <div
                 className={`border-grey-300 text-grey-900 dark:border-grey-900 dark:bg-grey-900 dark:placeholder:text-grey-800 relative flex w-full cursor-text flex-wrap gap-1 border py-2 pl-3 pr-5 text-left font-sans font-normal focus-visible:outline-none dark:text-white ${open ? 'rounded-t' : 'rounded'}`}
                 type="button"
@@ -99,6 +106,7 @@ export function LabelDropdown({value = [], menu, onChange}) {
                     <button
                         key={label.id}
                         className="bg-grey-900 dark:bg-grey-100 dark:text-grey-900 flex cursor-pointer items-center rounded-sm py-1 px-2 leading-none text-white"
+                        data-testid="label-dropdown-selected"
                         type="button"
                         onMouseDownCapture={event => handleDeselect(event, label)}
                     >

--- a/packages/koenig-lexical/src/components/ui/MultiSelectDropdown.jsx
+++ b/packages/koenig-lexical/src/components/ui/MultiSelectDropdown.jsx
@@ -24,7 +24,7 @@ function Item({item, selected, onChange}) {
         <li key={item.name} className={selectionClass}>
             <button
                 className="h-full w-full cursor-pointer px-3 py-1 text-left dark:text-white"
-                data-testid="label-dropdown-item"
+                data-testid="multiselect-dropdown-item"
                 type="button"
                 onMouseDownCapture={handleOptionMouseDown}
             >
@@ -34,10 +34,10 @@ function Item({item, selected, onChange}) {
     );
 }
 
-export function LabelDropdown({value = [], menu, onChange, dataTestId}) {
+export function MultiSelectDropdown({value = [], menu, onChange, dataTestId}) {
     const [open, setOpen] = React.useState(false);
     const [filter, setFilter] = React.useState('');
-    const [newLabels, setNewLabels] = React.useState([]);
+    const [newItems, setNewItems] = React.useState([]);
     const inputRef = React.useRef(null);
 
     const handleOpen = (event) => {
@@ -58,22 +58,22 @@ export function LabelDropdown({value = [], menu, onChange, dataTestId}) {
             return;
         }
 
-        // TODO: How to handle new labels?
+        // TODO: How to handle new items?
         if (!item.id) {
-            item.id = `new-label-${item.name}`;
-            setNewLabels(newLabels.concat({id: item.id, name: item.name}));
+            item.id = `new-item-${item.name}`;
+            setNewItems(newItems.concat({id: item.id, name: item.name}));
         }
 
         onChange(value.concat(item.id));
         setFilter('');
     };
 
-    const handleDeselect = (event, item) => {
+    const handleDeselect = (event, selectedItem) => {
         // Prevent losing focus when clicking an option
         event.preventDefault();
 
-        onChange(value.filter(selection => selection !== item.id));
-        setNewLabels(newLabels.filter(label => label.id !== item.id));
+        onChange(value.filter(selection => selection !== selectedItem.id));
+        setNewItems(newItems.filter(item => item.id !== selectedItem.id));
     };
 
     const handleBackspace = (event) => {
@@ -88,10 +88,10 @@ export function LabelDropdown({value = [], menu, onChange, dataTestId}) {
         );
     };
 
-    const allLabels = menu.concat(newLabels).map(label => ({...label, label: label.name}));
-    const [selectedLabels, nonSelectedLabels] = partition(allLabels, label => value?.includes(label.id));
-    const filteredItems = nonSelectedLabels.filter(item => item.name.toLowerCase().includes(filter.toLowerCase()));
-    const emptyItem = filter && !selectedLabels?.some(label => label.name === filter)
+    const allItems = menu.concat(newItems).map(item => ({...item, label: item.name}));
+    const [selectedItems, nonSelectedItems] = partition(allItems, item => value?.includes(item.id));
+    const filteredItems = nonSelectedItems.filter(item => item.name.toLowerCase().includes(filter.toLowerCase()));
+    const emptyItem = filter && !selectedItems?.some(item => item.name === filter)
         ? [{id: undefined, name: filter, label: <>Add <strong>&quot;{filter}&quot;...</strong></>}]
         : [{id: undefined, name: undefined, label: 'Type to search'}];
 
@@ -102,15 +102,15 @@ export function LabelDropdown({value = [], menu, onChange, dataTestId}) {
                 type="button"
                 onClick={() => inputRef.current.focus()}
             >
-                {selectedLabels.map(label => (
+                {selectedItems.map(item => (
                     <button
-                        key={label.id}
+                        key={item.id}
                         className="flex cursor-pointer items-center rounded-sm bg-grey-900 py-1 px-2 leading-none text-white dark:bg-grey-100 dark:text-grey-900"
-                        data-testid="label-dropdown-selected"
+                        data-testid="multiselect-dropdown-selected"
                         type="button"
-                        onMouseDownCapture={event => handleDeselect(event, label)}
+                        onMouseDownCapture={event => handleDeselect(event, item)}
                     >
-                        {label.label}
+                        {item.label}
                         <CloseIcon className="ml-2 h-2 w-2" />
                     </button>
                 ))}

--- a/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
+++ b/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
@@ -128,11 +128,12 @@ export function DropdownSetting({label, description, value, menu, onChange}) {
     );
 }
 
-export function LabelDropdownSetting({label, description, value, menu, onChange}) {
+export function LabelDropdownSetting({label, description, value, menu, onChange, dataTestId}) {
     return (
         <div className="mt-2 flex w-full flex-col justify-between gap-2 text-[1.3rem] first:mt-0">
             <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
             <LabelDropdown
+                dataTestId={dataTestId}
                 menu={menu}
                 value={value}
                 onChange={onChange}

--- a/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
+++ b/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
@@ -128,12 +128,12 @@ export function DropdownSetting({label, description, value, menu, onChange}) {
     );
 }
 
-export function LabelDropdownSetting({label, description, value, labels, onChange}) {
+export function LabelDropdownSetting({label, description, value, menu, onChange}) {
     return (
         <div className="mt-2 flex w-full flex-col justify-between gap-2 text-[1.3rem] first:mt-0">
             <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
             <LabelDropdown
-                labels={labels}
+                menu={menu}
                 value={value}
                 onChange={onChange}
             />

--- a/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
+++ b/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
@@ -23,7 +23,7 @@ export function SettingsPanel({children, darkMode}) {
         // Using Portal to avoid such issue as some cards using transformation
         <div className={`!mt-0 ${darkMode ? 'dark' : ''}`}>
             <div ref={ref}
-                className="not-kg-prose dark:bg-grey-950 z-[9999999] m-0 flex w-[320px] flex-col gap-2 rounded-lg bg-white bg-clip-padding p-6 font-sans shadow"
+                className="not-kg-prose z-[9999999] m-0 flex w-[320px] flex-col gap-2 rounded-lg bg-white bg-clip-padding p-6 font-sans shadow dark:bg-grey-950"
                 data-testid="settings-panel"
             >
                 {children}
@@ -36,9 +36,9 @@ export function ToggleSetting({label, description, isChecked, onChange, dataTest
     return (
         <div className="mt-2 flex min-h-[3rem] w-full items-center justify-between text-[1.3rem] first:mt-0">
             <div>
-                <div className="text-grey-900 dark:text-grey-300 font-bold">{label}</div>
+                <div className="font-bold text-grey-900 dark:text-grey-300">{label}</div>
                 {description &&
-                    <p className="text-grey-700 w-11/12 text-[1.25rem] font-normal leading-snug">{description}</p>
+                    <p className="w-11/12 text-[1.25rem] font-normal leading-snug text-grey-700">{description}</p>
                 }
             </div>
             <div className="flex shrink-0 pl-2">
@@ -51,10 +51,10 @@ export function ToggleSetting({label, description, isChecked, onChange, dataTest
 export function InputSetting({label, description, onChange, value, placeholder, dataTestId}) {
     return (
         <div className="mt-2 flex w-full flex-col justify-between gap-2 text-[1.3rem] first:mt-0">
-            <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
+            <div className="font-bold text-grey-900 dark:text-grey-200">{label}</div>
             <Input dataTestId={dataTestId} placeholder={placeholder} value={value} onChange={onChange} />
             {description &&
-                <p className="text-grey-700 text-[1.25rem] font-normal leading-snug">{description}</p>
+                <p className="text-[1.25rem] font-normal leading-snug text-grey-700">{description}</p>
             }
         </div>
     );
@@ -103,10 +103,10 @@ export function InputUrlSetting({dataTestId, label, value, onChange}) {
 export function InputListSetting({dataTestId, description, label, listOptions, onChange, placeholder, value}) {
     return (
         <div className="mt-2 flex w-full flex-col justify-between gap-2 text-[1.3rem] first:mt-0">
-            <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
+            <div className="font-bold text-grey-900 dark:text-grey-200">{label}</div>
             <InputList dataTestId={dataTestId} listOptions={listOptions} placeholder={placeholder} value={value} onChange={onChange} />
             {description &&
-                    <p className="text-grey-700 text-[1.25rem] font-normal leading-snug">{description}</p>
+                    <p className="text-[1.25rem] font-normal leading-snug text-grey-700">{description}</p>
             }
         </div>
     );
@@ -115,14 +115,14 @@ export function InputListSetting({dataTestId, description, label, listOptions, o
 export function DropdownSetting({label, description, value, menu, onChange}) {
     return (
         <div className="mt-2 flex w-full flex-col justify-between gap-2 text-[1.3rem] first:mt-0">
-            <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
+            <div className="font-bold text-grey-900 dark:text-grey-200">{label}</div>
             <Dropdown
                 menu={menu}
                 value={value}
                 onChange={onChange}
             />
             {description &&
-                    <p className="text-grey-700 text-[1.25rem] font-normal leading-snug">{description}</p>
+                    <p className="text-[1.25rem] font-normal leading-snug text-grey-700">{description}</p>
             }
         </div>
     );
@@ -131,7 +131,7 @@ export function DropdownSetting({label, description, value, menu, onChange}) {
 export function LabelDropdownSetting({label, description, value, menu, onChange, dataTestId}) {
     return (
         <div className="mt-2 flex w-full flex-col justify-between gap-2 text-[1.3rem] first:mt-0">
-            <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
+            <div className="font-bold text-grey-900 dark:text-grey-200">{label}</div>
             <LabelDropdown
                 dataTestId={dataTestId}
                 menu={menu}
@@ -139,7 +139,7 @@ export function LabelDropdownSetting({label, description, value, menu, onChange,
                 onChange={onChange}
             />
             {description &&
-                    <p className="text-grey-700 text-[1.25rem] font-normal leading-snug">{description}</p>
+                    <p className="text-[1.25rem] font-normal leading-snug text-grey-700">{description}</p>
             }
         </div>
     );
@@ -148,7 +148,7 @@ export function LabelDropdownSetting({label, description, value, menu, onChange,
 export function ButtonGroupSetting({label, onClick, selectedName, buttons, dataTestId}) {
     return (
         <div className="mt-2 flex w-full items-center justify-between text-[1.3rem] first:mt-0">
-            <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
+            <div className="font-bold text-grey-900 dark:text-grey-200">{label}</div>
 
             <div className="shrink-0 pl-2">
                 <ButtonGroup buttons={buttons} selectedName={selectedName} onClick={onClick} />
@@ -160,7 +160,7 @@ export function ButtonGroupSetting({label, onClick, selectedName, buttons, dataT
 export function ColorPickerSetting({label, onClick, selectedName, buttons, layout, dataTestId}) {
     return (
         <div className={`mt-2 flex w-full text-[1.3rem] first:mt-0 ${layout === 'stacked' ? 'flex-col' : 'items-center justify-between'}`} data-testid={dataTestId}>
-            <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
+            <div className="font-bold text-grey-900 dark:text-grey-200">{label}</div>
 
             <div className={`shrink-0 ${layout === 'stacked' ? '-mx-1 pt-1' : 'pl-2'}`}>
                 <ColorPicker buttons={buttons} selectedName={selectedName} onClick={onClick} />
@@ -189,7 +189,7 @@ export function ThumbnailSetting({label, onFileChange, isDraggedOver, placeholde
 
     return (
         <div className="mt-2 text-[1.3rem] first:mt-0" data-testid="custom-thumbnail">
-            <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
+            <div className="font-bold text-grey-900 dark:text-grey-200">{label}</div>
 
             {isEmpty &&
                 <div className="h-32">
@@ -231,7 +231,7 @@ export function ThumbnailSetting({label, onFileChange, isDraggedOver, placeholde
 
                     {isLoading && (
                         <div
-                            className="border-grey/20 bg-grey-50 absolute inset-0 flex min-w-full items-center justify-center overflow-hidden rounded border border-dashed"
+                            className="absolute inset-0 flex min-w-full items-center justify-center overflow-hidden rounded border border-dashed border-grey/20 bg-grey-50"
                             data-testid="custom-thumbnail-progress"
                         >
                             <ProgressBar style={progressStyle} />
@@ -245,6 +245,6 @@ export function ThumbnailSetting({label, onFileChange, isDraggedOver, placeholde
 
 export function SettingsDivider() {
     return (
-        <hr className="border-grey-200 -mx-6 mt-2 dark:border-white/5" />
+        <hr className="-mx-6 mt-2 border-grey-200 dark:border-white/5" />
     );
 }

--- a/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
+++ b/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
@@ -9,6 +9,7 @@ import {Dropdown} from './Dropdown';
 import {IconButton} from './IconButton';
 import {Input} from './Input';
 import {InputList} from './InputList';
+import {LabelDropdown} from './LabelDropdown';
 import {MediaPlaceholder} from './MediaPlaceholder';
 import {ProgressBar} from './ProgressBar';
 import {Toggle} from './Toggle';
@@ -22,7 +23,7 @@ export function SettingsPanel({children, darkMode}) {
         // Using Portal to avoid such issue as some cards using transformation
         <div className={`!mt-0 ${darkMode ? 'dark' : ''}`}>
             <div ref={ref}
-                className="not-kg-prose z-[9999999] m-0 flex w-[320px] flex-col gap-2 rounded-lg bg-white bg-clip-padding p-6 font-sans shadow dark:bg-grey-950"
+                className="not-kg-prose dark:bg-grey-950 z-[9999999] m-0 flex w-[320px] flex-col gap-2 rounded-lg bg-white bg-clip-padding p-6 font-sans shadow"
                 data-testid="settings-panel"
             >
                 {children}
@@ -35,9 +36,9 @@ export function ToggleSetting({label, description, isChecked, onChange, dataTest
     return (
         <div className="mt-2 flex min-h-[3rem] w-full items-center justify-between text-[1.3rem] first:mt-0">
             <div>
-                <div className="font-bold text-grey-900 dark:text-grey-300">{label}</div>
+                <div className="text-grey-900 dark:text-grey-300 font-bold">{label}</div>
                 {description &&
-                    <p className="w-11/12 text-[1.25rem] font-normal leading-snug text-grey-700">{description}</p>
+                    <p className="text-grey-700 w-11/12 text-[1.25rem] font-normal leading-snug">{description}</p>
                 }
             </div>
             <div className="flex shrink-0 pl-2">
@@ -50,10 +51,10 @@ export function ToggleSetting({label, description, isChecked, onChange, dataTest
 export function InputSetting({label, description, onChange, value, placeholder, dataTestId}) {
     return (
         <div className="mt-2 flex w-full flex-col justify-between gap-2 text-[1.3rem] first:mt-0">
-            <div className="font-bold text-grey-900 dark:text-grey-200">{label}</div>
+            <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
             <Input dataTestId={dataTestId} placeholder={placeholder} value={value} onChange={onChange} />
             {description &&
-                <p className="text-[1.25rem] font-normal leading-snug text-grey-700">{description}</p>
+                <p className="text-grey-700 text-[1.25rem] font-normal leading-snug">{description}</p>
             }
         </div>
     );
@@ -102,10 +103,10 @@ export function InputUrlSetting({dataTestId, label, value, onChange}) {
 export function InputListSetting({dataTestId, description, label, listOptions, onChange, placeholder, value}) {
     return (
         <div className="mt-2 flex w-full flex-col justify-between gap-2 text-[1.3rem] first:mt-0">
-            <div className="font-bold text-grey-900 dark:text-grey-200">{label}</div>
+            <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
             <InputList dataTestId={dataTestId} listOptions={listOptions} placeholder={placeholder} value={value} onChange={onChange} />
             {description &&
-                    <p className="text-[1.25rem] font-normal leading-snug text-grey-700">{description}</p>
+                    <p className="text-grey-700 text-[1.25rem] font-normal leading-snug">{description}</p>
             }
         </div>
     );
@@ -114,14 +115,30 @@ export function InputListSetting({dataTestId, description, label, listOptions, o
 export function DropdownSetting({label, description, value, menu, onChange}) {
     return (
         <div className="mt-2 flex w-full flex-col justify-between gap-2 text-[1.3rem] first:mt-0">
-            <div className="font-bold text-grey-900 dark:text-grey-200">{label}</div>
+            <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
             <Dropdown
                 menu={menu}
                 value={value}
                 onChange={onChange}
             />
             {description &&
-                    <p className="text-[1.25rem] font-normal leading-snug text-grey-700">{description}</p>
+                    <p className="text-grey-700 text-[1.25rem] font-normal leading-snug">{description}</p>
+            }
+        </div>
+    );
+}
+
+export function LabelDropdownSetting({label, description, value, labels, onChange}) {
+    return (
+        <div className="mt-2 flex w-full flex-col justify-between gap-2 text-[1.3rem] first:mt-0">
+            <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
+            <LabelDropdown
+                labels={labels}
+                value={value}
+                onChange={onChange}
+            />
+            {description &&
+                    <p className="text-grey-700 text-[1.25rem] font-normal leading-snug">{description}</p>
             }
         </div>
     );
@@ -130,7 +147,7 @@ export function DropdownSetting({label, description, value, menu, onChange}) {
 export function ButtonGroupSetting({label, onClick, selectedName, buttons, dataTestId}) {
     return (
         <div className="mt-2 flex w-full items-center justify-between text-[1.3rem] first:mt-0">
-            <div className="font-bold text-grey-900 dark:text-grey-200">{label}</div>
+            <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
 
             <div className="shrink-0 pl-2">
                 <ButtonGroup buttons={buttons} selectedName={selectedName} onClick={onClick} />
@@ -142,7 +159,7 @@ export function ButtonGroupSetting({label, onClick, selectedName, buttons, dataT
 export function ColorPickerSetting({label, onClick, selectedName, buttons, layout, dataTestId}) {
     return (
         <div className={`mt-2 flex w-full text-[1.3rem] first:mt-0 ${layout === 'stacked' ? 'flex-col' : 'items-center justify-between'}`} data-testid={dataTestId}>
-            <div className="font-bold text-grey-900 dark:text-grey-200">{label}</div>
+            <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
 
             <div className={`shrink-0 ${layout === 'stacked' ? '-mx-1 pt-1' : 'pl-2'}`}>
                 <ColorPicker buttons={buttons} selectedName={selectedName} onClick={onClick} />
@@ -171,7 +188,7 @@ export function ThumbnailSetting({label, onFileChange, isDraggedOver, placeholde
 
     return (
         <div className="mt-2 text-[1.3rem] first:mt-0" data-testid="custom-thumbnail">
-            <div className="font-bold text-grey-900 dark:text-grey-200">{label}</div>
+            <div className="text-grey-900 dark:text-grey-200 font-bold">{label}</div>
 
             {isEmpty &&
                 <div className="h-32">
@@ -213,7 +230,7 @@ export function ThumbnailSetting({label, onFileChange, isDraggedOver, placeholde
 
                     {isLoading && (
                         <div
-                            className="absolute inset-0 flex min-w-full items-center justify-center overflow-hidden rounded border border-dashed border-grey/20 bg-grey-50"
+                            className="border-grey/20 bg-grey-50 absolute inset-0 flex min-w-full items-center justify-center overflow-hidden rounded border border-dashed"
                             data-testid="custom-thumbnail-progress"
                         >
                             <ProgressBar style={progressStyle} />
@@ -227,6 +244,6 @@ export function ThumbnailSetting({label, onFileChange, isDraggedOver, placeholde
 
 export function SettingsDivider() {
     return (
-        <hr className="-mx-6 mt-2 border-grey-200 dark:border-white/5" />
+        <hr className="border-grey-200 -mx-6 mt-2 dark:border-white/5" />
     );
 }

--- a/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
+++ b/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
@@ -9,8 +9,8 @@ import {Dropdown} from './Dropdown';
 import {IconButton} from './IconButton';
 import {Input} from './Input';
 import {InputList} from './InputList';
-import {LabelDropdown} from './LabelDropdown';
 import {MediaPlaceholder} from './MediaPlaceholder';
+import {MultiSelectDropdown} from './MultiSelectDropdown';
 import {ProgressBar} from './ProgressBar';
 import {Toggle} from './Toggle';
 import {openFileSelection} from '../../utils/openFileSelection';
@@ -128,11 +128,11 @@ export function DropdownSetting({label, description, value, menu, onChange}) {
     );
 }
 
-export function LabelDropdownSetting({label, description, value, menu, onChange, dataTestId}) {
+export function MultiSelectDropdownSetting({label, description, value, menu, onChange, dataTestId}) {
     return (
         <div className="mt-2 flex w-full flex-col justify-between gap-2 text-[1.3rem] first:mt-0">
             <div className="font-bold text-grey-900 dark:text-grey-200">{label}</div>
-            <LabelDropdown
+            <MultiSelectDropdown
                 dataTestId={dataTestId}
                 menu={menu}
                 value={value}

--- a/packages/koenig-lexical/src/components/ui/SettingsPanel.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/SettingsPanel.stories.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-key */
 import React from 'react';
 
-import {ButtonGroupSetting, ColorPickerSetting, DropdownSetting, InputSetting, LabelDropdownSetting, SettingsDivider, SettingsPanel, ThumbnailSetting, ToggleSetting} from './SettingsPanel';
+import {ButtonGroupSetting, ColorPickerSetting, DropdownSetting, InputSetting, MultiSelectDropdownSetting, SettingsDivider, SettingsPanel, ThumbnailSetting, ToggleSetting} from './SettingsPanel';
 import {ReactComponent as CenterAlignIcon} from '../../assets/icons/kg-align-center.svg';
 import {ReactComponent as ImgFullIcon} from '../../assets/icons/kg-img-full.svg';
 import {ReactComponent as ImgRegularIcon} from '../../assets/icons/kg-img-regular.svg';
@@ -96,7 +96,7 @@ EmailCtaCard.args = {
 export const SignupLabelsCard = Template.bind({});
 SignupLabelsCard.args = {
     children: [
-        <LabelDropdownSetting
+        <MultiSelectDropdownSetting
             description='These labels will be applied to members who sign up via this form.'
             label='Labels'
             menu={[{id: '1', name: 'Free members'}, {id: '2', name: 'Paid members'}]}

--- a/packages/koenig-lexical/src/components/ui/SettingsPanel.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/SettingsPanel.stories.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-key */
 import React from 'react';
 
-import {ButtonGroupSetting, ColorPickerSetting, DropdownSetting, InputSetting, SettingsDivider, SettingsPanel, ThumbnailSetting, ToggleSetting} from './SettingsPanel';
+import {ButtonGroupSetting, ColorPickerSetting, DropdownSetting, InputSetting, LabelDropdownSetting, SettingsDivider, SettingsPanel, ThumbnailSetting, ToggleSetting} from './SettingsPanel';
 import {ReactComponent as CenterAlignIcon} from '../../assets/icons/kg-align-center.svg';
 import {ReactComponent as ImgFullIcon} from '../../assets/icons/kg-img-full.svg';
 import {ReactComponent as ImgRegularIcon} from '../../assets/icons/kg-img-regular.svg';
@@ -90,6 +90,18 @@ EmailCtaCard.args = {
         <ToggleSetting label='Button' />,
         <InputSetting label='Button text' placeholder='Add button text' />,
         <InputSetting label='Button URL' placeholder='https://yoursite.com/#/portal/signup/' />
+    ]
+};
+
+export const SignupLabelsCard = Template.bind({});
+SignupLabelsCard.args = {
+    children: [
+        <LabelDropdownSetting
+            description='These labels will be applied to members who sign up via this form.'
+            label='Labels'
+            menu={[{id: '1', name: 'Free members'}, {id: '2', name: 'Paid members'}]}
+            value={['1']}
+        />
     ]
 };
 

--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {BackgroundImagePicker} from '../BackgroundImagePicker';
 import {Button} from '../Button';
-import {ButtonGroupSetting, ColorPickerSetting, InputSetting, LabelDropdownSetting, SettingsDivider, SettingsPanel, ToggleSetting} from '../SettingsPanel';
+import {ButtonGroupSetting, ColorPickerSetting, InputSetting, MultiSelectDropdownSetting, SettingsDivider, SettingsPanel, ToggleSetting} from '../SettingsPanel';
 import {ReactComponent as CenterAlignIcon} from '../../../assets/icons/kg-align-center.svg';
 import {ReactComponent as ImgFullIcon} from '../../../assets/icons/kg-img-full.svg';
 import {ReactComponent as ImgRegularIcon} from '../../../assets/icons/kg-img-regular.svg';
@@ -244,7 +244,7 @@ export function SignupCard({alignment,
                         value={buttonText}
                         onChange={handleButtonText}
                     />
-                    <LabelDropdownSetting
+                    <MultiSelectDropdownSetting
                         dataTestId='labels-dropdown'
                         description='These labels will be applied to members who sign up via this form.'
                         label='Labels'

--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {BackgroundImagePicker} from '../BackgroundImagePicker';
 import {Button} from '../Button';
-import {ButtonGroupSetting, ColorPickerSetting, DropdownSetting, InputSetting, SettingsDivider, SettingsPanel, ToggleSetting} from '../SettingsPanel';
+import {ButtonGroupSetting, ColorPickerSetting, InputSetting, LabelDropdownSetting, SettingsDivider, SettingsPanel, ToggleSetting} from '../SettingsPanel';
 import {ReactComponent as CenterAlignIcon} from '../../../assets/icons/kg-align-center.svg';
 import {ReactComponent as ImgFullIcon} from '../../../assets/icons/kg-img-full.svg';
 import {ReactComponent as ImgRegularIcon} from '../../../assets/icons/kg-img-regular.svg';
@@ -48,6 +48,8 @@ export function SignupCard({alignment,
     fileInputRef,
     handleButtonText,
     handleClearBackgroundImage,
+    labels,
+    handleLabels,
     openFilePicker,
     onFileChange,
     headerTextEditor,
@@ -111,8 +113,10 @@ export function SignupCard({alignment,
     ];
 
     const dropdownOptions = [{
+        name: 'Label 1',
         label: 'Label 1'
     }, {
+        name: 'Label 2',
         label: 'Label 2'
     }];
 
@@ -246,14 +250,14 @@ export function SignupCard({alignment,
                         placeholder='Add button text'
                         value={buttonText}
                         onChange={handleButtonText}
-
                     />
-                    <DropdownSetting
+                    <LabelDropdownSetting
                         description='These labels will be applied to members who sign up via this form.'
                         label='Labels'
-                        menu={dropdownOptions}
+                        labels={dropdownOptions.map(option => option.label)}
+                        value={labels}
+                        onChange={handleLabels}
                     />
-
                 </SettingsPanel>
             )}
         </>
@@ -282,6 +286,8 @@ SignupCard.propTypes = {
     handleSizeSelector: PropTypes.func,
     handleButtonText: PropTypes.func,
     handleClearBackgroundImage: PropTypes.func,
+    handleLabels: PropTypes.func,
+    labels: PropTypes.arrayOf(PropTypes.string),
     openFilePicker: PropTypes.func,
     onFileChange: PropTypes.func,
     headerTextEditor: PropTypes.object,

--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
@@ -247,7 +247,7 @@ export function SignupCard({alignment,
                     <LabelDropdownSetting
                         description='These labels will be applied to members who sign up via this form.'
                         label='Labels'
-                        labels={availableLabels}
+                        menu={availableLabels}
                         value={labels}
                         onChange={handleLabels}
                     />

--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
@@ -245,6 +245,7 @@ export function SignupCard({alignment,
                         onChange={handleButtonText}
                     />
                     <LabelDropdownSetting
+                        dataTestId='labels-dropdown'
                         description='These labels will be applied to members who sign up via this form.'
                         label='Labels'
                         menu={availableLabels}

--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
@@ -49,6 +49,7 @@ export function SignupCard({alignment,
     handleButtonText,
     handleClearBackgroundImage,
     labels,
+    availableLabels,
     handleLabels,
     openFilePicker,
     onFileChange,
@@ -111,14 +112,6 @@ export function SignupCard({alignment,
             color: 'bg-grey-50'
         }
     ];
-
-    const dropdownOptions = [{
-        name: 'Label 1',
-        label: 'Label 1'
-    }, {
-        name: 'Label 2',
-        label: 'Label 2'
-    }];
 
     const {isLoading: isUploading, progress} = fileUploader || {};
 
@@ -254,7 +247,7 @@ export function SignupCard({alignment,
                     <LabelDropdownSetting
                         description='These labels will be applied to members who sign up via this form.'
                         label='Labels'
-                        labels={dropdownOptions.map(option => option.label)}
+                        labels={availableLabels}
                         value={labels}
                         onChange={handleLabels}
                     />
@@ -288,6 +281,7 @@ SignupCard.propTypes = {
     handleClearBackgroundImage: PropTypes.func,
     handleLabels: PropTypes.func,
     labels: PropTypes.arrayOf(PropTypes.string),
+    availableLabels: PropTypes.arrayOf(PropTypes.object),
     openFilePicker: PropTypes.func,
     onFileChange: PropTypes.func,
     headerTextEditor: PropTypes.object,

--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.stories.jsx
@@ -84,7 +84,8 @@ Empty.args = {
     disclaimerPlaceholder: 'Enter disclaimer text',
     buttonText: '',
     buttonPlaceholder: 'Add button text',
-    splitLayout: false
+    splitLayout: false,
+    availableLabels: [{id: '1',name: 'First label'},{id: '2',name: 'Second label'}]
 };
 
 export const Populated = Template.bind({});
@@ -101,5 +102,6 @@ Populated.args = {
     disclaimerPlaceholder: 'Enter disclaimer text',
     buttonText: 'Subscribe',
     buttonPlaceholder: 'Add button text',
-    splitLayout: false
+    splitLayout: false,
+    availableLabels: [{id: '1',name: 'First label'},{id: '2',name: 'Second label'}]
 };

--- a/packages/koenig-lexical/src/nodes/SignupNode.jsx
+++ b/packages/koenig-lexical/src/nodes/SignupNode.jsx
@@ -130,6 +130,7 @@ export class SignupNode extends BaseSignupNode {
                     headerPlaceholder={'Enter heading'}
                     headerTextEditor={this.__headerTextEditor}
                     headerTextEditorInitialState={this.__headerTextEditorInitialState}
+                    labels={this.getLabels()}
                     nodeKey={this.getKey()}
                     subheader={this.getSubheader()}
                     subheaderPlaceholder={'Enter subheading text'}

--- a/packages/koenig-lexical/src/nodes/SignupNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/SignupNodeComponent.jsx
@@ -12,7 +12,6 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
 function SignupNodeComponent({
     backgroundImageSrc,
-    button,
     buttonPlaceholder,
     buttonText,
     nodeKey,
@@ -28,7 +27,8 @@ function SignupNodeComponent({
     subheaderPlaceholder,
     subheaderTextEditor,
     subheaderTextEditorInitialState,
-    type
+    type,
+    labels
 }) {
     const [editor] = useLexicalComposerContext();
     const {cardConfig} = useContext(KoenigComposerContext);
@@ -108,6 +108,13 @@ function SignupNodeComponent({
         });
     };
 
+    const handleLabels = (newLabels) => {
+        editor.update(() => {
+            const node = $getNodeByKey(nodeKey);
+            node.setLabels(newLabels);
+        });
+    };
+
     useEffect(() => {
         headerTextEditor.setEditable(isEditing);
         subheaderTextEditor.setEditable(isEditing);
@@ -128,12 +135,14 @@ function SignupNodeComponent({
                 handleButtonText={handleButtonText}
                 handleClearBackgroundImage={handleClearBackgroundImage}
                 handleColorSelector={handleColorSelector}
+                handleLabels={handleLabels}
                 handleSizeSelector={handleSizeSelector}
                 header={header}
                 headerPlaceholder={headerPlaceholder}
                 headerTextEditor={headerTextEditor}
                 headerTextEditorInitialState={headerTextEditorInitialState}
                 isEditing={isEditing}
+                labels={labels}
                 openFilePicker={openFilePicker}
                 subheader={subheader}
                 subheaderPlaceholder={subheaderPlaceholder}

--- a/packages/koenig-lexical/src/nodes/SignupNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/SignupNodeComponent.jsx
@@ -38,10 +38,12 @@ function SignupNodeComponent({
     const [availableLabels, setAvailableLabels] = useState([]);
 
     useEffect(() => {
-        cardConfig.signup.fetchAvailableLabels().then((options) => {
-            setAvailableLabels(options);
-        });
-    }, [cardConfig.signup]);
+        if (cardConfig?.fetchLabels) {
+            cardConfig.fetchLabels().then((options) => {
+                setAvailableLabels(options);
+            });
+        }
+    }, [cardConfig]);
 
     const handleToolbarEdit = (event) => {
         event.preventDefault();

--- a/packages/koenig-lexical/src/nodes/SignupNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/SignupNodeComponent.jsx
@@ -35,6 +35,13 @@ function SignupNodeComponent({
     const {fileUploader} = useContext(KoenigComposerContext);
     const {isEditing, isSelected} = useContext(CardContext);
     const [showSnippetToolbar, setShowSnippetToolbar] = useState(false);
+    const [availableLabels, setAvailableLabels] = useState([]);
+
+    useEffect(() => {
+        cardConfig.signup.fetchAvailableLabels().then((options) => {
+            setAvailableLabels(options);
+        });
+    }, [cardConfig.signup]);
 
     const handleToolbarEdit = (event) => {
         event.preventDefault();
@@ -122,6 +129,7 @@ function SignupNodeComponent({
     return (
         <>
             <SignupCard
+                availableLabels={availableLabels}
                 backgroundImagePreview={backgroundImagePreview}
                 backgroundImageSrc={backgroundImageSrc}
                 buttonPlaceholder={buttonPlaceholder}

--- a/packages/koenig-lexical/test/e2e/cards/signup-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/signup-card.test.js
@@ -157,29 +157,29 @@ test.describe('Signup card', async () => {
         // Add existing label
 
         await page.keyboard.type('Label 1');
-        await page.click('[data-testid="labels-dropdown"] [data-testid="label-dropdown-item"]');
+        await page.click('[data-testid="labels-dropdown"] [data-testid="multiselect-dropdown-item"]');
 
-        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="label-dropdown-selected"]')).toHaveCount(1);
-        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="label-dropdown-selected"]')).toHaveText('Label 1');
+        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="multiselect-dropdown-selected"]')).toHaveCount(1);
+        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="multiselect-dropdown-selected"]')).toHaveText('Label 1');
 
         // Add new label
 
         await page.keyboard.type('Some new label');
         await page.keyboard.press('Enter');
 
-        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="label-dropdown-selected"]')).toHaveCount(2);
-        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="label-dropdown-selected"]:nth-child(2)')).toHaveText('Some new label');
+        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="multiselect-dropdown-selected"]')).toHaveCount(2);
+        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="multiselect-dropdown-selected"]:nth-child(2)')).toHaveText('Some new label');
 
         // Remove label with backspace
 
         await page.keyboard.press('Backspace');
 
-        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="label-dropdown-selected"]')).toHaveCount(1);
+        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="multiselect-dropdown-selected"]')).toHaveCount(1);
 
         // Remove label by clicking
 
-        await page.click('[data-testid="labels-dropdown"] [data-testid="label-dropdown-selected"]');
+        await page.click('[data-testid="labels-dropdown"] [data-testid="multiselect-dropdown-selected"]');
 
-        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="label-dropdown-selected"]')).toHaveCount(0);
+        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="multiselect-dropdown-selected"]')).toHaveCount(0);
     });
 });

--- a/packages/koenig-lexical/test/e2e/cards/signup-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/signup-card.test.js
@@ -147,4 +147,39 @@ test.describe('Signup card', async () => {
         // Check if it is also set as an image in the panel
         await expect(page.getByTestId('image-picker-background')).toHaveAttribute('src', /blob:/);
     });
+
+    test('can add and remove labels', async function ({page}) {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'signup'});
+
+        await page.click('[data-testid="labels-dropdown"] input');
+
+        // Add existing label
+
+        await page.keyboard.type('Label 1');
+        await page.click('[data-testid="labels-dropdown"] [data-testid="label-dropdown-item"]');
+
+        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="label-dropdown-selected"]')).toHaveCount(1);
+        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="label-dropdown-selected"]')).toHaveText('Label 1');
+
+        // Add new label
+
+        await page.keyboard.type('Some new label');
+        await page.keyboard.press('Enter');
+
+        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="label-dropdown-selected"]')).toHaveCount(2);
+        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="label-dropdown-selected"]:nth-child(2)')).toHaveText('Some new label');
+
+        // Remove label with backspace
+
+        await page.keyboard.press('Backspace');
+
+        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="label-dropdown-selected"]')).toHaveCount(1);
+
+        // Remove label by clicking
+
+        await page.click('[data-testid="labels-dropdown"] [data-testid="label-dropdown-selected"]');
+
+        await expect(page.locator('[data-testid="labels-dropdown"] [data-testid="label-dropdown-selected"]')).toHaveCount(0);
+    });
 });


### PR DESCRIPTION
No issue

Pretty experimental, although it works OK. I would usually use `react-select` but that clashes horribly with the drag-and-drop event handlers on the settings pane. So I ended up just doing a simple custom multiselect based on the existing `Dropdown` component. There may well be better options out there though.

I guess the available labels will need to be passed via `cardConfig` so we'll need a PR on https://github.com/TryGhost/Ghost for that