### PR TITLE
🐛 Fixed signup and header card not removing background

### DIFF
--- a/packages/koenig-lexical/src/nodes/SignupNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/SignupNodeComponent.jsx
@@ -44,6 +44,10 @@ function SignupNodeComponent({
     const [availableLabels, setAvailableLabels] = useState([]);
     const [showBackgroundImage, setShowBackgroundImage] = useState(Boolean(backgroundImageSrc));
     const [lastBackgroundImage, setLastBackgroundImage] = useState(backgroundImageSrc);
+
+    // this is used to determine if the image was deliberately removed by the user or not, for some UX finesse
+    const [imageRemoved, setImageRemoved] = useState(false);
+
     const {isEnabled: isPinturaEnabled, openEditor: openImageEditor} = usePinturaEditor({config: cardConfig.pinturaConfig});
     const fileInputRef = useRef(null);
 
@@ -104,6 +108,7 @@ function SignupNodeComponent({
         });
 
         setLastBackgroundImage(imageSrc);
+        setImageRemoved(false);
     };
 
     const onFileChange = async (e) => {
@@ -140,12 +145,13 @@ function SignupNodeComponent({
             const node = $getNodeByKey(nodeKey);
             node.backgroundImageSrc = '';
         });
+        setImageRemoved(true);
     };
 
     const handleShowBackgroundImage = () => {
         setShowBackgroundImage(true);
 
-        if (lastBackgroundImage) {
+        if (lastBackgroundImage && !imageRemoved) {
             editor.update(() => {
                 const node = $getNodeByKey(nodeKey);
                 node.backgroundImageSrc = lastBackgroundImage;
@@ -157,7 +163,10 @@ function SignupNodeComponent({
 
     const handleHideBackgroundImage = () => {
         setShowBackgroundImage(false);
-        handleClearBackgroundImage();
+        editor.update(() => {
+            const node = $getNodeByKey(nodeKey);
+            node.backgroundImageSrc = '';
+        });
     };
 
     const handleBackgroundColor = (color, matchingTextColor) => {

--- a/packages/koenig-lexical/src/nodes/header/v2/HeaderNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/header/v2/HeaderNodeComponent.jsx
@@ -48,6 +48,10 @@ function HeaderNodeComponent({
     const [showSnippetToolbar, setShowSnippetToolbar] = useState(false);
     const [showBackgroundImage, setShowBackgroundImage] = useState(Boolean(backgroundImageSrc));
     const [lastBackgroundImage, setLastBackgroundImage] = useState(backgroundImageSrc);
+
+    // this is used to determine if the image was deliberately removed by the user or not, for some UX finesse
+    const [imageRemoved, setImageRemoved] = useState(false);
+
     const {isEnabled: isPinturaEnabled, openEditor: openImageEditor} = usePinturaEditor({config: cardConfig.pinturaConfig});
     const fileInputRef = useRef(null);
 
@@ -111,6 +115,7 @@ function HeaderNodeComponent({
         });
 
         setLastBackgroundImage(imageSrc);
+        setImageRemoved(false);
     };
 
     const onFileChange = async (e) => {
@@ -147,12 +152,13 @@ function HeaderNodeComponent({
             const node = $getNodeByKey(nodeKey);
             node.backgroundImageSrc = '';
         });
+        setImageRemoved(true);
     };
 
     const handleShowBackgroundImage = () => {
         setShowBackgroundImage(true);
 
-        if (lastBackgroundImage) {
+        if (lastBackgroundImage && !imageRemoved) {
             editor.update(() => {
                 const node = $getNodeByKey(nodeKey);
                 node.backgroundImageSrc = lastBackgroundImage;
@@ -164,7 +170,10 @@ function HeaderNodeComponent({
 
     const handleHideBackgroundImage = () => {
         setShowBackgroundImage(false);
-        handleClearBackgroundImage();
+        editor.update(() => {
+            const node = $getNodeByKey(nodeKey);
+            node.backgroundImageSrc = '';
+        });
     };
 
     const handleBackgroundColor = (color, matchingTextColor) => {


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C05EQPTMEP7/p1691416830348919?thread_ts=1691399976.076089&cid=C05EQPTMEP7

- the background image was being cached in the state to keep it when toggling between background colour states. However it wasn't fully removed when explicitly removing / deleting the background image.
- this ensures a user can truly remove an image.
- fixes both the new header card and the signup card.