### PR TITLE
Fix settings panel position

### DIFF
--- a/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
@@ -1,6 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+const CARD_WIDTH_CLASSES = {
+    wide: [
+        'w-[calc(100%+3.6rem)] left-[calc(50%-(100%+3.6rem)/2)]',
+        'sm:w-[calc(100%+10rem)] sm:left-[calc(50%-(100%+10rem)/2)]',
+        'lg:w-[calc(100%+18rem)] lg:left-[calc(50%-(100%+18rem)/2)]'
+    ].join(' '),
+    full: 'inset-x-[-1px] mx-[calc(50%-50vw+(var(--kg-breakout-adjustment)/2))] w-[calc(100vw-var(--kg-breakout-adjustment)+2px)]'
+};
+
 export const CardWrapper = React.forwardRef(({
     cardType,
     cardWidth,
@@ -13,6 +22,26 @@ export const CardWrapper = React.forwardRef(({
     children,
     ...props
 }, ref) => {
+    const wrapperClass = () => {
+        if ((wrapperStyle === 'wide') && (isEditing || isSelected)) {
+            return '!-mx-3 !px-3';
+        } else if (((wrapperStyle === 'code-card') && isEditing)) {
+            return '-mx-6';
+        } else if (wrapperStyle === 'wide') {
+            return 'hover:-mx-3 hover:px-3';
+        } else {
+            return 'border';
+        }
+    };
+
+    const className = [
+        'relative border-transparent caret-grey-800',
+        isSelected && !isDragging ? 'shadow-[0_0_0_2px] shadow-green' : '',
+        !isSelected && !isDragging ? 'hover:shadow-[0_0_0_1px] hover:shadow-green' : '',
+        CARD_WIDTH_CLASSES[cardWidth] || '',
+        wrapperClass()
+    ].join(' ');
+
     return (
         <>
             {IndicatorIcon &&
@@ -22,7 +51,7 @@ export const CardWrapper = React.forwardRef(({
             }
             <div
                 ref={ref}
-                className={`relative border-transparent caret-grey-800 ${isSelected && !isDragging ? 'shadow-[0_0_0_2px] shadow-green' : ''} ${!isSelected && !isDragging ? 'hover:shadow-[0_0_0_1px] hover:shadow-green' : ''} ${(cardWidth === 'wide') ? 'mx-[calc(50%-(50vw-var(--kg-breakout-adjustment))-.8rem)] w-[calc(65vw+2px-var(--kg-breakout-adjustment))] min-w-[calc(100%+3.6rem)] translate-x-[calc(50vw-50%+.8rem-var(--kg-breakout-adjustment))] sm:min-w-[calc(100%+10rem)] lg:min-w-[calc(100%+18rem)]' : (cardWidth === 'full') ? 'inset-x-[-1px] mx-[calc(50%-50vw+(var(--kg-breakout-adjustment)/2))] w-[calc(100vw-var(--kg-breakout-adjustment)+2px)]' : ''} ${((wrapperStyle === 'wide') && (isEditing || isSelected)) ? '!-mx-3 !px-3' : ((wrapperStyle === 'code-card') && isEditing) ? '-mx-6' : ''} ${(wrapperStyle === 'wide') ? 'hover:-mx-3 hover:px-3' : 'border'}`}
+                className={className}
                 data-kg-card={cardType}
                 data-kg-card-editing={isEditing}
                 data-kg-card-selected={isSelected}

--- a/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
+++ b/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
@@ -24,8 +24,8 @@ export function SettingsPanel({children, darkMode}) {
     const {ref,repositionPanel} = useSettingsPanelReposition();
 
     return (
-        // Block with fixed position and transformed ancestor can be incorrectly positioned https://bugs.chromium.org/p/chromium/issues/detail?id=20574
-        // Using Portal to avoid such issue as some cards using transformation
+        // Ideally we would use Portal to avoid issues with transformed ancestors (https://bugs.chromium.org/p/chromium/issues/detail?id=20574)
+        // However, Portal causes problems with drag/drop, focus, etc
         <SettingsPanelContext.Provider value={{repositionPanel}}>
             <div className={`!mt-0 ${darkMode ? 'dark' : ''}`}>
                 <div ref={ref}


### PR DESCRIPTION
refs: https://github.com/TryGhost/Team/issues/3207

There's a particularly annoying issue in Chromium (and possibly others) where `position: fixed` is broken if the parent element has a `transform`. This was breaking the settings panel position on the "wide" card layout and making it jump around weirdly when changing layouts.

I thought `Portal` would be a fix as mentioned in `SettingsPanel`, but adding it back caused a bunch of problems with dragging the settings panel, dragging on nested elements such as the colour picker, etc. So this is a simpler alternative using relative position instead of transforms.

Not sure if this is a reasonable change though since I'm not sure what the `--kg-breakout-adjustment` variable is meant to do (it didn't seem to be doing anything substantial on the `wide` breakpoint, but I may well be missing something). Maybe @kevinansfield could shed some light?

(note: it still jumps a little in Safari, but seems fine in Chromium/Firefox)