### PR TITLE
Fixed Signup Card losing selection on `toggleBackgroundSize`

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
@@ -166,7 +166,8 @@ export function SignupCard({alignment,
         };
     };
 
-    const toggleBackgroundSize = () => {
+    const toggleBackgroundSize = (event) => {
+        event.stopPropagation();
         if (backgroundSize === 'cover') {
             handleBackgroundSize('contain');
             trackEvent('Signup Card Toggle Size', {size: 'contain'});


### PR DESCRIPTION
no issue

- card was losing selection when toggling the background image size on the SignupCard
- This adds stopPropagation to avoid it from propagating to the parent element.