### PR TITLE
:bug: Fixed up down arrow keys in caption editors

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigCaptionEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCaptionEditor.jsx
@@ -1,6 +1,6 @@
 import CardContext from '../context/CardContext.jsx';
 import React, {useCallback, useContext} from 'react';
-import {BLUR_COMMAND, COMMAND_PRIORITY_LOW, FOCUS_COMMAND, KEY_ENTER_COMMAND} from 'lexical';
+import {BLUR_COMMAND, COMMAND_PRIORITY_HIGH, COMMAND_PRIORITY_LOW, FOCUS_COMMAND, KEY_ARROW_DOWN_COMMAND, KEY_ARROW_UP_COMMAND, KEY_ENTER_COMMAND} from 'lexical';
 import {KoenigComposableEditor, KoenigNestedComposer, MINIMAL_NODES, MINIMAL_TRANSFORMERS, RestrictContentPlugin} from '../index.js';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
@@ -80,6 +80,26 @@ function CaptionPlugin({parentEditor}) {
                         return true;
                     },
                     COMMAND_PRIORITY_LOW
+                ),
+                editor.registerCommand(
+                    KEY_ARROW_DOWN_COMMAND,
+                    (event) => {
+                        // handle moving focus at the parent editor level (select next card)
+                        event._fromCaptionEditor = true;
+                        editor._parentEditor.dispatchCommand(KEY_ARROW_DOWN_COMMAND, event);
+                        return true;
+                    },
+                    COMMAND_PRIORITY_HIGH
+                ),
+                editor.registerCommand(
+                    KEY_ARROW_UP_COMMAND,
+                    (event) => {
+                        // handle moving focus at the parent editor level (select next card)
+                        event._fromCaptionEditor = true;
+                        editor._parentEditor.dispatchCommand(KEY_ARROW_UP_COMMAND, event);
+                        return true;
+                    },
+                    COMMAND_PRIORITY_HIGH
                 )
             );
         },

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -409,7 +409,12 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                         return false;
                     }
 
-                    // avoid processing card behaviours when an inner element has focus
+                    // if we're in a nested editor, we need to move selection back to the parent editor
+                    if (event._fromCaptionEditor) {
+                        $selectCard(editor, selectedCardKey);
+                    }
+
+                    // avoid processing card behaviours when an inner element has focus (e.g. nested editors)
                     if (document.activeElement !== editor.getRootElement()) {
                         return true;
                     }
@@ -488,7 +493,12 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                         return false;
                     }
 
-                    // avoid processing card behaviours when an inner element has focus
+                    // if we're in a nested editor, we need to move selection back to the parent editor
+                    if (event._fromCaptionEditor) {
+                        $selectCard(editor, selectedCardKey);
+                    }
+
+                    // avoid processing card behaviours when an inner element has focus (e.g. nested editors)
                     if (document.activeElement !== editor.getRootElement()) {
                         return true;
                     }


### PR DESCRIPTION
closes TryGhost/Team#3492
- need to move focus back to parent editor before processing key actions