### PR TITLE
Add shift selection handling

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -547,7 +547,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                             // if using the root node, simply add the card below
                             if ($isRootNode(anchorNode)) {
                                 const offset = selection.focus.offset;
-                                if (offset < anchorNode.getLastChildOrThrow().getIndexWithinParent()) {
+                                if (offset <= anchorNode.getLastChildOrThrow().getIndexWithinParent()) {
                                     selection.focus.set('root', selection.focus.offset + 1, 'element');
                                 }
                                 event.preventDefault();

--- a/packages/koenig-lexical/test/e2e/card-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/card-behaviour.test.js
@@ -1328,7 +1328,7 @@ test.describe('Card behaviour', async () => {
     });
 
     test.describe('SELECTION', function () {
-        test.skip('shift+down does not put card in selected state', async function () {
+        test('shift+down does not put card in selected state', async function () {
             await focusEditor(page);
             await page.keyboard.type('First');
             await page.keyboard.press('Enter');
@@ -1350,30 +1350,30 @@ test.describe('Card behaviour', async () => {
             await page.keyboard.press('ArrowDown');
             await page.keyboard.press('ArrowDown');
             await page.keyboard.up('Shift');
-
+            // offsets are based on the root node offset
             await assertSelection(page, {
-                anchorPath: [0, 0, 0],
+                anchorPath: [],
                 anchorOffset: 0,
-                focusPath: [2, 0, 0],
-                focusOffset: 6
+                focusPath: [],
+                focusOffset: 2
             });
-
+            // this is a range selection, so the card isn't explicitly selected
             await expect(page.locator('[data-kg-card-selected="true"]')).not.toBeVisible();
         });
 
-        test.skip('shift+up does not put card in selected state', async function () {
+        test('shift+up does not put card in selected state', async function () {
             await focusEditor(page);
             await page.keyboard.type('First');
             await page.keyboard.press('Enter');
-            await insertCard(page, {cardName: 'button'});
+            await page.keyboard.type('--- ');
             await page.keyboard.press('Enter');
             await page.keyboard.type('Second');
 
             // sanity check
             await assertSelection(page, {
-                anchorPath: [2, 0, 0],
+                anchorPath: [3, 0, 0],
                 anchorOffset: 6,
-                focusPath: [2, 0, 0],
+                focusPath: [3, 0, 0],
                 focusOffset: 6
             });
 
@@ -1382,13 +1382,14 @@ test.describe('Card behaviour', async () => {
             await page.keyboard.press('ArrowUp');
             await page.keyboard.up('Shift');
 
+            // offsets are based on the root node offset
             await assertSelection(page, {
-                anchorPath: [2, 0, 0],
-                anchorOffset: 6,
-                focusPath: [0, 0, 0],
-                focusOffset: 0
+                anchorPath: [],
+                anchorOffset: 4,
+                focusPath: [],
+                focusOffset: 2
             });
-
+            // this is a range selection, so the card isn't explicitly selected
             await expect(page.locator('[data-kg-card-selected="true"]')).not.toBeVisible();
         });
     });

--- a/packages/koenig-lexical/test/e2e/card-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/card-behaviour.test.js
@@ -1328,7 +1328,7 @@ test.describe('Card behaviour', async () => {
     });
 
     test.describe('SELECTION', function () {
-        test('shift+down does not put card in selected state', async function () {
+        test.skip('shift+down does not put card in selected state', async function () {
             await focusEditor(page);
             await page.keyboard.type('First');
             await page.keyboard.press('Enter');
@@ -1361,11 +1361,12 @@ test.describe('Card behaviour', async () => {
             await expect(page.locator('[data-kg-card-selected="true"]')).not.toBeVisible();
         });
 
-        test('shift+up does not put card in selected state', async function () {
+        test.skip('shift+up does not put card in selected state', async function () {
             await focusEditor(page);
             await page.keyboard.type('First');
             await page.keyboard.press('Enter');
-            await page.keyboard.type('--- ');
+            await insertCard(page, {cardName: 'button'});
+            await page.keyboard.press('Enter');
             await page.keyboard.type('Second');
 
             // sanity check


### PR DESCRIPTION
closes TryGhost/Team#3087
-adds support for decorator nodes when using shift+up and shift+down
-text selection behaves as normal until moving to decorator node, then block selection is used
-requires upstream fix to work properly, see PR Facebook/lexical#4586