### PR TITLE
Update settings panel to use a portal outside the card wrapper

### DIFF
--- a/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
@@ -1,14 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
-const CARD_WIDTH_CLASSES = {
-    wide: [
-        'w-[calc(100%+3.6rem)] left-[calc(50%-(100%+3.6rem)/2)]',
-        'sm:w-[calc(100%+10rem)] sm:left-[calc(50%-(100%+10rem)/2)]',
-        'lg:w-[calc(100%+18rem)] lg:left-[calc(50%-(100%+18rem)/2)]'
-    ].join(' '),
-    full: 'inset-x-[-1px] mx-[calc(50%-50vw+(var(--kg-breakout-adjustment)/2))] w-[calc(100vw-var(--kg-breakout-adjustment)+2px)]'
-};
+import clsx from 'clsx';
 
 export const CardWrapper = React.forwardRef(({
     cardType,
@@ -22,26 +14,6 @@ export const CardWrapper = React.forwardRef(({
     children,
     ...props
 }, ref) => {
-    const wrapperClass = () => {
-        if ((wrapperStyle === 'wide') && (isEditing || isSelected)) {
-            return '!-mx-3 !px-3';
-        } else if (((wrapperStyle === 'code-card') && isEditing)) {
-            return '-mx-6';
-        } else if (wrapperStyle === 'wide') {
-            return 'hover:-mx-3 hover:px-3';
-        } else {
-            return 'border';
-        }
-    };
-
-    const className = [
-        'relative border-transparent caret-grey-800',
-        isSelected && !isDragging ? 'shadow-[0_0_0_2px] shadow-green' : '',
-        !isSelected && !isDragging ? 'hover:shadow-[0_0_0_1px] hover:shadow-green' : '',
-        CARD_WIDTH_CLASSES[cardWidth] || '',
-        wrapperClass()
-    ].join(' ');
-
     return (
         <>
             {IndicatorIcon &&
@@ -51,13 +23,24 @@ export const CardWrapper = React.forwardRef(({
             }
             <div
                 ref={ref}
-                className={className}
                 data-kg-card={cardType}
                 data-kg-card-editing={isEditing}
                 data-kg-card-selected={isSelected}
                 {...props}
             >
-                {children}
+                {/* Apply styling to a child wrapper so that we can Portal the settings panel into here */}
+                <div className={clsx(
+                    'relative border-transparent caret-grey-800',
+                    isSelected && !isDragging && 'shadow-[0_0_0_2px] shadow-green',
+                    !isSelected && !isDragging && 'hover:shadow-[0_0_0_1px] hover:shadow-green',
+                    (cardWidth === 'wide') && 'mx-[calc(50%-(50vw-var(--kg-breakout-adjustment))-.8rem)] w-[calc(65vw+2px-var(--kg-breakout-adjustment))] min-w-[calc(100%+3.6rem)] translate-x-[calc(50vw-50%+.8rem-var(--kg-breakout-adjustment))] sm:min-w-[calc(100%+10rem)] lg:min-w-[calc(100%+18rem)]',
+                    (cardWidth === 'full') && 'inset-x-[-1px] mx-[calc(50%-50vw+(var(--kg-breakout-adjustment)/2))] w-[calc(100vw-var(--kg-breakout-adjustment)+2px)]',
+                    ((wrapperStyle === 'wide') && (isEditing || isSelected)) && '!-mx-3 !px-3',
+                    ((wrapperStyle === 'code-card') && isEditing) && '-mx-6',
+                    (wrapperStyle === 'wide') ? 'hover:-mx-3 hover:px-3' : 'border'
+                )}>
+                    {children}
+                </div>
             </div>
         </>
     );

--- a/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
+++ b/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
@@ -14,7 +14,9 @@ import {MediaPlaceholder} from './MediaPlaceholder';
 import {MultiSelectDropdown} from './MultiSelectDropdown';
 import {ProgressBar} from './ProgressBar';
 import {Toggle} from './Toggle';
+import {createPortal} from 'react-dom';
 import {openFileSelection} from '../../utils/openFileSelection';
+import {useCardContext} from '../../context/CardContext';
 
 const SettingsPanelContext = createContext();
 
@@ -22,10 +24,9 @@ export const useSettingsPanelContext = () => useContext(SettingsPanelContext);
 
 export function SettingsPanel({children, darkMode}) {
     const {ref,repositionPanel} = useSettingsPanelReposition();
+    const cardContext = useCardContext();
 
-    return (
-        // Ideally we would use Portal to avoid issues with transformed ancestors (https://bugs.chromium.org/p/chromium/issues/detail?id=20574)
-        // However, Portal causes problems with drag/drop, focus, etc
+    const element = (
         <SettingsPanelContext.Provider value={{repositionPanel}}>
             <div className={`!mt-0 ${darkMode ? 'dark' : ''}`}>
                 <div ref={ref}
@@ -37,6 +38,13 @@ export function SettingsPanel({children, darkMode}) {
             </div>
         </SettingsPanelContext.Provider>
     );
+
+    if (!cardContext?.cardContainerRef?.current) {
+        return element;
+    }
+
+    // Attach to the card wrapper to avoid problems with transformed ancestors https://bugs.chromium.org/p/chromium/issues/detail?id=20574
+    return createPortal(element, cardContext.cardContainerRef.current);
 }
 
 export function ToggleSetting({label, description, isChecked, onChange, dataTestId}) {

--- a/packages/koenig-lexical/src/context/CardContext.jsx
+++ b/packages/koenig-lexical/src/context/CardContext.jsx
@@ -3,3 +3,5 @@ import React from 'react';
 const CardContext = React.createContext({});
 
 export default CardContext;
+
+export const useCardContext = () => React.useContext(CardContext);

--- a/packages/koenig-lexical/test/e2e/card-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/card-behaviour.test.js
@@ -17,12 +17,12 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -33,12 +33,12 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -54,7 +54,7 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -70,7 +70,7 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -86,7 +86,7 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -190,16 +190,20 @@ test.describe('Card behaviour', async () => {
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="codeblock">
                         <div>
-                            <pre><code class="language-python">import pandas as pd</code></pre>
-                            <div><span>python</span></div>
+                            <div>
+                                <pre><code class="language-python">import pandas as pd</code></pre>
+                                <div><span>python</span></div>
+                            </div>
                         </div>
                     </div>
                 </div>
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="codeblock">
                         <div>
-                            <pre><code class="language-javascript">import React from "react"</code></pre>
-                            <div><span>javascript</span></div>
+                            <div>
+                                <pre><code class="language-javascript">import React from "react"</code></pre>
+                                <div><span>javascript</span></div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -260,7 +264,7 @@ test.describe('Card behaviour', async () => {
                 <p><br></p>
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -272,7 +276,7 @@ test.describe('Card behaviour', async () => {
                 <p><br></p>
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -297,12 +301,12 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -313,12 +317,12 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -338,7 +342,7 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -349,7 +353,7 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -373,12 +377,12 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -389,12 +393,12 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -405,12 +409,12 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -446,7 +450,9 @@ test.describe('Card behaviour', async () => {
                     <span data-lexical-text="true">Second line</span>
                 </p>
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <p><br /></p>
             `);
@@ -478,10 +484,14 @@ test.describe('Card behaviour', async () => {
             // sanity check, second card is selected
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <p><br /></p>
             `);
@@ -491,10 +501,14 @@ test.describe('Card behaviour', async () => {
             // first card is now selected
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <p><br /></p>
             `);
@@ -556,7 +570,9 @@ test.describe('Card behaviour', async () => {
             // card is selected
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <p dir="ltr">
                     <span data-lexical-text="true">
@@ -611,7 +627,9 @@ test.describe('Card behaviour', async () => {
             // card is selected
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <p dir="ltr">
                     <span data-lexical-text="true">First line</span>
@@ -639,7 +657,9 @@ test.describe('Card behaviour', async () => {
             // sanity check
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <p dir="ltr">
                     <span data-lexical-text="true">First line</span>
@@ -672,10 +692,14 @@ test.describe('Card behaviour', async () => {
             // sanity check, first card is selected
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <p><br /></p>
             `);
@@ -685,10 +709,14 @@ test.describe('Card behaviour', async () => {
             // first card is now selected
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <p><br /></p>
             `);
@@ -750,7 +778,9 @@ test.describe('Card behaviour', async () => {
                     <span data-lexical-text="true">Second line after break</span>
                 </p>
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <p><br /></p>
             `);
@@ -765,7 +795,7 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
             `);
@@ -776,7 +806,7 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br /></p>
@@ -800,7 +830,7 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -811,7 +841,7 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -840,7 +870,7 @@ test.describe('Card behaviour', async () => {
                 <p dir="ltr"><span data-lexical-text="true">Testing</span></p>
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -870,12 +900,12 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -886,7 +916,7 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -922,7 +952,7 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -961,7 +991,7 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p dir="ltr"><span data-lexical-text="true">Populated paragraph after empty paragraph</span></p>
@@ -984,7 +1014,7 @@ test.describe('Card behaviour', async () => {
                 <p dir="ltr"><span data-lexical-text="true">First paragraph</span></p>
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><span data-lexical-text="true">Second paragraph</span></p>
@@ -1024,7 +1054,7 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p dir="ltr"><span data-lexical-text="true">Testing</span></p>
@@ -1055,7 +1085,7 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -1085,7 +1115,7 @@ test.describe('Card behaviour', async () => {
                 <p><br></p>
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -1103,7 +1133,7 @@ test.describe('Card behaviour', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -1296,7 +1326,7 @@ test.describe('Card behaviour', async () => {
                         data-kg-card-selected="true"
                         data-kg-card="horizontalrule"
                     >
-                        <hr />
+                        <div><hr /></div>
                     </div>
                 </div>
                 <p><br /></p>
@@ -1413,7 +1443,7 @@ test.describe('Card behaviour', async () => {
                         data-kg-card-selected="true"
                         data-kg-card="horizontalrule"
                     >
-                        <hr />
+                        <div><hr /></div>
                     </div>
                 </div>
                 <div data-lexical-decorator="true" contenteditable="false">
@@ -1422,7 +1452,7 @@ test.describe('Card behaviour', async () => {
                         data-kg-card-selected="false"
                         data-kg-card="horizontalrule"
                     >
-                        <hr />
+                        <div><hr /></div>
                     </div>
                 </div>
                 <p><br /></p>
@@ -1445,7 +1475,7 @@ test.describe('Card behaviour', async () => {
                         data-kg-card-selected="true"
                         data-kg-card="horizontalrule"
                     >
-                        <hr />
+                        <div><hr /></div>
                     </div>
                 </div>
                 <p dir="ltr"><span data-lexical-text="true">First</span></p>
@@ -1489,7 +1519,7 @@ test.describe('Card behaviour', async () => {
                         data-kg-card-selected="false"
                         data-kg-card="horizontalrule"
                     >
-                        <hr />
+                        <div><hr /></div>
                     </div>
                 </div>
                 <div data-lexical-decorator="true" contenteditable="false">
@@ -1498,7 +1528,7 @@ test.describe('Card behaviour', async () => {
                         data-kg-card-selected="true"
                         data-kg-card="horizontalrule"
                     >
-                        <hr />
+                        <div><hr /></div>
                     </div>
                 </div>
             `);
@@ -1527,7 +1557,7 @@ test.describe('Card behaviour', async () => {
                         data-kg-card-selected="true"
                         data-kg-card="horizontalrule"
                     >
-                        <hr />
+                        <div><hr /></div>
                     </div>
                 </div>
             `);

--- a/packages/koenig-lexical/test/e2e/cards/callout-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/callout-card.test.js
@@ -36,21 +36,23 @@ test.describe('Callout Card', async () => {
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="callout">
                     <div>
-                        <div><button type="button">😚</button></div>
                         <div>
-                            <div data-kg="editor">
-                                <div
-                                    contenteditable="false"
-                                    spellcheck="true"
-                                    data-lexical-editor="true"
-                                    aria-autocomplete="none"
-                                >
-                                    <p dir="ltr"><span data-lexical-text="true">Hello World</span></p>
+                            <div><button type="button">😚</button></div>
+                            <div>
+                                <div data-kg="editor">
+                                    <div
+                                        contenteditable="false"
+                                        spellcheck="true"
+                                        data-lexical-editor="true"
+                                        aria-autocomplete="none"
+                                    >
+                                        <p dir="ltr"><span data-lexical-text="true">Hello World</span></p>
+                                    </div>
                                 </div>
                             </div>
                         </div>
+                        <div></div>
                     </div>
-                    <div></div>
                 </div>
             </div>
         `);
@@ -195,22 +197,24 @@ test.describe('Callout Card', async () => {
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="callout">
                         <div>
-                            <div><button type="button">💡</button></div>
                             <div>
-                                <div data-kg="editor">
-                                    <div
-                                        contenteditable="false"
-                                        spellcheck="true"
-                                        data-lexical-editor="true"
-                                        aria-autocomplete="none">
-                                        <p dir="ltr">
-                                            <span data-lexical-text="true">testing nesting</span>
-                                        </p>
+                                <div><button type="button">💡</button></div>
+                                <div>
+                                    <div data-kg="editor">
+                                        <div
+                                            contenteditable="false"
+                                            spellcheck="true"
+                                            data-lexical-editor="true"
+                                            aria-autocomplete="none">
+                                            <p dir="ltr">
+                                                <span data-lexical-text="true">testing nesting</span>
+                                            </p>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
+                            <div></div>
                         </div>
-                        <div></div>
                     </div>
                 </div>
                 <p><br /></p>
@@ -229,23 +233,25 @@ test.describe('Callout Card', async () => {
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="callout">
                         <div>
-                            <div><button type="button">💡</button></div>
                             <div>
-                                <div data-kg="editor">
-                                    <div
-                                        contenteditable="false"
-                                        spellcheck="true"
-                                        data-lexical-editor="true"
-                                        aria-autocomplete="none">
-                                        <p dir="ltr">
-                                            <span data-lexical-text="true">testing nesting</span>
-                                        </p>
+                                <div><button type="button">💡</button></div>
+                                <div>
+                                    <div data-kg="editor">
+                                        <div
+                                            contenteditable="false"
+                                            spellcheck="true"
+                                            data-lexical-editor="true"
+                                            aria-autocomplete="none">
+                                            <p dir="ltr">
+                                                <span data-lexical-text="true">testing nesting</span>
+                                            </p>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                        <div></div>
-                        <div data-kg-card-toolbar="callout">
+                            <div></div>
+                            <div data-kg-card-toolbar="callout">
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/packages/koenig-lexical/test/e2e/cards/email-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/email-card.test.js
@@ -39,15 +39,17 @@ test.describe('Email card', async () => {
             <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="email">
                 <div>
                     <div>
-                        <div data-kg="editor">
-                            <div contenteditable="false" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none">
-                                <p dir="ltr">
-                                    <span data-lexical-text="true">A paragraph</span>
-                                </p>
+                        <div>
+                            <div data-kg="editor">
+                                <div contenteditable="false" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none">
+                                    <p dir="ltr">
+                                        <span data-lexical-text="true">A paragraph</span>
+                                    </p>
+                                </div>
                             </div>
                         </div>
+                        <div></div>
                     </div>
-                    <div></div>
                 </div>
             </div>
         </div>
@@ -64,23 +66,25 @@ test.describe('Email card', async () => {
             <div data-kg-card-editing="true" data-kg-card-selected="true" data-kg-card="email">
                 <div>
                     <div>
-                        <div data-kg="editor">
-                            <div contenteditable="true" spellcheck="true" data-lexical-editor="true" role="textbox">
-                                <p dir="ltr">
-                                  <span data-lexical-text="true">Hey</span>
-                                  <code data-lexical-text="true">
-                                    <span>{first_name, "there"}</span>
-                                  </code>
-                                    <span data-lexical-text="true">,</span>
-                                </p>
+                        <div>
+                            <div data-kg="editor">
+                                <div contenteditable="true" spellcheck="true" data-lexical-editor="true" role="textbox">
+                                    <p dir="ltr">
+                                    <span data-lexical-text="true">Hey</span>
+                                    <code data-lexical-text="true">
+                                        <span>{first_name, "there"}</span>
+                                    </code>
+                                        <span data-lexical-text="true">,</span>
+                                    </p>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    <div>
-                        Only visible when delivered by email, this card will not be published on your site.
-                        <a href="https://ghost.org/help/email-newsletters/#email-cards" rel="noopener noreferrer" target="_blank">
-                            <svg></svg>
-                        </a>
+                        <div>
+                            Only visible when delivered by email, this card will not be published on your site.
+                            <a href="https://ghost.org/help/email-newsletters/#email-cards" rel="noopener noreferrer" target="_blank">
+                                <svg></svg>
+                            </a>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
@@ -43,15 +43,17 @@ test.describe('Email card', async () => {
                 <div><svg></svg></div>
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="email-cta">
                     <div>
-                        <div>Free members</div>
                         <div>
-                            <div data-kg="editor">
-                                <div contenteditable="false" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none">
-                                    <p dir="ltr"><span data-lexical-text="true">Hello</span></p>
+                            <div>Free members</div>
+                            <div>
+                                <div data-kg="editor">
+                                    <div contenteditable="false" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none">
+                                        <p dir="ltr"><span data-lexical-text="true">Hello</span></p>
+                                    </div>
                                 </div>
                             </div>
+                            <div></div>
                         </div>
-                        <div></div>
                     </div>
                 </div>
             </div>
@@ -87,17 +89,19 @@ test.describe('Email card', async () => {
                 <div><svg></svg></div>
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="email-cta">
                     <div>
-                        <div>Free members</div>
-                        <hr />
                         <div>
-                            <div data-kg="editor">
-                                <div contenteditable="false" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none">
-                                    <p dir="ltr"><span data-lexical-text="true">Hello</span></p>
+                            <div>Free members</div>
+                            <hr />
+                            <div>
+                                <div data-kg="editor">
+                                    <div contenteditable="false" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none">
+                                        <p dir="ltr"><span data-lexical-text="true">Hello</span></p>
+                                    </div>
                                 </div>
                             </div>
+                            <hr />
+                            <div></div>
                         </div>
-                        <hr />
-                        <div></div>
                     </div>
                 </div>
             </div>
@@ -131,20 +135,21 @@ test.describe('Email card', async () => {
             await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div class="sticky top-6 mb-6"><svg></svg></div>
-                <div class="relative border-transparent caret-grey-800 hover:shadow-[0_0_0_1px] hover:shadow-green hover:-mx-3 hover:px-3"
-                    data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="email-cta">
-                    <div class="w-full pb-6">
-                        <div class="pt-1 pb-7 font-sans text-xs font-semibold uppercase leading-8 tracking-tight text-grey
-                        dark:text-grey-800">Free members</div>
-                        <div
-                            class="koenig-lexical kg-inherit-styles w-full bg-transparent whitespace-normal font-serif text-xl text-grey-900 dark:text-grey-200 text-center">
-                            <div data-kg="editor">
-                                <div class="kg-prose" contenteditable="false" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none">
-                                    <p dir="ltr"><span data-lexical-text="true">Hello</span></p>
+                <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="email-cta">
+                    <div class="relative border-transparent caret-grey-800 hover:shadow-[0_0_0_1px] hover:shadow-green hover:-mx-3 hover:px-3">
+                        <div class="w-full pb-6">
+                            <div class="pt-1 pb-7 font-sans text-xs font-semibold uppercase leading-8 tracking-tight text-grey
+                            dark:text-grey-800">Free members</div>
+                            <div
+                                class="koenig-lexical kg-inherit-styles w-full bg-transparent whitespace-normal font-serif text-xl text-grey-900 dark:text-grey-200 text-center">
+                                <div data-kg="editor">
+                                    <div class="kg-prose" contenteditable="false" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none">
+                                        <p dir="ltr"><span data-lexical-text="true">Hello</span></p>
+                                    </div>
                                 </div>
                             </div>
+                            <div class="absolute top-0 z-10 !m-0 h-full w-full cursor-default p-0"></div>
                         </div>
-                        <div class="absolute top-0 z-10 !m-0 h-full w-full cursor-default p-0"></div>
                     </div>
                 </div>
             </div>
@@ -182,18 +187,20 @@ test.describe('Email card', async () => {
                 <div><svg></svg></div>
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="email-cta">
                     <div>
-                        <div>Free members</div>
                         <div>
-                            <div data-kg="editor">
-                                <div contenteditable="false" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none">
-                                    <p dir="ltr"><span data-lexical-text="true">Hello</span></p>
+                            <div>Free members</div>
+                            <div>
+                                <div data-kg="editor">
+                                    <div contenteditable="false" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none">
+                                        <p dir="ltr"><span data-lexical-text="true">Hello</span></p>
+                                    </div>
                                 </div>
                             </div>
+                            <div>
+                                <button type="button"><span>Subscribe</span></button>
+                            </div>
+                            <div></div>
                         </div>
-                        <div>
-                            <button type="button"><span>Subscribe</span></button>
-                        </div>
-                        <div></div>
                     </div>
                 </div>
             </div>
@@ -218,7 +225,7 @@ test.describe('Email card', async () => {
             leftAlignButton.click();
 
             // Check that the content is centered
-            const content = page.locator('[data-kg-card="email-cta"] > div > div.koenig-lexical');
+            const content = page.locator('[data-kg-card="email-cta"] > div > div > div.koenig-lexical');
             await expect(content).toHaveClass(/text-center/);
         });
 
@@ -277,17 +284,19 @@ test.describe('Email card', async () => {
             <div><svg></svg></div>
             <div data-kg-card-editing="true" data-kg-card-selected="true" data-kg-card="email-cta">
                 <div>
-                    <div>Free members</div>
-                    <hr />
                     <div>
-                        <div data-kg="editor">
-                            <div contenteditable="true" spellcheck="true" data-lexical-editor="true" role="textbox">
-                                <p><br /></p>
+                        <div>Free members</div>
+                        <hr />
+                        <div>
+                            <div data-kg="editor">
+                                <div contenteditable="true" spellcheck="true" data-lexical-editor="true" role="textbox">
+                                    <p><br /></p>
+                                </div>
                             </div>
+                            <div>Email only text... (optional)</div>
                         </div>
-                        <div>Email only text... (optional)</div>
+                        <hr />
                     </div>
-                    <hr />
                 </div>
                 <div>
                     <div draggable="true">
@@ -317,8 +326,8 @@ test.describe('Email card', async () => {
                             </div>
                             <div>
                                 <label id="dividers-settings">
-                                  <input type="checkbox" checked="" />
-                                  <div></div>
+                                <input type="checkbox" checked="" />
+                                <div></div>
                                 </label>
                             </div>
                         </div>
@@ -329,8 +338,8 @@ test.describe('Email card', async () => {
                             </div>
                             <div>
                                 <label id="button-settings">
-                                  <input type="checkbox" />
-                                  <div></div>
+                                <input type="checkbox" />
+                                <div></div>
                                 </label>
                             </div>
                         </div>
@@ -394,7 +403,7 @@ test.describe('Email card', async () => {
         // Create a list
         await page.keyboard.type('- List item 1');
 
-        const emailCard = page.locator('[data-kg-card="email-cta"] > div > div.koenig-lexical > div > div > ul > li:first-child');
+        const emailCard = page.locator('[data-kg-card="email-cta"] > div > div > div.koenig-lexical > div > div > ul > li:first-child');
         await expect(emailCard).toHaveText('List item 1');
     });
 

--- a/packages/koenig-lexical/test/e2e/cards/gallery-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/gallery-card.test.js
@@ -52,46 +52,48 @@ test.describe('Gallery card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="gallery">
-                    <figure>
-                        <div>
-                            <div data-gallery="true">
-                                <div data-row="0">
-                                    <div data-image="true">
-                                        <img
-                                            alt="Alt 1"
-                                            height="2160"
-                                            src="/content/images/2023/04/retreat-1.jpg"
-                                            width="3840" />
-                                        <div>
+                    <div>
+                        <figure>
+                            <div>
+                                <div data-gallery="true">
+                                    <div data-row="0">
+                                        <div data-image="true">
+                                            <img
+                                                alt="Alt 1"
+                                                height="2160"
+                                                src="/content/images/2023/04/retreat-1.jpg"
+                                                width="3840" />
                                             <div>
-                                                <button type="button"><svg></svg></button>
+                                                <div>
+                                                    <button type="button"><svg></svg></button>
+                                                </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div data-image="true">
-                                        <img
-                                            alt="Alt 2"
-                                            height="2160"
-                                            src="/content/images/2023/04/retreat-2.jpg"
-                                            width="3840" />
-                                        <div>
+                                        <div data-image="true">
+                                            <img
+                                                alt="Alt 2"
+                                                height="2160"
+                                                src="/content/images/2023/04/retreat-2.jpg"
+                                                width="3840" />
                                             <div>
-                                                <button type="button"><svg></svg></button>
+                                                <div>
+                                                    <button type="button"><svg></svg></button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
+                                <form>
+                                    <input
+                                        accept="image/gif,image/jpg,image/jpeg,image/png,image/svg+xml,image/webp"
+                                        hidden=""
+                                        multiple=""
+                                        name="image-input"
+                                        type="file" />
+                                </form>
                             </div>
-                            <form>
-                                <input
-                                    accept="image/gif,image/jpg,image/jpeg,image/png,image/svg+xml,image/webp"
-                                    hidden=""
-                                    multiple=""
-                                    name="image-input"
-                                    type="file" />
-                            </form>
-                        </div>
-                    </figure>
+                        </figure>
+                    </div>
                 </div>
             </div>
         `);
@@ -104,38 +106,40 @@ test.describe('Gallery card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="gallery">
-                    <figure>
-                        <div>
+                    <div>
+                        <figure>
                             <div>
                                 <div>
-                                    <button name="placeholder-button" type="button">
-                                        <svg></svg>
-                                        <p>Click to select up to 9 images</p>
-                                    </button>
-                                </div>
-                            </div>
-                            <form>
-                                <input
-                                    accept="image/gif,image/jpg,image/jpeg,image/png,image/svg+xml,image/webp"
-                                    hidden=""
-                                    multiple=""
-                                    name="image-input"
-                                    type="file" />
-                            </form>
-                        </div>
-                        <figcaption>
-                            <div>
-                                <div>
-                                    <div data-kg="editor">
-                                        <div contenteditable="true" spellcheck="true" data-lexical-editor="true" role="textbox">
-                                            <p><br /></p>
-                                        </div>
+                                    <div>
+                                        <button name="placeholder-button" type="button">
+                                            <svg></svg>
+                                            <p>Click to select up to 9 images</p>
+                                        </button>
                                     </div>
-                                    <div>Type caption for gallery (optional)</div>
                                 </div>
+                                <form>
+                                    <input
+                                        accept="image/gif,image/jpg,image/jpeg,image/png,image/svg+xml,image/webp"
+                                        hidden=""
+                                        multiple=""
+                                        name="image-input"
+                                        type="file" />
+                                </form>
                             </div>
-                        </figcaption>
-                    </figure>
+                            <figcaption>
+                                <div>
+                                    <div>
+                                        <div data-kg="editor">
+                                            <div contenteditable="true" spellcheck="true" data-lexical-editor="true" role="textbox">
+                                                <p><br /></p>
+                                            </div>
+                                        </div>
+                                        <div>Type caption for gallery (optional)</div>
+                                    </div>
+                                </div>
+                            </figcaption>
+                        </figure>
+                    </div>
                 </div>
             </div>
             <p><br /></p>
@@ -158,46 +162,48 @@ test.describe('Gallery card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="gallery">
-                    <figure>
-                        <div>
-                            <div data-gallery="true">
-                                <div data-row="0">
-                                    <div data-image="true">
-                                        <img
-                                            height="248"
-                                            src="blob:..."
-                                            width="248" />
-                                        <div>
+                    <div>
+                        <figure>
+                            <div>
+                                <div data-gallery="true">
+                                    <div data-row="0">
+                                        <div data-image="true">
+                                            <img
+                                                height="248"
+                                                src="blob:..."
+                                                width="248" />
                                             <div>
-                                                <button type="button"><svg></svg></button>
+                                                <div>
+                                                    <button type="button"><svg></svg></button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
+                                <form>
+                                    <input
+                                        accept="image/gif,image/jpg,image/jpeg,image/png,image/svg+xml,image/webp"
+                                        hidden=""
+                                        multiple=""
+                                        name="image-input"
+                                        type="file" />
+                                </form>
                             </div>
-                            <form>
-                                <input
-                                    accept="image/gif,image/jpg,image/jpeg,image/png,image/svg+xml,image/webp"
-                                    hidden=""
-                                    multiple=""
-                                    name="image-input"
-                                    type="file" />
-                            </form>
-                        </div>
-                        <figcaption>
-                            <div>
+                            <figcaption>
                                 <div>
-                                    <div data-kg="editor">
-                                        <div contenteditable="true" spellcheck="true" data-lexical-editor="true" role="textbox">
-                                            <p><br /></p>
+                                    <div>
+                                        <div data-kg="editor">
+                                            <div contenteditable="true" spellcheck="true" data-lexical-editor="true" role="textbox">
+                                                <p><br /></p>
+                                            </div>
                                         </div>
+                                        <div>Type caption for gallery (optional)</div>
                                     </div>
-                                    <div>Type caption for gallery (optional)</div>
                                 </div>
-                            </div>
-                        </figcaption>
-                    </figure>
-                    <div data-kg-card-toolbar="gallery"></div>
+                            </figcaption>
+                        </figure>
+                        <div data-kg-card-toolbar="gallery"></div>
+                    </div>
                 </div>
             </div>
             <p><br /></p>

--- a/packages/koenig-lexical/test/e2e/cards/header-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/header-card.test.js
@@ -50,28 +50,30 @@ test.describe('Header card', async () => {
             <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="header">
                 <div>
                     <div>
-                        <div data-kg="editor">
-                        <div
-                            contenteditable="false"
-                            spellcheck="true"
-                            data-lexical-editor="true"
-                            aria-autocomplete="none">
-                            <p dir="ltr"><span data-lexical-text="true">hello world</span></p>
+                        <div>
+                            <div data-kg="editor">
+                            <div
+                                contenteditable="false"
+                                spellcheck="true"
+                                data-lexical-editor="true"
+                                aria-autocomplete="none">
+                                <p dir="ltr"><span data-lexical-text="true">hello world</span></p>
+                            </div>
+                            </div>
                         </div>
+                        <div>
+                            <div data-kg="editor">
+                            <div
+                                contenteditable="false"
+                                spellcheck="true"
+                                data-lexical-editor="true"
+                                aria-autocomplete="none">
+                                <p dir="ltr"><span data-lexical-text="true">hello sub</span></p>
+                            </div>
+                            </div>
                         </div>
+                        <div></div>
                     </div>
-                    <div>
-                        <div data-kg="editor">
-                        <div
-                            contenteditable="false"
-                            spellcheck="true"
-                            data-lexical-editor="true"
-                            aria-autocomplete="none">
-                            <p dir="ltr"><span data-lexical-text="true">hello sub</span></p>
-                        </div>
-                        </div>
-                    </div>
-                    <div></div>
                 </div>
             </div>
             </div>
@@ -201,25 +203,25 @@ test.describe('Header card', async () => {
         const accentButton = page.locator('[aria-label="Accent"]');
 
         // Default class should be 'bg-black' on the card
-        await expect(page.locator('[data-kg-card="header"] > div:first-child')).toHaveClass(/ bg-black /);
+        await expect(page.locator('[data-kg-card="header"] > div:first-child > div:first-child')).toHaveClass(/ bg-black /);
 
         // Switch to light
         await lightButton.click();
 
         // Check that the background color has changed
-        await expect(page.locator('[data-kg-card="header"] > div:first-child')).toHaveClass(/ bg-grey-100 /);
+        await expect(page.locator('[data-kg-card="header"] > div:first-child > div:first-child')).toHaveClass(/ bg-grey-100 /);
 
         // Switch back to dark
         await darkButton.click();
 
         // Check that the background color has changed
-        await expect(page.locator('[data-kg-card="header"] > div:first-child')).toHaveClass(/ bg-black /);
+        await expect(page.locator('[data-kg-card="header"] > div:first-child > div:first-child')).toHaveClass(/ bg-black /);
 
         // Switch to accent
         await accentButton.click();
 
         // Check that the background color has changed
-        await expect(page.locator('[data-kg-card="header"] > div:first-child')).toHaveClass(/ bg-accent /);
+        await expect(page.locator('[data-kg-card="header"] > div:first-child > div:first-child')).toHaveClass(/ bg-accent /);
     });
 
     test('can add and remove background image', async function ({page}) {
@@ -237,7 +239,7 @@ test.describe('Header card', async () => {
         await fileChooser.setFiles([filePath]);
 
         // Check if it is set as a background image
-        await expect(page.locator('[data-kg-card="header"] > div:first-child')).toHaveCSS('background-image', /blob:/);
+        await expect(page.locator('[data-kg-card="header"] > div:first-child > div:first-child')).toHaveCSS('background-image', /blob:/);
 
         // Check if it is also set as an image in the panel
         await expect(page.getByTestId('image-picker-background')).toHaveAttribute('src', /blob:/);

--- a/packages/koenig-lexical/test/e2e/cards/image-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/image-card.test.js
@@ -90,17 +90,19 @@ test.describe('Image card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="image">
-                    <figure data-kg-card-width="regular">
-                        <div data-testid="media-placeholder">
-                            <div>
-                                <button name="placeholder-button" type="button">
-                                    <svg width="134" height="135" viewBox="0 0 134 135" xmlns="http://www.w3.org/2000/svg"></svg>
-                                    <p>Click to select an image</p>
-                                </button>
+                    <div>
+                        <figure data-kg-card-width="regular">
+                            <div data-testid="media-placeholder">
+                                <div>
+                                    <button name="placeholder-button" type="button">
+                                        <svg width="134" height="135" viewBox="0 0 134 135" xmlns="http://www.w3.org/2000/svg"></svg>
+                                        <p>Click to select an image</p>
+                                    </button>
+                                </div>
                             </div>
-                        </div>
-                        <form><input accept="image/*" hidden="" name="image-input" type="file" /></form>
-                    </figure>
+                            <form><input accept="image/*" hidden="" name="image-input" type="file" /></form>
+                        </figure>
+                    </div>
                 </div>
             </div>
             <div contenteditable="false" data-lexical-cursor="true"></div>
@@ -147,14 +149,16 @@ test.describe('Image card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="image">
-                    <figure data-kg-card-width="regular">
-                        <div><img alt="" src="blob:..." /></div>
-                        <figcaption>
-                            <input placeholder="Type alt text for image (optional)" value=""/>
-                            <button name="alt-toggle-button" type="button">Alt</button>
-                        </figcaption>
-                    </figure>
-                    <div data-kg-card-toolbar="image"></div>
+                    <div>
+                        <figure data-kg-card-width="regular">
+                            <div><img alt="" src="blob:..." /></div>
+                            <figcaption>
+                                <input placeholder="Type alt text for image (optional)" value=""/>
+                                <button name="alt-toggle-button" type="button">Alt</button>
+                            </figcaption>
+                        </figure>
+                        <div data-kg-card-toolbar="image"></div
+                    </div>
                 </div>
             </div>
         `, {ignoreCardToolbarContents: true});
@@ -203,28 +207,30 @@ test.describe('Image card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="image">
-                    <figure data-kg-card-width="regular">
-                        <div>
-                            <img alt="" src="blob:...">
-                        </div>
-                        <figcaption>
-                            <div data-testid="image-caption-editor">
-                                <div>
-                                    <div data-kg="editor">
-                                        <div contenteditable="true" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true" role="textbox">
-                                            <p dir="ltr" data-koenig-dnd-droppable="true">
-                                                <span data-lexical-text="true">This is link </span>
-                                                <a href="https://ghost.org/changelog/markdown/" dir="ltr">
-                                                    <span data-lexical-text="true">ghost.org/changelog/markdown/</span>
-                                                </a>
-                                            </p>
+                    <div>
+                        <figure data-kg-card-width="regular">
+                            <div>
+                                <img alt="" src="blob:...">
+                            </div>
+                            <figcaption>
+                                <div data-testid="image-caption-editor">
+                                    <div>
+                                        <div data-kg="editor">
+                                            <div contenteditable="true" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true" role="textbox">
+                                                <p dir="ltr" data-koenig-dnd-droppable="true">
+                                                    <span data-lexical-text="true">This is link </span>
+                                                    <a href="https://ghost.org/changelog/markdown/" dir="ltr">
+                                                        <span data-lexical-text="true">ghost.org/changelog/markdown/</span>
+                                                    </a>
+                                                </p>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
-                            </div>
-                            <button name="alt-toggle-button" type="button">Alt</button>
-                        </figcaption>
-                    </figure>
+                                <button name="alt-toggle-button" type="button">Alt</button>
+                            </figcaption>
+                        </figure>
+                    </div>
                 </div>
             </div>
         `, {ignoreCardToolbarContents: true});
@@ -374,25 +380,27 @@ test.describe('Image card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="image">
-                    <figure data-kg-card-width="regular">
-                        <div>
-                            <img alt="" src="blob:...">
-                        </div>
-                        <figcaption>
-                            <div data-testid="image-caption-editor">
-                                <div>
-                                    <div data-kg="editor">
-                                        <div contenteditable="true" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true" role="textbox">
-                                            <p><br /></p>
-                                        </div>
-                                    </div>
-                                    <div>Type caption for image (optional)</div>
-                                </div>
+                    <div>
+                        <figure data-kg-card-width="regular">
+                            <div>
+                                <img alt="" src="blob:...">
                             </div>
-                            <button name="alt-toggle-button" type="button">Alt</button>
-                        </figcaption>
-                    </figure>
-                    <div data-kg-card-toolbar="image"></div>
+                            <figcaption>
+                                <div data-testid="image-caption-editor">
+                                    <div>
+                                        <div data-kg="editor">
+                                            <div contenteditable="true" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true" role="textbox">
+                                                <p><br /></p>
+                                            </div>
+                                        </div>
+                                        <div>Type caption for image (optional)</div>
+                                    </div>
+                                </div>
+                                <button name="alt-toggle-button" type="button">Alt</button>
+                            </figcaption>
+                        </figure>
+                        <div data-kg-card-toolbar="image"></div>
+                    </div>
                 </div>
             </div>
         `, {ignoreCardToolbarContents: true});
@@ -508,11 +516,13 @@ test.describe('Image card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="image">
-                    <figure data-kg-card-width="regular">
-                        <div>
-                            <img alt="" src="blob:..." />
-                        </div>
-                    </figure>
+                    <div>
+                        <figure data-kg-card-width="regular">
+                            <div>
+                                <img alt="" src="blob:..." />
+                            </div>
+                        </figure>
+                    </div>
                 </div>
             </div>
             <div contenteditable="false" data-lexical-cursor="true"></div>
@@ -644,27 +654,29 @@ test.describe('Image card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="image">
-                    <figure data-kg-card-width="regular">
-                        <div>
-                            <img
-                                alt="a group of people walking down a street next to tall buildings"
-                                src="http://127.0.0.1:5173/Koenig-editor-1.png" />
-                        </div>
-                        <figcaption>
-                            <div data-testid="image-caption-editor">
-                                <div>
-                                    <div data-kg="editor">
-                                        <div contenteditable="true" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true" role="textbox">
-                                            <p><br /></p>
-                                        </div>
-                                    </div>
-                                    <div>Type caption for image (optional)</div>
-                                </div>
+                    <div>
+                        <figure data-kg-card-width="regular">
+                            <div>
+                                <img
+                                    alt="a group of people walking down a street next to tall buildings"
+                                    src="http://127.0.0.1:5173/Koenig-editor-1.png" />
                             </div>
-                            <button name="alt-toggle-button" type="button">Alt</button>
-                        </figcaption>
-                    </figure>
-                    <div data-kg-card-toolbar="image"></div>
+                            <figcaption>
+                                <div data-testid="image-caption-editor">
+                                    <div>
+                                        <div data-kg="editor">
+                                            <div contenteditable="true" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true" role="textbox">
+                                                <p><br /></p>
+                                            </div>
+                                        </div>
+                                        <div>Type caption for image (optional)</div>
+                                    </div>
+                                </div>
+                                <button name="alt-toggle-button" type="button">Alt</button>
+                            </figcaption>
+                        </figure>
+                        <div data-kg-card-toolbar="image"></div>
+                    </div>
                 </div>
             </div>
             <p><br /></p>
@@ -687,27 +699,29 @@ test.describe('Image card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="image">
-                    <figure data-kg-card-width="regular">
-                        <div>
-                            <img
-                                alt=""
-                                src="https://media.tenor.com/ocbMLlwniWQAAAAC/steve-harvey-oh.gif" />
-                        </div>
-                        <figcaption>
-                            <div data-testid="image-caption-editor">
-                                <div>
-                                    <div data-kg="editor">
-                                        <div contenteditable="true" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true" role="textbox">
-                                            <p><br /></p>
-                                        </div>
-                                    </div>
-                                    <div>Type caption for image (optional)</div>
-                                </div>
+                    <div>
+                        <figure data-kg-card-width="regular">
+                            <div>
+                                <img
+                                    alt=""
+                                    src="https://media.tenor.com/ocbMLlwniWQAAAAC/steve-harvey-oh.gif" />
                             </div>
-                            <button name="alt-toggle-button" type="button">Alt</button>
-                        </figcaption>
-                    </figure>
-                    <div data-kg-card-toolbar="image"></div>
+                            <figcaption>
+                                <div data-testid="image-caption-editor">
+                                    <div>
+                                        <div data-kg="editor">
+                                            <div contenteditable="true" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true" role="textbox">
+                                                <p><br /></p>
+                                            </div>
+                                        </div>
+                                        <div>Type caption for image (optional)</div>
+                                    </div>
+                                </div>
+                                <button name="alt-toggle-button" type="button">Alt</button>
+                            </figcaption>
+                        </figure>
+                        <div data-kg-card-toolbar="image"></div>
+                    </div>
                 </div>
             </div>
             <p><br /></p>
@@ -733,27 +747,29 @@ test.describe('Image card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="image">
-                    <figure data-kg-card-width="regular">
-                        <div>
-                            <img
-                                alt=""
-                                src="https://media.tenor.com/Sm9aylrzSyMAAAAC/cats-animals.gif" />
-                        </div>
-                        <figcaption>
-                            <div data-testid="image-caption-editor">
-                                <div>
-                                    <div data-kg="editor">
-                                        <div contenteditable="true" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true" role="textbox">
-                                            <p><br /></p>
-                                        </div>
-                                    </div>
-                                    <div>Type caption for image (optional)</div>
-                                </div>
+                    <div>
+                        <figure data-kg-card-width="regular">
+                            <div>
+                                <img
+                                    alt=""
+                                    src="https://media.tenor.com/Sm9aylrzSyMAAAAC/cats-animals.gif" />
                             </div>
-                            <button name="alt-toggle-button" type="button">Alt</button>
-                        </figcaption>
-                    </figure>
-                    <div data-kg-card-toolbar="image"></div>
+                            <figcaption>
+                                <div data-testid="image-caption-editor">
+                                    <div>
+                                        <div data-kg="editor">
+                                            <div contenteditable="true" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true" role="textbox">
+                                                <p><br /></p>
+                                            </div>
+                                        </div>
+                                        <div>Type caption for image (optional)</div>
+                                    </div>
+                                </div>
+                                <button name="alt-toggle-button" type="button">Alt</button>
+                            </figcaption>
+                        </figure>
+                        <div data-kg-card-toolbar="image"></div>
+                    </div>
                 </div>
             </div>
             <p><br /></p>

--- a/packages/koenig-lexical/test/e2e/cards/markdown-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/markdown-card.test.js
@@ -45,7 +45,9 @@ test.describe('Markdown card', async () => {
             <div data-lexical-decorator="true" contenteditable="false">
                 <div><svg></svg></div>
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="markdown">
-                    <div><h1 id="this-is-a-heading">This is a heading</h1></div>
+                    <div>
+                        <div><h1 id="this-is-a-heading">This is a heading</h1></div>
+                    </div>
                 </div>
             </div>
         `);

--- a/packages/koenig-lexical/test/e2e/cards/paywall-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/paywall-card.test.js
@@ -32,7 +32,9 @@ test.describe('Paywall card', async () => {
             <div data-lexical-decorator="true" contenteditable="false" data-koenig-dnd-draggable="true" data-koenig-dnd-droppable="true">
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="paywall">
                     <div>
-                        Free public preview<span>↑</span>/<span>↓</span>Only visible to members
+                        <div>
+                            Free public preview<span>↑</span>/<span>↓</span>Only visible to members
+                        </div>
                     </div>
                 </div>
             </div>
@@ -47,7 +49,9 @@ test.describe('Paywall card', async () => {
             <div data-lexical-decorator="true" contenteditable="false" data-koenig-dnd-draggable="true" data-koenig-dnd-droppable="true">
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="paywall">
                     <div>
-                        Free public preview<span>↑</span>/<span>↓</span>Only visible to members
+                        <div>
+                            Free public preview<span>↑</span>/<span>↓</span>Only visible to members
+                        </div>
                     </div>
                 </div>
             </div>

--- a/packages/koenig-lexical/test/e2e/cards/product-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/product-card.test.js
@@ -43,8 +43,33 @@ test.describe('Product card', async () => {
                     data-kg-card-selected="false"
                     data-kg-card="product">
                     <div>
-                        <div><img src="/content/images/2022/11/koenig-lexical.jpg" /></div>
                         <div>
+                            <div><img src="/content/images/2022/11/koenig-lexical.jpg" /></div>
+                            <div>
+                                <div>
+                                    <div>
+                                        <div data-kg="editor">
+                                            <div
+                                                contenteditable="false"
+                                                spellcheck="true"
+                                                data-lexical-editor="true"
+                                                aria-autocomplete="none">
+                                                <p dir="ltr">
+                                                    <span data-lexical-text="true">This is</span>
+                                                    <em data-lexical-text="true">title</em>
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div>
+                                    <button type="button"><svg></svg></button>
+                                    <button type="button"><svg></svg></button>
+                                    <button type="button"><svg></svg></button>
+                                    <button type="button"><svg></svg></button>
+                                    <button type="button"><svg></svg></button>
+                                </div>
+                            </div>
                             <div>
                                 <div>
                                     <div data-kg="editor">
@@ -53,40 +78,17 @@ test.describe('Product card', async () => {
                                             spellcheck="true"
                                             data-lexical-editor="true"
                                             aria-autocomplete="none">
-                                            <p dir="ltr">
-                                                <span data-lexical-text="true">This is</span>
-                                                <em data-lexical-text="true">title</em>
-                                            </p>
+                                            <p dir="ltr"><span data-lexical-text="true">Description</span></p>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                             <div>
-                                <button type="button"><svg></svg></button>
-                                <button type="button"><svg></svg></button>
-                                <button type="button"><svg></svg></button>
-                                <button type="button"><svg></svg></button>
-                                <button type="button"><svg></svg></button>
+                                <a href="https://google.com/"><span>Button</span></a>
                             </div>
                         </div>
-                        <div>
-                            <div>
-                                <div data-kg="editor">
-                                    <div
-                                        contenteditable="false"
-                                        spellcheck="true"
-                                        data-lexical-editor="true"
-                                        aria-autocomplete="none">
-                                        <p dir="ltr"><span data-lexical-text="true">Description</span></p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div>
-                            <a href="https://google.com/"><span>Button</span></a>
-                        </div>
+                        <div></div>
                     </div>
-                    <div></div>
                 </div>
             </div>
             `, {ignoreCardToolbarContents: true, ignoreInnerSVG: true});
@@ -241,21 +243,36 @@ test.describe('Product card', async () => {
                         <div>
                             <div>
                                 <div>
-                                    <button name="placeholder-button" type="button">
-                                        <svg></svg>
-                                        <p>Click to select a product image</p>
-                                    </button>
+                                    <div>
+                                        <button name="placeholder-button" type="button">
+                                            <svg></svg>
+                                            <p>Click to select a product image</p>
+                                        </button>
+                                    </div>
+                                </div>
+                                <form>
+                                    <input
+                                        accept="image/gif,image/jpg,image/jpeg,image/png,image/svg+xml,image/webp"
+                                        hidden=""
+                                        name="image-input"
+                                        type="file" />
+                                </form>
+                            </div>
+                            <div>
+                                <div>
+                                    <div>
+                                        <div data-kg="editor">
+                                            <div
+                                                contenteditable="true"
+                                                spellcheck="true"
+                                                data-lexical-editor="true"
+                                                role="textbox">
+                                                <p dir="ltr"><span data-lexical-text="true">Title</span></p>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
-                            <form>
-                                <input
-                                    accept="image/gif,image/jpg,image/jpeg,image/png,image/svg+xml,image/webp"
-                                    hidden=""
-                                    name="image-input"
-                                    type="file" />
-                            </form>
-                        </div>
-                        <div>
                             <div>
                                 <div>
                                     <div data-kg="editor">
@@ -264,21 +281,8 @@ test.describe('Product card', async () => {
                                             spellcheck="true"
                                             data-lexical-editor="true"
                                             role="textbox">
-                                            <p dir="ltr"><span data-lexical-text="true">Title</span></p>
+                                            <p dir="ltr"><span data-lexical-text="true">Description</span></p>
                                         </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div>
-                            <div>
-                                <div data-kg="editor">
-                                    <div
-                                        contenteditable="true"
-                                        spellcheck="true"
-                                        data-lexical-editor="true"
-                                        role="textbox">
-                                        <p dir="ltr"><span data-lexical-text="true">Description</span></p>
                                     </div>
                                 </div>
                             </div>

--- a/packages/koenig-lexical/test/e2e/cards/signup-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/signup-card.test.js
@@ -137,7 +137,7 @@ test.describe('Signup card', async () => {
         await fileChooser.setFiles([filePath]);
 
         // Check if it is set as a background image
-        await expect(page.locator('[data-kg-card="signup"] > div:first-child')).toHaveCSS('background-image', /blob:/);
+        await expect(page.locator('[data-kg-card="signup"] > div:first-child > div:first-child')).toHaveCSS('background-image', /blob:/);
 
         // Check if it is also set as an image in the panel
         await expect(page.locator('[data-testid="media-upload-filled"] img')).toHaveAttribute('src', /blob:/);

--- a/packages/koenig-lexical/test/e2e/cards/toggle-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/toggle-card.test.js
@@ -37,10 +37,30 @@ test.describe('Toggle card', async () => {
         await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="toggle">
-                        <div class="rounded border border-grey/40 py-4 px-6 dark:border-grey/30">
-                            <div class="flex cursor-text items-start justify-between">
-                                <div class="mr-2 w-full">
-                                    <div class="koenig-lexical-toggle-heading">
+                        <div>
+                            <div class="rounded border border-grey/40 py-4 px-6 dark:border-grey/30">
+                                <div class="flex cursor-text items-start justify-between">
+                                    <div class="mr-2 w-full">
+                                        <div class="koenig-lexical-toggle-heading">
+                                            <div data-kg="editor">
+                                                <div
+                                                    contenteditable="false"
+                                                    spellcheck="true"
+                                                    data-lexical-editor="true"
+                                                    aria-autocomplete="none"
+                                                >
+                                                    <p dir="ltr"><em data-lexical-text="true">Heading</em></p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div
+                                        class="ml-auto mt-[-1px] flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center">
+                                        <svg></svg>
+                                    </div>
+                                </div>
+                                <div class="mt-2 w-full visible">
+                                    <div class="koenig-lexical-toggle-description">
                                         <div data-kg="editor">
                                             <div
                                                 contenteditable="false"
@@ -48,32 +68,14 @@ test.describe('Toggle card', async () => {
                                                 data-lexical-editor="true"
                                                 aria-autocomplete="none"
                                             >
-                                                <p dir="ltr"><em data-lexical-text="true">Heading</em></p>
+                                                <p dir="ltr"><span data-lexical-text="true">Content</span></p>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
-                                <div
-                                    class="ml-auto mt-[-1px] flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center">
-                                    <svg></svg>
-                                </div>
                             </div>
-                            <div class="mt-2 w-full visible">
-                                <div class="koenig-lexical-toggle-description">
-                                    <div data-kg="editor">
-                                        <div
-                                            contenteditable="false"
-                                            spellcheck="true"
-                                            data-lexical-editor="true"
-                                            aria-autocomplete="none"
-                                        >
-                                            <p dir="ltr"><span data-lexical-text="true">Content</span></p>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+                            <div></div>
                         </div>
-                        <div></div>
                     </div>
                 </div>
             `, {ignoreCardToolbarContents: true, ignoreInnerSVG: true});
@@ -86,10 +88,31 @@ test.describe('Toggle card', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="true" data-kg-card-selected="true" data-kg-card="toggle">
-                    <div class="rounded border border-grey/40 py-4 px-6 dark:border-grey/30">
-                        <div class="flex cursor-text items-start justify-between">
-                            <div class="mr-2 w-full">
-                                <div class="koenig-lexical-toggle-heading">
+                    <div>
+                        <div class="rounded border border-grey/40 py-4 px-6 dark:border-grey/30">
+                            <div class="flex cursor-text items-start justify-between">
+                                <div class="mr-2 w-full">
+                                    <div class="koenig-lexical-toggle-heading">
+                                        <div data-kg="editor">
+                                            <div
+                                                contenteditable="true"
+                                                spellcheck="true"
+                                                data-lexical-editor="true"
+                                                role="textbox"
+                                            >
+                                                <p><br /></p>
+                                            </div>
+                                        </div>
+                                        <div>Toggle header</div>
+                                    </div>
+                                </div>
+                                <div
+                                    class="ml-auto mt-[-1px] flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center">
+                                    <svg></svg>
+                                </div>
+                            </div>
+                            <div class="mt-2 w-full visible">
+                                <div class="koenig-lexical-toggle-description">
                                     <div data-kg="editor">
                                         <div
                                             contenteditable="true"
@@ -100,27 +123,8 @@ test.describe('Toggle card', async () => {
                                             <p><br /></p>
                                         </div>
                                     </div>
-                                    <div>Toggle header</div>
+                                    <div>Collapsible content</div>
                                 </div>
-                            </div>
-                            <div
-                                class="ml-auto mt-[-1px] flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center">
-                                <svg></svg>
-                            </div>
-                        </div>
-                        <div class="mt-2 w-full visible">
-                            <div class="koenig-lexical-toggle-description">
-                                <div data-kg="editor">
-                                    <div
-                                        contenteditable="true"
-                                        spellcheck="true"
-                                        data-lexical-editor="true"
-                                        role="textbox"
-                                    >
-                                        <p><br /></p>
-                                    </div>
-                                </div>
-                                <div>Collapsible content</div>
                             </div>
                         </div>
                     </div>

--- a/packages/koenig-lexical/test/e2e/list-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/list-behaviour.test.js
@@ -78,7 +78,9 @@ test.describe('List behaviour', async () => {
             // sanity check - contents are as we expect
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <ul>
                     <li value="1" dir="ltr"><span data-lexical-text="true">first li</span></li>
@@ -105,7 +107,9 @@ test.describe('List behaviour', async () => {
             // first list item converted to a paragraph
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <p dir="ltr"><span data-lexical-text="true">first li</span></p>
                 <ul>

--- a/packages/koenig-lexical/test/e2e/plus-button.test.js
+++ b/packages/koenig-lexical/test/e2e/plus-button.test.js
@@ -318,7 +318,7 @@ test.describe('Plus button', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -340,7 +340,7 @@ test.describe('Plus button', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>
@@ -353,7 +353,7 @@ test.describe('Plus button', async () => {
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
                     <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                        <hr>
+                        <div><hr></div>
                     </div>
                 </div>
                 <p><br></p>

--- a/packages/koenig-lexical/test/e2e/selection.test.js
+++ b/packages/koenig-lexical/test/e2e/selection.test.js
@@ -48,7 +48,7 @@ test.describe('Selection behaviour', async () => {
             <p dir="ltr"><span data-lexical-text="true">First paragraph</span></p>
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                    <hr>
+                    <div><hr></div>
                 </div>
             </div>
             <p><span data-lexical-text="true">Second paragraph</span></p>

--- a/packages/koenig-lexical/test/e2e/slash-menu.test.js
+++ b/packages/koenig-lexical/test/e2e/slash-menu.test.js
@@ -226,7 +226,9 @@ test.describe('Slash menu', async () => {
 
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <p><br /></p>
             `);
@@ -251,7 +253,9 @@ test.describe('Slash menu', async () => {
             await assertHTML(page, html`
                 <p dir="ltr"><span data-lexical-text="true">Testing</span></p>
                 <div data-lexical-decorator="true" contenteditable="false">
-                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule"><hr /></div>
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <div><hr /></div>
+                    </div>
                 </div>
                 <p><br /></p>
             `);

--- a/packages/koenig-lexical/test/e2e/text-transforms/horizontal-line-rule.test.js
+++ b/packages/koenig-lexical/test/e2e/text-transforms/horizontal-line-rule.test.js
@@ -12,7 +12,7 @@ test.describe('Renders horizontal line rule', async () => {
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
-                    <hr>
+                    <div><hr></div>
                 </div>
             </div>
             <p><br></p>

--- a/packages/koenig-lexical/test/e2e/title-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/title-behaviour.test.js
@@ -164,7 +164,9 @@ test.describe('Title behaviour (ExternalControlPlugin)', async () => {
                 // card is selected
                 await assertHTML(page, html`
                     <div data-lexical-decorator="true" contenteditable="false">
-                       <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule"><hr /></div>
+                        <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="horizontalrule">
+                            <div><hr /></div>
+                        </div>
                     </div>
                     <p><br /></p>
                 `);
@@ -175,7 +177,9 @@ test.describe('Title behaviour (ExternalControlPlugin)', async () => {
 
                 await assertHTML(page, html`
                     <div data-lexical-decorator="true" contenteditable="false">
-                       <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule"><hr /></div>
+                        <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                            <div><hr /></div>
+                        </div>
                     </div>
                     <p dir="ltr"><span data-lexical-text="true">Testing</span></p>
                     <p><br /></p>
@@ -218,7 +222,9 @@ test.describe('Title behaviour (ExternalControlPlugin)', async () => {
                 // card is not selected
                 await assertHTML(page, html`
                     <div data-lexical-decorator="true" contenteditable="false">
-                        <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule"><hr /></div>
+                        <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                            <div><hr /></div>
+                        </div>
                     </div>
                     <p><br /></p>
                 `);
@@ -314,7 +320,9 @@ test.describe('Title behaviour (ExternalControlPlugin)', async () => {
                 // card is not selected
                 await assertHTML(page, html`
                     <div data-lexical-decorator="true" contenteditable="false">
-                        <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule"><hr /></div>
+                        <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                            <div><hr /></div>
+                        </div>
                     </div>
                     <p><br /></p>
                 `);


### PR DESCRIPTION
Alternative to https://github.com/TryGhost/Koenig/pull/673 which keeps the original card wrapper styles intact (to match mobiledoc and make sure it works with the sidebar)