### PR TITLE
Added launch config for debugging koenig-lexical

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,25 @@
                 "dev"
             ],
             "cwd": "${workspaceFolder}/packages/koenig-lexical/"
+        },
+        {
+          "name": "Run Lexical",
+          "type": "node",
+          "request": "launch",
+          "skipFiles": [
+            "${workspaceFolder}/node_modules/**/*.js"
+          ],
+          "cwd": "${workspaceFolder}/packages/koenig-lexical/",
+          "runtimeExecutable": "yarn",
+          "runtimeArgs": [
+            "dev"
+          ],
+          "serverReadyAction": {
+            "pattern": "Local:   http://localhost:(\\d+)/",
+            "uriFormat": "http://localhost:%s",
+            "action": "debugWithChrome",
+            "webRoot": "${workspaceFolder}/packages/koenig-lexical/"
+          }
         }
     ]
 }


### PR DESCRIPTION
In order for VS Code to be used as the debugger for browser applications we need to have the launch config launch the browser, this can be done by changing the `type` to "chrome" - but that approach does not work well with running the script in the background. We could add a prelaunchTask, but that task needs to exit before launching, and our dev script doesn't exit as we watch for changes.

Sooo, the approach here is to run a "node" launch config, which starts our watch task, and then the `serverReadyAction` config will launch the browser for us, unfortuantely this config can only read the output of the debug console, and not the integrated terminal, which means we can't output the logs to the integrated terminal and have a clean debug console for evaluating expressions.