### PR TITLE
Swapped out backgroundImagePreview with type

### DIFF
--- a/packages/koenig-lexical/src/components/ui/BackgroundImagePicker.jsx
+++ b/packages/koenig-lexical/src/components/ui/BackgroundImagePicker.jsx
@@ -22,7 +22,7 @@ function FileUploading({progress}) {
 
 export function BackgroundImagePicker({onFileChange,
     backgroundImageSrc,
-    backgroundImagePreview,
+    type,
     handleClearBackgroundImage,
     fileInputRef,
     openFilePicker,
@@ -45,7 +45,7 @@ export function BackgroundImagePicker({onFileChange,
                 />
             </form>
             {
-                backgroundImagePreview && (
+                type === 'image' && (
                     <div className="w-full">
                         <div className="relative">
                             <div className="flex w-full items-center justify-center">
@@ -84,7 +84,6 @@ FileUploading.propTypes = {
 };
 
 BackgroundImagePicker.propTypes = {
-    backgroundImagePreview: PropTypes.bool,
     backgroundImageSrc: PropTypes.string,
     fileInputRef: PropTypes.object,
     handleClearBackgroundImage: PropTypes.func,

--- a/packages/koenig-lexical/src/components/ui/cards/HeaderCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/HeaderCard.jsx
@@ -37,7 +37,6 @@ export function HeaderCard({isEditing,
     backgroundImageSrc,
     onFileChange,
     handleClearBackgroundImage,
-    backgroundImagePreview,
     fileInputRef,
     openFilePicker,
     type,
@@ -159,13 +158,13 @@ export function HeaderCard({isEditing,
                         onClick={handleColorSelector}
                     />
                     <BackgroundImagePicker
-                        backgroundImagePreview={backgroundImagePreview || (!backgroundImageSrc && type === 'image')} // for storybook compatibility
                         backgroundImageSrc={backgroundImageSrc}
                         fileInputRef={fileInputRef}
                         handleClearBackgroundImage={handleClearBackgroundImage}
                         isUploading={isUploading}
                         openFilePicker={openFilePicker}
                         progress={progress}
+                        type={type}
                         onFileChange={onFileChange}
                     />
                     <SettingsDivider />
@@ -211,7 +210,6 @@ HeaderCard.propTypes = {
     buttonPlaceholder: PropTypes.string,
     buttonUrl: PropTypes.string,
     backgroundImageSrc: PropTypes.string,
-    backgroundImagePreview: PropTypes.bool,
     isEditing: PropTypes.bool,
     isUploading: PropTypes.bool,
     progress: PropTypes.number,

--- a/packages/koenig-lexical/src/components/ui/cards/HeaderCard.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/HeaderCard.stories.jsx
@@ -91,7 +91,6 @@ Populated.args = {
     buttonText: 'Subscribe',
     buttonPlaceholder: 'Add button text',
     buttonUrl: 'https://ghost.org/',
-    backgroundImagePreview: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg',
     backgroundImageSrc: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg',
     type: 'image'
 };
@@ -109,7 +108,6 @@ Loading.args = {
     buttonText: 'Subscribe',
     buttonPlaceholder: 'Add button text',
     buttonUrl: 'https://ghost.org/',
-    backgroundImagePreview: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg',
     backgroundImageSrc: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg',
     type: 'image',
     fileUploader: {

--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
@@ -42,7 +42,6 @@ export function SignupCard({alignment,
     buttonText,
     buttonPlaceholder,
     backgroundImageSrc,
-    backgroundImagePreview,
     isEditing,
     fileUploader,
     fileInputRef,
@@ -207,13 +206,13 @@ export function SignupCard({alignment,
                     />
                     {splitLayout ?
                         <BackgroundImagePicker
-                            backgroundImagePreview={backgroundImagePreview || (!backgroundImageSrc && type === 'image')} // for storybook compatibility
                             backgroundImageSrc={backgroundImageSrc}
                             fileInputRef={fileInputRef}
                             handleClearBackgroundImage={handleClearBackgroundImage}
                             isUploading={isUploading}
                             openFilePicker={openFilePicker}
                             progress={progress}
+                            type={type}
                             onFileChange={onFileChange}
                         />
                         : <>
@@ -224,13 +223,13 @@ export function SignupCard({alignment,
                                 onClick={handleColorSelector}
                             />
                             <BackgroundImagePicker
-                                backgroundImagePreview={backgroundImagePreview || (!backgroundImageSrc && type === 'image')} // for storybook compatibility
                                 backgroundImageSrc={backgroundImageSrc}
                                 fileInputRef={fileInputRef}
                                 handleClearBackgroundImage={handleClearBackgroundImage}
                                 isUploading={isUploading}
                                 openFilePicker={openFilePicker}
                                 progress={progress}
+                                type={type}
                                 onFileChange={onFileChange}
                             />
                         </>
@@ -272,7 +271,6 @@ SignupCard.propTypes = {
     buttonText: PropTypes.string,
     buttonPlaceholder: PropTypes.string,
     backgroundImageSrc: PropTypes.string,
-    backgroundImagePreview: PropTypes.bool,
     isEditing: PropTypes.bool,
     fileUploader: PropTypes.object,
     fileInputRef: PropTypes.object,

--- a/packages/koenig-lexical/src/nodes/HeaderNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/HeaderNodeComponent.jsx
@@ -59,27 +59,13 @@ function HeaderNodeComponent({
         });
     };
 
-    const [backgroundImagePreview, setBackgroundImagePreview] = React.useState(false);
-
     const fileInputRef = React.useRef(null);
 
     const openFilePicker = () => {
         fileInputRef.current.click();
     };
 
-    const toggleBackgroundImagePreview = () => {
-        setBackgroundImagePreview(!backgroundImagePreview);
-    };
-
-    React.useEffect(() => {
-        if (backgroundImageSrc !== '') {
-            setBackgroundImagePreview(true);
-        }
-    }, [backgroundImageSrc]);
-
     const handleColorSelector = (color) => {
-        color === 'image' ? setBackgroundImagePreview(true) : setBackgroundImagePreview(false);
-
         if (color === 'image' && backgroundImageSrc === ''){
             openFilePicker();
         }
@@ -133,7 +119,6 @@ function HeaderNodeComponent({
     return (
         <>
             <HeaderCard
-                backgroundImagePreview={backgroundImagePreview}
                 backgroundImageSrc={backgroundImageSrc}
                 button={button}
                 buttonPlaceholder={buttonPlaceholder}
@@ -158,7 +143,6 @@ function HeaderNodeComponent({
                 subheaderPlaceholder={subheaderPlaceholder}
                 subheaderTextEditor={subheaderTextEditor}
                 subheaderTextEditorInitialState={subheaderTextEditorInitialState}
-                toggleBackgroundImagePreview={toggleBackgroundImagePreview}
                 type={type}
                 onFileChange={onFileChange}
             />

--- a/packages/koenig-lexical/src/nodes/SignupNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/SignupNodeComponent.jsx
@@ -70,23 +70,13 @@ function SignupNodeComponent({
         });
     };
 
-    const [backgroundImagePreview, setBackgroundImagePreview] = useState(false);
-
     const fileInputRef = useRef(null);
 
     const openFilePicker = () => {
         fileInputRef.current.click();
     };
 
-    useEffect(() => {
-        if (backgroundImageSrc !== '') {
-            setBackgroundImagePreview(true);
-        }
-    }, [backgroundImageSrc]);
-
     const handleColorSelector = (color) => {
-        color === 'image' ? setBackgroundImagePreview(true) : setBackgroundImagePreview(false);
-
         if (color === 'image' && backgroundImageSrc === ''){
             openFilePicker();
         }
@@ -132,7 +122,6 @@ function SignupNodeComponent({
         <>
             <SignupCard
                 availableLabels={availableLabels}
-                backgroundImagePreview={backgroundImagePreview}
                 backgroundImageSrc={backgroundImageSrc}
                 buttonPlaceholder={buttonPlaceholder}
                 buttonText={buttonText}


### PR DESCRIPTION
no issue

- backgroundImagePreview only had one purpose, which was to toggle a condition in the UI whether it will output the background preview or not. We can achieve the same by checking whether the type (maybe should should rather be renamed to style in future) is 'image' as opposed to 'dark, light, accent'.
- it's also more Storybook friendly which backgroundImagePreview wasn't because it had props passing from the Node, which Storybook doesn't have access to.