### PR TITLE
Reverted codemirror card copy changes

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/CodeBlockCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CodeBlockCard.jsx
@@ -2,7 +2,7 @@ import CodeMirror from '@uiw/react-codemirror';
 import KoenigComposerContext from '../../../context/KoenigComposerContext';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {COMMAND_PRIORITY_LOW, UNDO_COMMAND} from 'lexical';
+import {COMMAND_PRIORITY_CRITICAL, COMMAND_PRIORITY_LOW, COPY_COMMAND, UNDO_COMMAND} from 'lexical';
 import {CardCaptionEditor} from '../CardCaptionEditor';
 import {EditorView, keymap, lineNumbers} from '@codemirror/view';
 import {HighlightStyle, syntaxHighlighting} from '@codemirror/language';
@@ -41,6 +41,13 @@ export function CodeEditor({code, language, updateCode, updateLanguage, onBlur})
                     return true;
                 },
                 COMMAND_PRIORITY_LOW
+            ),
+            editor.registerCommand(
+                COPY_COMMAND, () => {
+                    // let the code editor handle the copy command
+                    return true;
+                },
+                COMMAND_PRIORITY_CRITICAL // critical to supersede the mobiledoc copy plugin
             )
         );
     }, [editor]);

--- a/packages/koenig-lexical/src/components/ui/cards/HtmlCard/HtmlEditor.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/HtmlCard/HtmlEditor.jsx
@@ -1,6 +1,6 @@
 import CodeMirror from '@uiw/react-codemirror';
 import React from 'react';
-import {COMMAND_PRIORITY_LOW, UNDO_COMMAND} from 'lexical';
+import {COMMAND_PRIORITY_CRITICAL, COMMAND_PRIORITY_LOW, COPY_COMMAND, UNDO_COMMAND} from 'lexical';
 import {EditorView, keymap, lineNumbers} from '@codemirror/view';
 import {HighlightStyle, syntaxHighlighting} from '@codemirror/language';
 import {closeBrackets, closeBracketsKeymap} from '@codemirror/autocomplete';
@@ -22,6 +22,13 @@ export default function HtmlEditor({darkMode, html, updateHtml, onBlur}) {
                     return true;
                 },
                 COMMAND_PRIORITY_LOW
+            ),
+            editor.registerCommand(
+                COPY_COMMAND, () => {
+                    // let the html editor handle the copy command
+                    return true;
+                },
+                COMMAND_PRIORITY_CRITICAL // critical to supersede the mobiledoc copy plugin
             )
         );
     }, [editor]);

--- a/packages/koenig-lexical/src/components/ui/cards/MarkdownCard/MarkdownEditor.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/MarkdownCard/MarkdownEditor.jsx
@@ -6,7 +6,7 @@ import UnsplashModal from '../../UnsplashModal';
 
 import ctrlOrCmd from '../../../../utils/ctrlOrCmd';
 import useMarkdownImageUploader from './useMarkdownImageUploader';
-import {COMMAND_PRIORITY_LOW, UNDO_COMMAND} from 'lexical';
+import {COMMAND_PRIORITY_CRITICAL, COMMAND_PRIORITY_LOW, COPY_COMMAND, UNDO_COMMAND} from 'lexical';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext.js';
 
@@ -48,6 +48,13 @@ export default function MarkdownEditor({
                     return true;
                 },
                 COMMAND_PRIORITY_LOW
+            ),
+            editor.registerCommand(
+                COPY_COMMAND, () => {
+                    // let the markdown editor handle copy
+                    return true;
+                },
+                COMMAND_PRIORITY_CRITICAL // needs to be critical to override the mobiledoc copy plugin
             )
         );
     }, [editor]);

--- a/packages/koenig-lexical/src/plugins/MobiledocCopyPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/MobiledocCopyPlugin.jsx
@@ -18,7 +18,7 @@ async function copyToClipboardWithMobiledoc(editor, event) {
     }
     // avoid processing card behaviours when an inner element has focus (e.g. nested editors)
     if (document.activeElement !== editor.getRootElement()) {
-        return true;
+        return;
     }
     await copyToClipboard(editor, event);
     // On copy/paste Lexical only stores an array of nodes but our converters expect


### PR DESCRIPTION
closes TryGhost/Team#3496
-alternative approach didn't work in all cases
-cmd a was needed to register clipboardevents
-not sure why keyboard events broke codemirror focus