### PR TITLE
🐛 Fixed email breaking when signup card is added

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/signup/SignupRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/SignupRenderer.js
@@ -90,9 +90,11 @@ export function renderSignupCardToDOM(dataset, options = {}) {
         swapped: dataset.__swapped
     };
 
-    const htmlString = options.target === 'email'
-        ? ''
-        : cardTemplate(node);
+    if (options.target === 'email') {
+        return {element: document.createElement('div')}; // Return an empty element since we don't want to render the card in email
+    }
+
+    const htmlString = cardTemplate(node);
 
     const element = document.createElement('div');
     element.innerHTML = htmlString?.trim();

--- a/packages/kg-default-nodes/test/nodes/signup.test.js
+++ b/packages/kg-default-nodes/test/nodes/signup.test.js
@@ -394,6 +394,13 @@ describe('SignupNode', function () {
                 </div>
             `);
         }));
+
+        it('returns empty element if target is email', editorTest(function () {
+            exportOptions.target = 'email';
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.equal('<div></div>');
+        }));
     });
     describe('importDOM', function () {
         it('parses a signup card', editorTest(function () {


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C04TMVA1D7A/p1687987311455289

The html renderer returned an empty string when the target was added. 
This caused the email renderer to received an undefined node, causing it crash.
This fix creates an empty html element that are passed to the renderer.