### PR TITLE
Focus back on the editor after changing layout options

### DIFF
--- a/packages/koenig-lexical/src/hooks/useFocusHistory.js
+++ b/packages/koenig-lexical/src/hooks/useFocusHistory.js
@@ -1,0 +1,28 @@
+import {useCallback, useEffect, useRef} from 'react';
+
+export default function useFocusHistory({length = 2, enabled = true} = {}) {
+    const focusHistory = useRef([]);
+
+    const handleFocus = useCallback((event) => {
+        focusHistory.current = [event.target].concat(focusHistory.current).slice(0, length);
+    }, [length]);
+
+    useEffect(() => {
+        if (enabled) {
+            document.addEventListener('focusin', handleFocus);
+
+            return () => {
+                document.removeEventListener('focusin', handleFocus);
+            };
+        } else {
+            focusHistory.current = [];
+        }
+    }, [enabled, handleFocus]);
+
+    return {
+        focusHistory,
+        restorePreviousFocus: () => {
+            focusHistory.current[1]?.focus();
+        }
+    };
+}

--- a/packages/koenig-lexical/src/nodes/SignupNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/SignupNodeComponent.jsx
@@ -1,6 +1,7 @@
 import CardContext from '../context/CardContext';
 import KoenigComposerContext from '../context/KoenigComposerContext';
 import useFileDragAndDrop from '../hooks/useFileDragAndDrop';
+import useFocusHistory from '../hooks/useFocusHistory';
 import {$getNodeByKey} from 'lexical';
 import {ActionToolbar} from '../components/ui/ActionToolbar';
 import {EDIT_CARD_COMMAND} from '../plugins/KoenigBehaviourPlugin';
@@ -41,6 +42,7 @@ function SignupNodeComponent({
     const [showSnippetToolbar, setShowSnippetToolbar] = useState(false);
     const [availableLabels, setAvailableLabels] = useState([]);
     const [showBackgroundImage, setShowBackgroundImage] = useState(Boolean(backgroundImageSrc));
+    const {restorePreviousFocus} = useFocusHistory({enabled: isEditing});
 
     useEffect(() => {
         if (cardConfig?.fetchLabels) {
@@ -62,6 +64,7 @@ function SignupNodeComponent({
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
             node.setAlignment(a);
+            restorePreviousFocus();
         });
     };
 
@@ -98,6 +101,7 @@ function SignupNodeComponent({
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
             node.setLayout(l);
+            restorePreviousFocus();
         });
     };
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3217

This is meant to be reusable in other components - we should probably add it to other ones with a settings panel for consistency.