### PR TITLE
🐛 Fixed callout card losing selection

### DIFF
--- a/packages/koenig-lexical/src/nodes/CalloutNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CalloutNodeComponent.jsx
@@ -46,6 +46,7 @@ export function CalloutNodeComponent({nodeKey, textEditor, textEditorInitialStat
             const node = $getNodeByKey(nodeKey);
             setEmoji(event.native);
             node.setCalloutEmoji(event.native);
+            setEditing(true);
             toggleEmojiPicker();
         });
     };


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/3495

- Callout Card was losing selection when selecting an emoji. This ensures it remains selected.