### PR TITLE
🐛 Fixed selection caret jumping to wrong node when closing emoji picker

### DIFF
--- a/packages/koenig-lexical/src/nodes/CalloutNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CalloutNodeComponent.jsx
@@ -46,15 +46,18 @@ export function CalloutNodeComponent({nodeKey, textEditor, textEditorInitialStat
             const node = $getNodeByKey(nodeKey);
             setEmoji(event.native);
             node.setCalloutEmoji(event.native);
-            setEditing(true);
             toggleEmojiPicker();
+            setEditing(true);
         });
     };
 
     const toggleEmojiPicker = () => {
         if (!isEditing) {
             setEditing(true);
-            return;
+        }
+
+        if (showEmojiPicker) {
+            textEditor.focus();
         }
         setShowEmojiPicker(!showEmojiPicker);
     };


### PR DESCRIPTION
no issue

- fixed selection caret jumping to wrong node when toggling the emoji picker on callout card.