### PR TITLE
✨ Added <WordCountPlugin>

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkNode.js
+++ b/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkNode.js
@@ -2,6 +2,7 @@ import {createCommand} from 'lexical';
 import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
 import {BookmarkParser} from './BookmarkParser';
 import {renderBookmarkNodeToDOM} from './BookmarkRenderer';
+import readTextContent from '../../utils/read-text-content';
 
 export const INSERT_BOOKMARK_COMMAND = createCommand();
 
@@ -48,7 +49,7 @@ export class BookmarkNode extends KoenigDecoratorNode {
                 thumbnail: self.__thumbnail
             },
             caption: self.__caption
-        
+
         };
     }
 
@@ -134,7 +135,7 @@ export class BookmarkNode extends KoenigDecoratorNode {
         const writable = this.getWritable();
         return writable.__title = title;
     }
-    
+
     getDescription() {
         const self = this.getLatest();
         return self.__description;
@@ -191,6 +192,19 @@ export class BookmarkNode extends KoenigDecoratorNode {
 
     isEmpty() {
         return !this.__url;
+    }
+
+    getTextContent() {
+        const self = this.getLatest();
+
+        const text = [
+            readTextContent(self, 'title'),
+            readTextContent(self, 'description'),
+            readTextContent(self, 'url'),
+            readTextContent(self, 'caption')
+        ].filter(Boolean).join('\n');
+
+        return text ? `${text}\n\n` : '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/callout/CalloutNode.js
+++ b/packages/kg-default-nodes/lib/nodes/callout/CalloutNode.js
@@ -2,6 +2,7 @@ import {createCommand} from 'lexical';
 import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
 import {renderCalloutNodeToDOM} from './CalloutRenderer';
 import {CalloutParser} from './CalloutParser';
+import readTextContent from '../../utils/read-text-content';
 
 export const INSERT_CALLOUT_COMMAND = createCommand();
 const NODE_TYPE = 'callout';
@@ -101,6 +102,12 @@ export class CalloutNode extends KoenigDecoratorNode {
 
     hasEditMode() {
         return true;
+    }
+
+    getTextContent() {
+        const self = this.getLatest();
+        const text = readTextContent(self, 'calloutText');
+        return text ? `${readTextContent(self, 'calloutText')}\n\n` : '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/codeblock/CodeBlockNode.js
+++ b/packages/kg-default-nodes/lib/nodes/codeblock/CodeBlockNode.js
@@ -2,6 +2,7 @@ import {createCommand} from 'lexical';
 import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
 import {CodeBlockParser} from './CodeBlockParser';
 import {renderCodeBlockNodeToDOM} from './CodeBlockRenderer';
+import readTextContent from '../../utils/read-text-content';
 
 export const INSERT_CODE_BLOCK_COMMAND = createCommand();
 
@@ -100,17 +101,22 @@ export class CodeBlockNode extends KoenigDecoratorNode {
         self.__language = language;
     }
 
-    getTextContent() {
-        const self = this.getLatest();
-        return self.__code;
-    }
-
     hasEditMode() {
         return true;
     }
 
     isEmpty() {
         return !this.__code;
+    }
+
+    getTextContent() {
+        const self = this.getLatest();
+        const text = [
+            readTextContent(self, 'code'),
+            readTextContent(self, 'caption')
+        ].filter(Boolean).join('\n');
+
+        return text ? `${text}\n\n` : '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/embed/EmbedNode.js
+++ b/packages/kg-default-nodes/lib/nodes/embed/EmbedNode.js
@@ -2,6 +2,7 @@ import {createCommand} from 'lexical';
 import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
 import {EmbedParser} from './EmbedParser';
 import {renderEmbedNodeToDOM} from './EmbedRenderer';
+import readTextContent from '../../utils/read-text-content';
 
 export const INSERT_EMBED_COMMAND = createCommand();
 
@@ -143,6 +144,12 @@ export class EmbedNode extends KoenigDecoratorNode {
 
     isEmpty() {
         return !this.__url && !this.__html;
+    }
+
+    getTextContent() {
+        const self = this.getLatest();
+        const text = readTextContent(self, 'caption');
+        return text ? `${text}\n\n` : '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/file/FileNode.js
+++ b/packages/kg-default-nodes/lib/nodes/file/FileNode.js
@@ -2,6 +2,7 @@ import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
 import {renderFileNodeToDOM} from './FileRenderer';
 import {FileParser} from './FileParser';
 import {createCommand} from 'lexical';
+import readTextContent from '../../utils/read-text-content';
 
 export const INSERT_FILE_COMMAND = createCommand();
 
@@ -154,6 +155,16 @@ export class FileNode extends KoenigDecoratorNode {
 
     hasEditMode() {
         return true;
+    }
+
+    getTextContent() {
+        const self = this.getLatest();
+        const text = [
+            readTextContent(self, 'fileTitle'),
+            readTextContent(self, 'fileCaption')
+        ].filter(Boolean).join('\n');
+
+        return text ? `${text}\n\n` : '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/gallery/GalleryNode.js
+++ b/packages/kg-default-nodes/lib/nodes/gallery/GalleryNode.js
@@ -2,6 +2,7 @@ import {createCommand} from 'lexical';
 import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
 import {GalleryParser} from './GalleryParser';
 import {renderGalleryNodeToDOM} from './GalleryRenderer';
+import readTextContent from '../../utils/read-text-content';
 
 export const INSERT_GALLERY_COMMAND = createCommand();
 
@@ -91,6 +92,12 @@ export class GalleryNode extends KoenigDecoratorNode {
 
     hasEditMode() {
         return false;
+    }
+
+    getTextContent() {
+        const self = this.getLatest();
+        const text = readTextContent(self, 'caption');
+        return text ? `${text}\n\n` : '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/header/HeaderNode.js
+++ b/packages/kg-default-nodes/lib/nodes/header/HeaderNode.js
@@ -2,6 +2,7 @@ import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
 import {renderHeaderNodeToDOM} from './HeaderRenderer';
 import {HeaderParser} from './HeaderParser';
 import {createCommand} from 'lexical';
+import readTextContent from '../../utils/read-text-content';
 
 export const INSERT_HEADER_COMMAND = createCommand();
 const NODE_TYPE = 'header';
@@ -197,6 +198,17 @@ export class HeaderNode extends KoenigDecoratorNode {
 
     isEmpty() {
         return !this.header && !this.subheader && (!this.__buttonEnabled || (!this.__buttonText && !this.__buttonUrl)) && !this.__backgroundImageSrc;
+    }
+
+    getTextContent() {
+        const self = this.getLatest();
+
+        let text = [
+            readTextContent(self, 'header'),
+            readTextContent(self, 'subheader')
+        ].filter(Boolean).join('\n');
+
+        return text ? `${text}\n\n` : '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleNode.js
+++ b/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleNode.js
@@ -48,7 +48,7 @@ export class HorizontalRuleNode extends KoenigDecoratorNode {
     }
 
     getTextContent() {
-        return '\n';
+        return '---\n\n';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/html/HtmlNode.js
+++ b/packages/kg-default-nodes/lib/nodes/html/HtmlNode.js
@@ -2,6 +2,7 @@ import {createCommand} from 'lexical';
 import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
 import {renderHtmlNodeToDOM} from './HtmlRenderer';
 import {HtmlParser} from './HtmlParser';
+import readTextContent from '../../utils/read-text-content';
 
 export const INSERT_HTML_COMMAND = createCommand();
 
@@ -78,6 +79,12 @@ export class HtmlNode extends KoenigDecoratorNode {
 
     isEmpty() {
         return !this.__html;
+    }
+
+    getTextContent() {
+        const self = this.getLatest();
+        const text = readTextContent(self, 'html');
+        return text ? `${text}\n\n` : '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/image/ImageNode.js
+++ b/packages/kg-default-nodes/lib/nodes/image/ImageNode.js
@@ -2,6 +2,7 @@ import {createCommand} from 'lexical';
 import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
 import {ImageParser} from './ImageParser';
 import {renderImageNodeToDOM} from './ImageRenderer';
+import readTextContent from '../../utils/read-text-content';
 
 export const INSERT_IMAGE_COMMAND = createCommand();
 export const UPLOAD_IMAGE_COMMAND = createCommand();
@@ -184,6 +185,12 @@ export class ImageNode extends KoenigDecoratorNode {
     setAlt(alt) {
         const writable = this.getWritable();
         return writable.__alt = alt;
+    }
+
+    getTextContent() {
+        const self = this.getLatest();
+        const text = readTextContent(self, 'caption');
+        return text ? `${text}\n\n` : '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/markdown/MarkdownNode.js
+++ b/packages/kg-default-nodes/lib/nodes/markdown/MarkdownNode.js
@@ -1,6 +1,7 @@
 import {createCommand} from 'lexical';
 import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
 import {renderMarkdownNodeToDOM} from './MarkdownRenderer';
+import readTextContent from '../../utils/read-text-content';
 
 export const INSERT_MARKDOWN_COMMAND = createCommand();
 
@@ -71,6 +72,13 @@ export class MarkdownNode extends KoenigDecoratorNode {
 
     isEmpty() {
         return !this.__markdown;
+    }
+
+    getTextContent() {
+        // NOTE: this varies from previous mobiledoc behaviour which used rendered markdown for word count
+        const self = this.getLatest();
+        const text = readTextContent(self, 'markdown');
+        return text ? `${text}\n\n` : '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/product/ProductNode.js
+++ b/packages/kg-default-nodes/lib/nodes/product/ProductNode.js
@@ -2,6 +2,7 @@ import {createCommand} from 'lexical';
 import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
 import {ProductParser} from './ProductParser';
 import {renderProductNodeToDOM} from './ProductRenderer';
+import readTextContent from '../../utils/read-text-content';
 
 export const INSERT_PRODUCT_COMMAND = createCommand();
 const NODE_TYPE = 'product';
@@ -224,6 +225,17 @@ export class ProductNode extends KoenigDecoratorNode {
     isEmpty() {
         const isButtonFilled = this.__productButtonEnabled && this.__productUrl && this.__productButton;
         return !this.__productTitle && !this.__productDescription && !isButtonFilled && !this.__productImageSrc && !this.__productRatingEnabled;
+    }
+
+    getTextContent() {
+        const self = this.getLatest();
+
+        const text = [
+            readTextContent(self, 'productTitle'),
+            readTextContent(self, 'productDescription')
+        ].filter(Boolean).join('\n');
+
+        return text ? `${text}\n\n` : '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/toggle/ToggleNode.js
+++ b/packages/kg-default-nodes/lib/nodes/toggle/ToggleNode.js
@@ -2,6 +2,7 @@ import {createCommand} from 'lexical';
 import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
 import {ToggleParser} from './ToggleParser';
 import {renderToggleNodeToDOM} from './ToggleRenderer';
+import readTextContent from '../../utils/read-text-content';
 
 export const INSERT_TOGGLE_COMMAND = createCommand();
 const NODE_TYPE = 'toggle';
@@ -97,6 +98,17 @@ export class ToggleNode extends KoenigDecoratorNode {
 
     isEmpty() {
         return !this.__heading && !this.__content;
+    }
+
+    getTextContent() {
+        const self = this.getLatest();
+
+        const text = [
+            readTextContent(self, 'heading'),
+            readTextContent(self, 'content')
+        ].filter(Boolean).join('\n');
+
+        return text ? `${text}\n\n` : '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/video/VideoNode.js
+++ b/packages/kg-default-nodes/lib/nodes/video/VideoNode.js
@@ -2,6 +2,7 @@ import {createCommand} from 'lexical';
 import {KoenigDecoratorNode} from '../../KoenigDecoratorNode';
 import {VideoParser} from './VideoParser';
 import {renderVideoNodeToDOM} from './VideoRenderer';
+import readTextContent from '../../utils/read-text-content';
 
 export const INSERT_VIDEO_COMMAND = createCommand();
 const NODE_TYPE = 'video';
@@ -272,6 +273,12 @@ export class VideoNode extends KoenigDecoratorNode {
 
     hasEditMode() {
         return true;
+    }
+
+    getTextContent() {
+        const self = this.getLatest();
+        const text = readTextContent(self, 'caption');
+        return text ? `${text}\n\n` : '';
     }
 }
 

--- a/packages/kg-default-nodes/lib/utils/read-text-content.js
+++ b/packages/kg-default-nodes/lib/utils/read-text-content.js
@@ -1,0 +1,35 @@
+import {$getRoot} from 'lexical';
+
+// when used nodes are used client-side their data attributes may be an editor
+// instance rather than a string in the case of nested editors
+export default function readTextContent(node, property) {
+    const propertyName = `__${property}`;
+    const propertyEditorName = `${propertyName}Editor`;
+
+    // prefer the editor if it exists as the underlying value isn't written until export
+    const value = node[propertyEditorName] || node[propertyName];
+
+    if (!value) {
+        return '';
+    }
+
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    if (typeof value === 'number') {
+        return value.toString();
+    }
+
+    if (typeof value.getEditorState === 'function') {
+        let text = '';
+
+        value.getEditorState().read(() => {
+            text = $getRoot().getTextContent();
+        });
+
+        return text;
+    }
+
+    return '';
+}

--- a/packages/kg-default-nodes/test/nodes/aside.test.js
+++ b/packages/kg-default-nodes/test/nodes/aside.test.js
@@ -1,5 +1,5 @@
 const {html} = require('../utils');
-const {$getRoot} = require('lexical');
+const {$getRoot, $createParagraphNode, $createTextNode} = require('lexical');
 const {createHeadlessEditor} = require('@lexical/headless');
 const {$generateNodesFromDOM} = require('@lexical/html');
 const {JSDOM} = require('jsdom');
@@ -95,5 +95,19 @@ describe('AsideNode', function () {
                 }
             });
         });
+    });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createAsideNode();
+            node.getTextContent().should.equal('');
+
+            const paragraph = $createParagraphNode();
+            paragraph.append($createTextNode('Hello'));
+
+            node.append(paragraph);
+
+            node.getTextContent().should.equal('Hello');
+        }));
     });
 });

--- a/packages/kg-default-nodes/test/nodes/audio.test.js
+++ b/packages/kg-default-nodes/test/nodes/audio.test.js
@@ -207,4 +207,14 @@ describe('AudioNode', function () {
             nodes[0].getMimeType().should.equal('');
         }));
     });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createAudioNode();
+            node.setTitle('Testing');
+
+            // audio nodes don't have text content
+            node.getTextContent().should.equal('');
+        }));
+    });
 });

--- a/packages/kg-default-nodes/test/nodes/bookmark.test.js
+++ b/packages/kg-default-nodes/test/nodes/bookmark.test.js
@@ -46,7 +46,7 @@ describe('BookmarkNode', function () {
 
         exportOptions = {
             createDocument() {
-                return (new JSDOM()).window.document; 
+                return (new JSDOM()).window.document;
             }
         };
     });
@@ -152,7 +152,7 @@ describe('BookmarkNode', function () {
             const prettyExpectedHtml = Prettier.format(expectedHtml, {parser: 'html'});
 
             element.outerHTML.should.prettifyTo(prettyExpectedHtml);
-        })); 
+        }));
 
         it('renders email target', editorTest(function () {
             const options = {
@@ -160,7 +160,7 @@ describe('BookmarkNode', function () {
             };
             const bookmarkNode = $createBookmarkNode(dataset);
             const {element} = bookmarkNode.exportDOM({...exportOptions, ...options});
-            
+
             element.innerHTML.should.containEql('<!--[if !mso !vml]-->');
             element.innerHTML.should.containEql('<figure class="kg-card kg-bookmark-card');
             element.innerHTML.should.containEql('<!--[if vml]>');
@@ -306,7 +306,7 @@ describe('BookmarkNode', function () {
         // Mobiledoc {\"version\":\"0.3.1\",\"atoms\":[],\"cards\":[[\"bookmark\",{\"url\":\"https://slack.engineering/typescript-at-slack-a81307fa288d\",\"metadata\":{\"url\":\"https://slack.engineering/typescript-at-slack-a81307fa288d\",\"title\":\"TypeScript at Slack\",\"description\":\"When Brendan Eich created the very first version of JavaScript for Netscape Navigator 2.0 in merely ten days, it’s likely that he did not expect how far the Slack Desktop App would take his…\",\"author\":\"Felix Rieseberg\",\"publisher\":\"Several People Are Coding\",\"thumbnail\":\"https://miro.medium.com/max/1200/1*-h1bH8gB3I7gPh5AG1HmsQ.png\",\"icon\":\"https://cdn-images-1.medium.com/fit/c/152/152/1*8I-HPL0bfoIzGied-dzOvA.png\"},\"type\":\"bookmark\"}]],\"markups\":[],\"sections\":[[10,0],[1,\"p\",[]]]}
         // Ghost HTML <figure class="kg-card kg-bookmark-card"><a class="kg-bookmark-container" href="https://slack.engineering/typescript-at-slack-a81307fa288d"><div class="kg-bookmark-content"><div class="kg-bookmark-title">TypeScript at Slack</div><div class="kg-bookmark-description">When Brendan Eich created the very first version of JavaScript for Netscape Navigator 2.0 in merely ten days, it’s likely that he did not expect how far the Slack Desktop App would take his…</div><div class="kg-bookmark-metadata"><img class="kg-bookmark-icon" src="https://cdn-images-1.medium.com/fit/c/152/152/1*8I-HPL0bfoIzGied-dzOvA.png"><span class="kg-bookmark-author">Felix Rieseberg</span><span class="kg-bookmark-publisher">Several People Are Coding</span></div></div><div class="kg-bookmark-thumbnail"><img src="https://miro.medium.com/max/1200/1*-h1bH8gB3I7gPh5AG1HmsQ.png"></div></a></figure>
         // Medium Export HTML <div class="graf graf--mixtapeEmbed graf-after--p"><a href="https://slack.engineering/typescript-at-slack-a81307fa288d" data-href="https://slack.engineering/typescript-at-slack-a81307fa288d" class="markup--anchor markup--mixtapeEmbed-anchor" title="https://slack.engineering/typescript-at-slack-a81307fa288d"><strong class="markup--strong markup--mixtapeEmbed-strong">TypeScript at Slack</strong><br><em class="markup--em markup--mixtapeEmbed-em">Or, How I Learned to Stop Worrying &amp; Trust the Compiler</em>slack.engineering</a><a href="https://slack.engineering/typescript-at-slack-a81307fa288d" class="js-mixtapeImage mixtapeImage u-ignoreBlock" data-media-id="abc123" data-thumbnail-img-id="1*-h1bH8gB3I7gPh5AG1HmsQ.png" style="background-image: url(https://cdn-images-1.medium.com/fit/c/160/160/1*-h1bH8gB3I7gPh5AG1HmsQ.png);"></a></div>
-            
+
             it('parses mixtape block with all data', editorTest(function () {
                 const dom = (new JSDOM(html`<div class="graf graf--mixtapeEmbed graf-after--p"><a href="https://slack.engineering/typescript-at-slack-a81307fa288d" data-href="https://slack.engineering/typescript-at-slack-a81307fa288d" class="markup--anchor markup--mixtapeEmbed-anchor" title="https://slack.engineering/typescript-at-slack-a81307fa288d"><strong class="markup--strong markup--mixtapeEmbed-strong">TypeScript at Slack</strong><br><em class="markup--em markup--mixtapeEmbed-em">Or, How I Learned to Stop Worrying &amp; Trust the Compiler</em>slack.engineering</a><a href="https://slack.engineering/typescript-at-slack-a81307fa288d" class="js-mixtapeImage mixtapeImage u-ignoreBlock" data-media-id="abc123" data-thumbnail-img-id="1*-h1bH8gB3I7gPh5AG1HmsQ.png" style="background-image: url(https://cdn-images-1.medium.com/fit/c/160/160/1*-h1bH8gB3I7gPh5AG1HmsQ.png);"></a></div>`)).window.document;
                 const nodes = $generateNodesFromDOM(editor, dom);
@@ -331,5 +331,19 @@ describe('BookmarkNode', function () {
                 nodes[0].getThumbnail().should.equal('https://cdn-images-1.medium.com/fit/c/160/160/1*-h1bH8gB3I7gPh5AG1HmsQ.png');
             }));
         });
+    });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createBookmarkNode();
+            node.getTextContent().should.equal('');
+
+            node.setTitle('Test');
+            node.setDescription('Test description');
+            node.setUrl('https://example.com');
+            node.setCaption('Test <strong>caption</strong>');
+
+            node.getTextContent().should.equal('Test\nTest description\nhttps://example.com\nTest <strong>caption</strong>\n\n');
+        }));
     });
 });

