### PR TITLE
🐛 Fixed signup card swap toggle not keeping state

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
@@ -376,8 +376,8 @@ export function SignupCard({alignment,
                     {
                         layout === 'split' && (
                             <ToggleSetting
-                                checked={isSwapped}
                                 dataTestId='signup-swapped'
+                                isChecked={isSwapped}
                                 label='Flip Layout'
                                 onChange={toggleSwapped}
                             />


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C04TMVA1D7A/p1687504604701429

- the prop passed to the ToggleSetting was `checked` instead of `isChecked`, which caused the state not to be passed to the component.