### PR TITLE
🐛 Fixed undo command inside HTML/Code/Markdown cards

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/CodeBlockCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CodeBlockCard.jsx
@@ -2,19 +2,23 @@ import CodeMirror from '@uiw/react-codemirror';
 import KoenigComposerContext from '../../../context/KoenigComposerContext';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {COMMAND_PRIORITY_LOW, UNDO_COMMAND} from 'lexical';
 import {CardCaptionEditor} from '../CardCaptionEditor';
 import {EditorView, keymap, lineNumbers} from '@codemirror/view';
 import {HighlightStyle, syntaxHighlighting} from '@codemirror/language';
 import {css} from '@codemirror/lang-css';
 import {html} from '@codemirror/lang-html';
 import {javascript} from '@codemirror/lang-javascript';
+import {mergeRegister} from '@lexical/utils';
 import {minimalSetup} from '@uiw/codemirror-extensions-basic-setup';
 import {standardKeymap} from '@codemirror/commands';
 import {tags as t} from '@lezer/highlight';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext.js';
 
 export function CodeEditor({code, language, updateCode, updateLanguage}) {
     const [showLanguage, setShowLanguage] = React.useState(true);
     const {darkMode} = React.useContext(KoenigComposerContext);
+    const [editor] = useLexicalComposerContext();
 
     // show the language input when the mouse moves
     React.useEffect(() => {
@@ -28,6 +32,18 @@ export function CodeEditor({code, language, updateCode, updateLanguage}) {
             window.removeEventListener('mousemove', onMouseMove);
         };
     }, []);
+
+    React.useEffect(() => {
+        return mergeRegister(
+            editor.registerCommand(
+                UNDO_COMMAND, () => {
+                    // let the code editor handle undo command
+                    return true;
+                },
+                COMMAND_PRIORITY_LOW
+            )
+        );
+    }, [editor]);
 
     const onChange = React.useCallback((value) => {
         setShowLanguage(false); // hide language input whenever the user types in the editor
@@ -124,7 +140,7 @@ export function CodeEditor({code, language, updateCode, updateLanguage}) {
         '&.cm-editor .cm-cursor, &.cm-editor .cm-dropCursor': {
             borderLeft: '1.2px solid white'
         }
-        
+
     });
 
     const editorLightHighlightStyle = HighlightStyle.define([

--- a/packages/koenig-lexical/src/components/ui/cards/HtmlCard/HtmlEditor.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/HtmlCard/HtmlEditor.jsx
@@ -1,14 +1,31 @@
 import CodeMirror from '@uiw/react-codemirror';
 import React from 'react';
+import {COMMAND_PRIORITY_LOW, UNDO_COMMAND} from 'lexical';
 import {EditorView, keymap, lineNumbers} from '@codemirror/view';
 import {HighlightStyle, syntaxHighlighting} from '@codemirror/language';
 import {closeBrackets, closeBracketsKeymap} from '@codemirror/autocomplete';
 import {html as langHtml} from '@codemirror/lang-html';
+import {mergeRegister} from '@lexical/utils';
 import {minimalSetup} from '@uiw/codemirror-extensions-basic-setup';
 import {standardKeymap} from '@codemirror/commands';
 import {tags as t} from '@lezer/highlight';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext.js';
 
 export default function HtmlEditor({darkMode, html, updateHtml}) {
+    const [editor] = useLexicalComposerContext();
+
+    React.useEffect(() => {
+        return mergeRegister(
+            editor.registerCommand(
+                UNDO_COMMAND, () => {
+                    // let the html editor handle undo command
+                    return true;
+                },
+                COMMAND_PRIORITY_LOW
+            )
+        );
+    }, [editor]);
+
     const onChange = React.useCallback((value) => {
         updateHtml(value);
     }, [updateHtml]);
@@ -99,7 +116,7 @@ export default function HtmlEditor({darkMode, html, updateHtml}) {
         '&.cm-editor .cm-cursor, &.cm-editor .cm-dropCursor': {
             borderLeft: '1.2px solid white'
         }
-        
+
     });
 
     const editorLightHighlightStyle = HighlightStyle.define([
@@ -133,7 +150,7 @@ export default function HtmlEditor({darkMode, html, updateHtml}) {
 
     const editorCSS = darkMode ? editorDarkCSS : editorLightCSS;
     const editorHighlightStyle = darkMode ? editorDarkHighlightStyle : editorLightHighlightStyle;
-    
+
     // Base extensions for the CodeMirror editor
     const extensions = [
         EditorView.lineWrapping, // wraps lines that exceed the viewport width

--- a/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
@@ -77,7 +77,7 @@ test.describe('Code Block card', async () => {
                 </div>
             `, {ignoreCardContents: true});
         });
-        
+
         test('renders with ```lang + space', async function () {
             await focusEditor(page);
             await page.keyboard.type('```javascript ');
@@ -151,6 +151,54 @@ test.describe('Code Block card', async () => {
         await page.keyboard.type('My caption');
         await page.keyboard.press('Enter');
         await page.keyboard.press('Backspace');
+        await page.keyboard.press('Backspace');
+        await page.keyboard.press(`${ctrlOrCmd}+z`);
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="codeblock">
+                    <div>
+                        <pre><code>Here are some words</code></pre>
+                        <div><span>javascript</span></div>
+                    </div>
+                    <figcaption>
+                        <div>
+                            <div>
+                                <div data-kg="editor">
+                                    <div
+                                        contenteditable="true"
+                                        spellcheck="true"
+                                        data-lexical-editor="true"
+                                        role="textbox">
+                                        <p dir="ltr">
+                                            <span data-lexical-text="true">My caption</span>
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </figcaption>
+                    <div data-kg-card-toolbar="button"></div>
+                </div>
+            </div>
+        `, {ignoreCardContents: false, ignoreCardToolbarContents: true});
+    });
+
+    test('can undo/redo content in code editor', async function () {
+        await focusEditor(page);
+        await page.keyboard.type('```javascript ');
+        await page.waitForSelector('[data-kg-card="codeblock"] .cm-editor');
+
+        // Types slower. Codemirror can be slow and needs some time to place the cursor after entering text.
+        await page.keyboard.type('Here are some words', {delay: 500});
+        await expect(page.getByText('Here are some words')).toBeVisible();
+        await page.keyboard.press('Backspace');
+        await expect(page.getByText('Here are some word')).toBeVisible();
+        await page.keyboard.press(`${ctrlOrCmd}+z`);
+        await expect(page.getByText('Here are some words')).toBeVisible();
+        await page.keyboard.press('Escape');
+        await page.click('[data-testid="codeblock-caption"]');
+        await page.keyboard.type('My caption');
         await page.keyboard.press('Backspace');
         await page.keyboard.press(`${ctrlOrCmd}+z`);
 

--- a/packages/koenig-lexical/test/e2e/cards/html-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/html-card.test.js
@@ -1,4 +1,4 @@
-import {assertHTML, createSnippet, focusEditor, html, initialize} from '../../utils/e2e';
+import {assertHTML, createSnippet, ctrlOrCmd, focusEditor, html, initialize} from '../../utils/e2e';
 import {expect, test} from '@playwright/test';
 
 test.describe('Html card', async () => {
@@ -89,5 +89,26 @@ test.describe('Html card', async () => {
         await page.waitForSelector('[data-kg-cardmenu-selected="true"]');
         await page.keyboard.press('Enter');
         await expect(await page.locator('[data-kg-card="html"]')).toHaveCount(2);
+    });
+
+    test('can undo/redo content in html editor', async function () {
+        await focusEditor(page);
+        // insert new card
+        await page.keyboard.type('/html');
+        await page.waitForSelector('[data-kg-card-menu-item="HTML"][data-kg-cardmenu-selected="true"]');
+        await page.keyboard.press('Enter');
+        await expect(await page.locator('[data-kg-card="html"][data-kg-card-editing="true"]')).toBeVisible();
+        // waiting for html editor
+        await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
+
+        // Types slower. Codemirror can be slow and needs some time to place the cursor after entering text.
+        await page.keyboard.type('Here are some words', {delay: 500});
+        await expect(page.getByText('Here are some words')).toBeVisible();
+        await page.keyboard.press('Backspace');
+        await expect(page.getByText('Here are some word')).toBeVisible();
+        await page.keyboard.press(`${ctrlOrCmd()}+z`);
+        await expect(page.getByText('Here are some words')).toBeVisible();
+        await page.keyboard.press('Escape');
+        await expect(page.getByText('Here are some words')).toBeVisible();
     });
 });

--- a/packages/koenig-lexical/test/e2e/cards/markdown-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/markdown-card.test.js
@@ -697,4 +697,22 @@ test.describe('Markdown card', async () => {
         await page.keyboard.press('Enter');
         await expect(await page.locator('[data-kg-card="markdown"]')).toHaveCount(2);
     });
+
+    test('can undo/redo content in markdown editor', async function () {
+        await focusEditor(page);
+        // insert new card
+        await insertCard(page, {cardName: 'markdown'});
+
+        // fill card
+        await expect(await page.locator('[data-kg-card="markdown"]')).toBeVisible();
+        await page.click('[data-kg-card="markdown"]');
+        await page.keyboard.type('Here are some words');
+        await expect(page.getByText('Here are some words')).toBeVisible();
+        await page.keyboard.press('Backspace');
+        await expect(page.getByText('Here are some word')).toBeVisible();
+        await page.keyboard.press(`${ctrlOrCmd}+z`);
+        await expect(page.getByText('Here are some words')).toBeVisible();
+        await page.keyboard.press('Escape');
+        await expect(page.getByText('Here are some words')).toBeVisible();
+    });
 });


### PR DESCRIPTION
refs TryGhost/Team#3486
- Disabled handling undo command by lexical to let the codemirror editor handle this.