### PR TITLE
Added ability to hide Toolbar formats

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigComposableEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigComposableEditor.jsx
@@ -37,7 +37,8 @@ const KoenigComposableEditor = ({
     readOnly = false,
     isDragEnabled = true,
     inheritStyles = false,
-    isSnippetsEnabled = true
+    isSnippetsEnabled = true,
+    hiddenFormats = []
 }) => {
     const {historyState} = useSharedHistoryContext();
     const [editor] = useLexicalComposerContext();
@@ -97,7 +98,7 @@ const KoenigComposableEditor = ({
             {!isCollabActive && <HistoryPlugin externalHistoryState={historyState} />} {/* adds undo/redo, in multiplayer that's handled by yjs */}
             <KoenigBehaviourPlugin containerElem={editorContainerRef} cursorDidExitAtTop={cursorDidExitAtTop} isNested={isNested} />
             <MarkdownShortcutPlugin transformers={markdownTransformers} />
-            {floatingAnchorElem && (<FloatingToolbarPlugin anchorElem={floatingAnchorElem} isSnippetsEnabled={isSnippetsEnabled} />)}
+            {floatingAnchorElem && (<FloatingToolbarPlugin anchorElem={floatingAnchorElem} hiddenFormats={hiddenFormats} isSnippetsEnabled={isSnippetsEnabled} />)}
             <DragDropPastePlugin />
             {registerAPI ? <ExternalControlPlugin registerAPI={registerAPI} /> : null}
             {isDragReorderEnabled && <DragDropReorderPlugin containerElem={editorContainerRef} />}

--- a/packages/koenig-lexical/src/components/KoenigNestedEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigNestedEditor.jsx
@@ -21,7 +21,8 @@ const KoenigNestedEditor = ({
     focusNext = null,
     singleParagraph = false,
     hasSettingsPanel = false,
-    defaultKoenigEnterBehaviour = false
+    defaultKoenigEnterBehaviour = false,
+    hiddenFormats = []
 }) => {
     const initialNodes = nodes === 'minimal' ? MINIMAL_NODES : BASIC_NODES;
     const markdownTransformers = nodes === 'minimal' ? MINIMAL_TRANSFORMERS : BASIC_TRANSFORMERS;
@@ -34,6 +35,7 @@ const KoenigNestedEditor = ({
         >
             <KoenigComposableEditor
                 className={textClassName}
+                hiddenFormats={hiddenFormats}
                 inheritStyles={true}
                 isDragEnabled={false}
                 markdownTransformers={markdownTransformers}

--- a/packages/koenig-lexical/src/components/ui/FloatingFormatToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/FloatingFormatToolbar.jsx
@@ -17,7 +17,8 @@ export function FloatingFormatToolbar({
     isSnippetsEnabled,
     toolbarItemType,
     setToolbarItemType,
-    selectionRangeRect
+    selectionRangeRect,
+    hiddenFormats = []
 }) {
     const toolbarRef = React.useRef(null);
     const [arrowStyles, setArrowStyles] = React.useState(null);
@@ -93,6 +94,7 @@ export function FloatingFormatToolbar({
                 <FormatToolbar
                     arrowStyles={arrowStyles}
                     editor={editor}
+                    hiddenFormats={hiddenFormats}
                     isLinkSelected={!!href}
                     isSnippetsEnabled={isSnippetsEnabled}
                     onLinkClick={() => setToolbarItemType(toolbarItemTypes.link)}

--- a/packages/koenig-lexical/src/components/ui/FormatToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/FormatToolbar.jsx
@@ -44,7 +44,8 @@ export default function FormatToolbar({
     isLinkSelected,
     onLinkClick,
     onSnippetClick,
-    arrowStyles
+    arrowStyles,
+    hiddenFormats = []
 }) {
     const [isBold, setIsBold] = React.useState(false);
     const [isItalic, setIsItalic] = React.useState(false);
@@ -63,6 +64,11 @@ export default function FormatToolbar({
     let hideSnippets = !isSnippetsEnabled;
     if (editor._parentEditor) {
         hideSnippets = true;
+    }
+
+    let hideBold = false;
+    if (hiddenFormats.includes('bold')) {
+        hideBold = true;
     }
 
     const updateState = React.useCallback(() => {
@@ -159,6 +165,7 @@ export default function FormatToolbar({
         <ToolbarMenu arrowStyles={arrowStyles}>
             <ToolbarMenuItem
                 data-kg-toolbar-button="bold"
+                hide={hideBold}
                 icon="bold"
                 isActive={isBold}
                 label="Format text as bold"

--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
@@ -195,6 +195,7 @@ export function SignupCard({alignment,
                         autoFocus={true}
                         focusNext={subheaderTextEditor}
                         hasSettingsPanel={true}
+                        hiddenFormats={['bold']}
                         initialEditor={headerTextEditor}
                         initialEditorState={headerTextEditorInitialState}
                         nodes="minimal"
@@ -225,6 +226,7 @@ export function SignupCard({alignment,
                     {<KoenigNestedEditor
                         focusNext={disclaimerTextEditor}
                         hasSettingsPanel={true}
+                        hiddenFormats={['bold']}
                         initialEditor={subheaderTextEditor}
                         initialEditorState={subheaderTextEditorInitialState}
                         nodes="minimal"

--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
@@ -226,7 +226,6 @@ export function SignupCard({alignment,
                     {<KoenigNestedEditor
                         focusNext={disclaimerTextEditor}
                         hasSettingsPanel={true}
-                        hiddenFormats={['bold']}
                         initialEditor={subheaderTextEditor}
                         initialEditorState={subheaderTextEditorInitialState}
                         nodes="minimal"

--- a/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
@@ -7,12 +7,12 @@ import {FloatingLinkToolbar} from '../components/ui/FloatingLinkToolbar';
 import {getSelectedNode} from '../utils/getSelectedNode';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
-export default function FloatingToolbarPlugin({anchorElem = document.body, isSnippetsEnabled}) {
+export default function FloatingToolbarPlugin({anchorElem = document.body, isSnippetsEnabled, hiddenFormats = []}) {
     const [editor] = useLexicalComposerContext();
-    return useFloatingFormatToolbar(editor, anchorElem, isSnippetsEnabled);
+    return useFloatingFormatToolbar(editor, anchorElem, isSnippetsEnabled, hiddenFormats);
 }
 
-function useFloatingFormatToolbar(editor, anchorElem, isSnippetsEnabled) {
+function useFloatingFormatToolbar(editor, anchorElem, isSnippetsEnabled, hiddenFormats = []) {
     const [toolbarItemType, setToolbarItemType] = React.useState(null);
     const [selectionRangeRect, setSelectionRangeRect] = React.useState(null);
     const [href, setHref] = React.useState(null);
@@ -99,12 +99,12 @@ function useFloatingFormatToolbar(editor, anchorElem, isSnippetsEnabled) {
         setToolbarItemType(toolbarItemTypes.link);
         setHref(data.href);
     };
-
     return (
         <>
             <FloatingFormatToolbar
                 anchorElem={anchorElem}
                 editor={editor}
+                hiddenFormats={hiddenFormats}
                 href={href}
                 isSnippetsEnabled={isSnippetsEnabled}
                 selectionRangeRect={selectionRangeRect}


### PR DESCRIPTION
no issue

Hides the bold toolbar option from the header nested editor of the Signup Card.