### PR TITLE
🐛 Fixed hidden toolbar in big Markdown cards

### DIFF
--- a/packages/kg-simplemde/src/js/simplemde.js
+++ b/packages/kg-simplemde/src/js/simplemde.js
@@ -1762,7 +1762,7 @@ SimpleMDE.prototype.createToolbar = function(items) {
 	});
 
 	var cmWrapper = cm.getWrapperElement();
-	cmWrapper.parentNode.insertBefore(bar, cmWrapper);
+	cmWrapper.parentNode.append(bar);
 	return bar;
 };
 

--- a/packages/koenig-lexical/src/styles/components/simplemde.css
+++ b/packages/koenig-lexical/src/styles/components/simplemde.css
@@ -27,6 +27,7 @@
         z-index: 2;
         display: flex;
         padding: 6px;
+        margin: auto -12px;
         border-top: 1px solid var(--grey-200);
         border-right: none;
         border-left: none;

--- a/packages/koenig-lexical/src/styles/components/simplemde.css
+++ b/packages/koenig-lexical/src/styles/components/simplemde.css
@@ -21,10 +21,8 @@
     }
 
     .editor-toolbar {
-        position: absolute;
-        right: 0;
+        position: sticky;
         bottom: 0;
-        left: 0;
         z-index: 2;
         display: flex;
         padding: 6px;

--- a/packages/koenig-lexical/src/styles/components/simplemde.css
+++ b/packages/koenig-lexical/src/styles/components/simplemde.css
@@ -22,6 +22,7 @@
 
     .editor-toolbar {
         position: sticky;
+        position: -webkit-sticky; /* Safari */
         bottom: 0;
         z-index: 2;
         display: flex;


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/3497

- makes the toolbar stick to the bottom of the markdown card