### PR TITLE
🐛 Added sanitation to callout renderer.

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/callout/CalloutRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/callout/CalloutRenderer.js
@@ -19,7 +19,7 @@ export function renderCalloutNode(node, options = {}) {
     textElement.classList.add('kg-callout-text');
     
     const dom = new JSDOM(node.calloutText);
-    const allowedTags = ['A', 'STRONG', 'EM'];
+    const allowedTags = ['A', 'STRONG', 'EM', 'B', 'I'];
     
     const body = dom.window.document.body;
     cleanDOM(body, allowedTags);

--- a/packages/kg-default-nodes/lib/nodes/callout/CalloutRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/callout/CalloutRenderer.js
@@ -1,3 +1,4 @@
+import {JSDOM} from 'jsdom';
 import {addCreateDocumentOption} from '../../utils/add-create-document-option';
 
 export function renderCalloutNode(node, options = {}) {
@@ -16,8 +17,30 @@ export function renderCalloutNode(node, options = {}) {
 
     const textElement = document.createElement('div');
     textElement.classList.add('kg-callout-text');
-    textElement.innerHTML = node.calloutText;
+    
+    const dom = new JSDOM(node.calloutText);
+    const allowedTags = ['A', 'STRONG', 'EM'];
+    
+    const body = dom.window.document.body;
+    cleanDOM(body, allowedTags);
+    
+    textElement.innerHTML = body.innerHTML;
     element.appendChild(textElement);
 
     return {element};
+}
+
+function cleanDOM(node, allowedTags) {
+    for (let i = 0; i < node.childNodes.length; i++) {
+        let child = node.childNodes[i];
+        if (child.nodeType === 1 && !allowedTags.includes(child.tagName)) {
+            while (child.firstChild) {
+                node.insertBefore(child.firstChild, child);
+            }
+            node.removeChild(child);
+            i -= 1;
+        } else {
+            cleanDOM(child, allowedTags);
+        }
+    }
 }

--- a/packages/kg-default-nodes/test/nodes/callout.test.js
+++ b/packages/kg-default-nodes/test/nodes/callout.test.js
@@ -125,8 +125,9 @@ describe('CalloutNode', function () {
                 <div class="kg-card kg-callout-card kg-callout-card-blue">
                     <div class="kg-callout-emoji">💡</div>
                     <div class="kg-callout-text">
-                        <strong>Hello!</strong>Check<em class="italic">this</em
-                        > <a href="https://ghost.org" rel="noopener">out</a>.
+                        <b><strong>Hello!</strong></b
+                        >Check<i><em class="italic">this</em></i
+                        ><a href="https://ghost.org" rel="noopener">out</a>.
                     </div>
                 </div>
                 `);
@@ -143,7 +144,8 @@ describe('CalloutNode', function () {
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-callout-card kg-callout-card-blue">
                     <div class="kg-callout-text">
-                        <strong>Hello!</strong>Check<em class="italic">this</em
+                        <b><strong>Hello!</strong></b
+                        >Check<i><em class="italic">this</em></i
                         ><a href="https://ghost.org" rel="noopener">out</a>.
                     </div>
                 </div>

--- a/packages/kg-default-nodes/test/nodes/callout.test.js
+++ b/packages/kg-default-nodes/test/nodes/callout.test.js
@@ -31,7 +31,7 @@ describe('CalloutNode', function () {
             nodes: editorNodes
         });
         dataset = {
-            calloutText: 'This is a callout',
+            calloutText: '<p dir="ltr"><b><strong>Hello!</strong></b><span> Check </span><i><em class="italic">this</em></i> <a href="https://ghost.org" rel="noopener"><span>out</span></a><span>.</span></p>',
             calloutEmoji: '💡',
             backgroundColor: 'blue'
         };
@@ -124,14 +124,17 @@ describe('CalloutNode', function () {
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-callout-card kg-callout-card-blue">
                     <div class="kg-callout-emoji">💡</div>
-                    <div class="kg-callout-text">This is a callout</div>
+                    <div class="kg-callout-text">
+                        <strong>Hello!</strong>Check<em class="italic">this</em
+                        > <a href="https://ghost.org" rel="noopener">out</a>.
+                    </div>
                 </div>
                 `);
         }));
 
         it('can render to HTML with no emoji', editorTest(function () {
             const dataset2 = {
-                calloutText: 'This is a callout',
+                calloutText: '<p dir="ltr"><b><strong>Hello!</strong></b><span> Check </span><i><em class="italic">this</em></i> <a href="https://ghost.org" rel="noopener"><span>out</span></a><span>.</span></p>',
                 calloutEmoji: '',
                 backgroundColor: 'blue'
             };
@@ -139,7 +142,10 @@ describe('CalloutNode', function () {
             const {element} = node.exportDOM(exportOptions);
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-callout-card kg-callout-card-blue">
-                    <div class="kg-callout-text">This is a callout</div>
+                    <div class="kg-callout-text">
+                        <strong>Hello!</strong>Check<em class="italic">this</em
+                        ><a href="https://ghost.org" rel="noopener">out</a>.
+                    </div>
                 </div>
                 `);
         }));


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/17215

- Fixes an issue that caused some templates to render the card incorrectly.
- Refactored the renderCalloutNode function to parse the calloutText into a DOM tree using jsdom
- Created a cleanDOM helper function to traverse the DOM tree and remove unwanted HTML tags
- Retained only 'A', 'STRONG', and 'EM' tags in the HTML string to bring
  it in line with how mobiledoc rendered HTML.