--- a/packages/kg-default-nodes/test/nodes/button.test.js
+++ b/packages/kg-default-nodes/test/nodes/button.test.js
@@ -201,4 +201,15 @@ describe('ButtonNode', function () {
             nodes[0].getAlignment().should.equal('center');
         }));
     });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createButtonNode();
+            node.setButtonText('Testing');
+            node.setButtonUrl('http://someblog.com/somepost');
+
+            // button nodes don't have text content
+            node.getTextContent().should.equal('');
+        }));
+    });
 });

--- a/packages/kg-default-nodes/test/nodes/callout.test.js
+++ b/packages/kg-default-nodes/test/nodes/callout.test.js
@@ -190,4 +190,15 @@ describe('CalloutNode', function () {
             });
         });
     });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createCalloutNode();
+            node.getTextContent().should.equal('');
+
+            node.setCalloutText('Test');
+
+            node.getTextContent().should.equal('Test\n\n');
+        }));
+    });
 });

--- a/packages/kg-default-nodes/test/nodes/codeblock.test.js
+++ b/packages/kg-default-nodes/test/nodes/codeblock.test.js
@@ -289,4 +289,16 @@ describe('CodeBlockNode', function () {
             should(nodes[0].getCaption()).be.undefined();
         }));
     });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createCodeBlockNode();
