### PR TITLE
Removed duplicated code in default nodes

### DIFF
--- a/packages/kg-default-nodes/lib/KoenigDecoratorNode.js
+++ b/packages/kg-default-nodes/lib/KoenigDecoratorNode.js
@@ -1,6 +1,37 @@
 import {DecoratorNode} from 'lexical';
 
-export class KoenigDecoratorNode extends DecoratorNode {}
+export class KoenigDecoratorNode extends DecoratorNode {
+    /* c8 ignore start */
+
+    // Transforms URLs contained in the payload to relative paths (`__GHOST_URL__/relative/path/`),
+    // so that URLs to be changed without having to update the database
+    // (cf. `@tryghost/url-utils` for more information)
+    //
+    // To be overwritten by subclasses if there is a url, html or markdown type of property in the payload
+    static get urlTransformMap() {
+        return {};
+    }
+
+    createDOM() {
+        return document.createElement('div');
+    }
+
+    updateDOM() {
+        return false;
+    }
+
+    // All our cards are top-level blocks
+    isInline() {
+        return false;
+    }
+
+    // To be overwritten in Koenig Lexical
+    decorate() {
+        return '';
+    }
+
+    /* c8 ignore stop */
+}
 
 export function $isKoenigCard(node) {
     return node instanceof KoenigDecoratorNode;

--- a/packages/kg-default-nodes/lib/nodes/aside/AsideNode.js
+++ b/packages/kg-default-nodes/lib/nodes/aside/AsideNode.js
@@ -12,11 +12,6 @@ export class AsideNode extends ElementNode {
         );
     }
 
-    // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
-    static get urlTransformMap() {
-        return {};
-    }
-
     constructor(key) {
         super(key);
     }
@@ -42,21 +37,6 @@ export class AsideNode extends ElementNode {
         const parser = new AsideParser(this);
         return parser.DOMConversionMap;
     }
-
-    /* c8 ignore start */
-    createDOM() {
-        const element = document.createElement('div');
-        return element;
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
 }
 
 export function $createAsideNode() {

--- a/packages/kg-default-nodes/lib/nodes/audio/AudioNode.js
+++ b/packages/kg-default-nodes/lib/nodes/audio/AudioNode.js
@@ -25,7 +25,6 @@ export class AudioNode extends KoenigDecoratorNode {
         );
     }
 
