### PR TITLE
🐛 Fixed Signup card editor autofocus

### DIFF
--- a/packages/koenig-lexical/src/utils/generateEditorState.js
+++ b/packages/koenig-lexical/src/utils/generateEditorState.js
@@ -1,4 +1,4 @@
-import {$createParagraphNode} from 'lexical';
+import {$createParagraphNode, $setSelection} from 'lexical';
 import {$generateNodesFromDOM} from '@lexical/html';
 import {$getRoot, $insertNodes} from 'lexical';
 
@@ -26,6 +26,14 @@ export default function generateEditorState({editor, initialHtml}) {
 
             // Insert them at a selection.
             $insertNodes(filteredNodes);
+
+            // $insertNodes is focusing an editor (https://github.com/facebook/lexical/issues/4546)
+            // This behaviour can break the ability to autofocus the editor because
+            // initial state filling can happen after the component is already mounted.
+            // Reset selection to make it easier to manage editor focus in components instead of editor state generation
+            if (filteredNodes.length) {
+                $setSelection(null);
+            }
         }, {discrete: true, tag: 'history-merge'});
     } else {
         // for empty initial values, create a paragraph because a completely empty

--- a/packages/koenig-lexical/test/e2e/cards/signup-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/signup-card.test.js
@@ -114,8 +114,7 @@ test.describe('Signup card', async () => {
         `, {ignoreCardContents: true});
     });
 
-    // the disclaimer editor is getting autofocus instead of the header editor, will fix it in a separate issue
-    test.skip('can edit header', async function () {
+    test('can edit header', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'signup'});
 
@@ -126,8 +125,7 @@ test.describe('Signup card', async () => {
         await expect(firstEditor).toHaveText('Sign up for Koenig Lexical, my friends');
     });
 
-    // the disclaimer editor is getting autofocus instead of the header editor, will fix it in a separate issue
-    test.skip('can edit subheader', async function () {
+    test('can edit subheader', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'signup'});
 
@@ -167,8 +165,7 @@ test.describe('Signup card', async () => {
         await expect(thirdEditor).toHaveText(/No spam. Unsubscribe anytime./);
     });
 
-    // the disclaimer editor is getting autofocus instead of the header editor, will fix it in a separate issue
-    test.skip('nested editors are hidden when not in edit mode', async function () {
+    test('nested editors are hidden when not in edit mode', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'signup'});
 


### PR DESCRIPTION
refs TryGhost/Team#3363
- $insertNodes is focusing an editor (https://github.com/facebook/lexical/issues/4546). This behaviour can break the ability to autofocus the editor because initial state filling can happen after the component is already mounted. Reset selection to make it easier to manage editor focus in components.