### PR TITLE
Fixed list nodes not rendering properly with start index > 1

### DIFF
--- a/packages/kg-lexical-html-renderer/lib/transformers/element/list.js
+++ b/packages/kg-lexical-html-renderer/lib/transformers/element/list.js
@@ -6,6 +6,7 @@ const exportList = function (node, options, exportChildren) {
     }
 
     const tag = node.getTag();
+    const start = node.getStart();
 
     const exportListContent = (listNode) => {
         const output = [];
@@ -30,7 +31,12 @@ const exportList = function (node, options, exportChildren) {
 
     const listContent = exportListContent(node);
 
-    return `<${tag}>${listContent}</${tag}>`;
+    // CASE: list has a start value specified > 1
+    if (start !== 1 && start !== null && start !== undefined) {
+        return `<${tag} start="${start}">${listContent}</${tag}>`;
+    } else {
+        return `<${tag}>${listContent}</${tag}>`;
+    }
 };
 
 module.exports = {

--- a/packages/kg-lexical-html-renderer/test/lists.test.js
+++ b/packages/kg-lexical-html-renderer/test/lists.test.js
@@ -46,6 +46,11 @@ describe('Lists', function () {
         output: '<ol><li><strong>bold</strong></li><li><em>italic</em></li><li><strong><em>bold+italic</em></strong></li></ol>'
     }));
 
+    it('ol with start value > 1', shouldRender({
+        input: `{"root":{"children":[{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"two","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"listitem","version":1,"value":2},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"three","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"listitem","version":1,"value":3}],"direction":"ltr","format":"","indent":0,"type":"list","version":1,"listType":"number","start":2,"tag":"ol"}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+        output: '<ol start="2"><li>two</li><li>three</li></ol>'
+    }));
+
     it('containing double formats', shouldRender({
         input: `{
             "root": {


### PR DESCRIPTION
refs TryGhost/Team#3269

- In the editor, you are able to create a list with a start index > 1 by either pasting or by typing '2. ' at the start of a new paragraph.
- This is a common pattern when there are other types of nodes between ordered list items (e.g. a blockquote in a list)
- We were parsing and storing this correctly in the lexical string with a `start` attribute on the list node, but we weren't rendering the list with the start attribute at all
- This change updates the kg-lexical-html-renderer to add the `start` attribute to the `ol` element when rendering a list node that has a `start` attribute > 1