### PR TITLE
Fixed caption rendering in embed, bookmark nodes

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkRenderer.js
@@ -173,7 +173,7 @@ function frontendTemplate(node, document) {
 
     if (caption) {
         const figCaption = document.createElement('figcaption');
-        figCaption.textContent = caption;
+        figCaption.innerHTML = caption;
         card.appendChild(figCaption);
     }
 

--- a/packages/kg-default-nodes/lib/nodes/embed/EmbedRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/embed/EmbedRenderer.js
@@ -63,7 +63,7 @@ function renderTemplate(node, document, options) {
     const caption = node.getCaption();
     if (caption) {
         const figcaption = document.createElement('figcaption');
-        figcaption.textContent = caption;
+        figcaption.innerHTML = caption;
         figure.appendChild(figcaption);
         figure.setAttribute('class', `${figure.getAttribute('class')} kg-card-hascaption`);
     }

--- a/packages/kg-default-nodes/lib/nodes/embed/types/twitter.js
+++ b/packages/kg-default-nodes/lib/nodes/embed/types/twitter.js
@@ -162,7 +162,7 @@ export default function render(node, document, options) {
     const caption = node.getCaption();
     if (caption) {
         const figcaption = document.createElement('figcaption');
-        figcaption.textContent = caption;
+        figcaption.innerHTML = caption;
         figure.appendChild(figcaption);
         figure.setAttribute('class', `${figure.getAttribute('class')} kg-card-hascaption`);
     }

--- a/packages/koenig-lexical/src/components/ui/cards/BookmarkCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/BookmarkCard.jsx
@@ -26,8 +26,8 @@ export function BookmarkCard({
 }) {
     if (url && !urlError && title) {
         return (
-            <div className="not-kg-prose">
-                <div className="relative flex min-h-[120px] w-full rounded border border-grey/40 bg-transparent font-sans dark:border-grey/20" data-testid="bookmark-container">
+            <div>
+                <div className="not-kg-prose relative flex min-h-[120px] w-full rounded border border-grey/40 bg-transparent font-sans dark:border-grey/20" data-testid="bookmark-container">
                     <div className="flex grow basis-full flex-col items-start justify-start p-5" data-testid="bookmark-text-container">
                         <div className="text-[1.5rem] font-semibold leading-normal tracking-normal text-grey-900 dark:text-grey-100" data-testid="bookmark-title">{title}</div>
                         <div className="mt-1 max-h-[44px] overflow-y-hidden text-sm font-normal leading-normal text-grey-800 line-clamp-2 dark:text-grey-600" data-testid="bookmark-description">{description}</div>

--- a/packages/koenig-lexical/src/components/ui/cards/EmbedCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/EmbedCard.jsx
@@ -7,8 +7,8 @@ import {UrlInput} from '../UrlInput';
 export function EmbedCard({captionEditor, captionEditorInitialState, html, isSelected, urlInputValue, urlPlaceholder, urlError, isLoading, handleUrlChange, handleUrlSubmit, handleRetry, handlePasteAsLink, handleClose}) {
     if (html) {
         return (
-            <div className="not-kg-prose">
-                <div className="relative">
+            <div>
+                <div className="not-kg-prose relative">
                     <EmbedIframe dataTestId="embed-iframe" html={html} />
                     <div className="absolute inset-0 z-50 mt-0"></div>
                 </div>


### PR DESCRIPTION
refs TryGhost/Team#3341

- The renderer for the bookmark, embed nodes was setting the textContent on the caption element, which was causing the raw HTML to be rendered
- Changed it to set the innerHTML instead, so the HTML is rendered properly
- Embed and bookmark cards wrapped the entire card in `.not-kg-prose` which was overriding the styles in the caption editor
- Moved `.not-kg-prose` to just the content of the card, excluding the caption editor