-    // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
     static get urlTransformMap() {
         return {
             src: 'url'
@@ -90,21 +89,6 @@ export class AudioNode extends KoenigDecoratorNode {
         return {element};
     }
 
-    /* c8 ignore start */
-    createDOM() {
-        const element = document.createElement('div');
-        return element;
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
-
     getSrc() {
         const self = this.getLatest();
         return self.__src;
@@ -153,12 +137,6 @@ export class AudioNode extends KoenigDecoratorNode {
     setThumbnailSrc(thumbnailSrc) {
         const writable = this.getWritable();
         return writable.__thumbnailSrc = thumbnailSrc;
-    }
-
-    // should be overridden
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 
     hasEditMode() {

--- a/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkNode.js
+++ b/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkNode.js
@@ -27,7 +27,6 @@ export class BookmarkNode extends KoenigDecoratorNode {
         );
     }
 
-    // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
     static get urlTransformMap() {
         return {
             url: 'url',
@@ -104,21 +103,6 @@ export class BookmarkNode extends KoenigDecoratorNode {
         const element = renderBookmarkNodeToDOM(this, options);
         return {element};
     }
-
-    /* c8 ignore start */
-    createDOM() {
-        const element = document.createElement('div');
-        return element;
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
 
     getUrl() {
         const self = this.getLatest();
@@ -199,12 +183,6 @@ export class BookmarkNode extends KoenigDecoratorNode {
     setCaption(caption) {
         const writable = this.getWritable();
         return writable.__caption = caption;
-    }
-
-    // should be overridden
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 
     hasEditMode() {

--- a/packages/kg-default-nodes/lib/nodes/button/ButtonNode.js
+++ b/packages/kg-default-nodes/lib/nodes/button/ButtonNode.js
@@ -22,7 +22,6 @@ export class ButtonNode extends KoenigDecoratorNode {
         );
     }
 
-    // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
     static get urlTransformMap() {
         return {
             buttonUrl: 'url'
@@ -78,21 +77,6 @@ export class ButtonNode extends KoenigDecoratorNode {
         return {element};
     }
 
-    /* c8 ignore start */
-    createDOM() {
-        const element = document.createElement('div');
-        return element;
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
-
     getButtonText() {
         const self = this.getLatest();
         return self.__buttonText;
@@ -121,12 +105,6 @@ export class ButtonNode extends KoenigDecoratorNode {
     setButtonUrl(buttonUrl) {
         const writable = this.getWritable();
         return writable.__buttonUrl = buttonUrl;
-    }
-
-    // should be overridden
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 
     hasEditMode() {

--- a/packages/kg-default-nodes/lib/nodes/callout/CalloutNode.js
+++ b/packages/kg-default-nodes/lib/nodes/callout/CalloutNode.js
@@ -69,19 +69,6 @@ export class CalloutNode extends KoenigDecoratorNode {
         return {element};
     }
 
-    createDom() {
-        const element = document.createElement('div');
-        return element;
-    }
-
-    updateDom() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-
     getCalloutText() {
         const self = this.getLatest();
         return self.__calloutText;
@@ -110,10 +97,6 @@ export class CalloutNode extends KoenigDecoratorNode {
     setCalloutEmoji(emoji) {
         const writeable = this.getWritable();
         writeable.__calloutEmoji = emoji;
-    }
-
-    decorate() {
-        return '';
     }
 
     hasEditMode() {

--- a/packages/kg-default-nodes/lib/nodes/codeblock/CodeBlockNode.js
+++ b/packages/kg-default-nodes/lib/nodes/codeblock/CodeBlockNode.js
@@ -6,6 +6,7 @@ import {renderCodeBlockNodeToDOM} from './CodeBlockRenderer';
 export const INSERT_CODE_BLOCK_COMMAND = createCommand();
 
 export class CodeBlockNode extends KoenigDecoratorNode {
+    // payload properties
     __code;
     __language;
     __caption;
@@ -15,15 +16,12 @@ export class CodeBlockNode extends KoenigDecoratorNode {
     }
 
     static clone(node) {
-        // must use `this` so the extended class in the Editor uses the correct class when cloning
-        // without needing to override this method
         return new this(
             node.getDataset(),
             node.__key
         );
     }
 
-    // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
     static get urlTransformMap() {
         return {
             caption: 'html'
@@ -72,20 +70,6 @@ export class CodeBlockNode extends KoenigDecoratorNode {
         return {element};
     }
 
-    /* c8 ignore start */
-    createDOM() {
-        return document.createElement('div');
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
-
     getCaption() {
         const self = this.getLatest();
         return self.__caption;
@@ -119,12 +103,6 @@ export class CodeBlockNode extends KoenigDecoratorNode {
     getTextContent() {
         const self = this.getLatest();
         return self.__code;
-    }
-
-    // should be overwritten
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 
     hasEditMode() {

--- a/packages/kg-default-nodes/lib/nodes/email-cta/EmailCtaNode.js
+++ b/packages/kg-default-nodes/lib/nodes/email-cta/EmailCtaNode.js
@@ -90,20 +90,6 @@ export class EmailCtaNode extends KoenigDecoratorNode {
         return {element};
     }
 
-    /* c8 ignore start */
-    createDOM() {
-        return document.createElement('div');
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
-
     getAlignment() {
         const self = this.getLatest();
         return self.__alignment;
@@ -180,12 +166,6 @@ export class EmailCtaNode extends KoenigDecoratorNode {
 
     isEmpty() {
         return !this.__html && (!this.__showButton || (!this.__buttonText && !this.__buttonUrl));
-    }
-
-    // should be overridden
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/email/EmailNode.js
+++ b/packages/kg-default-nodes/lib/nodes/email/EmailNode.js
@@ -59,20 +59,6 @@ export class EmailNode extends KoenigDecoratorNode {
         return {element, type: 'inner'};
     }
 
-    /* c8 ignore start */
-    createDOM() {
-        return document.createElement('div');
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
-
     getHtml() {
         const self = this.getLatest();
         return self.__html;
@@ -89,12 +75,6 @@ export class EmailNode extends KoenigDecoratorNode {
 
     isEmpty() {
         return !this.__html;
-    }
-
-    // should be overridden
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/embed/EmbedNode.js
+++ b/packages/kg-default-nodes/lib/nodes/embed/EmbedNode.js
@@ -24,7 +24,6 @@ export class EmbedNode extends KoenigDecoratorNode {
         );
     }
 
-    // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
     static get urlTransformMap() {
         return {
             url: 'url'
@@ -88,21 +87,6 @@ export class EmbedNode extends KoenigDecoratorNode {
         return {element};
     }
 
-    /* c8 ignore start */
-    createDOM() {
-        const element = document.createElement('div');
-        return element;
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
-
     getUrl() {
         const self = this.getLatest();
         return self.__url;
@@ -151,12 +135,6 @@ export class EmbedNode extends KoenigDecoratorNode {
     setCaption(caption) {
         const writable = this.getWritable();
         return writable.__caption = caption;
-    }
-
-    // should be overridden
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 
     hasEditMode() {

--- a/packages/kg-default-nodes/lib/nodes/file/FileNode.js
+++ b/packages/kg-default-nodes/lib/nodes/file/FileNode.js
@@ -18,7 +18,7 @@ export function bytesToSize(bytes) {
 }
 
 export class FileNode extends KoenigDecoratorNode {
-    // file payload properties
+    // payload properties
     __src;
     __fileTitle;
     __fileCaption;
@@ -97,20 +97,6 @@ export class FileNode extends KoenigDecoratorNode {
         return {element};
     }
 
-    // c8 ignore start
-    createDOM() {
-        const element = document.createElement('div');
-        return element;
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-
     getSrc() {
         const self = this.getLatest();
         return self.__src;
@@ -168,10 +154,6 @@ export class FileNode extends KoenigDecoratorNode {
 
     hasEditMode() {
         return true;
-    }
-    // c8 ignore stop
-    decorate() {
-        return '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/gallery/GalleryNode.js
+++ b/packages/kg-default-nodes/lib/nodes/gallery/GalleryNode.js
@@ -69,21 +69,6 @@ export class GalleryNode extends KoenigDecoratorNode {
         return {element};
     }
 
-    /* c8 ignore start */
-    createDOM() {
-        const element = document.createElement('div');
-        return element;
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
-
     getImages() {
         const self = this.getLatest();
         return self.__images;
@@ -102,12 +87,6 @@ export class GalleryNode extends KoenigDecoratorNode {
     setCaption(caption) {
         const writable = this.getWritable();
         return writable.__caption = caption;
-    }
-
-    // should be overridden
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 
     hasEditMode() {

--- a/packages/kg-default-nodes/lib/nodes/header/HeaderNode.js
+++ b/packages/kg-default-nodes/lib/nodes/header/HeaderNode.js
@@ -7,7 +7,7 @@ export const INSERT_HEADER_COMMAND = createCommand();
 const NODE_TYPE = 'header';
 
 export class HeaderNode extends KoenigDecoratorNode {
-    // header payload properties
+    // payload properties
     __size;
     __style;
     __buttonEnabled;
@@ -111,19 +111,6 @@ export class HeaderNode extends KoenigDecoratorNode {
         return {element};
     }
 
-    /* c8 ignore start */
-    createDOM() {
-        return document.createElement('div');
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-
     getSize() {
         const self = this.getLatest();
         return self.__size;
@@ -210,12 +197,6 @@ export class HeaderNode extends KoenigDecoratorNode {
 
     isEmpty() {
         return !this.header && !this.subheader && (!this.__buttonEnabled || (!this.__buttonText && !this.__buttonUrl)) && !this.__backgroundImageSrc;
-    }
-
-    // should be overridden
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleNode.js
+++ b/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleNode.js
@@ -16,7 +16,6 @@ export class HorizontalRuleNode extends KoenigDecoratorNode {
         );
     }
 
-    // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
     static get urlTransformMap() {
         return {};
     }
@@ -50,27 +49,6 @@ export class HorizontalRuleNode extends KoenigDecoratorNode {
 
     getTextContent() {
         return '\n';
-    }
-
-    /* c8 ignore start */
-    createDOM() {
-        const element = document.createElement('div');
-        return element;
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
-
-    // should be overridden
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/html/HtmlNode.js
+++ b/packages/kg-default-nodes/lib/nodes/html/HtmlNode.js
@@ -6,6 +6,7 @@ import {HtmlParser} from './HtmlParser';
 export const INSERT_HTML_COMMAND = createCommand();
 
 export class HtmlNode extends KoenigDecoratorNode {
+    // payload properties
     __html;
 
     static getType() {
@@ -16,7 +17,6 @@ export class HtmlNode extends KoenigDecoratorNode {
         return new this(node.getDataset(), node.__key);
     }
 
-    // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
     static get urlTransformMap() {
         return {
             html: 'html'
@@ -62,21 +62,6 @@ export class HtmlNode extends KoenigDecoratorNode {
         };
     }
 
-    /* c8 ignore start */
-    createDOM() {
-        const element = document.createElement('div');
-        return element;
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
-
     getHtml() {
         const self = this.getLatest();
         return self.__html;
@@ -85,12 +70,6 @@ export class HtmlNode extends KoenigDecoratorNode {
     setHtml(html) {
         const writable = this.getWritable();
         return writable.__html = html;
-    }
-
-    // should be overwritten
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 
     hasEditMode() {

--- a/packages/kg-default-nodes/lib/nodes/image/ImageNode.js
+++ b/packages/kg-default-nodes/lib/nodes/image/ImageNode.js
@@ -28,7 +28,6 @@ export class ImageNode extends KoenigDecoratorNode {
         );
     }
 
-    // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
     static get urlTransformMap() {
         return {
             src: 'url',
@@ -106,21 +105,6 @@ export class ImageNode extends KoenigDecoratorNode {
         const element = renderImageNodeToDOM(this, options);
         return {element};
     }
-
-    /* c8 ignore start */
-    createDOM() {
-        const element = document.createElement('div');
-        return element;
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
 
     getSrc() {
         const self = this.getLatest();
@@ -200,12 +184,6 @@ export class ImageNode extends KoenigDecoratorNode {
     setAlt(alt) {
         const writable = this.getWritable();
         return writable.__alt = alt;
-    }
-
-    // should be overridden
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/markdown/MarkdownNode.js
+++ b/packages/kg-default-nodes/lib/nodes/markdown/MarkdownNode.js
@@ -5,6 +5,7 @@ import {renderMarkdownNodeToDOM} from './MarkdownRenderer';
 export const INSERT_MARKDOWN_COMMAND = createCommand();
 
 export class MarkdownNode extends KoenigDecoratorNode {
+    // payload properties
     __markdown;
 
     static getType() {
@@ -15,7 +16,6 @@ export class MarkdownNode extends KoenigDecoratorNode {
         return new this(node.getDataset(), node.__key);
     }
 
-    // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
     static get urlTransformMap() {
         return {
             markdown: 'markdown'
@@ -56,21 +56,6 @@ export class MarkdownNode extends KoenigDecoratorNode {
         };
     }
 
-    /* c8 ignore start */
-    createDOM() {
-        const element = document.createElement('div');
-        return element;
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
-
     getMarkdown() {
         return this.__markdown;
     }
@@ -78,12 +63,6 @@ export class MarkdownNode extends KoenigDecoratorNode {
     setMarkdown(markdown) {
         const writable = this.getWritable();
         return writable.__markdown = markdown;
-    }
-
-    // should be overwritten
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 
     hasEditMode() {

--- a/packages/kg-default-nodes/lib/nodes/paywall/PaywallNode.js
+++ b/packages/kg-default-nodes/lib/nodes/paywall/PaywallNode.js
@@ -17,10 +17,6 @@ export class PaywallNode extends KoenigDecoratorNode {
         );
     }
 
-    static get urlTransformMap() {
-        return {};
-    }
-
     constructor(key) {
         super(key);
     }
@@ -46,26 +42,6 @@ export class PaywallNode extends KoenigDecoratorNode {
     exportDOM(options = {}) {
         const element = renderPaywallNodeToDOM(this, options);
         return {element, type: 'inner'};
-    }
-
-    /* c8 ignore start */
-    createDOM() {
-        return document.createElement('div');
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
-
-    // should be overridden
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/product/ProductNode.js
+++ b/packages/kg-default-nodes/lib/nodes/product/ProductNode.js
@@ -30,7 +30,6 @@ export class ProductNode extends KoenigDecoratorNode {
         );
     }
 
-    // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
     static get urlTransformMap() {
         return {
             productImageSrc: 'url',
@@ -117,21 +116,6 @@ export class ProductNode extends KoenigDecoratorNode {
         const element = renderProductNodeToDOM(this, options);
         return {element};
     }
-
-    /* c8 ignore start */
-    createDOM() {
-        const element = document.createElement('div');
-        return element;
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
 
     getProductImageSrc() {
         const self = this.getLatest();
@@ -231,12 +215,6 @@ export class ProductNode extends KoenigDecoratorNode {
     setProductUrl(productUrl) {
         const writable = this.getWritable();
         return writable.__productUrl = productUrl;
-    }
-
-    // should be overridden
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 
     hasEditMode() {

--- a/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
@@ -160,20 +160,6 @@ export class SignupNode extends KoenigDecoratorNode {
         return dataset;
     }
 
-    /* c8 ignore start */
-    createDOM() {
-        return document.createElement('div');
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
-
     getAlignment() {
         const self = this.getLatest();
         return self.__alignment;
@@ -342,12 +328,6 @@ export class SignupNode extends KoenigDecoratorNode {
             !this.__labels.length &&
             !this.__subheader &&
             !this.__successMessage;
-    }
-
-    // should be overridden
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/toggle/ToggleNode.js
+++ b/packages/kg-default-nodes/lib/nodes/toggle/ToggleNode.js
@@ -71,20 +71,6 @@ export class ToggleNode extends KoenigDecoratorNode {
         return {element};
     }
 
-    /* c8 ignore start */
-    createDOM() {
-        return document.createElement('div');
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
-
     getContent() {
         const self = this.getLatest();
         return self.__content;
@@ -111,12 +97,6 @@ export class ToggleNode extends KoenigDecoratorNode {
 
     isEmpty() {
         return !this.__heading && !this.__content;
-    }
-
-    // should be overridden
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/video/VideoNode.js
+++ b/packages/kg-default-nodes/lib/nodes/video/VideoNode.js
@@ -33,7 +33,6 @@ export class VideoNode extends KoenigDecoratorNode {
         );
     }
 
-    // used by `@tryghost/url-utils` to transform URLs contained in the serialized JSON
     static get urlTransformMap() {
         return {
             src: 'url',
@@ -132,21 +131,6 @@ export class VideoNode extends KoenigDecoratorNode {
         const element = renderVideoNodeToDOM(this, options);
         return {element};
     }
-
-    /* c8 ignore start */
-    createDOM() {
-        const element = document.createElement('div');
-        return element;
-    }
-
-    updateDOM() {
-        return false;
-    }
-
-    isInline() {
-        return false;
-    }
-    /* c8 ignore stop */
 
     getSrc() {
         const self = this.getLatest();
@@ -284,12 +268,6 @@ export class VideoNode extends KoenigDecoratorNode {
     setLoop(loop) {
         const writable = this.getWritable();
         return writable.__loop = loop;
-    }
-
-    // should be overridden
-    /* c8 ignore next 3 */
-    decorate() {
-        return '';
     }
 
     hasEditMode() {


### PR DESCRIPTION
no issue
- we had a couple of methods that were used systematically in each node without changes (e.g. createDOM(), updateDOM(), isInline(), decorate()). This commit moves them to the parent class KoenigDecoratorNode