+            node.getTextContent().should.equal('');
+
+            node.setCode('<script>const test = true;</script>');
+            node.setCaption('Test caption');
+
+            node.getTextContent().should.equal('<script>const test = true;</script>\nTest caption\n\n');
+        }));
+    });
 });

--- a/packages/kg-default-nodes/test/nodes/email-cta.test.js
+++ b/packages/kg-default-nodes/test/nodes/email-cta.test.js
@@ -453,4 +453,14 @@ describe('EmailCtaNode', function () {
             `);
         }));
     });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createEmailCtaNode();
+            node.setHtml('Testing');
+
+            // email CTA nodes don't have text content
+            node.getTextContent().should.equal('');
+        }));
+    });
 });

--- a/packages/kg-default-nodes/test/nodes/email.test.js
+++ b/packages/kg-default-nodes/test/nodes/email.test.js
@@ -346,4 +346,14 @@ describe('EmailNode', function () {
             `);
         }));
     });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createEmailNode();
+            node.setHtml('Testing');
+
+            // email nodes don't have text content
+            node.getTextContent().should.equal('');
+        }));
+    });
 });

--- a/packages/kg-default-nodes/test/nodes/embed.test.js
+++ b/packages/kg-default-nodes/test/nodes/embed.test.js
@@ -60,7 +60,7 @@ describe('EmbedNode', function () {
 
         exportOptions = {
             createDocument() {
-                return (new JSDOM()).window.document; 
+                return (new JSDOM()).window.document;
             }
         };
     });
