### PR TITLE
Improved embed card behaviour

### DIFF
--- a/packages/koenig-lexical/demo/utils/fetchEmbed.js
+++ b/packages/koenig-lexical/demo/utils/fetchEmbed.js
@@ -301,6 +301,10 @@ export async function fetchEmbed(url, {type}) {
                 thumbnail_url: 'https://i.ytimg.com/vi/E5yFcdPAGv0/hqdefault.jpg',
                 type: 'video'
             };
+            // for tests, should convert url to link
+            if (url === 'https://ghost.org/should-convert-to-link') {
+                throw new Error();
+            }
             return returnData;
         }
     } catch (e) {

--- a/packages/koenig-lexical/src/nodes/BookmarkNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/BookmarkNodeComponent.jsx
@@ -96,6 +96,10 @@ export function BookmarkNodeComponent({author, nodeKey, url, icon, title, descri
             node.setDescription(response.metadata.description);
             node.setPublisher(response.metadata.publisher);
             node.setThumbnail(response.metadata.thumbnail);
+
+            if (createdWithUrl) {
+                node.selectNext();
+            }
         });
         setLoading(false);
         // We only do this for init

--- a/packages/koenig-lexical/test/e2e/cards/embed-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/embed-card.test.js
@@ -178,6 +178,13 @@ test.describe('Embed card', async () => {
             await expect(retryButton).not.toBeVisible();
         });
 
+        test('should convert url to link if can\'t extract metadata', async function () {
+            await focusEditor(page);
+            await pasteText(page, 'https://ghost.org/should-convert-to-link');
+
+            await expect(page.locator('a[href="https://ghost.org/should-convert-to-link"]')).toBeVisible();
+        });
+
         // todo: test is failing, need to figure if the error in test logic or on code
         test.skip('paste as link button removes card and inserts text node link', async function () {
             await focusEditor(page);


### PR DESCRIPTION
refs TryGhost/Team#3350, TryGhost/Team#3391
- If embed failed, url should paste as link
- Pasting link should select the paragraph inserted after the embed node
- Fixed pasting link text before the embed node