### PR TITLE
Turned off spellchecker for markdown card by default

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/MarkdownCard/MarkdownEditor.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/MarkdownCard/MarkdownEditor.jsx
@@ -81,7 +81,7 @@ export default function MarkdownEditor({
                 {
                     name: 'spellcheck',
                     action: toggleSpellcheck,
-                    className: 'fa fa-check active',
+                    className: 'fa fa-check',
                     title: `Spellcheck (${shortcuts.toggleSpellcheck})`
                 },
                 {
@@ -119,6 +119,10 @@ export default function MarkdownEditor({
         });
 
         addShortcuts();
+
+        // spellchecker turned off by default
+        const codemirror = editor.current.codemirror;
+        codemirror.setOption('mode', 'gfm');
 
         // remove editor on unmount
         return () => {

--- a/packages/koenig-lexical/test/e2e/cards/markdown-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/markdown-card.test.js
@@ -121,14 +121,11 @@ test.describe('Markdown card', async () => {
 
     test('should toggle spellcheck on Cmd-Alt-S', async function () {
         await focusEditor(page);
-        await page.keyboard.type('/');
-        await page.click('[data-kg-card-menu-item="Markdown"]');
-        await page.click('[data-kg-card="markdown"]');
+        await insertCard(page, {cardName: 'markdown'});
 
-        expect(await page.locator('[title*="Spellcheck"][class*="active"]')).not.toBeNull();
+        await expect(page.locator('[title*="Spellcheck"]')).not.toBeNull();
         await page.keyboard.press(`Control+Alt+S`);
-        expect(await page.locator('[title*="Spellcheck"]')).not.toBeNull();
-        await expect(await page.locator('[title*="Spellcheck"][class*="active"]')).toHaveCount(0);
+        await expect(page.locator('[title*="Spellcheck"][class*="active"]')).toHaveCount(1);
     });
 
     test('should open image upload dialog on Cmd-Alt-I', async function () {
@@ -211,7 +208,7 @@ test.describe('Markdown card', async () => {
         // await expect(await page.getByTestId('progress-bar')).not.toBeVisible();
 
         // wait for image markdown to be inserted
-        await page.waitForSelector('[data-kg-card="markdown"] .cm-formatting-image');
+        await page.waitForSelector('[data-kg-card="markdown"] .cm-image');
 
         await assertRootChildren(page, JSON.stringify([
             {


### PR DESCRIPTION
refs TryGhost/Team#3453
- Spellchecker turned off in mobiledoc editor by default.