@@ -141,7 +141,7 @@ describe('EmbedNode', function () {
             const prettyExpectedHtml = Prettier.format(expectedHtml, {parser: 'html'});
 
             element.outerHTML.should.prettifyTo(prettyExpectedHtml);
-        })); 
+        }));
 
         it('renders a twitter embed without api token', editorTest(function () {
             const embedNode = $createEmbedNode({
@@ -303,7 +303,7 @@ describe('EmbedNode', function () {
             };
             const embedNode = $createEmbedNode(youtubeEmbed);
             const {element} = embedNode.exportDOM({...exportOptions, ...options});
-            
+
             element.outerHTML.should.containEql('<!--[if !mso !vml]-->');
             element.outerHTML.should.containEql('<a class="kg-video-preview"');
             element.outerHTML.should.containEql('<!--[if vml]>');
@@ -484,7 +484,7 @@ describe('EmbedNode', function () {
                 nodes[0].getHtml().should.prettifyTo('<iframe class="hs-responsive-embed-iframe hs-fullwidth-embed" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;" xml="lang" src="https://www.youtube.com/embed/YTVID" width="560" height="315" allowfullscreen="" data-service="youtube"></iframe>');
             }));
         });
-        
+
         describe('figure blockquote', function () {
             // Twitter
             // Mobiledoc {"version":"0.3.1","atoms":[],"cards":[["embed",{"url":"https://twitter.com/iamdevloper/status/1133348012439220226","html":"<blockquote class=\"twitter-tweet\"><p lang=\"en\" dir=\"ltr\">I see &quot;blockchain engineer&quot;, I hear &quot;fancy spreadsheet admin&quot;.</p>&mdash; I Am Devloper (@iamdevloper) <a href=\"https://twitter.com/iamdevloper/status/1133348012439220226?ref_src=twsrc%5Etfw\">May 28, 2019</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n","type":"rich"}]],"markups":[],"sections":[[10,0],[1,"p",[]]]}
@@ -530,5 +530,16 @@ describe('EmbedNode', function () {
                 nodes[0].getCaption().should.equal('<a href="https://twitter.com">A Tweet</a>');
             }));
         });
+    });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createEmbedNode();
+            node.getTextContent().should.equal('');
+
+            node.setCaption('Test caption');
+
+            node.getTextContent().should.equal('Test caption\n\n');
+        }));
     });
 });

--- a/packages/kg-default-nodes/test/nodes/file.test.js
+++ b/packages/kg-default-nodes/test/nodes/file.test.js
@@ -89,7 +89,7 @@ describe('FileNode', function () {
             const fileNode = $createFileNode(dataset);
             const {element} = fileNode.exportDOM(exportOptions);
             element.outerHTML.should.equal(`<div class="kg-card kg-file-card"><a class="kg-file-card-container" href="/content/files/2023/03/IMG_0196.jpeg" title="Download" download=""><div class="kg-file-card-contents"><div class="kg-file-card-title">Cool image to download</div><div class="kg-file-card-caption">This is a description</div><div class="kg-file-card-metadata"><div class="kg-file-card-filename">IMG_0196.jpeg</div><div class="kg-file-card-filesize">121 KB</div></div></div><div class="kg-file-card-icon"><svg viewBox="0 0 24 24"><defs><style>.a{fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5px;}</style></defs><title>download-circle</title><polyline class="a" points="8.25 14.25 12 18 15.75 14.25"></polyline><line class="a" x1="12" y1="6.75" x2="12" y2="18"></line><circle class="a" cx="12" cy="12" r="11.25"></circle></svg></div></a></div>`);
-            
+
             // FIXME: battling to get it pretty printed.
         }));
     });
@@ -208,6 +208,19 @@ describe('FileNode', function () {
                 type: 'file',
                 ...dataset
             });
+        }));
+    });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createFileNode();
+            node.getTextContent().should.equal('');
+
+            node.setFileTitle('Testing');
+            node.getTextContent().should.equal('Testing\n\n');
+
+            node.setFileCaption('Test caption');
+            node.getTextContent().should.equal('Testing\nTest caption\n\n');
         }));
     });
 });

--- a/packages/kg-default-nodes/test/nodes/gallery.test.js
+++ b/packages/kg-default-nodes/test/nodes/gallery.test.js
@@ -1076,4 +1076,14 @@ describe('GalleryNode', function () {
             }));
         });
     });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createGalleryNode();
+            node.getTextContent().should.equal('');
+
+            node.setCaption('Test caption');
+            node.getTextContent().should.equal('Test caption\n\n');
+        }));
+    });
 });

--- a/packages/kg-default-nodes/test/nodes/header.test.js
+++ b/packages/kg-default-nodes/test/nodes/header.test.js
@@ -176,4 +176,17 @@ describe('HeaderNode', function () {
             node.getButtonText().should.equal('Button');
         }));
     });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createHeaderNode();
+            node.getTextContent().should.equal('');
+
+            node.setHeader('Test');
+            node.getTextContent().should.equal('Test\n\n');
+
+            node.setSubheader('Subheader');
+            node.getTextContent().should.equal('Test\nSubheader\n\n');
+        }));
+    });
 });

--- a/packages/kg-default-nodes/test/nodes/horizontalrule.test.js
+++ b/packages/kg-default-nodes/test/nodes/horizontalrule.test.js
@@ -107,4 +107,11 @@ describe('HorizontalNode', function () {
             });
         });
     });
+
+    describe('getTextContent', function () {
+        it('returns plaintext representation', editorTest(function () {
+            const node = $createHorizontalRuleNode();
+            node.getTextContent().should.equal('---\n\n');
+        }));
+    });
 });

--- a/packages/kg-default-nodes/test/nodes/html.test.js
+++ b/packages/kg-default-nodes/test/nodes/html.test.js
@@ -202,4 +202,15 @@ describe('HtmlNode', function () {
             });
         }));
     });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createHtmlNode();
