### PR TITLE
🐛 Fixed pasting URLs mid-paragraph appending link at end of paragraph

### DIFF
--- a/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
@@ -1,0 +1,101 @@
+import {assertHTML, focusEditor, html, initialize, pasteText} from '../utils/e2e';
+import {expect, test} from '@playwright/test';
+
+test.describe('Paste behaviour', async () => {
+    let page;
+
+    test.beforeAll(async ({browser}) => {
+        page = await browser.newPage();
+    });
+
+    test.beforeEach(async () => {
+        await initialize({page});
+    });
+
+    test.afterAll(async () => {
+        await page.close();
+    });
+
+    test.describe('URLs', function () {
+        test('pasted at start of populated paragraph creates a link', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('1 2');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('Space');
+
+            await pasteText(page, 'https://ghost.org');
+
+            await assertHTML(page, html`
+                <p>
+                    <span data-lexical-text="true"></span>
+                    <a href="https://ghost.org" dir="ltr">
+                        <span data-lexical-text="true">https://ghost.org</span>
+                    </a>
+                    <span data-lexical-text="true">1 2</span>
+                </p>
+            `);
+        });
+
+        test('pasted mid populated paragraph creates a link', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('1 2');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('Space');
+
+            await pasteText(page, 'https://ghost.org');
+
+            await assertHTML(page, html`
+                <p>
+                    <span data-lexical-text="true">1</span>
+                    <a href="https://ghost.org" dir="ltr">
+                        <span data-lexical-text="true">https://ghost.org</span>
+                    </a>
+                    <span data-lexical-text="true">2</span>
+                </p>
+            `);
+        });
+
+        test('pasted at end of populated paragraph creates a link', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('1 2 ');
+            await pasteText(page, 'https://ghost.org');
+
+            await assertHTML(page, html`
+                <p>
+                    <span data-lexical-text="true">1 2</span>
+                    <a href="https://ghost.org" dir="ltr">
+                        <span data-lexical-text="true">https://ghost.org</span>
+                    </a>
+                </p>
+            `);
+        });
+
+        test('pasted on selected text converts to link', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('1 test');
+            await page.keyboard.press('Shift+ArrowLeft');
+            await page.keyboard.press('Shift+ArrowLeft');
+            await page.keyboard.press('Shift+ArrowLeft');
+            await page.keyboard.press('Shift+ArrowLeft');
+            await pasteText(page, 'https://ghost.org');
+
+            await assertHTML(page, html`
+                <p>
+                    <span data-lexical-text="true">1</span>
+                    <a href="https://ghost.org" dir="ltr">
+                        <span data-lexical-text="true">test</span>
+                    </a>
+                </p>
+            `);
+        });
+
+        test('pasted on blank paragraph creates embed/bookmark', async function () {
+            await focusEditor(page);
+            await pasteText(page, 'https://ghost.org/');
+            await expect(page.getByTestId('embed-iframe')).toBeVisible();
+        });
+    });
+});


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/3697

- logic for handling mid-paragraph URL pastes was incorrect and always appended the link to the paragraph rather than inserting the link
- added "extra space" workaround for a weird Lexical behaviour where inserting a link directly next to other text converts all of the text to a link
