### PR TITLE
Fixed callout card emoji bug

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/callout/CalloutNode.js
+++ b/packages/kg-default-nodes/lib/nodes/callout/CalloutNode.js
@@ -35,7 +35,7 @@ export class CalloutNode extends KoenigDecoratorNode {
     constructor({calloutText, calloutEmoji, backgroundColor} = {}, key) {
         super(key);
         this.__calloutText = calloutText || '';
-        this.__calloutEmoji = calloutEmoji || '💡';
+        this.__calloutEmoji = calloutEmoji !== undefined ? calloutEmoji : '💡';
         this.__backgroundColor = backgroundColor || 'blue';
     }
 

--- a/packages/kg-default-nodes/test/nodes/callout.test.js
+++ b/packages/kg-default-nodes/test/nodes/callout.test.js
@@ -35,6 +35,7 @@ describe('CalloutNode', function () {
             calloutEmoji: '💡',
             backgroundColor: 'blue'
         };
+
         exportOptions = {
             exportFormat: 'html',
             createDocument() {
@@ -91,9 +92,14 @@ describe('CalloutNode', function () {
                 </div>
                 `);
         }));
+
         it('can render to HTML with no emoji', editorTest(function () {
-            const node = $createCalloutNode(dataset);
-            node.setCalloutEmoji(null);
+            const dataset2 = {
+                calloutText: 'This is a callout',
+                calloutEmoji: '',
+                backgroundColor: 'blue'
+            };
+            const node = $createCalloutNode(dataset2);
             const {element} = node.exportDOM(exportOptions);
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-callout-card kg-callout-card-blue">
@@ -126,6 +132,19 @@ describe('CalloutNode', function () {
             nodes[0].getBackgroundColor().should.equal('red');
             nodes[0].getCalloutText().should.equal('This is a callout');
             nodes[0].getCalloutEmoji().should.equal('💡');
+        }));
+
+        it('parses callout card with no emoji', editorTest(function () {
+            const dom = (new JSDOM(html`
+                <div class="kg-card kg-callout-card kg-callout-card-red">
+                    <div class="kg-callout-text">This is a callout</div>
+                </div>
+                    `)).window.document;
+            const nodes = $generateNodesFromDOM(editor, dom);
+            nodes.length.should.equal(1);
+            nodes[0].getBackgroundColor().should.equal('red');
+            nodes[0].getCalloutText().should.equal('This is a callout');
+            nodes[0].getCalloutEmoji().should.equal('');
         }));
     });
 

--- a/packages/koenig-lexical/src/nodes/CalloutNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CalloutNodeComponent.jsx
@@ -26,7 +26,11 @@ export function CalloutNodeComponent({nodeKey, textEditor, textEditorInitialStat
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
             setHasEmoji(event.target.checked);
-            node.setCalloutEmoji(event.target.checked ? emoji : '');
+            if (event.target.checked && emoji === '') {
+                node.setCalloutEmoji('💡');
+            } else {
+                node.setCalloutEmoji(event.target.checked ? emoji : '');
+            }
         });
     };
 


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C056H5Z4HEK/p1686591123707249

- Bug caused by introducing empty strings and handling them like booleans.
- Largely affected the renderer and the parser, but small UI refinements had to be made.