### PR TITLE
:bug: Fixed copying in CodeMirror-based cards

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/CodeBlockCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CodeBlockCard.jsx
@@ -2,7 +2,7 @@ import CodeMirror from '@uiw/react-codemirror';
 import KoenigComposerContext from '../../../context/KoenigComposerContext';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {COMMAND_PRIORITY_LOW, UNDO_COMMAND} from 'lexical';
+import {COMMAND_PRIORITY_CRITICAL, COMMAND_PRIORITY_LOW, COPY_COMMAND, UNDO_COMMAND} from 'lexical';
 import {CardCaptionEditor} from '../CardCaptionEditor';
 import {EditorView, keymap, lineNumbers} from '@codemirror/view';
 import {HighlightStyle, syntaxHighlighting} from '@codemirror/language';
@@ -41,6 +41,13 @@ export function CodeEditor({code, language, updateCode, updateLanguage}) {
                     return true;
                 },
                 COMMAND_PRIORITY_LOW
+            ),
+            editor.registerCommand(
+                COPY_COMMAND, (event) => {
+                    // let the code editor handle copy command
+                    return true;
+                },
+                COMMAND_PRIORITY_CRITICAL // mobiledoc copy plugin uses HIGH and otherwise would intercept the copy
             )
         );
     }, [editor]);

--- a/packages/koenig-lexical/src/components/ui/cards/HtmlCard/HtmlEditor.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/HtmlCard/HtmlEditor.jsx
@@ -1,6 +1,6 @@
 import CodeMirror from '@uiw/react-codemirror';
 import React from 'react';
-import {COMMAND_PRIORITY_LOW, UNDO_COMMAND} from 'lexical';
+import {COMMAND_PRIORITY_CRITICAL, COMMAND_PRIORITY_LOW, COPY_COMMAND, UNDO_COMMAND} from 'lexical';
 import {EditorView, keymap, lineNumbers} from '@codemirror/view';
 import {HighlightStyle, syntaxHighlighting} from '@codemirror/language';
 import {closeBrackets, closeBracketsKeymap} from '@codemirror/autocomplete';
@@ -22,6 +22,13 @@ export default function HtmlEditor({darkMode, html, updateHtml}) {
                     return true;
                 },
                 COMMAND_PRIORITY_LOW
+            ),
+            editor.registerCommand(
+                COPY_COMMAND, () => {
+                    // let the html editor handle copy command
+                    return true;
+                },
+                COMMAND_PRIORITY_CRITICAL // mobiledoc copy plugin uses HIGH and otherwise would intercept the copy
             )
         );
     }, [editor]);

--- a/packages/koenig-lexical/src/components/ui/cards/MarkdownCard/MarkdownEditor.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/MarkdownCard/MarkdownEditor.jsx
@@ -6,7 +6,7 @@ import UnsplashModal from '../../UnsplashModal';
 
 import ctrlOrCmd from '../../../../utils/ctrlOrCmd';
 import useMarkdownImageUploader from './useMarkdownImageUploader';
-import {COMMAND_PRIORITY_LOW, UNDO_COMMAND} from 'lexical';
+import {COMMAND_PRIORITY_CRITICAL, COMMAND_PRIORITY_LOW, COPY_COMMAND, UNDO_COMMAND} from 'lexical';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext.js';
 
@@ -48,6 +48,13 @@ export default function MarkdownEditor({
                     return true;
                 },
                 COMMAND_PRIORITY_LOW
+            ),
+            editor.registerCommand(
+                COPY_COMMAND, () => {
+                    // let the markdown editor handle copy command
+                    return true;
+                },
+                COMMAND_PRIORITY_CRITICAL // mobiledoc copy plugin uses HIGH and otherwise would intercept the copy
             )
         );
     }, [editor]);


### PR DESCRIPTION
closes TryGhost/Team#3496, closes TryGhost/Team#3488
- copy was being handled by the editor, causing focus loss
- copy was being intercepted by mobiledoc copy plugin