+            node.getTextContent().should.equal('');
+
+            node.setHtml('<script>const test = true;</script>');
+
+            node.getTextContent().should.equal('<script>const test = true;</script>\n\n');
+        }));
+    });
 });

--- a/packages/kg-default-nodes/test/nodes/image.test.js
+++ b/packages/kg-default-nodes/test/nodes/image.test.js
@@ -496,4 +496,14 @@ describe('ImageNode', function () {
             });
         });
     });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createImageNode();
+            node.getTextContent().should.equal('');
+
+            node.setCaption('Test caption');
+            node.getTextContent().should.equal('Test caption\n\n');
+        }));
+    });
 });

--- a/packages/kg-default-nodes/test/nodes/markdown.test.js
+++ b/packages/kg-default-nodes/test/nodes/markdown.test.js
@@ -172,4 +172,15 @@ describe('MarkdownNode', function () {
             });
         }));
     });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createMarkdownNode();
+            node.getTextContent().should.equal('');
+
+            node.setMarkdown('#HEADING\r\n- list\r\n- items');
+
+            node.getTextContent().should.equal('#HEADING\r\n- list\r\n- items\n\n');
+        }));
+    });
 });

--- a/packages/kg-default-nodes/test/nodes/paywall.test.js
+++ b/packages/kg-default-nodes/test/nodes/paywall.test.js
@@ -107,4 +107,13 @@ describe('PaywallNode', function () {
             nodes[0].should.be.instanceof(PaywallNode);
         }));
     });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createPaywallNode();
+
+            // paywall nodes don't have text content
+            node.getTextContent().should.equal('');
+        }));
+    });
 });

--- a/packages/kg-default-nodes/test/nodes/product.test.js
+++ b/packages/kg-default-nodes/test/nodes/product.test.js
@@ -540,4 +540,17 @@ describe('ProductNode', function () {
             $isProductNode(nodes[0]).should.be.exactly(false);
         }));
     });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createProductNode();
+            node.getTextContent().should.equal('');
+
+            node.setProductTitle('Product title!');
+            node.getTextContent().should.equal('Product title!\n\n');
+
+            node.setProductDescription('This product is ok');
+            node.getTextContent().should.equal('Product title!\nThis product is ok\n\n');
+        }));
+    });
 });

--- a/packages/kg-default-nodes/test/nodes/signup.test.js
+++ b/packages/kg-default-nodes/test/nodes/signup.test.js
@@ -2,7 +2,7 @@ const {createHeadlessEditor} = require('@lexical/headless');
 const {html} = require('../utils');
 const {JSDOM} = require('jsdom');
 const {$getRoot} = require('lexical');
-const {SignupNode, $createSignupNode, $isSignupNode} = require('../../');
+const {SignupNode, $createSignupNode, $isSignupNode, $createPaywallNode} = require('../../');
 const {$generateNodesFromDOM} = require('@lexical/html');
 
 const editorNodes = [SignupNode];
@@ -542,5 +542,14 @@ describe('SignupNode', function () {
                 }
             });
         });
+    });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createPaywallNode();
+
+            // signup nodes don't have text content
+            node.getTextContent().should.equal('');
+        }));
     });
 });

--- a/packages/kg-default-nodes/test/nodes/toggle.test.js
+++ b/packages/kg-default-nodes/test/nodes/toggle.test.js
@@ -207,4 +207,17 @@ describe('ToggleNode', function () {
             nodes[0].getContent().should.equal('Content');
         }));
     });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createToggleNode();
+            node.getTextContent().should.equal('');
+
+            node.setHeading('header');
+            node.getTextContent().should.equal('header\n\n');
+
+            node.setContent('content');
+            node.getTextContent().should.equal('header\ncontent\n\n');
+        }));
+    });
 });

--- a/packages/kg-default-nodes/test/nodes/video.test.js
+++ b/packages/kg-default-nodes/test/nodes/video.test.js
@@ -417,4 +417,14 @@ describe('VideoNode', function () {
             nodes[0].getCustomThumbnailSrc().should.equal('/content/images/2022/11/koenig-lexical-custom.jpg');
         }));
     });
+
+    describe('getTextContent', function () {
+        it('returns contents', editorTest(function () {
+            const node = $createVideoNode();
+            node.getTextContent().should.equal('');
+
+            node.setCaption('Test caption');
+            node.getTextContent().should.equal('Test caption\n\n');
+        }));
+    });
 });

--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -5,6 +5,7 @@ import React, {useState} from 'react';
 import Sidebar from './components/Sidebar';
 import TitleTextBox from './components/TitleTextBox';
 import Watermark from './components/Watermark';
+import WordCount from './components/WordCount';
 import basicContent from './content/basic-content.json';
 import content from './content/content.json';
 import minimalContent from './content/minimal-content.json';
@@ -13,7 +14,8 @@ import {
     BASIC_NODES, BASIC_TRANSFORMERS, KoenigComposableEditor,
     KoenigComposer, KoenigEditor, MINIMAL_NODES, MINIMAL_TRANSFORMERS,
     MobiledocCopyPlugin,
-    RestrictContentPlugin
+    RestrictContentPlugin,
+    WordCountPlugin
 } from '../src';
 import {defaultHeaders as defaultUnsplashHeaders} from './utils/unsplashConfig';
 import {fetchEmbed} from './utils/fetchEmbed';
@@ -62,14 +64,16 @@ function getAllowedNodes({editorType}) {
     return undefined;
 }
 
