### PR TITLE
Fixed button not clearing 'subscribe'.

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
@@ -84,7 +84,7 @@ export class SignupNode extends KoenigDecoratorNode {
         this.__textColor = textColor || (backgroundColor === 'transparent' ? '' : '#000000');
         this.__buttonColor = buttonColor || 'accent';
         this.__buttonTextColor = buttonTextColor || '#FFFFFF';
-        this.__buttonText = buttonText || '';
+        this.__buttonText = buttonText || 'Subscribe';
         this.__disclaimer = disclaimer || '';
         this.__header = header || '';
         this.__labels = labels || [];

--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
@@ -273,7 +273,7 @@ export function SignupCard({alignment,
                                 color: hexColorValue(buttonTextColor)
                             } : {backgroundColor: `#000000`,
                                 color: `#ffffff`}}
-                            buttonText={buttonText || 'Subscribe'}
+                            buttonText={buttonText}
                             dataTestId='signup-card-button'
                             disabled={true}
                             placeholder='Your email'
@@ -360,7 +360,7 @@ export function SignupCard({alignment,
                             handleBackgroundColor(color, matchingTextColor(color));
                             setBackgroundColorPickerExpanded(false);
                         }}
-                        onTogglePicker={(isExpanded) => {
+                        onTogglePicker={ (isExpanded) => {
                             if (isExpanded) {
                                 if (layout !== 'split') {
                                     handleHideBackgroundImage();
@@ -420,7 +420,7 @@ export function SignupCard({alignment,
                         dataTestId='signup-button-text'
                         label='Button text'
                         placeholder='Add button text'
-                        value={buttonText || 'Subscribe'}
+                        value={buttonText}
                         hideLabel
                         onChange={handleButtonText}
                     />


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3394

- Fixed an issue where the InputSetting component would reset to the default 'Subscribe' value when cleared.
- The component now allows for the input field to be cleared and a new value to be entered from scratch.
- This was achieved by adjusting how the value is set in the Node and initialised the buttonText state with 'Subscribe' as the default value.