### PR TITLE
Reduced JSDOM instantiations when rendering

### DIFF
--- a/packages/kg-lexical-html-renderer/lib/convert-to-html-string.js
+++ b/packages/kg-lexical-html-renderer/lib/convert-to-html-string.js
@@ -56,7 +56,7 @@ function exportChildren(node, options) {
     const output = [];
     const children = node.getChildren();
 
-    const textContent = new TextContent();
+    const textContent = new TextContent(options.dom);
 
     for (const child of children) {
         if (!textContent.isEmpty() && !$isLineBreakNode(child) && !$isTextNode(child) && !$isLinkNode(child)) {

--- a/packages/kg-lexical-html-renderer/lib/lexical-html-renderer.js
+++ b/packages/kg-lexical-html-renderer/lib/lexical-html-renderer.js
@@ -1,5 +1,9 @@
 class LexicalHTMLRenderer {
     constructor({nodes} = {}) {
+        const jsdom = require('jsdom');
+        const {JSDOM} = jsdom;
+
+        this.dom = new JSDOM();
         this.nodes = nodes || [];
     }
 
@@ -11,7 +15,8 @@ class LexicalHTMLRenderer {
         const {$convertToHtmlString} = require('./convert-to-html-string');
 
         const defaultOptions = {
-            target: 'html'
+            target: 'html',
+            dom: this.dom
         };
         const options = Object.assign({}, defaultOptions, userOptions);
 

--- a/packages/kg-lexical-html-renderer/lib/utils/text-content.js
+++ b/packages/kg-lexical-html-renderer/lib/utils/text-content.js
@@ -14,11 +14,8 @@ const FORMAT_TAG_MAP = {
 // Builds and renders text content, useful to ensure proper format tag opening/closing
 // and html escaping
 class TextContent {
-    constructor() {
-        const jsdom = require('jsdom');
-        const {JSDOM} = jsdom;
-
-        this.dom = new JSDOM();
+    constructor(dom) {
+        this.dom = dom;
         this.doc = this.dom.window.document;
         this.root = this.doc.createElement('div');
         this.currentNode = this.root;


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3603

- for every block of text content we were instantiating a new JSDOM instance which has a not-insignificant performance implication
- moved JSDOM instantiation to the `LexicalHTMLRenderer` constructor so we can pass it through to conversion methods or sub-classes as needed
- updated `TextContent` to use the passed-in JSDOM instance rather than instantiating it's own