-function DemoEditor({editorType, registerAPI, cursorDidExitAtTop, darkMode}) {
+function DemoEditor({editorType, registerAPI, cursorDidExitAtTop, darkMode, setWordCount}) {
     if (editorType === 'basic') {
         return (
             <KoenigComposableEditor
                 cursorDidExitAtTop={cursorDidExitAtTop}
                 markdownTransformers={BASIC_TRANSFORMERS}
                 registerAPI={registerAPI}
-            />
+            >
+                <WordCountPlugin onChange={setWordCount} />
+            </KoenigComposableEditor>
         );
     } else if (editorType === 'minimal') {
         return (
@@ -80,6 +84,7 @@ function DemoEditor({editorType, registerAPI, cursorDidExitAtTop, darkMode}) {
                 registerAPI={registerAPI}
             >
                 <RestrictContentPlugin paragraphs={1} />
+                <WordCountPlugin onChange={setWordCount} />
             </KoenigComposableEditor>
         );
     }
@@ -91,6 +96,7 @@ function DemoEditor({editorType, registerAPI, cursorDidExitAtTop, darkMode}) {
             registerAPI={registerAPI}
         >
             <MobiledocCopyPlugin />
+            <WordCountPlugin onChange={setWordCount} />
         </KoenigEditor>
     );
 }
@@ -122,6 +128,7 @@ function DemoApp({editorType, isMultiplayer}) {
 
     const [title, setTitle] = useState(initialContent ? 'Meet the Koenig editor.' : '');
     const [editorAPI, setEditorAPI] = useState(null);
+    const [wordCount, setWordCount] = useState(0);
     const titleRef = React.useRef(null);
     const containerRef = React.useRef(null);
 
@@ -228,6 +235,7 @@ function DemoApp({editorType, isMultiplayer}) {
                 nodes={getAllowedNodes({editorType})}
             >
                 <div className={`koenig-demo relative h-full grow ${darkMode ? 'dark' : ''}`}>
+                    <WordCount wordCount={wordCount} />
                     {
                         !isMultiplayer && searchParams !== 'false'
                             ? <InitialContentToggle defaultContent={defaultContent} searchParams={searchParams} setSearchParams={setSearchParams} setTitle={setTitle} />
@@ -245,6 +253,7 @@ function DemoApp({editorType, isMultiplayer}) {
                                 darkMode={darkMode}
                                 editorType={editorType}
                                 registerAPI={setEditorAPI}
+                                setWordCount={setWordCount}
                             />
                         </div>
                     </div>

--- a/packages/koenig-lexical/demo/components/WordCount.jsx
+++ b/packages/koenig-lexical/demo/components/WordCount.jsx
@@ -1,0 +1,9 @@
+const WordCount = ({wordCount}) => {
+    return (
+        <div className="absolute top-4 left-6 z-20 block cursor-pointer rounded bg-white py-1 px-2 font-mono text-sm tracking-tight text-grey-600 dark:bg-transparent">
+            <span data-testid="word-count">{wordCount}</span> words
+        </div>
+    );
+};
+
+export default WordCount;

--- a/packages/koenig-lexical/package.json
+++ b/packages/koenig-lexical/package.json
@@ -57,6 +57,7 @@
     "@lexical/utils": "^0.11.1",
     "@lezer/highlight": "^1.1.3",
     "@tryghost/color-utils": "^0.1.26",
+    "@tryghost/helpers": "^1.1.81",
     "@tryghost/kg-clean-basic-html": "^3.0.19",
     "@tryghost/kg-converters": "^0.0.7",
     "@tryghost/kg-default-nodes": "^0.0.61",

--- a/packages/koenig-lexical/src/components/KoenigComposableEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigComposableEditor.jsx
@@ -52,7 +52,7 @@ const KoenigComposableEditor = ({
     const {onChange: sharedOnChange} = useSharedOnChangeContext();
     const _onChange = React.useCallback((editorState) => {
         if (sharedOnChange) {
-            // sharedInChange is called for the main editor and nested editors, we want to
+            // sharedOnChange is called for the main editor and nested editors, we want to
             // make sure we don't accidentally serialize only the contents of the nested
             // editor so we need to use the parent editor when it exists
             const primaryEditorState = (editor._parentEditor || editor).getEditorState();

--- a/packages/koenig-lexical/src/components/KoenigComposer.jsx
+++ b/packages/koenig-lexical/src/components/KoenigComposer.jsx
@@ -43,6 +43,7 @@ const KoenigComposer = ({
     }, [enableMultiplayer, initialEditorState, nodes, onError]);
 
     const editorContainerRef = React.useRef(null);
+    const onWordCountChangeRef = React.useRef(null);
 
     if (!fileUploader.useFileUpload) {
         fileUploader.useFileUpload = function () {
@@ -89,7 +90,8 @@ const KoenigComposer = ({
                 multiplayerEndpoint,
                 multiplayerDocId,
                 multiplayerUsername,
-                createWebsocketProvider
+                createWebsocketProvider,
+                onWordCountChangeRef
             }}>
                 <KoenigSelectedCardContext>
                     {enableMultiplayer ? (

--- a/packages/koenig-lexical/src/components/KoenigNestedComposer.jsx
+++ b/packages/koenig-lexical/src/components/KoenigNestedComposer.jsx
@@ -1,12 +1,13 @@
 import KoenigComposerContext from '../context/KoenigComposerContext';
 import React from 'react';
+import WordCountPlugin from '../plugins/WordCountPlugin';
 import {CollaborationPlugin} from '@lexical/react/LexicalCollaborationPlugin';
 import {LexicalNestedComposer} from '@lexical/react/LexicalNestedComposer';
 import {useCollaborationContext} from '@lexical/react/LexicalCollaborationContext';
 
 const KoenigNestedComposer = ({initialEditor, initialEditorState, initialNodes, initialTheme, skipCollabChecks, children} = {}) => {
     const {isCollabActive} = useCollaborationContext();
-    const {createWebsocketProvider} = React.useContext(KoenigComposerContext);
+    const {createWebsocketProvider, onWordCountChangeRef} = React.useContext(KoenigComposerContext);
 
     return (
         <LexicalNestedComposer
@@ -23,6 +24,9 @@ const KoenigNestedComposer = ({initialEditor, initialEditorState, initialNodes, 
                     shouldBootstrap={true}
                 />
             ) : null }
+            {onWordCountChangeRef.current ? (
+                <WordCountPlugin onChange={onWordCountChangeRef.current} />
+            ) : null}
             {children}
         </LexicalNestedComposer>
     );

--- a/packages/koenig-lexical/src/index.js
+++ b/packages/koenig-lexical/src/index.js
@@ -30,6 +30,7 @@ import SignupPlugin from './plugins/SignupPlugin';
 import SlashCardMenuPlugin from './plugins/SlashCardMenuPlugin';
 import TogglePlugin from './plugins/TogglePlugin';
 import VideoPlugin from './plugins/VideoPlugin';
+import WordCountPlugin from './plugins/WordCountPlugin';
 
 import AllDefaultPlugins from './plugins/AllDefaultPlugins';
 
@@ -69,6 +70,7 @@ export {
     FilePlugin,
     FloatingToolbarPlugin,
     GalleryPlugin,
+    HeaderPlugin,
     HorizontalRulePlugin,
     HtmlOutputPlugin,
     ImagePlugin,
@@ -78,11 +80,11 @@ export {
     MobiledocCopyPlugin,
     PlusCardMenuPlugin,
     RestrictContentPlugin,
+    SignupPlugin,
     SlashCardMenuPlugin,
     TogglePlugin,
-    HeaderPlugin,
     VideoPlugin,
-    SignupPlugin,
+    WordCountPlugin,
 
     AllDefaultPlugins,
 

--- a/packages/koenig-lexical/src/nodes/CalloutNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CalloutNode.jsx
@@ -12,8 +12,8 @@ import {populateNestedEditor, setupNestedEditor} from '../utils/nested-editors';
 export {INSERT_CALLOUT_COMMAND} from '@tryghost/kg-default-nodes';
 
 export class CalloutNode extends BaseCalloutNode {
-    __textEditor;
-    __textEditorInitialState;
+    __calloutTextEditor;
+    __calloutTextEditorInitialState;
 
     static kgMenu = [{
         label: 'Callout',
@@ -32,11 +32,11 @@ export class CalloutNode extends BaseCalloutNode {
         super(dataset, key);
 
         // set up nested editor instances
-        setupNestedEditor(this, '__textEditor', {editor: dataset.textEditor, nodes: MINIMAL_NODES});
+        setupNestedEditor(this, '__calloutTextEditor', {editor: dataset.calloutTextEditor, nodes: MINIMAL_NODES});
 
         // populate nested editors on initial construction
-        if (!dataset.textEditor && dataset.calloutText) {
-            populateNestedEditor(this, '__textEditor', `<p>${dataset.calloutText}</p>`); // we serialize with no wrapper
+        if (!dataset.calloutTextEditor && dataset.calloutText) {
+            populateNestedEditor(this, '__calloutTextEditor', `<p>${dataset.calloutText}</p>`); // we serialize with no wrapper
         }
     }
 
@@ -45,9 +45,9 @@ export class CalloutNode extends BaseCalloutNode {
 
         // convert nested editor instance back into HTML because `text` may not
         // be automatically updated when the nested editor changes
-        if (this.__textEditor) {
-            this.__textEditor.getEditorState().read(() => {
-                const html = $generateHtmlFromNodes(this.__textEditor, null);
+        if (this.__calloutTextEditor) {
+            this.__calloutTextEditor.getEditorState().read(() => {
+                const html = $generateHtmlFromNodes(this.__calloutTextEditor, null);
                 const cleanedHtml = cleanBasicHtml(html, {allowBr: true});
                 json.calloutText = cleanedHtml;
             });
@@ -65,8 +65,8 @@ export class CalloutNode extends BaseCalloutNode {
 
         // client-side only data properties such as nested editors
         const self = this.getLatest();
-        dataset.textEditor = self.__textEditor;
-        dataset.textEditorInitialState = self.__textEditorInitialState;
+        dataset.calloutTextEditor = self.__calloutTextEditor;
+        dataset.calloutTextEditorInitialState = self.__calloutTextEditorInitialState;
 
         return dataset;
     }
@@ -82,8 +82,8 @@ export class CalloutNode extends BaseCalloutNode {
                     backgroundColor={this.__backgroundColor}
                     calloutEmoji={this.__calloutEmoji}
                     nodeKey={this.getKey()}
-                    textEditor={this.__textEditor}
-                    textEditorInitialState={this.__textEditorInitialState}
+                    textEditor={this.__calloutTextEditor}
+                    textEditorInitialState={this.__calloutTextEditorInitialState}
                 />
             </KoenigCardWrapper>
         );

--- a/packages/koenig-lexical/src/nodes/ProductNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ProductNode.jsx
@@ -11,10 +11,10 @@ import {populateNestedEditor, setupNestedEditor} from '../utils/nested-editors.j
 // re-export here, so we don't need to import from multiple places throughout the app
 export {INSERT_PRODUCT_COMMAND} from '@tryghost/kg-default-nodes';
 export class ProductNode extends BaseProductNode {
-    __titleEditor;
-    __titleEditorInitialState;
-    __descriptionEditor;
-    __descriptionEditorInitialState;
+    __productTitleEditor;
+    __productTitleEditorInitialState;
+    __productDescriptionEditor;
+    __productDescriptionEditorInitialState;
 
     static kgMenu = [{
         label: 'Product',
@@ -33,15 +33,15 @@ export class ProductNode extends BaseProductNode {
         super(dataset, key);
 
         // set up nested editor instances
-        setupNestedEditor(this, '__titleEditor', {editor: dataset.titleEditor, nodes: MINIMAL_NODES});
-        setupNestedEditor(this, '__descriptionEditor', {editor: dataset.descriptionEditor, nodes: BASIC_NODES});
+        setupNestedEditor(this, '__productTitleEditor', {editor: dataset.productTitleEditor, nodes: MINIMAL_NODES});
+        setupNestedEditor(this, '__productDescriptionEditor', {editor: dataset.productDescriptionEditor, nodes: BASIC_NODES});
 
         // populate nested editors on initial construction
-        if (!dataset.titleEditor && dataset.productTitle) {
-            populateNestedEditor(this, '__titleEditor', `<p>${dataset.productTitle}</p>`); // we serialize with no wrapper
+        if (!dataset.productTitleEditor && dataset.productTitle) {
+            populateNestedEditor(this, '__productTitleEditor', `<p>${dataset.productTitle}</p>`); // we serialize with no wrapper
         }
-        if (!dataset.descriptionEditor) {
-            populateNestedEditor(this, '__descriptionEditor', dataset.productDescription);
+        if (!dataset.productDescriptionEditor) {
+            populateNestedEditor(this, '__productDescriptionEditor', dataset.productDescription);
         }
     }
 
@@ -50,10 +50,10 @@ export class ProductNode extends BaseProductNode {
 
         // client-side only data properties such as nested editors
         const self = this.getLatest();
-        dataset.titleEditor = self.__titleEditor;
-        dataset.titleEditorInitialState = self.__titleEditorInitialState;
-        dataset.descriptionEditor = self.__descriptionEditor;
-        dataset.descriptionEditorInitialState = self.__descriptionEditorInitialState;
+        dataset.productTitleEditor = self.__productTitleEditor;
+        dataset.productTitleEditorInitialState = self.__productTitleEditorInitialState;
+        dataset.productDescriptionEditor = self.__productDescriptionEditor;
+        dataset.productDescriptionEditorInitialState = self.__productDescriptionEditorInitialState;
 
         return dataset;
     }
@@ -63,16 +63,16 @@ export class ProductNode extends BaseProductNode {
 
         // convert nested editor instances back into HTML because their content may not
         // be automatically updated when the nested editor changes
-        if (this.__titleEditor) {
-            this.__titleEditor.getEditorState().read(() => {
-                const html = $generateHtmlFromNodes(this.__titleEditor, null);
+        if (this.__productTitleEditor) {
+            this.__productTitleEditor.getEditorState().read(() => {
+                const html = $generateHtmlFromNodes(this.__productTitleEditor, null);
                 const cleanedHtml = cleanBasicHtml(html, {firstChildInnerContent: true});
                 json.productTitle = cleanedHtml;
             });
         }
-        if (this.__descriptionEditor) {
-            this.__descriptionEditor.getEditorState().read(() => {
-                const html = $generateHtmlFromNodes(this.__descriptionEditor, null);
+        if (this.__productDescriptionEditor) {
+            this.__productDescriptionEditor.getEditorState().read(() => {
+                const html = $generateHtmlFromNodes(this.__productDescriptionEditor, null);
                 const cleanedHtml = cleanBasicHtml(html);
                 json.productDescription = cleanedHtml;
             });
@@ -88,8 +88,8 @@ export class ProductNode extends BaseProductNode {
                     buttonText={this.getProductButton()}
                     buttonUrl={this.getProductUrl()}
                     description={this.getProductDescription()}
-                    descriptionEditor={this.__descriptionEditor}
-                    descriptionEditorInitialState={this.__descriptionEditorInitialState}
+                    descriptionEditor={this.__productDescriptionEditor}
+                    descriptionEditorInitialState={this.__productDescriptionEditorInitialState}
                     imgHeight={this.getProductImageHeight()}
                     imgSrc={this.getProductImageSrc()}
                     imgWidth={this.getProductImageWidth()}
@@ -98,8 +98,8 @@ export class ProductNode extends BaseProductNode {
                     nodeKey={this.getKey()}
                     starRating={this.getProductStarRating()}
                     title={this.getProductTitle()}
-                    titleEditor={this.__titleEditor}
-                    titleEditorInitialState={this.__titleEditorInitialState}
+                    titleEditor={this.__productTitleEditor}
+                    titleEditorInitialState={this.__productTitleEditorInitialState}
                 />
             </KoenigCardWrapper>
         );
@@ -108,8 +108,8 @@ export class ProductNode extends BaseProductNode {
     // override the default `isEmpty` check because we need to check the nested editors
     // rather than the data properties themselves
     isEmpty() {
-        const isTitleEmpty = isEditorEmpty(this.__titleEditor);
-        const isDescriptionEmpty = isEditorEmpty(this.__descriptionEditor);
+        const isTitleEmpty = isEditorEmpty(this.__productTitleEditor);
+        const isDescriptionEmpty = isEditorEmpty(this.__productDescriptionEditor);
         const isButtonFilled = this.getProductButtonEnabled() && this.getProductUrl() && this.getProductButton();
 
         return isTitleEmpty && isDescriptionEmpty && !isButtonFilled && !this.getProductImageSrc() && !this.getProductRatingEnabled();

--- a/packages/koenig-lexical/src/plugins/WordCountPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/WordCountPlugin.jsx
@@ -1,0 +1,101 @@
+import KoenigComposerContext from '../context/KoenigComposerContext';
+import React from 'react';
+import {$getRoot, $isElementNode} from 'lexical';
+import {mergeRegister} from '@lexical/utils';
+import {throttle} from 'lodash';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {utils} from '@tryghost/helpers';
+
+const {countWords} = utils;
+
+// TODO: language is not currently used but in future we should switch to using
+// Intl.Segmenter to get more accurate word counts for non-latin languages. For
+// now we're using Ghost's existing countWords util which is regex based
+export const WordCountPlugin = ({onChange, language = 'en'} = {}) => {
+    const [editor] = useLexicalComposerContext();
+    const {onWordCountChangeRef} = React.useContext(KoenigComposerContext);
+
+    React.useLayoutEffect(() => {
+        if (!onChange) {
+            return;
+        }
+
+        // store onChange in context so that we can use it in the KoenigNestedComposer
+        // to render nested <WordCountPlugin /> without needing to pass onChange down
+        if (!editor._parentEditor) {
+            onWordCountChangeRef.current = onChange;
+        }
+
+        let lastWordCount = 0;
+
+        const countEditorWords = () => {
+            let wordCount = 0;
+            let topLevelEditor = editor;
+
+            while (topLevelEditor._parentEditor) {
+                topLevelEditor = topLevelEditor._parentEditor;
+            }
+
+            topLevelEditor.getEditorState().read(() => {
+                // NOTE: we can't use RootNode.getTextContent() here because it will
+                // return cached text content when there are no dirty nodes which is
+                // the case for changes in nested editors
+
+                const rootNode = $getRoot();
+
+                // Borrowing code from ElementNode.getTextContent() to bypass the cache
+                let textContent = '';
+                const children = rootNode.getChildren();
+                const childrenLength = children.length;
+                for (let i = 0; i < childrenLength; i++) {
+                    const child = children[i];
+                    textContent += child.getTextContent();
+                    if (
+                        $isElementNode(child) &&
+                        i !== childrenLength - 1 &&
+                        !child.isInline()
+                    ) {
+                        textContent += `\n\n`;
+                    }
+                }
+
+                wordCount = countWords(textContent);
+            });
+
+            if (wordCount !== lastWordCount) {
+                lastWordCount = wordCount;
+                onChange(wordCount);
+            }
+        };
+
+        countEditorWords();
+
+        const throttledCount = throttle(countEditorWords, 200);
+
+        const cleanupRegister = mergeRegister(
+            editor.registerUpdateListener(({
+                dirtyElements,
+                dirtyLeaves,
+                prevEditorState,
+                tags
+            }) => {
+                if ((dirtyElements.size === 0 && dirtyLeaves.size === 0) || tags.has('history-merge') || prevEditorState.isEmpty()) {
+                    return;
+                }
+
+                throttledCount();
+            })
+        );
+
+        return () => {
+            throttledCount.cancel();
+            cleanupRegister();
+
+            if (!editor._parentEditor) {
+                onWordCountChangeRef.current = null;
+            }
+        };
+    }, [editor, onChange, onWordCountChangeRef]);
+};
+
+export default WordCountPlugin;

--- a/packages/koenig-lexical/test/e2e/plugins/WordCountPlugin.test.js
+++ b/packages/koenig-lexical/test/e2e/plugins/WordCountPlugin.test.js
@@ -1,0 +1,70 @@
+import {expect, test} from '@playwright/test';
+import {focusEditor, initialize, insertCard} from '../../utils/e2e';
+
+test.describe('Word Count Plugin', async function () {
+    let page;
+
+    test.beforeAll(async ({browser}) => {
+        page = await browser.newPage();
+    });
+
+    test.beforeEach(async () => {
+        await initialize({page});
+    });
+
+    test.afterAll(async () => {
+        await page.close();
+    });
+
+    test('counts words in editor', async function () {
+        await focusEditor(page);
+        await expect(page.getByTestId('word-count')).toHaveText('0');
+        await page.keyboard.type('Hello World');
+        await expect(page.getByTestId('word-count')).toHaveText('2');
+    });
+
+    test('counts words in nested editors', async function () {
+        await focusEditor(page);
+        await page.keyboard.type('Hello World');
+        await page.keyboard.press('Enter');
+        await insertCard(page, {cardName: 'callout'});
+        await page.keyboard.type('Nested content');
+        await expect(page.getByTestId('word-count')).toHaveText('4');
+    });
+
+    test('counts words immediately after initialization', async function () {
+        const contentParam = encodeURIComponent(JSON.stringify({
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                detail: 0,
+                                format: 0,
+                                mode: 'normal',
+                                style: '',
+                                text: 'Hello word',
+                                type: 'text',
+                                version: 1
+                            }
+                        ],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        }));
+
+        await initialize({page, uri: `/#/?content=${contentParam}`});
+
+        await expect(page.getByTestId('word-count')).toHaveText('2');
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4541,6 +4541,13 @@
   dependencies:
     color "^3.2.1"
 
+"@tryghost/helpers@^1.1.81":
+  version "1.1.81"
+  resolved "https://registry.yarnpkg.com/@tryghost/helpers/-/helpers-1.1.81.tgz#c98ad86191beb46ea28caf0814804cec8a51db1b"
+  integrity sha512-sxRIi4X+b3DD9QnFe/VrCwZUJ5R450zqVUQBwmYbPb36ldp7hBCQK9dgzUJw1B4TlRGmyUxqnwnaVA4Wy0sm7Q==
+  dependencies:
+    lodash-es "^4.17.11"
+
 "@tryghost/mobiledoc-kit@0.11.2-ghost.4":
   version "0.11.2-ghost.4"
   resolved "https://registry.yarnpkg.com/@tryghost/mobiledoc-kit/-/mobiledoc-kit-0.11.2-ghost.4.tgz#144189e7e62748b3c56e7b723fa18a5e8c807ccf"
@@ -13058,7 +13065,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.21:
+lodash-es@^4.17.11, lodash-es@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3242

Adds a `<WordCountPlugin onChange={updateWordCount}>` component that can be composed into an editor by a consuming app to call a function each time the word count changes.

- updated all relevant nodes in `kg-default-nodes` to override the `getTextContent()` method
  - added `readTextContent()` util fn to cover the case where a node property has a nested editor attached to it as that requires a different way of reading content. **NOTE:** requires strict naming of editor properties to be `${propertyName}Editor`
  - this works for Ghost's current use-cases where we don't make use of Lexical's plain text output except for copy/paste from the editor into a plain text editor but that has never been a well supported path. If that becomes a desired use-case and we want better formatting of plain text we may need to swap to a custom method for getting word-count specific text
- added `<WordCountPlugin>`
  - `onChange` argument accepts a function that is called with a word count number on each change
  - internally throttles the word count for better performance
  - when used in nested editors, finds the parent editor and runs word count on that to avoid calling `onChange` with a word count of only the nested editor content
  - manually walks child nodes to bypass text caching in `RootNode.getTextContent()` as changes in nested editors do not clear the cache
- adds `onWordCountChangeRef` to `KoenigComposerContext` so we can automatically add a nested `<WordCountPlugin>` child to `<KoenigNestedComposer>` when the word count plugin is used in the parent editor, otherwise changes in nested editors won't trigger the word count update fn
- updated demo app to use the word count plugin and display count in top-left
