### PR TITLE
:bug: Fix copy outside editor

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/CodeBlockCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CodeBlockCard.jsx
@@ -2,7 +2,7 @@ import CodeMirror from '@uiw/react-codemirror';
 import KoenigComposerContext from '../../../context/KoenigComposerContext';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {COMMAND_PRIORITY_CRITICAL, COMMAND_PRIORITY_LOW, COPY_COMMAND, UNDO_COMMAND} from 'lexical';
+import {COMMAND_PRIORITY_LOW, UNDO_COMMAND} from 'lexical';
 import {CardCaptionEditor} from '../CardCaptionEditor';
 import {EditorView, keymap, lineNumbers} from '@codemirror/view';
 import {HighlightStyle, syntaxHighlighting} from '@codemirror/language';
@@ -41,13 +41,6 @@ export function CodeEditor({code, language, updateCode, updateLanguage, onBlur})
                     return true;
                 },
                 COMMAND_PRIORITY_LOW
-            ),
-            editor.registerCommand(
-                COPY_COMMAND, (event) => {
-                    // let the code editor handle copy command
-                    return true;
-                },
-                COMMAND_PRIORITY_CRITICAL // mobiledoc copy plugin uses HIGH and otherwise would intercept the copy
             )
         );
     }, [editor]);

--- a/packages/koenig-lexical/src/components/ui/cards/HtmlCard/HtmlEditor.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/HtmlCard/HtmlEditor.jsx
@@ -1,6 +1,6 @@
 import CodeMirror from '@uiw/react-codemirror';
 import React from 'react';
-import {COMMAND_PRIORITY_CRITICAL, COMMAND_PRIORITY_LOW, COPY_COMMAND, UNDO_COMMAND} from 'lexical';
+import {COMMAND_PRIORITY_LOW, UNDO_COMMAND} from 'lexical';
 import {EditorView, keymap, lineNumbers} from '@codemirror/view';
 import {HighlightStyle, syntaxHighlighting} from '@codemirror/language';
 import {closeBrackets, closeBracketsKeymap} from '@codemirror/autocomplete';
@@ -22,13 +22,6 @@ export default function HtmlEditor({darkMode, html, updateHtml, onBlur}) {
                     return true;
                 },
                 COMMAND_PRIORITY_LOW
-            ),
-            editor.registerCommand(
-                COPY_COMMAND, () => {
-                    // let the html editor handle copy command
-                    return true;
-                },
-                COMMAND_PRIORITY_CRITICAL // mobiledoc copy plugin uses HIGH and otherwise would intercept the copy
             )
         );
     }, [editor]);

--- a/packages/koenig-lexical/src/components/ui/cards/MarkdownCard/MarkdownEditor.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/MarkdownCard/MarkdownEditor.jsx
@@ -6,7 +6,7 @@ import UnsplashModal from '../../UnsplashModal';
 
 import ctrlOrCmd from '../../../../utils/ctrlOrCmd';
 import useMarkdownImageUploader from './useMarkdownImageUploader';
-import {COMMAND_PRIORITY_CRITICAL, COMMAND_PRIORITY_LOW, COPY_COMMAND, UNDO_COMMAND} from 'lexical';
+import {COMMAND_PRIORITY_LOW, UNDO_COMMAND} from 'lexical';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext.js';
 
@@ -48,13 +48,6 @@ export default function MarkdownEditor({
                     return true;
                 },
                 COMMAND_PRIORITY_LOW
-            ),
-            editor.registerCommand(
-                COPY_COMMAND, () => {
-                    // let the markdown editor handle copy command
-                    return true;
-                },
-                COMMAND_PRIORITY_CRITICAL // mobiledoc copy plugin uses HIGH and otherwise would intercept the copy
             )
         );
     }, [editor]);

--- a/packages/koenig-lexical/src/plugins/MobiledocCopyPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/MobiledocCopyPlugin.jsx
@@ -16,6 +16,11 @@ async function copyToClipboardWithMobiledoc(editor, event) {
     if (!(event instanceof ClipboardEvent)) { 
         return;
     }
+    // avoid processing card behaviours when an inner element has focus (e.g. nested editors)
+    if (document.activeElement !== editor.getRootElement()) {
+        console.log(`stopped copy to mobiledoc because active element is not the editor`)
+        return true;
+    }
     await copyToClipboard(editor, event);
     // On copy/paste Lexical only stores an array of nodes but our converters expect
     // a full document with a root node.

--- a/packages/koenig-lexical/src/plugins/MobiledocCopyPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/MobiledocCopyPlugin.jsx
@@ -18,7 +18,6 @@ async function copyToClipboardWithMobiledoc(editor, event) {
     }
     // avoid processing card behaviours when an inner element has focus (e.g. nested editors)
     if (document.activeElement !== editor.getRootElement()) {
-        console.log(`stopped copy to mobiledoc because active element is not the editor`)
         return true;
     }
     await copyToClipboard(editor, event);


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/3461
-removed copy with mobiledoc when not on editor
-we only need md conversion when selecting nodes
-could back out specific plugin copy behavior