### PR TITLE
Added blur handling to html and code cards

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/CodeBlockCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CodeBlockCard.jsx
@@ -15,7 +15,7 @@ import {standardKeymap} from '@codemirror/commands';
 import {tags as t} from '@lezer/highlight';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext.js';
 
-export function CodeEditor({code, language, updateCode, updateLanguage}) {
+export function CodeEditor({code, language, updateCode, updateLanguage, onBlur}) {
     const [showLanguage, setShowLanguage] = React.useState(true);
     const {darkMode} = React.useContext(KoenigComposerContext);
     const [editor] = useLexicalComposerContext();
@@ -211,6 +211,7 @@ export function CodeEditor({code, language, updateCode, updateLanguage}) {
                 basicSetup={false} // basic setup includes unnecessary extensions
                 extensions={extensions}
                 value={code}
+                onBlur={onBlur}
                 onChange={onChange}
             />
             <input
@@ -244,7 +245,7 @@ export function CodeBlock({code, darkMode, language}) {
     );
 }
 
-export function CodeBlockCard({captionEditor, captionEditorInitialState, code, darkMode, isEditing, isSelected, language, updateCode, updateLanguage}) {
+export function CodeBlockCard({captionEditor, captionEditorInitialState, code, darkMode, isEditing, isSelected, language, updateCode, updateLanguage, onBlur}) {
     if (isEditing) {
         return (
             <CodeEditor
@@ -253,6 +254,7 @@ export function CodeBlockCard({captionEditor, captionEditorInitialState, code, d
                 language={language}
                 updateCode={updateCode}
                 updateLanguage={updateLanguage}
+                onBlur={onBlur}
             />
         );
     } else {
@@ -275,7 +277,8 @@ CodeEditor.propTypes = {
     code: PropTypes.string,
     language: PropTypes.string,
     updateCode: PropTypes.func,
-    updateLanguage: PropTypes.func
+    updateLanguage: PropTypes.func,
+    onBlur: PropTypes.func
 };
 
 CodeBlock.propTypes = {
@@ -293,5 +296,6 @@ CodeBlockCard.propTypes = {
     isEditing: PropTypes.bool,
     isSelected: PropTypes.bool,
     updateCode: PropTypes.func,
-    updateLanguage: PropTypes.func
+    updateLanguage: PropTypes.func,
+    onBlur: PropTypes.func
 };

--- a/packages/koenig-lexical/src/components/ui/cards/HtmlCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/HtmlCard.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {sanitizeHtml} from '../../../utils/sanitize-html';
 
-export function HtmlCard({html, updateHtml, isEditing, darkMode}) {
+export function HtmlCard({html, updateHtml, isEditing, darkMode, onBlur}) {
     return (
         <>
             {isEditing
@@ -13,6 +13,7 @@ export function HtmlCard({html, updateHtml, isEditing, darkMode}) {
                         darkMode={darkMode}
                         html={html}
                         updateHtml={updateHtml}
+                        onBlur={onBlur}
                     />
                 )
                 : <div><HtmlDisplay html={html} /><div className="absolute inset-0 z-50 mt-0"></div></div>
@@ -35,5 +36,6 @@ HtmlCard.propTypes = {
     html: PropTypes.string,
     updateHtml: PropTypes.func,
     isEditing: PropTypes.bool,
-    darkMode: PropTypes.bool
+    darkMode: PropTypes.bool,
+    onBlur: PropTypes.func
 };

--- a/packages/koenig-lexical/src/components/ui/cards/HtmlCard/HtmlEditor.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/HtmlCard/HtmlEditor.jsx
@@ -11,7 +11,7 @@ import {standardKeymap} from '@codemirror/commands';
 import {tags as t} from '@lezer/highlight';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext.js';
 
-export default function HtmlEditor({darkMode, html, updateHtml}) {
+export default function HtmlEditor({darkMode, html, updateHtml, onBlur}) {
     const [editor] = useLexicalComposerContext();
 
     React.useEffect(() => {
@@ -178,6 +178,7 @@ export default function HtmlEditor({darkMode, html, updateHtml}) {
                 basicSetup={false} // basic setup includes unnecessary extensions
                 extensions={extensions}
                 value={html}
+                onBlur={onBlur}
                 onChange={onChange}
             />
         </div>

--- a/packages/koenig-lexical/src/nodes/CodeBlockNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CodeBlockNodeComponent.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {$getNodeByKey} from 'lexical';
 import {ActionToolbar} from '../components/ui/ActionToolbar.jsx';
 import {CodeBlockCard} from '../components/ui/cards/CodeBlockCard';
+import {DESELECT_CARD_COMMAND} from '../plugins/KoenigBehaviourPlugin';
 import {SnippetActionToolbar} from '../components/ui/SnippetActionToolbar.jsx';
 import {ToolbarMenu, ToolbarMenuItem, ToolbarMenuSeparator} from '../components/ui/ToolbarMenu.jsx';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
@@ -34,6 +35,14 @@ export function CodeBlockNodeComponent({nodeKey, captionEditor, captionEditorIni
         setEditing(true);
     };
 
+    const onBlur = (event) => {
+        // deselect if clicking outside the card
+        //  this check results in deferring to the Cmd+Enter handling in KoenigBehaviourPlugin when the cause of the blur
+        if (event?.relatedTarget?.className !== 'kg-prose') {
+            editor.dispatchCommand(DESELECT_CARD_COMMAND, {cardKey: nodeKey});
+        }
+    };
+
     return (
         <>
             <CodeBlockCard
@@ -48,6 +57,7 @@ export function CodeBlockNodeComponent({nodeKey, captionEditor, captionEditorIni
                 nodeKey={nodeKey}
                 updateCode={updateCode}
                 updateLanguage={updateLanguage}
+                onBlur={onBlur}
             />
             <ActionToolbar
                 data-kg-card-toolbar="button"

--- a/packages/koenig-lexical/src/nodes/HtmlNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/HtmlNodeComponent.jsx
@@ -3,7 +3,7 @@ import KoenigComposerContext from '../context/KoenigComposerContext.jsx';
 import React from 'react';
 import {$getNodeByKey} from 'lexical';
 import {ActionToolbar} from '../components/ui/ActionToolbar.jsx';
-import {EDIT_CARD_COMMAND} from '../plugins/KoenigBehaviourPlugin.jsx';
+import {DESELECT_CARD_COMMAND, EDIT_CARD_COMMAND} from '../plugins/KoenigBehaviourPlugin.jsx';
 import {HtmlCard} from '../components/ui/cards/HtmlCard';
 import {SnippetActionToolbar} from '../components/ui/SnippetActionToolbar.jsx';
 import {ToolbarMenu, ToolbarMenuItem, ToolbarMenuSeparator} from '../components/ui/ToolbarMenu.jsx';
@@ -14,16 +14,26 @@ export function HtmlNodeComponent({nodeKey, html}) {
     const cardContext = React.useContext(CardContext);
     const {cardConfig, darkMode} = React.useContext(KoenigComposerContext);
     const [showSnippetToolbar, setShowSnippetToolbar] = React.useState(false);
+
     const updateHtml = (value) => {
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
             node.html = value;
         });
     };
+
     const handleToolbarEdit = (event) => {
         event.preventDefault();
         event.stopPropagation();
         editor.dispatchCommand(EDIT_CARD_COMMAND, {cardKey: nodeKey, focusEditor: false});
+    };
+
+    const onBlur = (event) => {
+        // deselect if clicking outside the card
+        //  this check results in deferring to the Cmd+Enter handling in KoenigBehaviourPlugin when the cause of the blur
+        if (event?.relatedTarget?.className !== 'kg-prose') {
+            editor.dispatchCommand(DESELECT_CARD_COMMAND, {cardKey: nodeKey});
+        }
     };
 
     return (
@@ -35,6 +45,7 @@ export function HtmlNodeComponent({nodeKey, html}) {
                 nodeKey={nodeKey}
                 unsplashConf={cardConfig.unsplash}
                 updateHtml={updateHtml}
+                onBlur={onBlur}
             />
 
             <ActionToolbar


### PR DESCRIPTION
refs TryGhost/Team#3410
- CodeMirror component has an onBlur prop we can leverage
- simpleMDE does not have the same pattern, will need different handling