### PR TITLE
Aligned lexical JSON payloads to match mobiledoc

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkNode.js
+++ b/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkNode.js
@@ -81,7 +81,7 @@ export class BookmarkNode extends KoenigDecoratorNode {
             version: 1,
             url: this.getUrl(),
             metadata: {
-                icon: this.getIcon(),
+                icon: this.getIconSrc(),
                 title: this.getTitle(),
                 description: this.getDescription(),
                 author: this.getAuthor(),
@@ -130,12 +130,13 @@ export class BookmarkNode extends KoenigDecoratorNode {
         return writable.__url = url;
     }
 
-    getIcon() {
+    // getIcon() is reserved for the card's icon in the editor
+    getIconSrc() {
         const self = this.getLatest();
         return self.__icon;
     }
 
-    setIcon(icon) {
+    setIconSrc(icon) {
         const writable = this.getWritable();
         return writable.__icon = icon;
     }

--- a/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkNode.js
+++ b/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkNode.js
@@ -40,39 +40,36 @@ export class BookmarkNode extends KoenigDecoratorNode {
         const self = this.getLatest();
         return {
             url: self.__url,
-            icon: self.__icon,
-            title: self.__title,
-            description: self.__description,
-            author: self.__author,
-            publisher: self.__publisher,
-            thumbnail: self.__thumbnail,
+            metadata: {
+                icon: self.__icon,
+                title: self.__title,
+                description: self.__description,
+                author: self.__author,
+                publisher: self.__publisher,
+                thumbnail: self.__thumbnail
+            },
             caption: self.__caption
         
         };
     }
 
-    constructor({url, icon, title, description, author, publisher, thumbnail, caption} = {}, key) {
+    constructor({url, metadata, caption} = {}, key) {
         super(key);
         this.__url = url || '';
-        this.__icon = icon || '';
-        this.__title = title || '';
-        this.__description = description || '';
-        this.__author = author || '';
-        this.__publisher = publisher || '';
-        this.__thumbnail = thumbnail || '';
+        this.__icon = metadata?.icon || '';
+        this.__title = metadata?.title || '';
+        this.__description = metadata?.description || '';
+        this.__author = metadata?.author || '';
+        this.__publisher = metadata?.publisher || '';
+        this.__thumbnail = metadata?.thumbnail || '';
         this.__caption = caption || '';
     }
 
     static importJSON(serializedNode) {
-        const {url, icon, title, description, author, publisher, thumbnail, caption} = serializedNode;
+        const {url, metadata, caption} = serializedNode;
         const node = new this({
             url,
-            icon,
-            title,
-            description,
-            author,
-            publisher, 
-            thumbnail,
+            metadata,
             caption
         });
         return node;
@@ -83,12 +80,14 @@ export class BookmarkNode extends KoenigDecoratorNode {
             type: 'bookmark',
             version: 1,
             url: this.getUrl(),
-            icon: this.getIcon(),
-            title: this.getTitle(),
-            description: this.getDescription(),
-            author: this.getAuthor(),
-            publisher: this.getPublisher(),
-            thumbnail: this.getThumbnail(),
+            metadata: {
+                icon: this.getIcon(),
+                title: this.getTitle(),
+                description: this.getDescription(),
+                author: this.getAuthor(),
+                publisher: this.getPublisher(),
+                thumbnail: this.getThumbnail()
+            },
             caption: this.getCaption()
         };
         return dataset;

--- a/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkParser.js
+++ b/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkParser.js
@@ -22,12 +22,14 @@ export class BookmarkParser {
                             const caption = domNode?.querySelector('figure.kg-bookmark-card figcaption').textContent;
                             const payload = {
                                 url: url,
-                                icon: icon,
-                                title: title,
-                                description: description,
-                                author: author,
-                                publisher: publisher,
-                                thumbnail: thumbnail,
+                                metadata: {
+                                    icon: icon,
+                                    title: title,
+                                    description: description,
+                                    author: author,
+                                    publisher: publisher,
+                                    thumbnail: thumbnail
+                                },
                                 caption: caption
                             };
                             const node = new self.NodeClass(payload);
@@ -78,7 +80,13 @@ export class BookmarkParser {
                                 thumbnail = imgElement.style['background-image'].match(/url\(([^)]*?)\)/)[1];
                             }
 
-                            let payload = {url, title, description, publisher, thumbnail};
+                            let payload = {url, 
+                                metadata: {
+                                    title, 
+                                    description, 
+                                    publisher, 
+                                    thumbnail
+                                }};
                             const node = new self.NodeClass(payload);
                             return {node};
                         },

--- a/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkRenderer.js
@@ -20,7 +20,7 @@ function emailTemplate(node, document) {
     const title = node.getTitle();
     const publisher = node.getPublisher();
     const author = node.getAuthor();
-    const icon = node.getIcon();
+    const icon = node.getIconSrc();
     const description = node.getDescription();
     const url = node.getUrl();
     const thumbnail = node.getThumbnail();
@@ -134,7 +134,7 @@ function frontendTemplate(node, document) {
     metadata.setAttribute('class','kg-bookmark-metadata');
     content.appendChild(metadata);
 
-    metadata.icon = node.getIcon();
+    metadata.icon = node.getIconSrc();
     if (metadata.icon) {
         const icon = document.createElement('img');
         icon.setAttribute('class','kg-bookmark-icon');

--- a/packages/kg-default-nodes/lib/nodes/callout/CalloutNode.js
+++ b/packages/kg-default-nodes/lib/nodes/callout/CalloutNode.js
@@ -8,9 +8,8 @@ const NODE_TYPE = 'callout';
 
 export class CalloutNode extends KoenigDecoratorNode {
     // payload properties
-    __text;
-    __hasEmoji;
-    __emojiValue;
+    __calloutText;
+    __calloutEmoji;
     __backgroundColor;
 
     static getType() {
@@ -27,27 +26,24 @@ export class CalloutNode extends KoenigDecoratorNode {
     getDataset() {
         const self = this.getLatest();
         return {
-            text: self.__text,
-            hasEmoji: self.__hasEmoji,
-            emojiValue: self.__emojiValue,
+            calloutText: self.__calloutText,
+            calloutEmoji: self.__calloutEmoji,
             backgroundColor: self.__backgroundColor
         };
     }
 
-    constructor({text, hasEmoji = true, emojiValue, backgroundColor} = {}, key) {
+    constructor({calloutText, calloutEmoji, backgroundColor} = {}, key) {
         super(key);
-        this.__text = text || '';
-        this.__hasEmoji = hasEmoji;
-        this.__emojiValue = emojiValue || '💡';
+        this.__calloutText = calloutText || '';
+        this.__calloutEmoji = calloutEmoji || '💡';
         this.__backgroundColor = backgroundColor || 'blue';
     }
 
     static importJSON(serializedNode) {
-        const {text, hasEmoji, backgroundColor, emojiValue} = serializedNode;
+        const {calloutText, backgroundColor, calloutEmoji} = serializedNode;
         return new this({
-            text,
-            hasEmoji,
-            emojiValue,
+            calloutText,
+            calloutEmoji,
             backgroundColor
         });
     }
@@ -56,10 +52,9 @@ export class CalloutNode extends KoenigDecoratorNode {
         const dataset = {
             type: NODE_TYPE,
             version: 1,
-            text: this.getText(),
-            hasEmoji: this.__hasEmoji,
-            emojiValue: this.__emojiValue,
-            backgroundColor: this.__backgroundColor
+            calloutText: this.getCalloutText(),
+            calloutEmoji: this.getCalloutEmoji(),
+            backgroundColor: this.getBackgroundColor()
         };
         return dataset;
     }
@@ -87,14 +82,14 @@ export class CalloutNode extends KoenigDecoratorNode {
         return false;
     }
 
-    getText() {
+    getCalloutText() {
         const self = this.getLatest();
-        return self.__text;
+        return self.__calloutText;
     }
 
-    setText(text) {
+    setCalloutText(text) {
         const writeable = this.getWritable();
-        writeable.__text = text;
+        writeable.__calloutText = text;
     }
 
     getBackgroundColor() {
@@ -107,24 +102,14 @@ export class CalloutNode extends KoenigDecoratorNode {
         writeable.__backgroundColor = color;
     }
 
-    getHasEmoji() {
+    getCalloutEmoji() {
         const self = this.getLatest();
-        return self.__hasEmoji;
+        return self.__calloutEmoji;
     }
 
-    setHasEmoji(hasEmoji) {
+    setCalloutEmoji(emoji) {
         const writeable = this.getWritable();
-        writeable.__hasEmoji = hasEmoji;
-    }
-
-    getEmojiValue() {
-        const self = this.getLatest();
-        return self.__emojiValue;
-    }
-
-    setEmojiValue(emojiValue) {
-        const writeable = this.getWritable();
-        writeable.__emojiValue = emojiValue;
+        writeable.__calloutEmoji = emoji;
     }
 
     decorate() {

--- a/packages/kg-default-nodes/lib/nodes/callout/CalloutParser.js
+++ b/packages/kg-default-nodes/lib/nodes/callout/CalloutParser.js
@@ -22,9 +22,8 @@ export class CalloutParser {
                             const color = getColorTag(domNode);
 
                             const payload = {
-                                text: textNode && textNode.innerHTML.trim(),
-                                hasEmoji: emojiNode ? true : false,
-                                emojiValue: emojiNode && emojiNode.innerHTML.trim(),
+                                calloutText: textNode && textNode.innerHTML.trim(),
+                                calloutEmoji: emojiNode && emojiNode.innerHTML.trim(),
                                 backgroundColor: color
                             };
 

--- a/packages/kg-default-nodes/lib/nodes/callout/CalloutRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/callout/CalloutRenderer.js
@@ -9,15 +9,15 @@ export function renderCalloutNodeToDOM(node, options = {}) {
 
     const element = document.createElement('div');
     element.classList.add('kg-card', 'kg-callout-card', `kg-callout-card-${node.getBackgroundColor()}`);
-    if (node.getHasEmoji()) {
+    if (node.getCalloutEmoji()) {
         const emojiElement = document.createElement('div');
         emojiElement.classList.add('kg-callout-emoji');
-        emojiElement.textContent = node.getEmojiValue();
+        emojiElement.textContent = node.getCalloutEmoji();
         element.appendChild(emojiElement);
     }
     const textElement = document.createElement('div');
     textElement.classList.add('kg-callout-text');
-    textElement.innerHTML = node.getText();
+    textElement.innerHTML = node.getCalloutText();
     element.appendChild(textElement);
     return element;
 }

--- a/packages/kg-default-nodes/lib/nodes/file/FileNode.js
+++ b/packages/kg-default-nodes/lib/nodes/file/FileNode.js
@@ -70,7 +70,7 @@ export class FileNode extends KoenigDecoratorNode {
             fileTitle,
             fileCaption,
             fileName,
-            fileSize: typeof fileSize === 'number' ? bytesToSize(Math.round(fileSize)) : fileSize
+            fileSize
         });
     }
 
@@ -153,13 +153,17 @@ export class FileNode extends KoenigDecoratorNode {
 
     getFileSize() {
         const self = this.getLatest();
-        return typeof self.__fileSize === 'number' ? bytesToSize(Math.round(self.__fileSize)) : self.__fileSize;
+        return self.__fileSize;
     }
 
-    setFileSize(fileSize) {
+    setFileSize(size) {
         const writable = this.getWritable();
-        const size = typeof fileSize === 'number' ? bytesToSize(Math.round(fileSize)) : fileSize;
         writable.__fileSize = size;
+    }
+
+    getFormattedFileSize() {
+        const self = this.getLatest();
+        return bytesToSize(self.__fileSize);
     }
 
     hasEditMode() {

--- a/packages/kg-default-nodes/lib/nodes/file/FileNode.js
+++ b/packages/kg-default-nodes/lib/nodes/file/FileNode.js
@@ -20,8 +20,8 @@ export function bytesToSize(bytes) {
 export class FileNode extends KoenigDecoratorNode {
     // file payload properties
     __src;
-    __title;
-    __description;
+    __fileTitle;
+    __fileCaption;
     __fileName;
     __fileSize;
 
@@ -46,30 +46,31 @@ export class FileNode extends KoenigDecoratorNode {
         const self = this.getLatest();
         return {
             src: self.__src,
-            title: self.__title,
-            description: self.__description,
+            fileTitle: self.__fileTitle,
+            fileCaption: self.__fileCaption,
             fileName: self.__fileName,
             fileSize: self.__fileSize
         };
     }
 
-    constructor({src, title, description, fileName, fileSize} = {}, key) {
+    constructor({src, fileTitle, fileCaption, fileName, fileSize} = {}, key) {
         super(key);
         this.__src = src || '';
-        this.__title = title || '';
-        this.__description = description || '';
+        this.__fileTitle = fileTitle || '';
+        this.__fileCaption = fileCaption || '';
         this.__fileName = fileName || '';
         this.__fileSize = fileSize || '';
     }
 
     static importJSON(serializedNode) {
-        const {src, title, description, fileName, fileSize} = serializedNode;
+        const {src, fileTitle, fileCaption, fileName, fileSize} = serializedNode;
+
         return new this({
             src,
-            title,
-            description,
+            fileTitle,
+            fileCaption,
             fileName,
-            fileSize
+            fileSize: typeof fileSize === 'number' ? bytesToSize(Math.round(fileSize)) : fileSize
         });
     }
 
@@ -79,10 +80,10 @@ export class FileNode extends KoenigDecoratorNode {
         return {
             type: this.getType(),
             src: isBlob ? '<base64String>' : this.getSrc(),
-            title: this.__title,
-            description: this.__description,
-            fileName: this.__fileName,
-            fileSize: this.__fileSize
+            fileTitle: this.getFileTitle(),
+            fileCaption: this.getFileCaption(),
+            fileName: this.getFileName(),
+            fileSize: this.getFileSize()
         };
     }
 
@@ -120,24 +121,24 @@ export class FileNode extends KoenigDecoratorNode {
         writable.__src = src;
     }
 
-    getTitle() {
+    getFileTitle() {
         const self = this.getLatest();
-        return self.__title;
+        return self.__fileTitle;
     }
 
-    setTitle(title) {
+    setFileTitle(fileTitle) {
         const writable = this.getWritable();
-        writable.__title = title;
+        writable.__fileTitle = fileTitle;
     }
 
-    getDescription() {
+    getFileCaption() {
         const self = this.getLatest();
-        return self.__description;
+        return self.__fileCaption;
     }
 
-    setDescription(description) {
+    setFileCaption(fileCaption) {
         const writable = this.getWritable();
-        writable.__description = description;
+        writable.__fileCaption = fileCaption;
     }
 
     getFileName() {
@@ -152,12 +153,12 @@ export class FileNode extends KoenigDecoratorNode {
 
     getFileSize() {
         const self = this.getLatest();
-        return self.__fileSize;
+        return typeof self.__fileSize === 'number' ? bytesToSize(Math.round(self.__fileSize)) : self.__fileSize;
     }
 
     setFileSize(fileSize) {
         const writable = this.getWritable();
-        const size = bytesToSize(fileSize);
+        const size = typeof fileSize === 'number' ? bytesToSize(Math.round(fileSize)) : fileSize;
         writable.__fileSize = size;
     }
 

--- a/packages/kg-default-nodes/lib/nodes/file/FileParser.js
+++ b/packages/kg-default-nodes/lib/nodes/file/FileParser.js
@@ -1,3 +1,17 @@
+function sizeToBytes(size) {
+    if (!size) {
+        return 0;
+    }
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+    const sizeParts = size.split(' ');
+    const sizeNumber = parseFloat(sizeParts[0]);
+    const sizeUnit = sizeParts[1];
+    const sizeUnitIndex = sizes.indexOf(sizeUnit);
+    if (sizeUnitIndex === -1) {
+        return 0;
+    }
+    return Math.round(sizeNumber * Math.pow(1024, sizeUnitIndex));
+}
 export class FileParser {
     constructor(NodeClass) {
         this.NodeClass = NodeClass;
@@ -17,7 +31,7 @@ export class FileParser {
                             const fileTitle = domNode.querySelector('.kg-file-card-title')?.textContent || '';
                             const fileCaption = domNode.querySelector('.kg-file-card-caption')?.textContent || '';
                             const fileName = domNode.querySelector('.kg-file-card-filename')?.textContent || '';
-                            let fileSize = domNode.querySelector('.kg-file-card-filesize')?.textContent || '';
+                            let fileSize = sizeToBytes(domNode.querySelector('.kg-file-card-filesize')?.textContent || '');
                             const payload = {
                                 src,
                                 fileTitle,

--- a/packages/kg-default-nodes/lib/nodes/file/FileParser.js
+++ b/packages/kg-default-nodes/lib/nodes/file/FileParser.js
@@ -14,14 +14,14 @@ export class FileParser {
                         conversion(domNode) {
                             const link = domNode.querySelector('a');
                             const src = link.getAttribute('href');
-                            const title = domNode.querySelector('.kg-file-card-title')?.textContent || '';
-                            const description = domNode.querySelector('.kg-file-card-caption')?.textContent || '';
+                            const fileTitle = domNode.querySelector('.kg-file-card-title')?.textContent || '';
+                            const fileCaption = domNode.querySelector('.kg-file-card-caption')?.textContent || '';
                             const fileName = domNode.querySelector('.kg-file-card-filename')?.textContent || '';
                             let fileSize = domNode.querySelector('.kg-file-card-filesize')?.textContent || '';
                             const payload = {
                                 src,
-                                title,
-                                description,
+                                fileTitle,
+                                fileCaption,
                                 fileName,
                                 fileSize
                             };

--- a/packages/kg-default-nodes/lib/nodes/file/FileRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/file/FileRenderer.js
@@ -23,11 +23,11 @@ export function renderFileNodeToDOM(node, options = {}) {
   
     const title = document.createElement('div');
     title.setAttribute('class', 'kg-file-card-title');
-    title.textContent = node.getTitle() || '';
+    title.textContent = node.getFileTitle() || '';
   
     const caption = document.createElement('div');
     caption.setAttribute('class', 'kg-file-card-caption');
-    caption.textContent = node.getDescription() || '';
+    caption.textContent = node.getFileCaption() || '';
   
     const metadata = document.createElement('div');
     metadata.setAttribute('class', 'kg-file-card-metadata');

--- a/packages/kg-default-nodes/lib/nodes/file/FileRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/file/FileRenderer.js
@@ -38,7 +38,7 @@ export function renderFileNodeToDOM(node, options = {}) {
   
     const filesize = document.createElement('div');
     filesize.setAttribute('class', 'kg-file-card-filesize');
-    filesize.textContent = node.getFileSize() || '';
+    filesize.textContent = node.getFormattedFileSize() || '';
   
     metadata.appendChild(filename);
     metadata.appendChild(filesize);

--- a/packages/kg-default-nodes/lib/nodes/image/ImageNode.js
+++ b/packages/kg-default-nodes/lib/nodes/image/ImageNode.js
@@ -11,7 +11,7 @@ export class ImageNode extends KoenigDecoratorNode {
     __src;
     __caption;
     __title;
-    __altText;
+    __alt;
     __cardWidth;
     __width;
     __height;
@@ -43,7 +43,7 @@ export class ImageNode extends KoenigDecoratorNode {
             src: self.__src,
             caption: self.__caption,
             title: self.__title,
-            altText: self.__altText,
+            alt: self.__alt,
             width: self.__width,
             height: self.__height,
             cardWidth: self.__cardWidth,
@@ -51,12 +51,12 @@ export class ImageNode extends KoenigDecoratorNode {
         };
     }
 
-    constructor({src, caption, title, altText, cardWidth, width, height, href} = {}, key) {
+    constructor({src, caption, title, alt, cardWidth, width, height, href} = {}, key) {
         super(key);
         this.__src = src || '';
         this.__title = title || '';
         this.__caption = caption || '';
-        this.__altText = altText || '';
+        this.__alt = alt || '';
         this.__width = width || null;
         this.__height = height || null;
         this.__cardWidth = cardWidth || 'regular';
@@ -64,12 +64,12 @@ export class ImageNode extends KoenigDecoratorNode {
     }
 
     static importJSON(serializedNode) {
-        const {src, caption, title, altText, width, height, cardWidth, href} = serializedNode;
+        const {src, caption, title, alt, width, height, cardWidth, href} = serializedNode;
         const node = new this({
             src,
             caption,
             title,
-            altText,
+            alt,
             width,
             height,
             href,
@@ -89,7 +89,7 @@ export class ImageNode extends KoenigDecoratorNode {
             width: this.getImgWidth(),
             height: this.getImgHeight(),
             title: this.getTitle(),
-            altText: this.getAltText(),
+            alt: this.getAlt(),
             caption: this.getCaption(),
             cardWidth: this.getCardWidth(),
             href: this.getHref()
@@ -192,14 +192,14 @@ export class ImageNode extends KoenigDecoratorNode {
         return writable.__caption = caption;
     }
 
-    getAltText() {
+    getAlt() {
         const self = this.getLatest();
-        return self.__altText;
+        return self.__alt;
     }
 
-    setAltText(altText) {
+    setAlt(alt) {
         const writable = this.getWritable();
-        return writable.__altText = altText;
+        return writable.__alt = alt;
     }
 
     // should be overridden

--- a/packages/kg-default-nodes/lib/nodes/image/ImageParser.js
+++ b/packages/kg-default-nodes/lib/nodes/image/ImageParser.js
@@ -13,9 +13,9 @@ export class ImageParser {
             img: () => ({
                 conversion(domNode) {
                     if (domNode.tagName === 'IMG') {
-                        const {src, width, height, alt: altText, title} = readImageAttributesFromElement(domNode);
+                        const {src, width, height, alt, title} = readImageAttributesFromElement(domNode);
 
-                        const node = new self.NodeClass({altText, src, title, width, height});
+                        const node = new self.NodeClass({alt, src, title, width, height});
                         return {node};
                     }
 
@@ -47,8 +47,8 @@ export class ImageParser {
 
                         payload.caption = readCaptionFromElement(domNode);
 
-                        const {src, width, height, alt: altText, title, caption, cardWidth, href} = payload;
-                        const node = new self.NodeClass({altText, src, title, width, height, caption, cardWidth, href});
+                        const {src, width, height, alt, title, caption, cardWidth, href} = payload;
+                        const node = new self.NodeClass({alt, src, title, width, height, caption, cardWidth, href});
                         return {node};
                     },
                     priority: 1

--- a/packages/kg-default-nodes/lib/nodes/image/ImageRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/image/ImageRenderer.js
@@ -24,7 +24,7 @@ export function renderImageNodeToDOM(node, options = {}) {
 
     const img = document.createElement('img');
     img.setAttribute('src', node.getSrc());
-    img.setAttribute('alt', node.getAltText());
+    img.setAttribute('alt', node.getAlt());
     img.setAttribute('loading', 'lazy');
 
     if (node.getTitle()) {

--- a/packages/kg-default-nodes/lib/nodes/product/ProductNode.js
+++ b/packages/kg-default-nodes/lib/nodes/product/ProductNode.js
@@ -8,16 +8,16 @@ const NODE_TYPE = 'product';
 
 export class ProductNode extends KoenigDecoratorNode {
     // payload properties
-    __imgSrc;
-    __imgWidth;
-    __imgHeight;
-    __title;
-    __description;
-    __isRatingEnabled;
-    __starRating;
-    __isButtonEnabled;
-    __buttonText;
-    __buttonUrl;
+    __productImageSrc;
+    __productImageWidth;
+    __productImageHeight;
+    __productTitle;
+    __productDescription;
+    __productRatingEnabled;
+    __productStarRating;
+    __productButtonEnabled;
+    __productButton;
+    __productUrl;
 
     static getType() {
         return NODE_TYPE;
@@ -33,76 +33,76 @@ export class ProductNode extends KoenigDecoratorNode {
     // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
     static get urlTransformMap() {
         return {
-            imgSrc: 'url',
-            title: 'html',
-            description: 'html'
+            productImageSrc: 'url',
+            productTitle: 'html',
+            productDescription: 'html'
         };
     }
 
     getDataset() {
         const self = this.getLatest();
         return {
-            imgSrc: self.__imgSrc,
-            imgWidth: self.__imgWidth,
-            imgHeight: self.__imgHeight,
-            title: self.__title,
-            description: self.__description,
-            isRatingEnabled: self.__isRatingEnabled,
-            starRating: self.__starRating,
-            isButtonEnabled: self.__isButtonEnabled,
-            buttonText: self.__buttonText,
-            buttonUrl: self.__buttonUrl
+            productImageSrc: self.__productImageSrc,
+            productImageWidth: self.__productImageWidth,
+            productImageHeight: self.__productImageHeight,
+            productTitle: self.__productTitle,
+            productDescription: self.__productDescription,
+            productRatingEnabled: self.__productRatingEnabled,
+            productStarRating: self.__productStarRating,
+            productButtonEnabled: self.__productButtonEnabled,
+            productButton: self.__productButton,
+            productUrl: self.__productUrl
         };
     }
 
-    constructor({imgSrc, imgWidth, imgHeight, title, description, isRatingEnabled, starRating, isButtonEnabled, buttonText, buttonUrl} = {}, key) {
+    constructor({productImageSrc, productImageWidth, productImageHeight, productTitle, productDescription, productRatingEnabled, productStarRating, productButtonEnabled, productButton, productUrl} = {}, key) {
         super(key);
-        this.__imgSrc = imgSrc || '';
-        this.__imgWidth = imgWidth || null;
-        this.__imgHeight = imgHeight || null;
-        this.__title = title || '';
-        this.__description = description || '';
-        this.__isRatingEnabled = !!isRatingEnabled;
-        this.__starRating = starRating || 5;
-        this.__isButtonEnabled = !!isButtonEnabled;
-        this.__buttonText = buttonText || '';
-        this.__buttonUrl = buttonUrl || '';
+        this.__productImageSrc = productImageSrc || '';
+        this.__productImageWidth = productImageWidth || null;
+        this.__productImageHeight = productImageHeight || null;
+        this.__productTitle = productTitle || '';
+        this.__productDescription = productDescription || '';
+        this.__productRatingEnabled = !!productRatingEnabled;
+        this.__productStarRating = productStarRating || 5;
+        this.__productButtonEnabled = !!productButtonEnabled;
+        this.__productButton = productButton || '';
+        this.__productUrl = productUrl || '';
     }
 
     static importJSON(serializedNode) {
-        const {imgSrc, imgWidth, imgHeight, title, description, isRatingEnabled, starRating, isButtonEnabled, buttonText, buttonUrl} = serializedNode;
+        const {productImageSrc, productImageWidth, productImageHeight, productTitle, productDescription, productRatingEnabled, productStarRating, productButtonEnabled, productButton, productUrl} = serializedNode;
         const node = new this({
-            imgSrc,
-            imgWidth,
-            imgHeight,
-            title,
-            description,
-            isRatingEnabled,
-            starRating,
-            isButtonEnabled,
-            buttonText,
-            buttonUrl
+            productImageSrc,
+            productImageWidth,
+            productImageHeight,
+            productTitle,
+            productDescription,
+            productRatingEnabled,
+            productStarRating,
+            productButtonEnabled,
+            productButton,
+            productUrl
         });
         return node;
     }
 
     exportJSON() {
         // checks if src is a data string
-        const src = this.getImgSrc();
+        const src = this.getProductImageSrc();
         const isBlob = src.startsWith('data:');
         const dataset = {
             type: NODE_TYPE,
             version: 1,
-            imgSrc: isBlob ? '<base64String>' : this.getImgSrc(),
-            imgWidth: this.getImgWidth(),
-            imgHeight: this.getImgHeight(),
-            title: this.getTitle(),
-            description: this.getDescription(),
-            isRatingEnabled: this.getIsRatingEnabled(),
-            starRating: this.getStarRating(),
-            isButtonEnabled: this.getIsButtonEnabled(),
-            buttonText: this.getButtonText(),
-            buttonUrl: this.getButtonUrl()
+            productImageSrc: isBlob ? '<base64String>' : this.getProductImageSrc(),
+            productImageWidth: this.getProductImageWidth(),
+            productImageHeight: this.getProductImageHeight(),
+            productTitle: this.getProductTitle(),
+            productDescription: this.getProductDescription(),
+            productRatingEnabled: this.getProductRatingEnabled(),
+            productStarRating: this.getProductStarRating(),
+            productButtonEnabled: this.getProductButtonEnabled(),
+            productButton: this.getProductButton(),
+            productUrl: this.getProductUrl()
 
         };
         return dataset;
@@ -133,104 +133,104 @@ export class ProductNode extends KoenigDecoratorNode {
     }
     /* c8 ignore stop */
 
-    getImgSrc() {
+    getProductImageSrc() {
         const self = this.getLatest();
-        return self.__imgSrc;
+        return self.__productImageSrc;
     }
 
-    setImgSrc(imgSrc) {
+    setProductImageSrc(productImageSrc) {
         const writable = this.getWritable();
-        return writable.__imgSrc = imgSrc;
+        return writable.__productImageSrc = productImageSrc;
     }
 
-    getImgWidth() {
+    getProductImageWidth() {
         const self = this.getLatest();
-        return self.__imgWidth;
+        return self.__productImageWidth;
     }
 
-    setImgWidth(imgWidth) {
+    setProductImageWidth(productImageWidth) {
         const writable = this.getWritable();
-        return writable.__imgWidth = imgWidth;
+        return writable.__productImageWidth = productImageWidth;
     }
 
-    getImgHeight() {
+    getProductImageHeight() {
         const self = this.getLatest();
-        return self.__imgHeight;
+        return self.__productImageHeight;
     }
 
-    setImgHeight(imgHeight) {
+    setProductImageHeight(productImageHeight) {
         const writable = this.getWritable();
-        return writable.__imgHeight = imgHeight;
+        return writable.__productImageHeight = productImageHeight;
     }
 
-    getTitle() {
+    getProductTitle() {
         const self = this.getLatest();
-        return self.__title;
+        return self.__productTitle;
     }
 
-    setTitle(title) {
+    setProductTitle(title) {
         const writable = this.getWritable();
-        return writable.__title = title;
+        return writable.__productTitle = title;
     }
 
-    getDescription() {
+    getProductDescription() {
         const self = this.getLatest();
-        return self.__description;
+        return self.__productDescription;
     }
 
-    setDescription(description) {
+    setProductDescription(description) {
         const writable = this.getWritable();
-        return writable.__description = description;
+        return writable.__productDescription = description;
     }
 
-    getIsRatingEnabled() {
+    getProductRatingEnabled() {
         const self = this.getLatest();
-        return self.__isRatingEnabled;
+        return self.__productRatingEnabled;
     }
 
-    setIsRatingEnabled(isRatingEnabled) {
+    setProductRatingEnabled(productRatingEnabled) {
         const writable = this.getWritable();
-        return writable.__isRatingEnabled = isRatingEnabled;
+        return writable.__productRatingEnabled = productRatingEnabled;
     }
 
-    getStarRating() {
+    getProductStarRating() {
         const self = this.getLatest();
-        return self.__starRating;
+        return self.__productStarRating;
     }
 
-    setStarRating(starRating) {
+    setProductStarRating(starRating) {
         const writable = this.getWritable();
-        return writable.__starRating = starRating;
+        return writable.__productStarRating = starRating;
     }
 
-    getIsButtonEnabled() {
+    getProductButtonEnabled() {
         const self = this.getLatest();
-        return self.__isButtonEnabled;
+        return self.__productButtonEnabled;
     }
 
-    setIsButtonEnabled(isButtonEnabled) {
+    setProductButtonEnabled(productButtonEnabled) {
         const writable = this.getWritable();
-        return writable.__isButtonEnabled = isButtonEnabled;
+        return writable.__productButtonEnabled = productButtonEnabled;
     }
 
-    getButtonText() {
+    getProductButton() {
         const self = this.getLatest();
-        return self.__buttonText;
+        return self.__productButton;
     }
 
-    setButtonText(buttonText) {
+    setProductButton(productButton) {
         const writable = this.getWritable();
-        return writable.__buttonText = buttonText;
+        return writable.__productButton = productButton;
     }
 
-    getButtonUrl() {
+    getProductUrl() {
         const self = this.getLatest();
-        return self.__buttonUrl;
+        return self.__productUrl;
     }
 
-    setButtonUrl(buttonUrl) {
+    setProductUrl(productUrl) {
         const writable = this.getWritable();
-        return writable.__buttonUrl = buttonUrl;
+        return writable.__productUrl = productUrl;
     }
 
     // should be overridden
@@ -244,8 +244,8 @@ export class ProductNode extends KoenigDecoratorNode {
     }
 
     isEmpty() {
-        const isButtonFilled = this.__isButtonEnabled && this.__buttonUrl && this.__buttonText;
-        return !this.__title && !this.__description && !isButtonFilled && !this.__imgSrc && !this.__isRatingEnabled;
+        const isButtonFilled = this.__productButtonEnabled && this.__productUrl && this.__productButton;
+        return !this.__productTitle && !this.__productDescription && !isButtonFilled && !this.__productImageSrc && !this.__productRatingEnabled;
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/product/ProductParser.js
+++ b/packages/kg-default-nodes/lib/nodes/product/ProductParser.js
@@ -17,29 +17,29 @@ export class ProductParser {
                         const description = readCaptionFromElement(domNode, {selector: '.kg-product-card-description'});
 
                         const payload = {
-                            isButtonEnabled: false,
-                            isRatingEnabled: false,
-                            title: title,
-                            description: description
+                            productButtonEnabled: false,
+                            productRatingEnabled: false,
+                            productTitle: title,
+                            productDescription: description
                         };
 
                         const img = domNode.querySelector('.kg-product-card-image');
                         if (img && img.getAttribute('src')) {
-                            payload.imgSrc = img.getAttribute('src');
+                            payload.productImageSrc = img.getAttribute('src');
 
                             if (img.getAttribute('width')) {
-                                payload.imgWidth = img.getAttribute('width');
+                                payload.productImageWidth = img.getAttribute('width');
                             }
 
                             if (img.getAttribute('height')) {
-                                payload.imgHeight = img.getAttribute('height');
+                                payload.productImageHeight = img.getAttribute('height');
                             }
                         }
 
                         const stars = [...domNode.querySelectorAll('.kg-product-card-rating-active')].length;
                         if (stars) {
-                            payload.isRatingEnabled = true;
-                            payload.starRating = stars;
+                            payload.productRatingEnabled = true;
+                            payload.productStarRating = stars;
                         }
 
                         const button = domNode.querySelector('a');
@@ -49,9 +49,9 @@ export class ProductParser {
                             const buttonText = getButtonText(button);
 
                             if (buttonUrl && buttonText) {
-                                payload.isButtonEnabled = true;
-                                payload.buttonText = buttonText;
-                                payload.buttonUrl = buttonUrl;
+                                payload.productButtonEnabled = true;
+                                payload.productButton = buttonText;
+                                payload.productUrl = buttonUrl;
                             }
                         }
 

--- a/packages/kg-default-nodes/lib/nodes/product/ProductRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/product/ProductRenderer.js
@@ -17,7 +17,7 @@ export function renderProductNodeToDOM(node, options = {}) {
     const starActiveClasses = 'kg-product-card-rating-active';
     for (let i = 1; i <= 5; i++) {
         templateData['star' + i] = '';
-        if (node.getStarRating() >= i) {
+        if (node.getProductStarRating() >= i) {
             templateData['star' + i] = starActiveClasses;
         }
     }
@@ -37,11 +37,11 @@ export function cardTemplate({data}) {
         `
         <div class="kg-card kg-product-card">
             <div class="kg-product-card-container">
-                ${data.imgSrc ? `<img src="${data.imgSrc}" ${data.imgWidth ? `width="${data.imgWidth}"` : ''} ${data.imgHeight ? `height="${data.imgHeight}"` : ''} class="kg-product-card-image" loading="lazy" />` : ''}
+                ${data.productImageSrc ? `<img src="${data.productImageSrc}" ${data.productImageWidth ? `width="${data.productImageWidth}"` : ''} ${data.productImageHeight ? `height="${data.productImageHeight}"` : ''} class="kg-product-card-image" loading="lazy" />` : ''}
                 <div class="kg-product-card-title-container">
-                    <h4 class="kg-product-card-title">${data.title}</h4>
+                    <h4 class="kg-product-card-title">${data.productTitle}</h4>
                 </div>
-                ${data.isRatingEnabled ? `
+                ${data.productRatingEnabled ? `
                     <div class="kg-product-card-rating">
                         <span class="${data.star1} kg-product-card-rating-star">${data.starIcon}</span>
                         <span class="${data.star2} kg-product-card-rating-star">${data.starIcon}</span>
@@ -51,9 +51,9 @@ export function cardTemplate({data}) {
                     </div>
                 ` : ''}
 
-                <div class="kg-product-card-description">${data.description}</div>
-                ${data.isButtonEnabled ? `
-                    <a href="${data.buttonUrl}" class="kg-product-card-button kg-product-card-btn-accent" target="_blank" rel="noopener noreferrer"><span>${data.buttonText}</span></a>
+                <div class="kg-product-card-description">${data.productDescription}</div>
+                ${data.productButtonEnabled ? `
+                    <a href="${data.productUrl}" class="kg-product-card-button kg-product-card-btn-accent" target="_blank" rel="noopener noreferrer"><span>${data.productButton}</span></a>
                 ` : ''}
             </div>
         </div>
@@ -65,35 +65,35 @@ export function emailCardTemplate({data}) {
     return (
         `
          <table cellspacing="0" cellpadding="0" border="0" style="width:100%; padding:20px; border:1px solid #E9E9E9; border-radius: 5px; margin: 0 0 1.5em; width: 100%;">
-            ${data.imgSrc ? `
+            ${data.productImageSrc ? `
                 <tr>
                     <td align="center" style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;">
-                        <img src="${data.imgSrc}" ${data.imgWidth ? `width="${data.imgWidth}"` : ''} ${data.imgHeight ? `height="${data.imgHeight}"` : ''} style="height: auto; border: none; padding-bottom: 16px;" border="0">
+                        <img src="${data.productImageSrc}" ${data.productImageWidth ? `width="${data.productImageWidth}"` : ''} ${data.productImageHeight ? `height="${data.productImageHeight}"` : ''} style="height: auto; border: none; padding-bottom: 16px;" border="0">
                     </td>
                 </tr>
             ` : ''}
             <tr>
                 <td valign="top">
-                    <h4 style="font-size: 22px !important; margin-top: 0 !important; margin-bottom: 0 !important; font-weight: 700;">${data.title}</h4>
+                    <h4 style="font-size: 22px !important; margin-top: 0 !important; margin-bottom: 0 !important; font-weight: 700;">${data.productTitle}</h4>
                 </td>
             </tr>
-            ${data.isRatingEnabled ? `
+            ${data.productRatingEnabled ? `
                 <tr style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;">
                     <td valign="top">
-                        <img src="${`https://static.ghost.org/v4.0.0/images/star-rating-${data.starRating}.png`}" style="border: none; width: 96px;" border="0">
+                        <img src="${`https://static.ghost.org/v4.0.0/images/star-rating-${data.productStarRating}.png`}" style="border: none; width: 96px;" border="0">
                     </td>
                 </tr>
             ` : ''}
             <tr>
                 <td style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;">
-                    <div style="padding-top: 8px; opacity: 0.7; font-size: 17px; line-height: 1.4; margin-bottom: -24px;">${data.description}</div>
+                    <div style="padding-top: 8px; opacity: 0.7; font-size: 17px; line-height: 1.4; margin-bottom: -24px;">${data.productDescription}</div>
                 </td>
             </tr>
-            ${data.isButtonEnabled ? `
+            ${data.productButtonEnabled ? `
                 <tr>
                     <td style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;">
                         <div class="btn btn-accent" style="box-sizing: border-box;display: table;width: 100%;padding-top: 16px;">
-                            <a href="${data.buttonUrl}" style="overflow-wrap: anywhere;border: solid 1px;border-radius: 5px;box-sizing: border-box;cursor: pointer;display: inline-block;font-size: 14px;font-weight: bold;margin: 0;padding: 0;text-decoration: none;color: #FFFFFF; width: 100%; text-align: center;"><span style="display: block;padding: 12px 25px;">${data.buttonText}</span></a>
+                            <a href="${data.productUrl}" style="overflow-wrap: anywhere;border: solid 1px;border-radius: 5px;box-sizing: border-box;cursor: pointer;display: inline-block;font-size: 14px;font-weight: bold;margin: 0;padding: 0;text-decoration: none;color: #FFFFFF; width: 100%; text-align: center;"><span style="display: block;padding: 12px 25px;">${data.productButton}</span></a>
                         </div>
                     </td>
                 </tr>

--- a/packages/kg-default-nodes/lib/nodes/toggle/ToggleNode.js
+++ b/packages/kg-default-nodes/lib/nodes/toggle/ToggleNode.js
@@ -9,7 +9,7 @@ const NODE_TYPE = 'toggle';
 export class ToggleNode extends KoenigDecoratorNode {
     // payload properties
     __content;
-    __header;
+    __heading;
 
     static getType() {
         return NODE_TYPE;
@@ -25,7 +25,7 @@ export class ToggleNode extends KoenigDecoratorNode {
     static get urlTransformMap() {
         return {
             content: 'html',
-            header: 'html'
+            heading: 'html'
         };
     }
 
@@ -33,21 +33,21 @@ export class ToggleNode extends KoenigDecoratorNode {
         const self = this.getLatest();
         return {
             content: self.__content,
-            header: self.__header
+            heading: self.__heading
         };
     }
 
-    constructor({content, header} = {}, key) {
+    constructor({content, heading} = {}, key) {
         super(key);
         this.__content = content || '';
-        this.__header = header || '';
+        this.__heading = heading || '';
     }
 
     static importJSON(serializedNode) {
-        const {content, header} = serializedNode;
+        const {content, heading} = serializedNode;
         return new this({
             content,
-            header
+            heading
         });
     }
 
@@ -56,7 +56,7 @@ export class ToggleNode extends KoenigDecoratorNode {
             type: NODE_TYPE,
             version: 1,
             content: this.getContent(),
-            header: this.getHeader()
+            heading: this.getHeading()
         };
         return dataset;
     }
@@ -95,14 +95,14 @@ export class ToggleNode extends KoenigDecoratorNode {
         return writable.__content = content;
     }
 
-    getHeader() {
+    getHeading() {
         const self = this.getLatest();
-        return self.__header;
+        return self.__heading;
     }
 
-    setHeader(header) {
+    setHeading(heading) {
         const writable = this.getWritable();
-        return writable.__header = header;
+        return writable.__heading = heading;
     }
 
     hasEditMode() {
@@ -110,7 +110,7 @@ export class ToggleNode extends KoenigDecoratorNode {
     }
 
     isEmpty() {
-        return !this.__header && !this.__content;
+        return !this.__heading && !this.__content;
     }
 
     // should be overridden

--- a/packages/kg-default-nodes/lib/nodes/toggle/ToggleParser.js
+++ b/packages/kg-default-nodes/lib/nodes/toggle/ToggleParser.js
@@ -11,14 +11,14 @@ export class ToggleParser {
                 conversion(domNode) {
                     const isKgToggleCard = domNode.classList?.contains('kg-toggle-card');
                     if (domNode.tagName === 'DIV' && isKgToggleCard) {
-                        const headerNode = domNode.querySelector('.kg-toggle-heading-text');
-                        const header = headerNode.textContent;
+                        const headingNode = domNode.querySelector('.kg-toggle-heading-text');
+                        const heading = headingNode.textContent;
 
                         const contentNode = domNode.querySelector('.kg-toggle-content');
                         const content = contentNode.textContent;
 
                         const payload = {
-                            header,
+                            heading,
                             content
                         };
 

--- a/packages/kg-default-nodes/lib/nodes/toggle/ToggleRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/toggle/ToggleRenderer.js
@@ -2,13 +2,13 @@ import {addCreateDocumentOption} from '../../utils/add-create-document-option';
 
 function cardTemplate({node}) {
     const content = node.getContent();
-    const header = node.getHeader();
+    const heading = node.getHeading();
 
     return (
         `
         <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
             <div class="kg-toggle-heading">
-                <h4 class="kg-toggle-heading-text">${header}</h4>
+                <h4 class="kg-toggle-heading-text">${heading}</h4>
                 <button class="kg-toggle-card-icon">
                     <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                         <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
@@ -23,13 +23,13 @@ function cardTemplate({node}) {
 
 function emailCardTemplate({node}) {
     const content = node.getContent();
-    const header = node.getHeader();
+    const heading = node.getHeading();
 
     return (
         `
         <div style="background: transparent;
         border: 1px solid rgba(124, 139, 154, 0.25); border-radius: 4px; padding: 20px; margin-bottom: 1.5em;">
-            <h4 style="font-size: 1.375rem; font-weight: 600; margin-bottom: 8px; margin-top:0px">${header}</h4>
+            <h4 style="font-size: 1.375rem; font-weight: 600; margin-bottom: 8px; margin-top:0px">${heading}</h4>
             <div style="font-size: 1rem; line-height: 1.5; margin-bottom: -1.5em;">${content}</div>
         </div>
         `

--- a/packages/kg-default-nodes/lib/nodes/video/VideoNode.js
+++ b/packages/kg-default-nodes/lib/nodes/video/VideoNode.js
@@ -10,11 +10,15 @@ export class VideoNode extends KoenigDecoratorNode {
     // payload properties
     __src;
     __caption;
+    __fileName;
+    __mimeType;
     __width;
     __height;
     __duration;
     __thumbnailSrc;
     __customThumbnailSrc;
+    __thumbnailWidth;
+    __thumbnailHeight;
     __cardWidth;
     __loop;
 
@@ -44,39 +48,51 @@ export class VideoNode extends KoenigDecoratorNode {
         return {
             src: self.__src,
             caption: self.__caption,
+            fileName: self.__fileName,
+            mimeType: self.__mimeType,
             width: self.__width,
             height: self.__height,
             duration: self.__duration,
             thumbnailSrc: self.__thumbnailSrc,
             customThumbnailSrc: self.__customThumbnailSrc,
+            thumbnailWidth: self.__thumbnailWidth,
+            thumbnailHeight: self.__thumbnailHeight,
             cardWidth: self.__cardWidth,
             loop: self.__loop
         };
     }
 
-    constructor({src, caption, width, height, duration, thumbnailSrc, customThumbnailSrc, cardWidth, loop} = {}, key) {
+    constructor({src, caption, fileName, mimeType, width, height, duration, thumbnailSrc, customThumbnailSrc, thumbnailWidth, thumbnailHeight, cardWidth, loop} = {}, key) {
         super(key);
         this.__src = src || '';
         this.__caption = caption || '';
+        this.__fileName = fileName || '';
+        this.__mimeType = mimeType || '';
         this.__width = width || null;
         this.__height = height || null;
         this.__duration = duration || 0;
         this.__thumbnailSrc = thumbnailSrc || '';
         this.__customThumbnailSrc = customThumbnailSrc || '';
+        this.__thumbnailWidth = thumbnailWidth || null;
+        this.__thumbnailHeight = thumbnailHeight || null;
         this.__cardWidth = cardWidth || 'regular';
         this.__loop = !!loop;
     }
 
     static importJSON(serializedNode) {
-        const {src, caption, width, height, duration, thumbnailSrc, customThumbnailSrc, cardWidth, loop} = serializedNode;
+        const {src, caption, fileName, mimeType, width, height, duration, thumbnailSrc, customThumbnailSrc, thumbnailWidth, thumbnailHeight, cardWidth, loop} = serializedNode;
         const node = new this({
             src,
             caption,
+            fileName,
+            mimeType,
             width,
             height,
             duration,
             thumbnailSrc,
             customThumbnailSrc,
+            thumbnailWidth,
+            thumbnailHeight,
             cardWidth,
             loop
         });
@@ -92,11 +108,15 @@ export class VideoNode extends KoenigDecoratorNode {
             version: 1,
             src: isBlob ? '<base64String>' : this.getSrc(),
             caption: this.getCaption(),
+            fileName: this.getFileName(),
+            mimeType: this.getMimeType(),
             width: this.getVideoWidth(),
             height: this.getVideoHeight(),
             duration: this.getDuration(),
             thumbnailSrc: this.getThumbnailSrc(),
             customThumbnailSrc: this.getCustomThumbnailSrc(),
+            thumbnailWidth: this.getThumbnailWidth(),
+            thumbnailHeight: this.getThumbnailHeight(),
             cardWidth: this.getCardWidth(),
             loop: this.getLoop()
         };
@@ -146,6 +166,26 @@ export class VideoNode extends KoenigDecoratorNode {
     setCaption(caption) {
         const writable = this.getWritable();
         return writable.__caption = caption;
+    }
+
+    getFileName() {
+        const self = this.getLatest();
+        return self.__fileName;
+    }
+
+    setFileName(fileName) {
+        const writable = this.getWritable();
+        return writable.__fileName = fileName;
+    }
+
+    getMimeType() {
+        const self = this.getLatest();
+        return self.__mimeType;
+    }
+
+    setMimeType(mimeType) {
+        const writable = this.getWritable();
+        return writable.__mimeType = mimeType;
     }
 
     getVideoWidth() {
@@ -204,6 +244,26 @@ export class VideoNode extends KoenigDecoratorNode {
     setCustomThumbnailSrc(customThumbnailSrc) {
         const writable = this.getWritable();
         return writable.__customThumbnailSrc = customThumbnailSrc;
+    }
+
+    getThumbnailWidth() {
+        const self = this.getLatest();
+        return self.__thumbnailWidth;
+    }
+
+    setThumbnailWidth(thumbnailWidth) {
+        const writable = this.getWritable();
+        return writable.__thumbnailWidth = thumbnailWidth;
+    }
+
+    getThumbnailHeight() {
+        const self = this.getLatest();
+        return self.__thumbnailHeight;
+    }
+
+    setThumbnailHeight(thumbnailHeight) {
+        const writable = this.getWritable();
+        return writable.__thumbnailHeight = thumbnailHeight;
     }
 
     setCardWidth(cardWidth) {

--- a/packages/kg-default-nodes/test/nodes/bookmark.test.js
+++ b/packages/kg-default-nodes/test/nodes/bookmark.test.js
@@ -61,7 +61,7 @@ describe('BookmarkNode', function () {
             const bookmarkNode = $createBookmarkNode(dataset);
 
             bookmarkNode.getUrl().should.equal(dataset.url);
-            bookmarkNode.getIcon().should.equal(dataset.metadata.icon);
+            bookmarkNode.getIconSrc().should.equal(dataset.metadata.icon);
             bookmarkNode.getTitle().should.equal(dataset.metadata.title);
             bookmarkNode.getDescription().should.equal(dataset.metadata.description);
             bookmarkNode.getAuthor().should.equal(dataset.metadata.author);
@@ -77,9 +77,9 @@ describe('BookmarkNode', function () {
             bookmarkNode.setUrl('https://www.ghost.org/');
             bookmarkNode.getUrl().should.equal('https://www.ghost.org/');
 
-            bookmarkNode.getIcon().should.equal('');
-            bookmarkNode.setIcon('https://www.ghost.org/favicon.ico');
-            bookmarkNode.getIcon().should.equal('https://www.ghost.org/favicon.ico');
+            bookmarkNode.getIconSrc().should.equal('');
+            bookmarkNode.setIconSrc('https://www.ghost.org/favicon.ico');
+            bookmarkNode.getIconSrc().should.equal('https://www.ghost.org/favicon.ico');
 
             bookmarkNode.getTitle().should.equal('');
             bookmarkNode.setTitle('Ghost: The Creator Economy Platform');
@@ -222,7 +222,7 @@ describe('BookmarkNode', function () {
                     const [bookmarkNode] = $getRoot().getChildren();
 
                     bookmarkNode.getUrl().should.equal(dataset.url);
-                    bookmarkNode.getIcon().should.equal(dataset.metadata.icon);
+                    bookmarkNode.getIconSrc().should.equal(dataset.metadata.icon);
                     bookmarkNode.getTitle().should.equal(dataset.metadata.title);
                     bookmarkNode.getDescription().should.equal(dataset.metadata.description);
                     bookmarkNode.getAuthor().should.equal(dataset.metadata.author);
@@ -293,7 +293,7 @@ describe('BookmarkNode', function () {
 
             nodes.length.should.equal(1);
             nodes[0].getUrl().should.equal(dataset.url);
-            nodes[0].getIcon().should.equal(dataset.metadata.icon);
+            nodes[0].getIconSrc().should.equal(dataset.metadata.icon);
             nodes[0].getTitle().should.equal(dataset.metadata.title);
             nodes[0].getDescription().should.equal(dataset.metadata.description);
             nodes[0].getAuthor().should.equal(dataset.metadata.author);

--- a/packages/kg-default-nodes/test/nodes/bookmark.test.js
+++ b/packages/kg-default-nodes/test/nodes/bookmark.test.js
@@ -33,12 +33,14 @@ describe('BookmarkNode', function () {
 
         dataset = {
             url: 'https://www.ghost.org/',
-            icon: 'https://www.ghost.org/favicon.ico',
-            title: 'Ghost: The Creator Economy Platform',
-            description: 'doing kewl stuff',
-            author: 'ghost',
-            publisher: 'Ghost - The Professional Publishing Platform',
-            thumbnail: 'https://ghost.org/images/meta/ghost.png',
+            metadata: {
+                icon: 'https://www.ghost.org/favicon.ico',
+                title: 'Ghost: The Creator Economy Platform',
+                description: 'doing kewl stuff',
+                author: 'ghost',
+                publisher: 'Ghost - The Professional Publishing Platform',
+                thumbnail: 'https://ghost.org/images/meta/ghost.png'
+            },
             caption: 'caption here'
         };
 
@@ -59,12 +61,12 @@ describe('BookmarkNode', function () {
             const bookmarkNode = $createBookmarkNode(dataset);
 
             bookmarkNode.getUrl().should.equal(dataset.url);
-            bookmarkNode.getIcon().should.equal(dataset.icon);
-            bookmarkNode.getTitle().should.equal(dataset.title);
-            bookmarkNode.getDescription().should.equal(dataset.description);
-            bookmarkNode.getAuthor().should.equal(dataset.author);
-            bookmarkNode.getPublisher().should.equal(dataset.publisher);
-            bookmarkNode.getThumbnail().should.equal(dataset.thumbnail);
+            bookmarkNode.getIcon().should.equal(dataset.metadata.icon);
+            bookmarkNode.getTitle().should.equal(dataset.metadata.title);
+            bookmarkNode.getDescription().should.equal(dataset.metadata.description);
+            bookmarkNode.getAuthor().should.equal(dataset.metadata.author);
+            bookmarkNode.getPublisher().should.equal(dataset.metadata.publisher);
+            bookmarkNode.getThumbnail().should.equal(dataset.metadata.thumbnail);
             bookmarkNode.getCaption().should.equal(dataset.caption);
         }));
 
@@ -131,16 +133,16 @@ describe('BookmarkNode', function () {
                 <figure class="kg-card kg-bookmark-card kg-card-hascaption">
                     <a class="kg-bookmark-container" href="${dataset.url}">
                         <div class="kg-bookmark-content">
-                            <div class="kg-bookmark-title">${dataset.title}</div>
-                            <div class="kg-bookmark-description">${dataset.description}</div>
+                            <div class="kg-bookmark-title">${dataset.metadata.title}</div>
+                            <div class="kg-bookmark-description">${dataset.metadata.description}</div>
                             <div class="kg-bookmark-metadata">
-                                <img class="kg-bookmark-icon" src="${dataset.icon}" alt="">
-                                <span class="kg-bookmark-author">${dataset.author}</span>
-                                <span class="kg-bookmark-publisher">${dataset.publisher}</span>
+                                <img class="kg-bookmark-icon" src="${dataset.metadata.icon}" alt="">
+                                <span class="kg-bookmark-author">${dataset.metadata.author}</span>
+                                <span class="kg-bookmark-publisher">${dataset.metadata.publisher}</span>
                             </div>
                         </div>
                         <div class="kg-bookmark-thumbnail">
-                            <img src="${dataset.thumbnail}" alt="">
+                            <img src="${dataset.metadata.thumbnail}" alt="">
                         </div>
                     </a>
                     <figcaption>${dataset.caption}</figcaption>
@@ -183,12 +185,14 @@ describe('BookmarkNode', function () {
                 type: 'bookmark',
                 version: 1,
                 url: dataset.url,
-                icon: dataset.icon,
-                title: dataset.title,
-                description: dataset.description,
-                author: dataset.author,
-                publisher: dataset.publisher,
-                thumbnail: dataset.thumbnail,
+                metadata: {
+                    icon: dataset.metadata.icon,
+                    title: dataset.metadata.title,
+                    description: dataset.metadata.description,
+                    author: dataset.metadata.author,
+                    publisher: dataset.metadata.publisher,
+                    thumbnail: dataset.metadata.thumbnail
+                },
                 caption: dataset.caption
             });
         }));
@@ -218,12 +222,12 @@ describe('BookmarkNode', function () {
                     const [bookmarkNode] = $getRoot().getChildren();
 
                     bookmarkNode.getUrl().should.equal(dataset.url);
-                    bookmarkNode.getIcon().should.equal(dataset.icon);
-                    bookmarkNode.getTitle().should.equal(dataset.title);
-                    bookmarkNode.getDescription().should.equal(dataset.description);
-                    bookmarkNode.getAuthor().should.equal(dataset.author);
-                    bookmarkNode.getPublisher().should.equal(dataset.publisher);
-                    bookmarkNode.getThumbnail().should.equal(dataset.thumbnail);
+                    bookmarkNode.getIcon().should.equal(dataset.metadata.icon);
+                    bookmarkNode.getTitle().should.equal(dataset.metadata.title);
+                    bookmarkNode.getDescription().should.equal(dataset.metadata.description);
+                    bookmarkNode.getAuthor().should.equal(dataset.metadata.author);
+                    bookmarkNode.getPublisher().should.equal(dataset.metadata.publisher);
+                    bookmarkNode.getThumbnail().should.equal(dataset.metadata.thumbnail);
                     bookmarkNode.getCaption().should.equal(dataset.caption);
 
                     done();
@@ -270,16 +274,16 @@ describe('BookmarkNode', function () {
                 <figure class="kg-card kg-bookmark-card kg-card-hascaption">
                     <a class="kg-bookmark-container" href="${dataset.url}">
                         <div class="kg-bookmark-content">
-                            <div class="kg-bookmark-title">${dataset.title}</div>
-                            <div class="kg-bookmark-description">${dataset.description}</div>
+                            <div class="kg-bookmark-title">${dataset.metadata.title}</div>
+                            <div class="kg-bookmark-description">${dataset.metadata.description}</div>
                             <div class="kg-bookmark-metadata">
-                                <img class="kg-bookmark-icon" src="${dataset.icon}" alt="">
-                                <span class="kg-bookmark-author">${dataset.author}</span>
-                                <span class="kg-bookmark-publisher">${dataset.publisher}</span>
+                                <img class="kg-bookmark-icon" src="${dataset.metadata.icon}" alt="">
+                                <span class="kg-bookmark-author">${dataset.metadata.author}</span>
+                                <span class="kg-bookmark-publisher">${dataset.metadata.publisher}</span>
                             </div>
                         </div>
                         <div class="kg-bookmark-thumbnail">
-                            <img src="${dataset.thumbnail}" alt="">
+                            <img src="${dataset.metadata.thumbnail}" alt="">
                         </div>
                     </a>
                     <figcaption>${dataset.caption}</figcaption>
@@ -289,12 +293,12 @@ describe('BookmarkNode', function () {
 
             nodes.length.should.equal(1);
             nodes[0].getUrl().should.equal(dataset.url);
-            nodes[0].getIcon().should.equal(dataset.icon);
-            nodes[0].getTitle().should.equal(dataset.title);
-            nodes[0].getDescription().should.equal(dataset.description);
-            nodes[0].getAuthor().should.equal(dataset.author);
-            nodes[0].getPublisher().should.equal(dataset.publisher);
-            nodes[0].getThumbnail().should.equal(dataset.thumbnail);
+            nodes[0].getIcon().should.equal(dataset.metadata.icon);
+            nodes[0].getTitle().should.equal(dataset.metadata.title);
+            nodes[0].getDescription().should.equal(dataset.metadata.description);
+            nodes[0].getAuthor().should.equal(dataset.metadata.author);
+            nodes[0].getPublisher().should.equal(dataset.metadata.publisher);
+            nodes[0].getThumbnail().should.equal(dataset.metadata.thumbnail);
             nodes[0].getCaption().should.equal(dataset.caption);
         }));
 

--- a/packages/kg-default-nodes/test/nodes/callout.test.js
+++ b/packages/kg-default-nodes/test/nodes/callout.test.js
@@ -31,9 +31,8 @@ describe('CalloutNode', function () {
             nodes: editorNodes
         });
         dataset = {
-            text: 'This is a callout',
-            hasEmoji: true,
-            emojiValue: '💡',
+            calloutText: 'This is a callout',
+            calloutEmoji: '💡',
             backgroundColor: 'blue'
         };
         exportOptions = {
@@ -59,22 +58,19 @@ describe('CalloutNode', function () {
     describe('data access', function (){
         it('has getters for all properties', editorTest(function () {
             const node = $createCalloutNode(dataset);
-            node.getText().should.equal(dataset.text);
-            node.getHasEmoji().should.equal(dataset.hasEmoji);
-            node.getEmojiValue().should.equal(dataset.emojiValue);
+            node.getCalloutText().should.equal(dataset.calloutText);
+            node.getCalloutEmoji().should.equal(dataset.calloutEmoji);
             node.getBackgroundColor().should.equal(dataset.backgroundColor);
         }));
 
         it('has setters for all properties', editorTest(function () {
             const node = $createCalloutNode(dataset);
-            node.setText('new text');
-            node.getText().should.equal('new text');
-            node.setHasEmoji(true);
-            node.getHasEmoji().should.be.true;
+            node.setCalloutText('new text');
+            node.getCalloutText().should.equal('new text');
             node.setBackgroundColor('red');
             node.getBackgroundColor().should.equal('red');
-            node.setEmojiValue('👍');
-            node.getEmojiValue().should.equal('👍');
+            node.setCalloutEmoji('👍');
+            node.getCalloutEmoji().should.equal('👍');
         }));
 
         it('has getDataset() method', editorTest(function () {
@@ -97,7 +93,7 @@ describe('CalloutNode', function () {
         }));
         it('can render to HTML with no emoji', editorTest(function () {
             const node = $createCalloutNode(dataset);
-            node.setHasEmoji(false);
+            node.setCalloutEmoji(null);
             const {element} = node.exportDOM(exportOptions);
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-callout-card kg-callout-card-blue">
@@ -108,6 +104,7 @@ describe('CalloutNode', function () {
 
         it('can export JSON', editorTest(function () {
             const node = $createCalloutNode(dataset);
+            console.log(dataset);
             const json = node.exportJSON();
             json.should.deepEqual({
                 type: 'callout',
@@ -129,9 +126,8 @@ describe('CalloutNode', function () {
             // console.log(nodes);
             nodes.length.should.equal(1);
             nodes[0].getBackgroundColor().should.equal('red');
-            nodes[0].getHasEmoji().should.be.true;
-            nodes[0].getText().should.equal('This is a callout');
-            nodes[0].getEmojiValue().should.equal('💡');
+            nodes[0].getCalloutText().should.equal('This is a callout');
+            nodes[0].getCalloutEmoji().should.equal('💡');
         }));
     });
 
@@ -140,9 +136,8 @@ describe('CalloutNode', function () {
             const node = $createCalloutNode(dataset);
             const clone = CalloutNode.clone(node);
             clone.getBackgroundColor().should.equal(node.getBackgroundColor());
-            clone.getHasEmoji().should.equal(node.getHasEmoji());
-            clone.getText().should.equal(node.getText());
-            clone.getEmojiValue().should.equal(node.getEmojiValue());
+            clone.getCalloutText().should.equal(node.getCalloutText());
+            clone.getCalloutEmoji().should.equal(node.getCalloutEmoji());
         }));
     });
 
@@ -168,9 +163,8 @@ describe('CalloutNode', function () {
             editor.getEditorState().read(() => {
                 try {
                     const [calloutNode] = $getRoot().getChildren();
-                    calloutNode.getText().should.equal(dataset.text);
-                    calloutNode.getHasEmoji().should.equal(dataset.hasEmoji);
-                    calloutNode.getEmojiValue().should.equal(dataset.emojiValue);
+                    calloutNode.getCalloutText().should.equal(dataset.calloutText);
+                    calloutNode.getCalloutEmoji().should.equal(dataset.calloutEmoji);
                     calloutNode.getBackgroundColor().should.equal(dataset.backgroundColor);
                     done();
                 } catch (e) {

--- a/packages/kg-default-nodes/test/nodes/file.test.js
+++ b/packages/kg-default-nodes/test/nodes/file.test.js
@@ -32,9 +32,9 @@ describe('FileNode', function () {
         });
         dataset = {
             src: '/content/files/2023/03/IMG_0196.jpeg',
-            title: 'Cool image to download',
+            fileTitle: 'Cool image to download',
             fileSize: '121 KB',
-            description: 'This is a description',
+            fileCaption: 'This is a description',
             fileName: 'IMG_0196.jpeg'
         };
         exportOptions = {
@@ -56,9 +56,9 @@ describe('FileNode', function () {
         it('has getters from all properties', editorTest(function () {
             const node = $createFileNode(dataset);
             node.getSrc().should.equal(dataset.src);
-            node.getTitle().should.equal(dataset.title);
+            node.getFileTitle().should.equal(dataset.fileTitle);
             node.getFileSize().should.equal(dataset.fileSize);
-            node.getDescription().should.equal(dataset.description);
+            node.getFileCaption().should.equal(dataset.fileCaption);
             node.getFileName().should.equal(dataset.fileName);
         }));
 
@@ -66,12 +66,12 @@ describe('FileNode', function () {
             const node = $createFileNode(dataset);
             node.setSrc('/content/files/2023/03/IMG_0196.jpeg');
             node.getSrc().should.equal('/content/files/2023/03/IMG_0196.jpeg');
-            node.setTitle('new title');
-            node.getTitle().should.equal('new title');
+            node.setFileTitle('new title');
+            node.getFileTitle().should.equal('new title');
             node.setFileSize(123456);
             node.getFileSize().should.equal('121 KB');
-            node.setDescription('new description');
-            node.getDescription().should.equal('new description');
+            node.setFileCaption('new description');
+            node.getFileCaption().should.equal('new description');
             node.setFileName('IMG_0196.jpeg');
             node.getFileName().should.equal('IMG_0196.jpeg');
         }));
@@ -131,8 +131,8 @@ describe('FileNode', function () {
             const nodes = $generateNodesFromDOM(editor, dom);
             nodes.length.should.equal(1);
             nodes[0].getSrc().should.equal('/content/files/2023/03/IMG_0196.jpeg');
-            nodes[0].getTitle().should.equal('Cool image to download');
-            nodes[0].getDescription().should.equal('This is a description');
+            nodes[0].getFileTitle().should.equal('Cool image to download');
+            nodes[0].getFileCaption().should.equal('This is a description');
             nodes[0].getFileName().should.equal('IMG_0196.jpeg');
             nodes[0].getFileSize().should.equal('121 KB'); // ~121 KB
         }));
@@ -161,8 +161,43 @@ describe('FileNode', function () {
                 try {
                     const [fileNode] = $getRoot().getChildren();
                     fileNode.getSrc().should.equal('/content/files/2023/03/IMG_0196.jpeg');
-                    fileNode.getTitle().should.equal('Cool image to download');
-                    fileNode.getDescription().should.equal('This is a description');
+                    fileNode.getFileTitle().should.equal('Cool image to download');
+                    fileNode.getFileCaption().should.equal('This is a description');
+                    fileNode.getFileName().should.equal('IMG_0196.jpeg');
+                    fileNode.getFileSize().should.equal('121 KB');
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            });
+        });
+
+        // NOTE: for easier compatibility with mobiledoc, we accept `fileSize` as a formatted string or a number of bytes
+        it('accepts filesize as a number in bytes', function (done) {
+            const serializedState = JSON.stringify({
+                root: {
+                    children: [{
+                        type: 'file',
+                        ...dataset,
+                        fileSize: 123456
+                    }],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            });
+
+            const editorState = editor.parseEditorState(serializedState);
+            editor.setEditorState(editorState);
+
+            editor.getEditorState().read(() => {
+                try {
+                    const [fileNode] = $getRoot().getChildren();
+                    fileNode.getSrc().should.equal('/content/files/2023/03/IMG_0196.jpeg');
+                    fileNode.getFileTitle().should.equal('Cool image to download');
+                    fileNode.getFileCaption().should.equal('This is a description');
                     fileNode.getFileName().should.equal('IMG_0196.jpeg');
                     fileNode.getFileSize().should.equal('121 KB');
                     done();
@@ -179,8 +214,8 @@ describe('FileNode', function () {
             const clonedNode = FileNode.clone(fileNode);
             $isFileNode(clonedNode).should.be.true();
             clonedNode.getSrc().should.equal('/content/files/2023/03/IMG_0196.jpeg');
-            clonedNode.getTitle().should.equal('Cool image to download');
-            clonedNode.getDescription().should.equal('This is a description');
+            clonedNode.getFileTitle().should.equal('Cool image to download');
+            clonedNode.getFileCaption().should.equal('This is a description');
             clonedNode.getFileName().should.equal('IMG_0196.jpeg');
             clonedNode.getFileSize().should.equal('121 KB');
         }));

--- a/packages/kg-default-nodes/test/nodes/file.test.js
+++ b/packages/kg-default-nodes/test/nodes/file.test.js
@@ -33,7 +33,7 @@ describe('FileNode', function () {
         dataset = {
             src: '/content/files/2023/03/IMG_0196.jpeg',
             fileTitle: 'Cool image to download',
-            fileSize: '121 KB',
+            fileSize: 123456,
             fileCaption: 'This is a description',
             fileName: 'IMG_0196.jpeg'
         };
@@ -69,7 +69,8 @@ describe('FileNode', function () {
             node.setFileTitle('new title');
             node.getFileTitle().should.equal('new title');
             node.setFileSize(123456);
-            node.getFileSize().should.equal('121 KB');
+            node.getFileSize().should.equal(123456);
+            node.getFormattedFileSize().should.equal('121 KB');
             node.setFileCaption('new description');
             node.getFileCaption().should.equal('new description');
             node.setFileName('IMG_0196.jpeg');
@@ -134,7 +135,7 @@ describe('FileNode', function () {
             nodes[0].getFileTitle().should.equal('Cool image to download');
             nodes[0].getFileCaption().should.equal('This is a description');
             nodes[0].getFileName().should.equal('IMG_0196.jpeg');
-            nodes[0].getFileSize().should.equal('121 KB'); // ~121 KB
+            nodes[0].getFileSize().should.equal(123904); // ~121 KB
         }));
     });
 
@@ -164,42 +165,8 @@ describe('FileNode', function () {
                     fileNode.getFileTitle().should.equal('Cool image to download');
                     fileNode.getFileCaption().should.equal('This is a description');
                     fileNode.getFileName().should.equal('IMG_0196.jpeg');
-                    fileNode.getFileSize().should.equal('121 KB');
-                    done();
-                } catch (e) {
-                    done(e);
-                }
-            });
-        });
-
-        // NOTE: for easier compatibility with mobiledoc, we accept `fileSize` as a formatted string or a number of bytes
-        it('accepts filesize as a number in bytes', function (done) {
-            const serializedState = JSON.stringify({
-                root: {
-                    children: [{
-                        type: 'file',
-                        ...dataset,
-                        fileSize: 123456
-                    }],
-                    direction: null,
-                    format: '',
-                    indent: 0,
-                    type: 'root',
-                    version: 1
-                }
-            });
-
-            const editorState = editor.parseEditorState(serializedState);
-            editor.setEditorState(editorState);
-
-            editor.getEditorState().read(() => {
-                try {
-                    const [fileNode] = $getRoot().getChildren();
-                    fileNode.getSrc().should.equal('/content/files/2023/03/IMG_0196.jpeg');
-                    fileNode.getFileTitle().should.equal('Cool image to download');
-                    fileNode.getFileCaption().should.equal('This is a description');
-                    fileNode.getFileName().should.equal('IMG_0196.jpeg');
-                    fileNode.getFileSize().should.equal('121 KB');
+                    fileNode.getFileSize().should.equal(123456);
+                    fileNode.getFormattedFileSize().should.equal('121 KB'); // ~121 KB
                     done();
                 } catch (e) {
                     done(e);
@@ -217,7 +184,8 @@ describe('FileNode', function () {
             clonedNode.getFileTitle().should.equal('Cool image to download');
             clonedNode.getFileCaption().should.equal('This is a description');
             clonedNode.getFileName().should.equal('IMG_0196.jpeg');
-            clonedNode.getFileSize().should.equal('121 KB');
+            clonedNode.getFileSize().should.equal(123456);
+            clonedNode.getFormattedFileSize().should.equal('121 KB'); // ~121 KB
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/image.test.js
+++ b/packages/kg-default-nodes/test/nodes/image.test.js
@@ -35,7 +35,7 @@ describe('ImageNode', function () {
             height: 2160,
             href: '',
             title: 'This is a title',
-            altText: 'This is some alt text',
+            alt: 'This is some alt text',
             caption: 'This is a <b>caption</b>'
         };
 
@@ -68,7 +68,7 @@ describe('ImageNode', function () {
             imageNode.getImgWidth().should.equal(3840);
             imageNode.getImgHeight().should.equal(2160);
             imageNode.getTitle().should.equal('This is a title');
-            imageNode.getAltText().should.equal('This is some alt text');
+            imageNode.getAlt().should.equal('This is some alt text');
             imageNode.getCaption().should.equal('This is a <b>caption</b>');
             imageNode.getCardWidth().should.equal('regular');
             imageNode.getHref().should.equal('');
@@ -93,9 +93,9 @@ describe('ImageNode', function () {
             imageNode.setTitle('I am a title');
             imageNode.getTitle().should.equal('I am a title');
 
-            imageNode.getAltText().should.equal('');
-            imageNode.setAltText('I am alt text');
-            imageNode.getAltText().should.equal('I am alt text');
+            imageNode.getAlt().should.equal('');
+            imageNode.setAlt('I am alt text');
+            imageNode.getAlt().should.equal('I am alt text');
 
             imageNode.getCaption().should.equal('');
             imageNode.setCaption('I am a <b>Caption</b>');
@@ -321,7 +321,7 @@ describe('ImageNode', function () {
 
             nodes.length.should.equal(1);
             nodes[0].getSrc().should.equal('/image.png');
-            nodes[0].getAltText().should.equal('Alt text');
+            nodes[0].getAlt().should.equal('Alt text');
             nodes[0].getTitle().should.equal('Title text');
             nodes[0].getImgWidth().should.equal(3000);
             nodes[0].getImgHeight().should.equal(2000);
@@ -337,7 +337,7 @@ describe('ImageNode', function () {
 
             nodes.length.should.equal(1);
             nodes[0].getSrc().should.equal('http://example.com/test.png');
-            nodes[0].getAltText().should.equal('Alt test');
+            nodes[0].getAlt().should.equal('Alt test');
             nodes[0].getTitle().should.equal('Title test');
         }));
 
@@ -450,7 +450,7 @@ describe('ImageNode', function () {
                 width: 3840,
                 height: 2160,
                 title: 'This is a title',
-                altText: 'This is some alt text',
+                alt: 'This is some alt text',
                 caption: 'This is a <b>caption</b>',
                 cardWidth: 'wide',
                 href: ''
@@ -486,7 +486,7 @@ describe('ImageNode', function () {
                     imageNode.getImgWidth().should.equal(3840);
                     imageNode.getImgHeight().should.equal(2160);
                     imageNode.getTitle().should.equal('This is a title');
-                    imageNode.getAltText().should.equal('This is some alt text');
+                    imageNode.getAlt().should.equal('This is some alt text');
                     imageNode.getCaption().should.equal('This is a <b>caption</b>');
                     imageNode.getCardWidth().should.equal('wide');
 

--- a/packages/kg-default-nodes/test/nodes/product.test.js
+++ b/packages/kg-default-nodes/test/nodes/product.test.js
@@ -27,31 +27,31 @@ describe('ProductNode', function () {
     };
 
     const checkGetters = (productNode, data) => {
-        productNode.getImgSrc().should.equal(data.imgSrc);
-        productNode.getImgWidth().should.equal(data.imgWidth);
-        productNode.getImgHeight().should.equal(data.imgHeight);
-        productNode.getTitle().should.equal(data.title);
-        productNode.getDescription().should.equal(data.description);
-        productNode.getIsRatingEnabled().should.be.exactly(true);
-        productNode.getStarRating().should.equal(5);
-        productNode.getIsButtonEnabled().should.be.exactly(true);
-        productNode.getButtonText().should.equal(data.buttonText);
-        productNode.getButtonUrl().should.equal(data.buttonUrl);
+        productNode.getProductImageSrc().should.equal(data.productImageSrc);
+        productNode.getProductImageWidth().should.equal(data.productImageWidth);
+        productNode.getProductImageHeight().should.equal(data.productImageHeight);
+        productNode.getProductTitle().should.equal(data.productTitle);
+        productNode.getProductDescription().should.equal(data.productDescription);
+        productNode.getProductRatingEnabled().should.be.exactly(true);
+        productNode.getProductStarRating().should.equal(5);
+        productNode.getProductButtonEnabled().should.be.exactly(true);
+        productNode.getProductButton().should.equal(data.productButton);
+        productNode.getProductUrl().should.equal(data.productUrl);
     };
 
     beforeEach(function () {
         editor = createHeadlessEditor({nodes: editorNodes});
 
         dataset = {
-            imgSrc: '/content/images/2022/11/koenig-lexical.jpg',
-            imgWidth: 200,
-            imgHeight: 100,
-            title: 'This is a <b>title</b>',
-            description: 'This is a <b>description</b>',
-            isRatingEnabled: true,
-            isButtonEnabled: true,
-            buttonText: 'Button text',
-            buttonUrl: 'https://google.com/'
+            productImageSrc: '/content/images/2022/11/koenig-lexical.jpg',
+            productImageWidth: 200,
+            productImageHeight: 100,
+            productTitle: 'This is a <b>title</b>',
+            productDescription: 'This is a <b>description</b>',
+            productRatingEnabled: true,
+            productButtonEnabled: true,
+            productButton: 'Button text',
+            productUrl: 'https://google.com/'
         };
 
         exportOptions = new Object({
@@ -76,41 +76,41 @@ describe('ProductNode', function () {
         it('has setters for all properties', editorTest(function () {
             const productNode = $createProductNode();
 
-            productNode.getImgSrc().should.equal('');
-            productNode.setImgSrc('/content/images/2022/11/koenig-lexical.jpg');
-            productNode.getImgSrc().should.equal('/content/images/2022/11/koenig-lexical.jpg');
+            productNode.getProductImageSrc().should.equal('');
+            productNode.setProductImageSrc('/content/images/2022/11/koenig-lexical.jpg');
+            productNode.getProductImageSrc().should.equal('/content/images/2022/11/koenig-lexical.jpg');
 
-            should(productNode.getImgWidth()).equal(null);
-            productNode.setImgWidth(600);
-            productNode.getImgWidth().should.equal(600);
+            should(productNode.getProductImageWidth()).equal(null);
+            productNode.setProductImageWidth(600);
+            productNode.getProductImageWidth().should.equal(600);
 
-            should(productNode.getImgHeight()).equal(null);
-            productNode.setImgHeight(700);
-            productNode.getImgHeight().should.equal(700);
+            should(productNode.getProductImageHeight()).equal(null);
+            productNode.setProductImageHeight(700);
+            productNode.getProductImageHeight().should.equal(700);
 
-            productNode.getTitle().should.equal('');
-            productNode.setTitle('Title');
-            productNode.getTitle().should.equal('Title');
+            productNode.getProductTitle().should.equal('');
+            productNode.setProductTitle('Title');
+            productNode.getProductTitle().should.equal('Title');
 
-            productNode.getDescription().should.equal('');
-            productNode.setDescription('Description');
-            productNode.getDescription().should.equal('Description');
+            productNode.getProductDescription().should.equal('');
+            productNode.setProductDescription('Description');
+            productNode.getProductDescription().should.equal('Description');
 
-            productNode.getIsRatingEnabled().should.be.exactly(false);
-            productNode.setIsRatingEnabled(true);
-            productNode.getIsRatingEnabled().should.be.exactly(true);
+            productNode.getProductRatingEnabled().should.be.exactly(false);
+            productNode.setProductRatingEnabled(true);
+            productNode.getProductRatingEnabled().should.be.exactly(true);
 
-            productNode.getStarRating().should.equal(5);
-            productNode.setStarRating(3);
-            productNode.getStarRating().should.equal(3);
+            productNode.getProductStarRating().should.equal(5);
+            productNode.setProductStarRating(3);
+            productNode.getProductStarRating().should.equal(3);
 
-            productNode.getButtonText().should.equal('');
-            productNode.setButtonText('Button text');
-            productNode.getButtonText().should.equal('Button text');
+            productNode.getProductButton().should.equal('');
+            productNode.setProductButton('Button text');
+            productNode.getProductButton().should.equal('Button text');
 
-            productNode.getButtonUrl().should.equal('');
-            productNode.setButtonUrl('https://google.com/');
-            productNode.getButtonUrl().should.equal('https://google.com/');
+            productNode.getProductUrl().should.equal('');
+            productNode.setProductUrl('https://google.com/');
+            productNode.getProductUrl().should.equal('https://google.com/');
         }));
 
         it('has getDataset() convenience method', editorTest(function () {
@@ -119,7 +119,7 @@ describe('ProductNode', function () {
 
             productNodeDataset.should.deepEqual({
                 ...dataset,
-                starRating: 5
+                productStarRating: 5
             });
         }));
 
@@ -127,15 +127,15 @@ describe('ProductNode', function () {
             const productNode = $createProductNode(dataset);
 
             productNode.isEmpty().should.be.exactly(false);
-            productNode.setImgSrc('');
+            productNode.setProductImageSrc('');
             productNode.isEmpty().should.be.exactly(false);
-            productNode.setIsButtonEnabled(false);
+            productNode.setProductButtonEnabled(false);
             productNode.isEmpty().should.be.exactly(false);
-            productNode.setTitle('');
+            productNode.setProductTitle('');
             productNode.isEmpty().should.be.exactly(false);
-            productNode.setDescription('');
+            productNode.setProductDescription('');
             productNode.isEmpty().should.be.exactly(false);
-            productNode.setIsRatingEnabled(false);
+            productNode.setProductRatingEnabled(false);
             productNode.isEmpty().should.be.exactly(true);
         }));
     });
@@ -148,16 +148,16 @@ describe('ProductNode', function () {
             json.should.deepEqual({
                 type: 'product',
                 version: 1,
-                imgSrc: dataset.imgSrc,
-                imgWidth: dataset.imgWidth,
-                imgHeight: dataset.imgHeight,
-                title: dataset.title,
-                description: dataset.description,
-                isRatingEnabled: dataset.isRatingEnabled,
-                isButtonEnabled: dataset.isButtonEnabled,
-                buttonText: dataset.buttonText,
-                buttonUrl: dataset.buttonUrl,
-                starRating: 5
+                productImageSrc: dataset.productImageSrc,
+                productImageWidth: dataset.productImageWidth,
+                productImageHeight: dataset.productImageHeight,
+                productTitle: dataset.productTitle,
+                productDescription: dataset.productDescription,
+                productRatingEnabled: dataset.productRatingEnabled,
+                productButtonEnabled: dataset.productButtonEnabled,
+                productButton: dataset.productButton,
+                productUrl: dataset.productUrl,
+                productStarRating: 5
             });
         }));
     });
@@ -216,14 +216,14 @@ describe('ProductNode', function () {
     describe('exportDOM', function () {
         it('renders', editorTest(function () {
             const payload = {
-                buttonText: 'Click me',
-                isButtonEnabled: true,
-                description: 'This product is ok',
-                imgSrc: 'https://example.com/images/ok.jpg',
-                isRatingEnabled: true,
-                starRating: 3,
-                title: 'Product title!',
-                buttonUrl: 'https://example.com/product/ok'
+                productButton: 'Click me',
+                productButtonEnabled: true,
+                productDescription: 'This product is ok',
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productRatingEnabled: true,
+                productStarRating: 3,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
             };
             const productNode = $createProductNode(payload);
             const {element} = productNode.exportDOM(exportOptions);
@@ -235,16 +235,16 @@ describe('ProductNode', function () {
 
         it('renders with img width and height', editorTest(function () {
             const payload = {
-                buttonText: 'Click me',
-                isButtonEnabled: true,
-                description: 'This product is ok',
-                imgSrc: 'https://example.com/images/ok.jpg',
-                imgWidth: 200,
-                imgHeight: 100,
-                isRatingEnabled: true,
-                starRating: 3,
-                title: 'Product title!',
-                buttonUrl: 'https://example.com/product/ok'
+                productButton: 'Click me',
+                productButtonEnabled: true,
+                productDescription: 'This product is ok',
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productImageWidth: 200,
+                productImageHeight: 100,
+                productRatingEnabled: true,
+                productStarRating: 3,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
             };
             const productNode = $createProductNode(payload);
             const {element} = productNode.exportDOM(exportOptions);
@@ -256,8 +256,8 @@ describe('ProductNode', function () {
 
         it('renders nothing if title, description, button and image are missing', editorTest(function () {
             const payload = {
-                title: '',
-                description: ''
+                productTitle: '',
+                productDescription: ''
             };
             const productNode = $createProductNode(payload);
             const {element} = productNode.exportDOM(exportOptions);
@@ -268,7 +268,7 @@ describe('ProductNode', function () {
 
         it('renders if only title is present', editorTest(function () {
             const payload = {
-                title: 'Just a title'
+                productTitle: 'Just a title'
             };
             const productNode = $createProductNode(payload);
             const {element} = productNode.exportDOM(exportOptions);
@@ -280,7 +280,7 @@ describe('ProductNode', function () {
 
         it('renders if only description is present', editorTest(function () {
             const payload = {
-                description: 'Just a description'
+                productDescription: 'Just a description'
             };
             const productNode = $createProductNode(payload);
             const {element} = productNode.exportDOM(exportOptions);
@@ -292,9 +292,9 @@ describe('ProductNode', function () {
 
         it('renders if only button is present', editorTest(function () {
             const payload = {
-                isButtonEnabled: true,
-                buttonText: 'Button text',
-                buttonUrl: 'https://example.com/product/ok'
+                productButtonEnabled: true,
+                productButton: 'Button text',
+                productUrl: 'https://example.com/product/ok'
             };
             const productNode = $createProductNode(payload);
             const {element} = productNode.exportDOM(exportOptions);
@@ -306,14 +306,14 @@ describe('ProductNode', function () {
 
         it('renders email', editorTest(function () {
             const payload = {
-                buttonText: 'Click me',
-                isButtonEnabled: true,
-                description: 'This product is ok',
-                imgSrc: 'https://example.com/images/ok.jpg',
-                isRatingEnabled: true,
-                starRating: 3,
-                title: 'Product title!',
-                buttonUrl: 'https://example.com/product/ok'
+                productButton: 'Click me',
+                productButtonEnabled: true,
+                productDescription: 'This product is ok',
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productRatingEnabled: true,
+                productStarRating: 3,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
             };
 
             const options = {
@@ -330,16 +330,16 @@ describe('ProductNode', function () {
 
         it('renders email with img width and height', editorTest(function () {
             const payload = {
-                buttonText: 'Click me',
-                isButtonEnabled: true,
-                description: 'This product is ok',
-                imgSrc: 'https://example.com/images/ok.jpg',
-                imgWidth: 200,
-                imgHeight: 100,
-                isRatingEnabled: true,
-                starRating: 3,
-                title: 'Product title!',
-                buttonUrl: 'https://example.com/product/ok'
+                productButton: 'Click me',
+                productButtonEnabled: true,
+                productDescription: 'This product is ok',
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productImageWidth: 200,
+                productImageHeight: 100,
+                productRatingEnabled: true,
+                productStarRating: 3,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
             };
 
             const options = {
@@ -356,13 +356,13 @@ describe('ProductNode', function () {
 
         it('renders email when the star-rating is disabled', editorTest(function () {
             const payload = {
-                buttonText: 'Click me',
-                isButtonEnabled: true,
-                description: 'This product is ok',
-                imgSrc: 'https://example.com/images/ok.jpg',
-                isRatingEnabled: false,
-                title: 'Product title!',
-                buttonUrl: 'https://example.com/product/ok'
+                productButton: 'Click me',
+                productButtonEnabled: true,
+                productDescription: 'This product is ok',
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productRatingEnabled: false,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
             };
 
             const options = {
@@ -379,13 +379,13 @@ describe('ProductNode', function () {
 
         it('renders email when the button is disabled', editorTest(function () {
             const payload = {
-                buttonText: 'Click me',
-                isButtonEnabled: false,
-                description: 'This product is ok',
-                imgSrc: 'https://example.com/images/ok.jpg',
-                isRatingEnabled: false,
-                title: 'Product title!',
-                buttonUrl: 'https://example.com/product/ok'
+                productButton: 'Click me',
+                productButtonEnabled: false,
+                productDescription: 'This product is ok',
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productRatingEnabled: false,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
             };
 
             const options = {
@@ -402,12 +402,12 @@ describe('ProductNode', function () {
 
         it('renders email without an image if the attribute isn\'t there', editorTest(function () {
             const payload = {
-                buttonText: 'Click me',
-                isButtonEnabled: false,
-                description: 'This product is ok',
-                isRatingEnabled: false,
-                title: 'Product title!',
-                buttonUrl: 'https://example.com/product/ok'
+                productButton: 'Click me',
+                productButtonEnabled: false,
+                productDescription: 'This product is ok',
+                productRatingEnabled: false,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
             };
 
             const options = {
@@ -434,14 +434,14 @@ describe('ProductNode', function () {
             const productNode = nodes[0];
             $isProductNode(productNode).should.be.exactly(true);
 
-            productNode.getImgSrc().should.equal('https://example.com/images/ok.jpg');
-            productNode.getTitle().should.equal('Product title!');
-            productNode.getDescription().should.equal('This product is ok');
-            productNode.getIsRatingEnabled().should.be.exactly(true);
-            productNode.getStarRating().should.equal(3);
-            productNode.getIsButtonEnabled().should.be.exactly(true);
-            productNode.getButtonText().should.equal('Click me');
-            productNode.getButtonUrl().should.equal('https://example.com/product/ok');
+            productNode.getProductImageSrc().should.equal('https://example.com/images/ok.jpg');
+            productNode.getProductTitle().should.equal('Product title!');
+            productNode.getProductDescription().should.equal('This product is ok');
+            productNode.getProductRatingEnabled().should.be.exactly(true);
+            productNode.getProductStarRating().should.equal(3);
+            productNode.getProductButtonEnabled().should.be.exactly(true);
+            productNode.getProductButton().should.equal('Click me');
+            productNode.getProductUrl().should.equal('https://example.com/product/ok');
         }));
 
         it('parses a product card with disabled star rating', editorTest(function () {
@@ -454,13 +454,13 @@ describe('ProductNode', function () {
             const productNode = nodes[0];
             $isProductNode(productNode).should.be.exactly(true);
 
-            productNode.getImgSrc().should.equal('https://example.com/images/ok.jpg');
-            productNode.getTitle().should.equal('Product title!');
-            productNode.getDescription().should.equal('This product is ok');
-            productNode.getIsRatingEnabled().should.be.exactly(false);
-            productNode.getIsButtonEnabled().should.be.exactly(true);
-            productNode.getButtonText().should.equal('Click me');
-            productNode.getButtonUrl().should.equal('https://example.com/product/ok');
+            productNode.getProductImageSrc().should.equal('https://example.com/images/ok.jpg');
+            productNode.getProductTitle().should.equal('Product title!');
+            productNode.getProductDescription().should.equal('This product is ok');
+            productNode.getProductRatingEnabled().should.be.exactly(false);
+            productNode.getProductButtonEnabled().should.be.exactly(true);
+            productNode.getProductButton().should.equal('Click me');
+            productNode.getProductUrl().should.equal('https://example.com/product/ok');
         }));
 
         it('parses a product card with disabled button', editorTest(function () {
@@ -473,11 +473,11 @@ describe('ProductNode', function () {
             const productNode = nodes[0];
             $isProductNode(productNode).should.be.exactly(true);
 
-            productNode.getImgSrc().should.equal('https://example.com/images/ok.jpg');
-            productNode.getTitle().should.equal('Product title!');
-            productNode.getDescription().should.equal('This product is ok');
-            productNode.getIsRatingEnabled().should.be.exactly(false);
-            productNode.getIsButtonEnabled().should.be.exactly(false);
+            productNode.getProductImageSrc().should.equal('https://example.com/images/ok.jpg');
+            productNode.getProductTitle().should.equal('Product title!');
+            productNode.getProductDescription().should.equal('This product is ok');
+            productNode.getProductRatingEnabled().should.be.exactly(false);
+            productNode.getProductButtonEnabled().should.be.exactly(false);
         }));
 
         it('parses a product card with image width/height', editorTest(function () {
@@ -490,13 +490,13 @@ describe('ProductNode', function () {
             const productNode = nodes[0];
             $isProductNode(productNode).should.be.exactly(true);
 
-            productNode.getImgSrc().should.equal('https://example.com/images/ok.jpg');
-            productNode.getTitle().should.equal('Product title!');
-            productNode.getDescription().should.equal('This product is ok');
-            productNode.getIsRatingEnabled().should.be.exactly(false);
-            productNode.getIsButtonEnabled().should.be.exactly(false);
-            productNode.getImgWidth().should.equal('200');
-            productNode.getImgHeight().should.equal('100');
+            productNode.getProductImageSrc().should.equal('https://example.com/images/ok.jpg');
+            productNode.getProductTitle().should.equal('Product title!');
+            productNode.getProductDescription().should.equal('This product is ok');
+            productNode.getProductRatingEnabled().should.be.exactly(false);
+            productNode.getProductButtonEnabled().should.be.exactly(false);
+            productNode.getProductImageWidth().should.equal('200');
+            productNode.getProductImageHeight().should.equal('100');
         }));
 
         it('handles arbitrary whitespace in button content', editorTest(function () {
@@ -524,13 +524,13 @@ describe('ProductNode', function () {
             const productNode = nodes[0];
             $isProductNode(productNode).should.be.exactly(true);
 
-            productNode.getImgSrc().should.equal('https://example.com/images/ok.jpg');
-            productNode.getTitle().should.equal('Product title!');
-            productNode.getDescription().should.equal('This product is ok');
-            productNode.getIsRatingEnabled().should.be.exactly(false);
-            productNode.getIsButtonEnabled().should.be.exactly(true);
-            productNode.getButtonText().should.equal('Click me');
-            productNode.getButtonUrl().should.equal('https://example.com/product/ok');
+            productNode.getProductImageSrc().should.equal('https://example.com/images/ok.jpg');
+            productNode.getProductTitle().should.equal('Product title!');
+            productNode.getProductDescription().should.equal('This product is ok');
+            productNode.getProductRatingEnabled().should.be.exactly(false);
+            productNode.getProductButtonEnabled().should.be.exactly(true);
+            productNode.getProductButton().should.equal('Click me');
+            productNode.getProductUrl().should.equal('https://example.com/product/ok');
         }));
 
         it('falls through if title, description, button and image are missing', editorTest(function () {

--- a/packages/kg-default-nodes/test/nodes/toggle.test.js
+++ b/packages/kg-default-nodes/test/nodes/toggle.test.js
@@ -32,7 +32,7 @@ describe('ToggleNode', function () {
         });
 
         dataset = {
-            header: 'Toggle Header',
+            heading: 'Toggle Heading',
             content: 'Collapsible content'
         };
 
@@ -53,16 +53,16 @@ describe('ToggleNode', function () {
         it('has getters for all properties', editorTest(function () {
             const toggleNode = $createToggleNode(dataset);
 
-            toggleNode.getHeader().should.equal(dataset.header);
+            toggleNode.getHeading().should.equal(dataset.heading);
             toggleNode.getContent().should.equal(dataset.content);
         }));
 
         it('has setters for all properties', editorTest(function () {
             const toggleNode = $createToggleNode();
 
-            toggleNode.getHeader().should.equal('');
-            toggleNode.setHeader('Header');
-            toggleNode.getHeader().should.equal('Header');
+            toggleNode.getHeading().should.equal('');
+            toggleNode.setHeading('Heading');
+            toggleNode.getHeading().should.equal('Heading');
 
             toggleNode.getContent().should.equal('');
             toggleNode.setContent('Content');
@@ -87,7 +87,7 @@ describe('ToggleNode', function () {
             json.should.deepEqual({
                 type: 'toggle',
                 version: 1,
-                header: dataset.header,
+                heading: dataset.heading,
                 content: dataset.content
             });
         }));
@@ -116,7 +116,7 @@ describe('ToggleNode', function () {
                 try {
                     const [toggleNode] = $getRoot().getChildren();
 
-                    toggleNode.getHeader().should.equal(dataset.header);
+                    toggleNode.getHeading().should.equal(dataset.heading);
                     toggleNode.getContent().should.equal(dataset.content);
 
                     done();
@@ -130,7 +130,7 @@ describe('ToggleNode', function () {
     describe('exportDOM', function () {
         it('renders', editorTest(function () {
             const payload = {
-                header: 'Header',
+                heading: 'Heading',
                 content: 'Content'
             };
             const toggleNode = $createToggleNode(payload);
@@ -139,7 +139,7 @@ describe('ToggleNode', function () {
             element.outerHTML.should.prettifyTo(html`
             <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
                 <div class="kg-toggle-heading">
-                    <h4 class="kg-toggle-heading-text">Header</h4>
+                    <h4 class="kg-toggle-heading-text">Heading</h4>
                     <button class="kg-toggle-card-icon">
                         <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                             <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
@@ -153,7 +153,7 @@ describe('ToggleNode', function () {
 
         it('renders for email target', editorTest(function () {
             const payload = {
-                header: 'Header',
+                heading: 'Heading',
                 content: 'Content'
             };
 
@@ -167,26 +167,26 @@ describe('ToggleNode', function () {
             element.outerHTML.should.prettifyTo(html`
                 <div style="background: transparent;
                 border: 1px solid rgba(124, 139, 154, 0.25); border-radius: 4px; padding: 20px; margin-bottom: 1.5em;">
-                    <h4 style="font-size: 1.375rem; font-weight: 600; margin-bottom: 8px; margin-top:0px">Header</h4>
+                    <h4 style="font-size: 1.375rem; font-weight: 600; margin-bottom: 8px; margin-top:0px">Heading</h4>
                     <div style="font-size: 1rem; line-height: 1.5; margin-bottom: -1.5em;">Content</div>
                 </div>
             `);
         }));
 
-        it('renders header', editorTest(function () {
+        it('renders heading', editorTest(function () {
             const payload = {
-                header: 'Header',
+                heading: 'Heading',
                 content: 'Content'
             };
 
             const toggleNode = $createToggleNode(payload);
             const {element} = toggleNode.exportDOM(exportOptions);
-            element.outerHTML.should.containEql('<h4 class="kg-toggle-heading-text">Header</h4>');
+            element.outerHTML.should.containEql('<h4 class="kg-toggle-heading-text">Heading</h4>');
         }));
 
         it('renders content', editorTest(function () {
             const payload = {
-                header: 'Header',
+                heading: 'Heading',
                 content: 'Content'
             };
 
@@ -199,11 +199,11 @@ describe('ToggleNode', function () {
     describe('importDOM', function () {
         it('parses toggle card', editorTest(function () {
             const dom = (new JSDOM(html`
-                <div class="kg-card kg-toggle-card" data-kg-toggle-state="close"><div class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">Header</h4><button class="kg-toggle-card-icon"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path></svg></button></div><div class="kg-toggle-content">Content</div></div>
+                <div class="kg-card kg-toggle-card" data-kg-toggle-state="close"><div class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">Heading</h4><button class="kg-toggle-card-icon"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path></svg></button></div><div class="kg-toggle-content">Content</div></div>
             `)).window.document;
             const nodes = $generateNodesFromDOM(editor, dom);
             nodes.length.should.equal(1);
-            nodes[0].getHeader().should.equal('Header');
+            nodes[0].getHeading().should.equal('Heading');
             nodes[0].getContent().should.equal('Content');
         }));
     });

--- a/packages/kg-default-nodes/test/nodes/video.test.js
+++ b/packages/kg-default-nodes/test/nodes/video.test.js
@@ -32,11 +32,15 @@ describe('VideoNode', function () {
         dataset = {
             src: '/content/images/2022/11/koenig-lexical.mp4',
             caption: 'This is a <b>caption</b>',
+            fileName: 'koenig-lexical.mp4',
+            mimeType: 'video/mp4',
             width: 200,
             height: 100,
             duration: 60,
             thumbnailSrc: '/content/images/2022/11/koenig-lexical.jpg',
-            customThumbnailSrc: '/content/images/2022/11/koenig-lexical-custom.jpg'
+            customThumbnailSrc: '/content/images/2022/11/koenig-lexical-custom.jpg',
+            thumbnailWidth: 100,
+            thumbnailHeight: 50
         };
 
         exportOptions = new Object({
@@ -57,11 +61,15 @@ describe('VideoNode', function () {
 
             videoNode.getSrc().should.equal(dataset.src);
             videoNode.getCaption().should.equal(dataset.caption);
+            videoNode.getFileName().should.equal(dataset.fileName);
+            videoNode.getMimeType().should.equal(dataset.mimeType);
             videoNode.getVideoWidth().should.equal(dataset.width);
             videoNode.getVideoHeight().should.equal(dataset.height);
             videoNode.getDuration().should.equal(dataset.duration);
             videoNode.getThumbnailSrc().should.equal(dataset.thumbnailSrc);
             videoNode.getCustomThumbnailSrc().should.equal(dataset.customThumbnailSrc);
+            videoNode.getThumbnailWidth().should.equal(dataset.thumbnailWidth);
+            videoNode.getThumbnailHeight().should.equal(dataset.thumbnailHeight);
             videoNode.getCardWidth().should.equal('regular');
             videoNode.getLoop().should.be.false;
         }));
@@ -76,6 +84,14 @@ describe('VideoNode', function () {
             videoNode.getCaption().should.equal('');
             videoNode.setCaption('Caption');
             videoNode.getCaption().should.equal('Caption');
+
+            videoNode.getFileName().should.equal('');
+            videoNode.setFileName('koenig-lexical.mp4');
+            videoNode.getFileName().should.equal('koenig-lexical.mp4');
+
+            videoNode.getMimeType().should.equal('');
+            videoNode.setMimeType('video/mp4');
+            videoNode.getMimeType().should.equal('video/mp4');
 
             should(videoNode.getVideoWidth()).equal(null);
             videoNode.setVideoWidth(600);
@@ -96,6 +112,14 @@ describe('VideoNode', function () {
             videoNode.getCustomThumbnailSrc().should.equal('');
             videoNode.setCustomThumbnailSrc('/content/images/2022/12/koenig-lexical-custom.png');
             videoNode.getCustomThumbnailSrc().should.equal('/content/images/2022/12/koenig-lexical-custom.png');
+
+            should(videoNode.getThumbnailWidth()).equal(null);
+            videoNode.setThumbnailWidth(100);
+            videoNode.getThumbnailWidth().should.equal(100);
+
+            should(videoNode.getThumbnailHeight()).equal(null);
+            videoNode.setThumbnailHeight(200);
+            videoNode.getThumbnailHeight().should.equal(200);
 
             videoNode.getCardWidth().should.equal('regular');
             videoNode.setCardWidth('wide');
@@ -154,11 +178,15 @@ describe('VideoNode', function () {
                 version: 1,
                 src: dataset.src,
                 caption: dataset.caption,
+                fileName: dataset.fileName,
+                mimeType: dataset.mimeType,
                 width: dataset.width,
                 height: dataset.height,
                 duration: dataset.duration,
                 thumbnailSrc: dataset.thumbnailSrc,
                 customThumbnailSrc: dataset.customThumbnailSrc,
+                thumbnailWidth: dataset.thumbnailWidth,
+                thumbnailHeight: dataset.thumbnailHeight,
                 cardWidth: dataset.cardWidth,
                 loop: false
             });
@@ -192,11 +220,15 @@ describe('VideoNode', function () {
 
                     videoNode.getSrc().should.equal(dataset.src);
                     videoNode.getCaption().should.equal(dataset.caption);
+                    videoNode.getFileName().should.equal(dataset.fileName);
+                    videoNode.getMimeType().should.equal(dataset.mimeType);
                     videoNode.getVideoWidth().should.equal(dataset.width);
                     videoNode.getVideoHeight().should.equal(dataset.height);
                     videoNode.getDuration().should.equal(dataset.duration);
                     videoNode.getThumbnailSrc().should.equal(dataset.thumbnailSrc);
                     videoNode.getCustomThumbnailSrc().should.equal(dataset.customThumbnailSrc);
+                    videoNode.getThumbnailWidth().should.equal(dataset.thumbnailWidth);
+                    videoNode.getThumbnailHeight().should.equal(dataset.thumbnailHeight);
                     videoNode.getCardWidth().should.equal('wide');
                     videoNode.getLoop().should.be.true;
 

--- a/packages/koenig-lexical/src/components/ui/UnsplashPlugin.jsx
+++ b/packages/koenig-lexical/src/components/ui/UnsplashPlugin.jsx
@@ -26,7 +26,7 @@ const UnsplashPlugin = ({nodeKey, isModalOpen = true}) => {
             node.setImgHeight(image.height);
             node.setImgWidth(image.width);
             node.setCaption(image.caption);
-            node.setAltText(image.alt);
+            node.setAlt(image.alt);
             const nodeSelection = $createNodeSelection();
             nodeSelection.add(node.getKey());
             $setSelection(nodeSelection);

--- a/packages/koenig-lexical/src/components/ui/cards/CalloutCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CalloutCard.jsx
@@ -83,13 +83,13 @@ export const calloutColorPicker = [
 
 export function CalloutCard({
     color,
-    emoji,
     isEditing,
     setShowEmojiPicker,
     toggleEmoji,
+    hasEmoji,
     handleColorChange,
     changeEmoji,
-    emojiValue,
+    calloutEmoji,
     textEditor,
     textEditorInitialState,
     nodeKey,
@@ -109,7 +109,7 @@ export function CalloutCard({
         <>
             <div className={`flex rounded border px-7 py-5 ${CALLOUT_COLORS[color]} `} data-testid={`callout-bg-${color}`}>
                 <div>
-                    {emoji &&
+                    {hasEmoji &&
                     <>
                         <button
                             ref={emojiButtonRef}
@@ -118,7 +118,7 @@ export function CalloutCard({
                             type="button"
                             onClick={toggleEmojiPicker}
                         >
-                            {emojiValue}
+                            {calloutEmoji}
                         </button>
                         {
                             isEditing && showEmojiPicker && (
@@ -149,7 +149,7 @@ export function CalloutCard({
                     >
                         <ToggleSetting
                             dataTestId='emoji-toggle'
-                            isChecked={emoji}
+                            isChecked={calloutEmoji}
                             label='Emoji'
                             onChange={toggleEmoji}
                         />
@@ -173,11 +173,11 @@ export function CalloutCard({
 CalloutCard.propTypes = {
     color: PropTypes.oneOf(['grey', 'white', 'blue', 'green', 'yellow', 'red', 'pink', 'purple', 'accent']),
     text: PropTypes.string,
+    hasEmoji: PropTypes.bool,
     placeholder: PropTypes.string,
     isEditing: PropTypes.bool,
     updateText: PropTypes.func,
-    emoji: PropTypes.bool,
-    emojiValue: PropTypes.string,
+    calloutEmoji: PropTypes.string,
     setShowEmojiPicker: PropTypes.func,
     toggleEmoji: PropTypes.func,
     handleColorChange: PropTypes.func,
@@ -191,5 +191,6 @@ CalloutCard.propTypes = {
 
 CalloutCard.defaultProps = {
     color: 'green',
-    emojiValue: '💡'
+    calloutEmoji: '💡',
+    hasEmoji: true
 };

--- a/packages/koenig-lexical/src/components/ui/cards/ToggleCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/ToggleCard.jsx
@@ -7,9 +7,9 @@ export function ToggleCard({
     contentEditor,
     contentEditorInitialState,
     contentPlaceholder,
-    headerEditor,
-    headerEditorInitialState,
-    headerPlaceholder,
+    headingEditor,
+    headingEditorInitialState,
+    headingPlaceholder,
     isEditing
 }) {
     return (
@@ -20,13 +20,13 @@ export function ToggleCard({
                         <KoenigNestedEditor
                             autoFocus={true}
                             focusNext={contentEditor}
-                            initialEditor={headerEditor}
-                            initialEditorState={headerEditorInitialState}
+                            initialEditor={headingEditor}
+                            initialEditorState={headingEditorInitialState}
                             nodes='minimal'
                             placeholderClassName={'!font-sans !text-[2.2rem] !font-bold !leading-snug !tracking-tight text-black dark:text-grey-50 opacity-40'}
-                            placeholderText={headerPlaceholder}
+                            placeholderText={headingPlaceholder}
                             singleParagraph={true}
-                            textClassName={'koenig-lexical-toggle-header whitespace-normal text-black dark:text-grey-50 opacity-100'}
+                            textClassName={'koenig-lexical-toggle-heading whitespace-normal text-black dark:text-grey-50 opacity-100'}
                         />
                     </div>
                     <div className='z-20 ml-auto !mt-[-1px] flex h-8 w-8 shrink-0 items-center justify-center'>
@@ -51,15 +51,15 @@ export function ToggleCard({
 ToggleCard.propTypes = {
     contentEditor: PropTypes.object,
     contentPlaceholder: PropTypes.string,
-    headerEditor: PropTypes.object,
-    headerPlaceholder: PropTypes.string,
+    headingEditor: PropTypes.object,
+    headingPlaceholder: PropTypes.string,
     isEditing: PropTypes.bool,
     contentEditorInitialState: PropTypes.string,
-    headerEditorInitialState: PropTypes.string
+    headingEditorInitialState: PropTypes.string
 };
 
 ToggleCard.defaultProps = {
     contentPlaceholder: 'Collapsible content',
-    headerPlaceholder: 'Toggle header',
+    headingPlaceholder: 'Toggle header',
     isEditing: false
 };

--- a/packages/koenig-lexical/src/components/ui/cards/ToggleCard.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/ToggleCard.stories.jsx
@@ -38,9 +38,9 @@ const story = {
 };
 export default story;
 
-const Template = ({display, header, content, ...args}) => {
-    const headerEditor = createEditor({nodes: MINIMAL_NODES});
-    populateNestedEditor({editor: headerEditor, initialHtml: `<p>${header}</p>`});
+const Template = ({display, heading, content, ...args}) => {
+    const headingEditor = createEditor({nodes: MINIMAL_NODES});
+    populateNestedEditor({editor: headingEditor, initialHtml: `<p>${heading}</p>`});
 
     const contentEditor = createEditor({nodes: BASIC_NODES});
     populateNestedEditor({editor: contentEditor, initialHtml: `<p>${content}</p>`});
@@ -49,13 +49,13 @@ const Template = ({display, header, content, ...args}) => {
         <div className="kg-prose">
             <div className="not-kg-prose mx-auto my-8 min-w-[initial] max-w-[740px] py-10">
                 <CardWrapper {...display}>
-                    <ToggleCard {...display} {...args} contentEditor={contentEditor} headerEditor={headerEditor} />
+                    <ToggleCard {...display} {...args} contentEditor={contentEditor} headingEditor={headingEditor} />
                 </CardWrapper>
             </div>
             <div className="w-full bg-black py-10">
                 <div className="not-kg-prose dark mx-auto my-8 min-w-[initial] max-w-[740px]">
                     <CardWrapper {...display}>
-                        <ToggleCard {...display} {...args} contentEditor={contentEditor} headerEditor={headerEditor} />
+                        <ToggleCard {...display} {...args} contentEditor={contentEditor} headingEditor={headingEditor} />
                     </CardWrapper>
                 </div>
             </div>
@@ -68,8 +68,8 @@ Empty.args = {
     content: '',
     contentPlaceholder: 'Collapsible content',
     display: 'Editing',
-    header: '',
-    headerPlaceholder: 'Toggle header'
+    heading: '',
+    headingPlaceholder: 'Toggle header'
 };
 
 export const Populated = Template.bind({});
@@ -77,7 +77,7 @@ Populated.args = {
     content: 'Toggles allow you to create collapsible sections of content which is a great way to make your content less overwhelming and easy to navigate. A common example is an FAQ section, like this one.',
     contentPlaceholder: 'Collapsible content',
     display: 'Editing',
-    header: 'When should I use Toggles?',
-    headerPlaceholder: 'Toggle header'
+    heading: 'When should I use Toggles?',
+    headingPlaceholder: 'Toggle header'
 };
 

--- a/packages/koenig-lexical/src/nodes/BookmarkNode.jsx
+++ b/packages/koenig-lexical/src/nodes/BookmarkNode.jsx
@@ -76,7 +76,7 @@ function BookmarkNodeComponent({author, nodeKey, url, icon, title, description, 
             const node = $getNodeByKey(nodeKey);
             node.setUrl(response.url);
             node.setAuthor(response.metadata.author);
-            node.setIcon(response.metadata.icon);
+            node.setIconSrc(response.metadata.icon);
             node.setTitle(response.metadata.title);
             node.setDescription(response.metadata.description);
             node.setPublisher(response.metadata.publisher);
@@ -100,7 +100,7 @@ function BookmarkNodeComponent({author, nodeKey, url, icon, title, description, 
             const node = $getNodeByKey(nodeKey);
             node.setUrl(response.url);
             node.setAuthor(response.metadata.author);
-            node.setIcon(response.metadata.icon);
+            node.setIconSrc(response.metadata.icon);
             node.setTitle(response.metadata.title);
             node.setDescription(response.metadata.description);
             node.setPublisher(response.metadata.publisher);

--- a/packages/koenig-lexical/src/nodes/FileNode.jsx
+++ b/packages/koenig-lexical/src/nodes/FileNode.jsx
@@ -50,12 +50,12 @@ export class FileNode extends BaseFileNode {
                 nodeKey={this.getKey()}
             >
                 <FileNodeComponent
-                    fileDesc={this.getDescription()}
+                    fileDesc={this.getFileCaption()}
                     fileDescPlaceholder={'Enter a description'}
                     fileName={this.getFileName()} 
                     fileSize={this.getFileSize()}
                     fileSrc = {this.getSrc()}
-                    fileTitle={this.getTitle()}
+                    fileTitle={this.getFileTitle()}
                     fileTitlePlaceholder={'Enter a title'}
                     initialFile={this.__initialFile}
                     nodeKey={this.getKey()}

--- a/packages/koenig-lexical/src/nodes/FileNode.jsx
+++ b/packages/koenig-lexical/src/nodes/FileNode.jsx
@@ -53,7 +53,7 @@ export class FileNode extends BaseFileNode {
                     fileDesc={this.getFileCaption()}
                     fileDescPlaceholder={'Enter a description'}
                     fileName={this.getFileName()} 
-                    fileSize={this.getFileSize()}
+                    fileSize={this.getFormattedFileSize()}
                     fileSrc = {this.getSrc()}
                     fileTitle={this.getFileTitle()}
                     fileTitlePlaceholder={'Enter a title'}

--- a/packages/koenig-lexical/src/nodes/FileNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/FileNodeComponent.jsx
@@ -82,7 +82,7 @@ function FileNodeComponent({
 
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
-            node.setTitle(title);
+            node.setFileTitle(title);
         });
     };
 
@@ -91,7 +91,7 @@ function FileNodeComponent({
 
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
-            node.setDescription(desc);
+            node.setFileCaption(desc);
         });
     };
 

--- a/packages/koenig-lexical/src/nodes/ImageNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNode.jsx
@@ -156,7 +156,7 @@ export class ImageNode extends BaseImageNode {
                 {
                     !this.__isImageHidden && (
                         <ImageNodeComponent
-                            altText={this.__altText}
+                            altText={this.__alt}
                             captionEditor={this.__captionEditor}
                             captionEditorInitialState={this.__captionEditorInitialState}
                             href={this.__href}

--- a/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
@@ -85,7 +85,7 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, captionE
     const setAltText = (newAltText) => {
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
-            node.setAltText(newAltText);
+            node.setAlt(newAltText);
         });
     };
 

--- a/packages/koenig-lexical/src/nodes/ProductNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ProductNode.jsx
@@ -39,7 +39,7 @@ export class ProductNode extends BaseProductNode {
         if (!this.__titleEditorInitialState) {
             // wrap the header in a paragraph so it gets parsed correctly
             // - we serialize with no wrapper so the renderer can decide how to wrap it
-            const initialHtml = dataset.title ? `<p>${dataset.title}</p>` : null;
+            const initialHtml = dataset.productTitle ? `<p>${dataset.productTitle}</p>` : null;
             this.__titleEditorInitialState = generateEditorState({
                 editor: createEditor({nodes: MINIMAL_NODES}),
                 initialHtml
@@ -50,7 +50,7 @@ export class ProductNode extends BaseProductNode {
         if (!this.__descriptionEditorInitialState) {
             this.__descriptionEditorInitialState = generateEditorState({
                 editor: createEditor({nodes: BASIC_NODES}),
-                initialHtml: dataset.description
+                initialHtml: dataset.productDescription
             });
         }
     }
@@ -77,14 +77,14 @@ export class ProductNode extends BaseProductNode {
             this.__titleEditor.getEditorState().read(() => {
                 const html = $generateHtmlFromNodes(this.__titleEditor, null);
                 const cleanedHtml = cleanBasicHtml(html, {firstChildInnerContent: true});
-                json.title = cleanedHtml;
+                json.productTitle = cleanedHtml;
             });
         }
         if (this.__descriptionEditor) {
             this.__descriptionEditor.getEditorState().read(() => {
                 const html = $generateHtmlFromNodes(this.__descriptionEditor, null);
                 const cleanedHtml = cleanBasicHtml(html);
-                json.description = cleanedHtml;
+                json.productDescription = cleanedHtml;
             });
         }
 
@@ -95,19 +95,19 @@ export class ProductNode extends BaseProductNode {
         return (
             <KoenigCardWrapper nodeKey={this.getKey()}>
                 <ProductNodeComponent
-                    buttonText={this.getButtonText()}
-                    buttonUrl={this.getButtonUrl()}
-                    description={this.getDescription()}
+                    buttonText={this.getProductButton()}
+                    buttonUrl={this.getProductUrl()}
+                    description={this.getProductDescription()}
                     descriptionEditor={this.__descriptionEditor}
                     descriptionEditorInitialState={this.__descriptionEditorInitialState}
-                    imgHeight={this.getImgHeight()}
-                    imgSrc={this.getImgSrc()}
-                    imgWidth={this.getImgWidth()}
-                    isButtonEnabled={this.getIsButtonEnabled()}
-                    isRatingEnabled={this.getIsRatingEnabled()}
+                    imgHeight={this.getProductImageHeight()}
+                    imgSrc={this.getProductImageSrc()}
+                    imgWidth={this.getProductImageWidth()}
+                    isButtonEnabled={this.getProductButtonEnabled()}
+                    isRatingEnabled={this.getProductRatingEnabled()}
                     nodeKey={this.getKey()}
-                    starRating={this.getStarRating()}
-                    title={this.getTitle()}
+                    starRating={this.getProductStarRating()}
+                    title={this.getProductTitle()}
                     titleEditor={this.__titleEditor}
                     titleEditorInitialState={this.__titleEditorInitialState}
                 />
@@ -120,9 +120,9 @@ export class ProductNode extends BaseProductNode {
     isEmpty() {
         const isTitleEmpty = isEditorEmpty(this.__titleEditor);
         const isDescriptionEmpty = isEditorEmpty(this.__descriptionEditor);
-        const isButtonFilled = this.getIsButtonEnabled() && this.getButtonUrl() && this.getButtonText();
+        const isButtonFilled = this.getProductButtonEnabled() && this.getProductUrl() && this.getProductButton();
 
-        return isTitleEmpty && isDescriptionEmpty && !isButtonFilled && !this.getImgSrc() && !this.getIsRatingEnabled();
+        return isTitleEmpty && isDescriptionEmpty && !isButtonFilled && !this.getProductImageSrc() && !this.getProductRatingEnabled();
     }
 }
 

--- a/packages/koenig-lexical/src/nodes/ProductNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ProductNodeComponent.jsx
@@ -54,9 +54,9 @@ export function ProductNodeComponent({
         if (imageUrl) {
             editor.update(() => {
                 const node = $getNodeByKey(nodeKey);
-                node.setImgSrc(imageUrl);
-                node.setImgHeight(height);
-                node.setImgWidth(width);
+                node.setProductImageSrc(imageUrl);
+                node.setImageHeight(height);
+                node.setImageWidth(width);
             });
         }
 
@@ -75,7 +75,7 @@ export function ProductNodeComponent({
     const onRemoveImage = () => {
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
-            node.setImgSrc('');
+            node.setProductImageSrc('');
         });
     };
 
@@ -86,35 +86,35 @@ export function ProductNodeComponent({
     const handleButtonToggle = (event) => {
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
-            node.setIsButtonEnabled(event.target.checked);
+            node.setProductButtonEnabled(event.target.checked);
         });
     };
 
     const handleButtonTextChange = (event) => {
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
-            node.setButtonText(event.target.value);
+            node.setProductButton(event.target.value);
         });
     };
 
     const handleButtonUrlChange = (val) => {
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
-            node.setButtonUrl(val);
+            node.setProductUrl(val);
         });
     };
 
     const handleRatingToggle = (event) => {
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
-            node.setIsRatingEnabled(event.target.checked);
+            node.setProductRatingEnabled(event.target.checked);
         });
     };
 
     const handleRatingChange = (rating) => {
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
-            node.setStarRating(rating);
+            node.setProductStarRating(rating);
         });
     };
 

--- a/packages/koenig-lexical/src/nodes/ProductNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ProductNodeComponent.jsx
@@ -55,8 +55,8 @@ export function ProductNodeComponent({
             editor.update(() => {
                 const node = $getNodeByKey(nodeKey);
                 node.setProductImageSrc(imageUrl);
-                node.setImageHeight(height);
-                node.setImageWidth(width);
+                node.setProductImageHeight(height);
+                node.setProductImageWidth(width);
             });
         }
 

--- a/packages/koenig-lexical/src/nodes/ToggleNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ToggleNode.jsx
@@ -13,8 +13,8 @@ import {createEditor} from 'lexical';
 export {INSERT_TOGGLE_COMMAND} from '@tryghost/kg-default-nodes';
 
 export class ToggleNode extends BaseToggleNode {
-    __headerEditor;
-    __headerEditorInitialState;
+    __headingEditor;
+    __headingEditorInitialState;
     __contentEditor;
     __contentEditorInitialState;
 
@@ -34,16 +34,16 @@ export class ToggleNode extends BaseToggleNode {
         super(dataset, key);
 
         // set up and populate nested editors from the serialized HTML
-        this.__headerEditor = dataset.headerEditor || createEditor({nodes: MINIMAL_NODES});
-        this.__headerEditorInitialState = dataset.headerEditorInitialState;
-        if (!this.__headerEditorInitialState) {
-            // wrap the header in a paragraph so it gets parsed correctly
+        this.__headingEditor = dataset.headingEditor || createEditor({nodes: MINIMAL_NODES});
+        this.__headingEditorInitialState = dataset.headingEditorInitialState;
+        if (!this.__headingEditorInitialState) {
+            // wrap the heading in a paragraph so it gets parsed correctly
             // - we serialize with no wrapper so the renderer can decide how to wrap it
-            const initialHtml = dataset.header ? `<p>${dataset.header}</p>` : null;
+            const initialHtml = dataset.heading ? `<p>${dataset.heading}</p>` : null;
 
             // store the initial state separately as it's passed in to `<CollaborationPlugin />`
             // for use when there is no YJS document already stored
-            this.__headerEditorInitialState = generateEditorState({
+            this.__headingEditorInitialState = generateEditorState({
                 // create a new editor instance so we don't pre-fill an editor that will be filled by YJS content
                 editor: createEditor({nodes: MINIMAL_NODES}),
                 initialHtml
@@ -66,8 +66,8 @@ export class ToggleNode extends BaseToggleNode {
 
         // client-side only data properties such as nested editors
         const self = this.getLatest();
-        dataset.headerEditor = self.__headerEditor;
-        dataset.headerEditorInitialState = self.__headerEditorInitialState;
+        dataset.headingEditor = self.__headingEditor;
+        dataset.headingEditorInitialState = self.__headingEditorInitialState;
         dataset.contentEditor = self.__contentEditor;
         dataset.contentEditorInitialState = self.__contentEditorInitialState;
 
@@ -79,11 +79,11 @@ export class ToggleNode extends BaseToggleNode {
 
         // convert nested editor instances back into HTML because their content may not
         // be automatically updated when the nested editor changes
-        if (this.__headerEditor) {
-            this.__headerEditor.getEditorState().read(() => {
-                const html = $generateHtmlFromNodes(this.__headerEditor, null);
+        if (this.__headingEditor) {
+            this.__headingEditor.getEditorState().read(() => {
+                const html = $generateHtmlFromNodes(this.__headingEditor, null);
                 const cleanedHtml = cleanBasicHtml(html, {firstChildInnerContent: true});
-                json.header = cleanedHtml;
+                json.heading = cleanedHtml;
             });
         }
         if (this.__contentEditor) {
@@ -108,8 +108,8 @@ export class ToggleNode extends BaseToggleNode {
                 <ToggleNodeComponent
                     contentEditor={this.__contentEditor}
                     contentEditorInitialState={this.__contentEditorInitialState}
-                    headerEditor={this.__headerEditor}
-                    headerEditorInitialState={this.__headerEditorInitialState}
+                    headingEditor={this.__headingEditor}
+                    headingEditorInitialState={this.__headingEditorInitialState}
                     nodeKey={this.getKey()}
                 />
             </KoenigCardWrapper>
@@ -119,10 +119,10 @@ export class ToggleNode extends BaseToggleNode {
     // override the default `isEmpty` check because we need to check the nested editors
     // rather than the data properties themselves
     isEmpty() {
-        const isHeaderEmpty = this.__headerEditor.getEditorState().read($canShowPlaceholderCurry(false));
+        const isHeadingEmpty = this.__headingEditor.getEditorState().read($canShowPlaceholderCurry(false));
         const isContentEmpty = this.__contentEditor.getEditorState().read($canShowPlaceholderCurry(false));
 
-        return isHeaderEmpty && isContentEmpty;
+        return isHeadingEmpty && isContentEmpty;
     }
 }
 

--- a/packages/koenig-lexical/src/nodes/ToggleNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ToggleNodeComponent.jsx
@@ -8,7 +8,7 @@ import {ToggleCard} from '../components/ui/cards/ToggleCard';
 import {ToolbarMenu, ToolbarMenuItem, ToolbarMenuSeparator} from '../components/ui/ToolbarMenu';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
-export function ToggleNodeComponent({nodeKey, headerEditor, headerEditorInitialState, contentEditor, contentEditorInitialState}) {
+export function ToggleNodeComponent({nodeKey, headingEditor, headingEditorInitialState, contentEditor, contentEditorInitialState}) {
     const [editor] = useLexicalComposerContext();
     const cardContext = React.useContext(CardContext);
     const {cardConfig} = React.useContext(KoenigComposerContext);
@@ -22,9 +22,9 @@ export function ToggleNodeComponent({nodeKey, headerEditor, headerEditorInitialS
     };
 
     React.useEffect(() => {
-        headerEditor.setEditable(isEditing);
+        headingEditor.setEditable(isEditing);
         contentEditor.setEditable(isEditing);
-    }, [isEditing, headerEditor, contentEditor]);
+    }, [isEditing, headingEditor, contentEditor]);
 
     return (
         <>
@@ -32,9 +32,9 @@ export function ToggleNodeComponent({nodeKey, headerEditor, headerEditorInitialS
                 contentEditor={contentEditor}
                 contentEditorInitialState={contentEditorInitialState}
                 contentPlaceholder={'Collapsible content'}
-                headerEditor={headerEditor}
-                headerEditorInitialState={headerEditorInitialState}
-                headerPlaceholder={'Toggle header'}
+                headingEditor={headingEditor}
+                headingEditorInitialState={headingEditorInitialState}
+                headingPlaceholder={'Toggle header'}
                 isEditing={isEditing}
             />
 

--- a/packages/koenig-lexical/src/styles/components/kg-prose.css
+++ b/packages/koenig-lexical/src/styles/components/kg-prose.css
@@ -799,7 +799,7 @@
         }
     }
 
-.koenig-lexical-toggle-header {
+.koenig-lexical-toggle-heading {
     .kg-prose {
         :where(
                     p,

--- a/packages/koenig-lexical/src/utils/fileUploadHandler.js
+++ b/packages/koenig-lexical/src/utils/fileUploadHandler.js
@@ -23,7 +23,7 @@ export const fileUploadHandler = async (files, nodeKey, editor, upload) => {
     };
     await editor.update(() => {
         const node = $getNodeByKey(nodeKey);
-        node.setTitle(stripFileExtension(dataset.fileName)); // initially sets the title to the file name
+        node.setFileTitle(stripFileExtension(dataset.fileName)); // initially sets the title to the file name
         node.setFileName(dataset.fileName);
         node.setFileSize(dataset.fileSize);
         node.setSrc(dataset.src);

--- a/packages/koenig-lexical/test/e2e/cards/callout-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/callout-card.test.js
@@ -15,9 +15,8 @@ test.describe('Callout Card', async () => {
                 root: {
                     children: [{
                         type: 'callout',
-                        text: '<p dir="ltr"><span>Hello World</span></p>',
-                        hasEmoji: true,
-                        emojiValue: '😚',
+                        calloutText: '<p dir="ltr"><span>Hello World</span></p>',
+                        calloutEmoji: '😚',
                         backgroundColor: 'blue'
                     }],
                     direction: null,

--- a/packages/koenig-lexical/test/e2e/cards/file-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/file-card.test.js
@@ -17,8 +17,8 @@ test.describe('File card', async () => {
                     children: [{
                         type: 'file',
                         src: '/content/images/2022/11/koenig-lexical.jpg',
-                        title: 'This is a title',
-                        description: 'This is a description',
+                        fileTitle: 'This is a title',
+                        fileCaption: 'This is a description',
                         fileName: 'koenig-lexical.jpg',
                         fileSize: '1.2 MB'
                     }],

--- a/packages/koenig-lexical/test/e2e/cards/product-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/product-card.test.js
@@ -16,13 +16,13 @@ test.describe('Product card', async () => {
                 root: {
                     children: [{
                         type: 'product',
-                        imgSrc: '/content/images/2022/11/koenig-lexical.jpg',
-                        title: '<span>This is <em>title</em></span>',
-                        description: '<p dir="ltr"><span>Description</span></p>',
-                        buttonUrl: 'https://google.com/',
-                        buttonText: 'Button',
-                        isButtonEnabled: true,
-                        isRatingEnabled: true
+                        productImageSrc: '/content/images/2022/11/koenig-lexical.jpg',
+                        productTitle: '<span>This is <em>title</em></span>',
+                        productDescription: '<p dir="ltr"><span>Description</span></p>',
+                        productUrl: 'https://google.com/',
+                        productButton: 'Button',
+                        productButtonEnabled: true,
+                        productRatingEnabled: true
                     }],
                     direction: null,
                     format: '',

--- a/packages/koenig-lexical/test/e2e/cards/toggle-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/toggle-card.test.js
@@ -19,7 +19,7 @@ test.describe('Toggle card', async () => {
                 root: {
                     children: [{
                         type: 'toggle',
-                        header: '<span><em>Header</em></span>', // header shouldn't have wrapper element like <p> or <h4>
+                        heading: '<span><em>Heading</em></span>', // heading shouldn't have wrapper element like <p> or <h4>
                         content: '<p dir="ltr"><span>Content</span></p>'
                     }],
                     direction: null,
@@ -40,7 +40,7 @@ test.describe('Toggle card', async () => {
                         <div class="rounded border border-grey/40 py-4 px-6 dark:border-grey/30">
                             <div class="flex cursor-text items-start justify-between">
                                 <div class="mr-2 w-full">
-                                    <div class="koenig-lexical-toggle-header">
+                                    <div class="koenig-lexical-toggle-heading">
                                         <div data-kg="editor">
                                             <div
                                                 contenteditable="false"
@@ -48,7 +48,7 @@ test.describe('Toggle card', async () => {
                                                 data-lexical-editor="true"
                                                 aria-autocomplete="none"
                                             >
-                                                <p dir="ltr"><em data-lexical-text="true">Header</em></p>
+                                                <p dir="ltr"><em data-lexical-text="true">Heading</em></p>
                                             </div>
                                         </div>
                                     </div>
@@ -89,7 +89,7 @@ test.describe('Toggle card', async () => {
                     <div class="rounded border border-grey/40 py-4 px-6 dark:border-grey/30">
                         <div class="flex cursor-text items-start justify-between">
                             <div class="mr-2 w-full">
-                                <div class="koenig-lexical-toggle-header">
+                                <div class="koenig-lexical-toggle-heading">
                                     <div data-kg="editor">
                                         <div
                                             contenteditable="true"
@@ -130,17 +130,17 @@ test.describe('Toggle card', async () => {
         `, {ignoreInnerSVG: true});
     });
 
-    test('focuses on the header input when rendered', async function ({page}) {
+    test('focuses on the heading input when rendered', async function ({page}) {
         await focusEditor(page);
         await insertToggleCard(page);
 
-        await page.keyboard.type('Header');
+        await page.keyboard.type('Heading');
 
-        const header = page.locator('.koenig-lexical-toggle-header');
-        await expect(header).toContainText('Header');
+        const heading = page.locator('.koenig-lexical-toggle-heading');
+        await expect(heading).toContainText('Heading');
     });
 
-    test('focuses on the content input when "Enter" is pressed from the header input', async function ({page}) {
+    test('focuses on the content input when "Enter" is pressed from the heading input', async function ({page}) {
         await focusEditor(page);
         await insertToggleCard(page);
 
@@ -151,7 +151,7 @@ test.describe('Toggle card', async () => {
         await expect(content).toContainText('Content');
     });
 
-    test('focuses on the content input when "Tab" is pressed from the header input', async function ({page}) {
+    test('focuses on the content input when "Tab" is pressed from the heading input', async function ({page}) {
         await focusEditor(page);
         await insertToggleCard(page);
 
@@ -162,7 +162,7 @@ test.describe('Toggle card', async () => {
         await expect(content).toContainText('Content');
     });
 
-    test('focuses on the content input when "Arrow Down" is pressed from the header input', async function ({page}) {
+    test('focuses on the content input when "Arrow Down" is pressed from the heading input', async function ({page}) {
         await focusEditor(page);
         await insertToggleCard(page);
 
@@ -173,17 +173,17 @@ test.describe('Toggle card', async () => {
         await expect(content).toContainText('Content');
     });
 
-    test('focuses on the header input when "Arrow Up" is pressed from the content input', async function ({page}) {
+    test('focuses on the heading input when "Arrow Up" is pressed from the content input', async function ({page}) {
         await focusEditor(page);
         await insertToggleCard(page);
 
         await page.keyboard.press('ArrowDown');
         await page.keyboard.type('Content');
         await page.keyboard.press('ArrowUp');
-        await page.keyboard.type('Header');
+        await page.keyboard.type('Heading');
 
-        const header = page.locator('.koenig-lexical-toggle-header');
-        await expect(header).toContainText('Header');
+        const heading = page.locator('.koenig-lexical-toggle-heading');
+        await expect(heading).toContainText('Heading');
     });
 
     test('renders in display mode when unfocused', async function ({page}) {
@@ -191,9 +191,9 @@ test.describe('Toggle card', async () => {
         await insertToggleCard(page);
 
         // add some content to avoid auto-removal when leaving empty
-        await page.keyboard.type('Header');
+        await page.keyboard.type('Heading');
 
-        // Shift focus away from header field
+        // Shift focus away from heading field
         await page.keyboard.press('ArrowDown');
 
         // Shift focus away from content field
@@ -208,7 +208,7 @@ test.describe('Toggle card', async () => {
         await insertToggleCard(page);
 
         // Add some content to avoid auto-removal
-        await page.keyboard.type('Header');
+        await page.keyboard.type('Heading');
 
         // Shift focus away from toggle card
         await page.keyboard.press('Escape');
@@ -221,7 +221,7 @@ test.describe('Toggle card', async () => {
         await focusEditor(page);
         await insertToggleCard(page);
 
-        // Shift focus away from header field
+        // Shift focus away from heading field
         await page.keyboard.press('ArrowDown');
 
         // Shift focus away from content field
@@ -236,7 +236,7 @@ test.describe('Toggle card', async () => {
         await insertToggleCard(page);
 
         // Add some content to avoid auto-removal
-        await page.keyboard.type('Header');
+        await page.keyboard.type('Heading');
 
         // create snippet
         await page.keyboard.press('Escape');

--- a/packages/koenig-lexical/test/e2e/cards/video-card.firefox.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/video-card.firefox.test.js
@@ -124,7 +124,7 @@ test.describe('Video card', async () => {
 
         // Can remove thumbnail
         const replaceButton = page.getByTestId('custom-thumbnail-replace');
-        replaceButton.click();
+        await replaceButton.click();
         await expect(await page.getByTestId('media-upload-placeholder')).toBeVisible();
     });
 


### PR DESCRIPTION
refs TryGhost/Team#3161

- For the launch of Lexical beta, we need to be able to freely convert both ways from mobiledoc <--> lexical. This process will be easier if the payloads of specific cards are aligned so we don't have to maintain a mapping between fieldnames in mobiledoc vs lexical. This commit renames some fields in the Lexical payloads to align with mobiledoc, since we already have a corpus of mobiledoc content in production, whereas Lexical is still in a very limited Alpha.
- Refactored BookmarkNode to use an embedded metadata object for `icon`, `title`, `description`, `author`, `publisher` and `thumbnail` fields
- Refactored CalloutNode to rename `text` to `calloutText` and `emojiValue` to `calloutEmoji` and to remove `hasEmoji`
- Refactored FileNode to rename `title` to `fileTitle` and `description` to `fileCaption`, and to store the `fileSize` as a number of bytes instead of a formatted string
- Refactored ImageNode to rename `altText` to `alt`
- Refactored ProductNode to rename all the properties
- Refactored ToggleNode to rename `header` to `heading`
- Refactored VideoCard to start recording `fileName`, `mimeType`, `thumbnailWidth`, and `thumbnailHeight`