### PR TITLE
Fixed editor losing focus when undoing card deletion

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigNestedEditorPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigNestedEditorPlugin.jsx
@@ -19,19 +19,24 @@ function KoenigNestedEditorPlugin({
     defaultKoenigEnterBehaviour = false
 }) {
     const [editor] = useLexicalComposerContext();
-    const {selectedCardKey} = useKoenigSelectedCardContext();
+    const {selectedCardKey, isEditingCard} = useKoenigSelectedCardContext();
 
     // using state here because this component can get re-rendered after the
     // editor's editable state changes so we need to re-focus on re-render
     const [shouldFocus, setShouldFocus] = React.useState(autoFocus);
 
     React.useEffect(() => {
+        // prevent nested editor getting focus when undoing card deletion
+        if (!isEditingCard) {
+            return;
+        }
+
         if (shouldFocus) {
             editor.focus(() => {
                 editor.getRootElement().focus({preventScroll: true});
             });
         }
-    }, [shouldFocus, editor]);
+    }, [shouldFocus, editor, isEditingCard]);
 
     React.useEffect(() => {
         return mergeRegister(


### PR DESCRIPTION
refs TryGhost/Team#3288
- Prevented nested editor getting autofocus for the card in non-edit mode.