### PR TITLE
Added 'kg-card-hascaption' class to image card when caption is present

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/image/ImageRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/image/ImageRenderer.js
@@ -20,6 +20,9 @@ export function renderImageNode(node, options = {}) {
     if (node.cardWidth !== 'regular') {
         figureClasses += ` kg-width-${node.cardWidth}`;
     }
+    if (node.caption) {
+        figureClasses += ' with-caption';
+    }
 
     figure.setAttribute('class', figureClasses);
 

--- a/packages/kg-default-nodes/lib/nodes/image/ImageRenderer.js
+++ b/packages/kg-default-nodes/lib/nodes/image/ImageRenderer.js
@@ -21,7 +21,7 @@ export function renderImageNode(node, options = {}) {
         figureClasses += ` kg-width-${node.cardWidth}`;
     }
     if (node.caption) {
-        figureClasses += ' with-caption';
+        figureClasses += ' kg-card-hascaption';
     }
 
     figure.setAttribute('class', figureClasses);

--- a/packages/kg-default-nodes/test/nodes/image.test.js
+++ b/packages/kg-default-nodes/test/nodes/image.test.js
@@ -127,7 +127,7 @@ describe('ImageNode', function () {
             const {element} = imageNode.exportDOM(exportOptions);
 
             element.outerHTML.should.prettifyTo(html`
-                <figure class="kg-card kg-image-card">
+                <figure class="kg-card kg-image-card kg-card-hascaption">
                     <img
                         src="/content/images/2022/11/koenig-lexical.jpg"
                         class="kg-image"
@@ -151,7 +151,7 @@ describe('ImageNode', function () {
             const {element} = imageNode.exportDOM(exportOptions);
 
             element.outerHTML.should.prettifyTo(html`
-                <figure class="kg-card kg-image-card">
+                <figure class="kg-card kg-image-card kg-card-hascaption">
                     <a href="https://example.com"
                         ><img
                         src="/content/images/2022/11/koenig-lexical.jpg"

--- a/packages/kg-lexical-html-renderer/test/cards.test.js
+++ b/packages/kg-lexical-html-renderer/test/cards.test.js
@@ -48,7 +48,7 @@ describe('Cards', function () {
         const output = Prettier.format((new Renderer({nodes})).render(JSON.stringify(lexicalState), options), {parser: 'html'});
 
         const expected =
-`<figure class="kg-card kg-image-card">
+`<figure class="kg-card kg-image-card kg-card-hascaption">
   <img
     src="/content/images/2022/11/koenig-lexical.jpg"
     class="kg-image"


### PR DESCRIPTION
Refs https://github.com/TryGhost/Product/issues/3589
- This class is needed to keep appropriate spacing between full-width cards when the first one has a caption.