### PR TITLE
🐛 Fixed format toolbar buttons not working well on selections containing cards

### DIFF
--- a/packages/koenig-lexical/src/components/ui/FormatToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/FormatToolbar.jsx
@@ -13,7 +13,7 @@ import {
 } from 'lexical';
 import {$getNearestNodeOfType} from '@lexical/utils';
 import {$isListNode, ListNode} from '@lexical/list';
-import {$wrapNodes} from '@lexical/selection';
+import {$setBlocksType} from '@lexical/selection';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {
     ToolbarMenu,
@@ -127,7 +127,7 @@ export default function FormatToolbar({
                 const selection = $getSelection();
 
                 if ($isRangeSelection(selection)) {
-                    $wrapNodes(selection, () => $createParagraphNode());
+                    $setBlocksType(selection, () => $createParagraphNode());
                 }
             });
         }
@@ -139,7 +139,7 @@ export default function FormatToolbar({
                 const selection = $getSelection();
 
                 if ($isRangeSelection(selection)) {
-                    $wrapNodes(selection, () => $createHeadingNode(headingSize));
+                    $setBlocksType(selection, () => $createHeadingNode(headingSize));
                 }
             });
         }
@@ -151,11 +151,11 @@ export default function FormatToolbar({
 
             if ($isRangeSelection(selection)) {
                 if (blockType === 'quote') {
-                    $wrapNodes(selection, () => $createAsideNode());
+                    $setBlocksType(selection, () => $createAsideNode());
                 } else if (blockType === 'aside') {
-                    $wrapNodes(selection, () => $createParagraphNode());
+                    $setBlocksType(selection, () => $createParagraphNode());
                 } else {
-                    $wrapNodes(selection, () => $createQuoteNode());
+                    $setBlocksType(selection, () => $createQuoteNode());
                 }
             }
         });

--- a/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
+++ b/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
@@ -32,7 +32,7 @@ test.describe('Editor text formatting keyboard shortcuts', async () => {
 
             await page.keyboard.press(`${ctrlOrCmd}+B`, {delay: 100});
 
-            await assertHTML(page, html`<p dir=\"ltr\"><strong data-lexical-text=\"true\">test</strong></p>`);
+            await assertHTML(page, html`<p dir="ltr"><strong data-lexical-text="true">test</strong></p>`);
         });
 
         test('italic', async function () {
@@ -49,7 +49,7 @@ test.describe('Editor text formatting keyboard shortcuts', async () => {
 
             await page.keyboard.press(`${ctrlOrCmd}+I`, {delay: 100});
 
-            await assertHTML(page, html`<p dir=\"ltr\"><em data-lexical-text=\"true\">test</em></p>`);
+            await assertHTML(page, html`<p dir="ltr"><em data-lexical-text="true">test</em></p>`);
         });
 
         test('strikethrough', async function () {
@@ -66,7 +66,7 @@ test.describe('Editor text formatting keyboard shortcuts', async () => {
 
             await page.keyboard.press(`${ctrlOrCmd}+Alt+U`, {delay: 100});
 
-            await assertHTML(page, html`<p dir=\"ltr\"><span data-lexical-text=\"true\" class="line-through">test</span></p>`);
+            await assertHTML(page, html`<p dir="ltr"><span data-lexical-text="true" class="line-through">test</span></p>`);
         });
 
         test('link', async function () {
@@ -108,7 +108,7 @@ test.describe('Editor text formatting keyboard shortcuts', async () => {
 
             await page.keyboard.press(`${ctrlOrCmd}+Shift+K`, {delay: 100});
 
-            await assertHTML(page, html`<p dir=\"ltr\"><code data-lexical-text=\"true\"><span>test</span></code></p>`);
+            await assertHTML(page, html`<p dir="ltr"><code data-lexical-text="true"><span>test</span></code></p>`);
         });
 
         // TODO : these are currently missing from the editor
@@ -129,7 +129,7 @@ test.describe('Editor text formatting keyboard shortcuts', async () => {
 
         //     // no extra paragraph created
         //     await assertHTML(page, html`
-        //         "<p dir=\"ltr\"><strong data-lexical-text=\"true\">B</strong></p>"
+        //         "<p dir="ltr"><strong data-lexical-text="true">B</strong></p>"
         //     `);
         // });
 
@@ -149,7 +149,7 @@ test.describe('Editor text formatting keyboard shortcuts', async () => {
 
         //     // no extra paragraph created
         //     await assertHTML(page, html`
-        //         "<p dir=\"ltr\"><strong data-lexical-text=\"true\">B</strong></p>"
+        //         "<p dir="ltr"><strong data-lexical-text="true">B</strong></p>"
         //     `);
         // });
     });


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3537

- `$wrapNodes` has been deprecated in favor of `$setBlocksType`, swapping it out fixed issues with only some content having format changed and decorator nodes getting their order moved around
- could not replicate the original reported error of the editor hanging when the toolbar buttons were used with certain text/card combinations
- added basic tests to confirm behaviour is correct
