### PR TITLE
Removed spacing between stacked full-width cards

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -62,6 +62,19 @@ const KoenigCardWrapper = ({nodeKey, width, wrapperStyle, IndicatorIcon, childre
         );
     });
 
+    React.useEffect(() => {
+        // add a property to the parent element that's added directly by Lexical
+        // so we can target it via CSS for things like spacing between stacked full-width cards
+        if (containerRef.current?.parentElement) {
+            // avoid setting property when 'regular' so there's less test churn
+            if (cardWidth === 'regular') {
+                delete containerRef.current.parentElement.dataset.kgCardWidth;
+            } else {
+                containerRef.current.parentElement.dataset.kgCardWidth = cardWidth;
+            }
+        }
+    }, [cardWidth, containerRef]);
+
     const setEditing = (shouldEdit) => {
         // convert nodeKey to int
         if (shouldEdit) {

--- a/packages/koenig-lexical/src/styles/components/kg-prose.css
+++ b/packages/koenig-lexical/src/styles/components/kg-prose.css
@@ -670,6 +670,12 @@
             margin: 3.2rem 0 0;
         }
 
+        > :where(
+            div[data-kg-card-width="full"] + div[data-kg-card-width="full"]
+        ):not(:where(.not-kg-prose, [class~='not-kg-prose'] *)) {
+            margin: 0;
+        }
+
         :where(
             p + div,
             blockquote + div,

--- a/packages/koenig-lexical/test/e2e/cards/gallery-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/gallery-card.test.js
@@ -57,7 +57,7 @@ test.describe('Gallery card', async () => {
         await initialize({page, uri: `/#/?content=${contentParam}`});
 
         await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
+            <div data-lexical-decorator="true" contenteditable="false" data-kg-card-width="wide">
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="gallery">
                     <figure>
                         <div>
@@ -109,7 +109,7 @@ test.describe('Gallery card', async () => {
         await insertCard(page, {cardName: 'gallery'});
 
         await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
+            <div data-lexical-decorator="true" contenteditable="false" data-kg-card-width="wide">
                 <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="gallery">
                     <figure>
                         <div>
@@ -163,7 +163,7 @@ test.describe('Gallery card', async () => {
         await page.waitForSelector('[data-gallery="true"]');
 
         await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
+            <div data-lexical-decorator="true" contenteditable="false" data-kg-card-width="wide">
                 <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="gallery">
                     <figure>
                         <div>
@@ -335,7 +335,7 @@ test.describe('Gallery card', async () => {
         await page.keyboard.press(`${ctrlOrCmd()}+z`);
 
         await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
+            <div data-lexical-decorator="true" contenteditable="false" data-kg-card-width="wide">
                 <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="gallery">
                     <figure>
                         <div>

--- a/packages/koenig-lexical/test/e2e/cards/header-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/header-card.test.js
@@ -64,7 +64,7 @@ test.describe('Header card V1', async () => {
         await initialize({page, uri: `/#/?content=${contentParam}`});
 
         await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
+            <div data-lexical-decorator="true" contenteditable="false" data-kg-card-width="full">
             <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="header">
                 <div>
                     <div>
@@ -104,7 +104,7 @@ test.describe('Header card V1', async () => {
         await createHeaderCard({page, version: 1});
 
         await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
+            <div data-lexical-decorator="true" contenteditable="false" data-kg-card-width="full">
                 <div data-kg-card-editing="true" data-kg-card-selected="true" data-kg-card="header">
                 </div>
             </div>
@@ -351,7 +351,7 @@ test.describe('Header card V1', async () => {
         await page.keyboard.press(`${ctrlOrCmd}+z`);
 
         await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
+            <div data-lexical-decorator="true" contenteditable="false" data-kg-card-width="full">
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="header">
                     <div>
                         <div>
@@ -445,7 +445,7 @@ test.describe('Header card V2', () => {
         await createHeaderCard({page, version: 2});
 
         await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
+            <div data-lexical-decorator="true" contenteditable="false" data-kg-card-width="wide">
                 <div data-kg-card-editing="true" data-kg-card-selected="true" data-kg-card="header">
                 </div>
             </div>

--- a/packages/koenig-lexical/test/e2e/cards/image-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/image-card.test.js
@@ -57,7 +57,7 @@ test.describe('Image card', async () => {
         await initialize({page, uri: `/#/?content=${contentParam}`});
 
         await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
+            <div data-lexical-decorator="true" contenteditable="false" data-kg-card-width="wide">
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="image">
                     <figure data-kg-card-width="wide">
                         <div><img alt="" src="/content/images/2022/11/koenig-lexical.jpg" /></div>

--- a/packages/koenig-lexical/test/e2e/cards/signup-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/signup-card.test.js
@@ -51,7 +51,7 @@ test.describe('Signup card', async () => {
         await initialize({page, uri: `/#/?content=${contentParam}`});
 
         await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
+            <div data-lexical-decorator="true" contenteditable="false" data-kg-card-width="full">
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="signup">
                     <div>
                         <div>
@@ -106,7 +106,7 @@ test.describe('Signup card', async () => {
         await insertCard(page, {cardName: 'signup'});
 
         await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
+            <div data-lexical-decorator="true" contenteditable="false" data-kg-card-width="wide">
                 <div data-kg-card-editing="true" data-kg-card-selected="true" data-kg-card="signup">
                 </div>
             </div>


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/3569

- uses an effect when rendering our `<KoenigCardWrapper>` component to add/modify a `data-kg-card-width` attribute on the parent `<div>` that Lexical renders for each DecoratorNode
- adds styling to remove spacing between full-width cards when they directly follow another full-width-card
