### PR TITLE
missing shortcuts

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {$createAsideNode, $isAsideNode} from '../nodes/AsideNode';
 import {$createCodeBlockNode} from '../nodes/CodeBlockNode';
 import {$createEmbedNode} from '../nodes/EmbedNode';
+import {$createHeadingNode, $createQuoteNode, $isHeadingNode, $isQuoteNode} from '@lexical/rich-text';
 import {$createLinkNode} from '@lexical/link';
 import {
     $createNodeSelection,
@@ -35,7 +36,6 @@ import {
     PASTE_COMMAND,
     createCommand
 } from 'lexical';
-import {$createQuoteNode, $isQuoteNode} from '@lexical/rich-text';
 import {$insertAndSelectNode} from '../utils/$insertAndSelectNode';
 import {
     $isAtStartOfDocument,
@@ -795,6 +795,30 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                                 $setBlocksType(selection, () => $createAsideNode());
                             } else if ($isAsideNode(firstNode)) {
                                 $setBlocksType(selection, () => $createParagraphNode());
+                            }
+                        }
+                    }
+
+                    if ((metaKey || ctrlKey) && code === 'KeyH') {
+                        // avoid hide behaviour
+                        event.preventDefault();
+
+                        const selection = $getSelection();
+                        if ($isRangeSelection(selection)) {
+                            const firstNode = selection.anchor.getNode().getTopLevelElement();
+
+                            if ($isParagraphNode(firstNode)) {
+                                $setBlocksType(selection, () => $createHeadingNode('h2'));
+                            } else if ($isHeadingNode(firstNode)) {
+                                const tag = firstNode.getTag();
+                                const level = parseInt(tag.slice(1), 10);
+                                const newLevel = level + 1;
+
+                                if (newLevel > 6) {
+                                    $setBlocksType(selection, () => $createParagraphNode());
+                                } else {
+                                    $setBlocksType(selection, () => $createHeadingNode(`h${newLevel}`));
+                                }
                             }
                         }
                     }

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -698,7 +698,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
             editor.registerCommand(
                 KEY_MODIFIER_COMMAND,
                 (event) => {
-                    const {ctrlKey, metaKey, code, key} = event;
+                    const {altKey, ctrlKey, metaKey, code, key} = event;
                     const isArrowUp = key === 'ArrowUp' || event.keyCode === 38;
                     const isArrowDown = key === 'ArrowDown' || event.keyCode === 40;
 
@@ -820,6 +820,15 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                                     $setBlocksType(selection, () => $createHeadingNode(`h${newLevel}`));
                                 }
                             }
+                        }
+                    }
+
+                    if (ctrlKey && altKey && key.match(/^[1-6]$/)) {
+                        event.preventDefault();
+
+                        const selection = $getSelection();
+                        if ($isRangeSelection(selection)) {
+                            $setBlocksType(selection, () => $createHeadingNode(`h${key}`));
                         }
                     }
 

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -44,7 +44,7 @@ import {
     getTopLevelNativeElement
 } from '../utils/';
 import {$isKoenigCard, ImageNode} from '@tryghost/kg-default-nodes';
-import {$isListItemNode, $isListNode, ListNode} from '@lexical/list';
+import {$isListItemNode, $isListNode, INSERT_UNORDERED_LIST_COMMAND, ListNode} from '@lexical/list';
 import {$setBlocksType} from '@lexical/selection';
 import {MIME_TEXT_HTML, MIME_TEXT_PLAIN, PASTE_MARKDOWN_COMMAND} from './MarkdownPastePlugin.jsx';
 import {mergeRegister} from '@lexical/utils';
@@ -829,6 +829,28 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                         const selection = $getSelection();
                         if ($isRangeSelection(selection)) {
                             $setBlocksType(selection, () => $createHeadingNode(`h${key}`));
+                        }
+                    }
+
+                    if (ctrlKey && code === 'KeyL') {
+                        event.preventDefault();
+
+                        const selection = $getSelection();
+                        if ($isRangeSelection(selection)) {
+                            const firstNode = selection.anchor.getNode().getTopLevelElement();
+
+                            if ($isListNode(firstNode)) {
+                                editor.update(() => {
+                                    const pNode = $createParagraphNode();
+                                    $setBlocksType(selection, () => pNode);
+
+                                    // Lexical will automatically indent the paragraph node to the
+                                    // list item level but we don't allow indented paragraphs
+                                    pNode.setIndent(0);
+                                });
+                            } else {
+                                editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined);
+                            }
                         }
                     }
 

--- a/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
+++ b/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
@@ -143,24 +143,45 @@ test.describe('Editor keyboard shortcuts', async () => {
         `);
     });
 
-        // test('header (h2)', async function () {
-        //     await focusEditor(page);
+    test('header cycle', async function () {
+        await focusEditor(page);
 
-        //     await page.keyboard.type('test');
+        await page.keyboard.type('test');
 
-        //     await page.keyboard.down('Shift');
-        //     await page.keyboard.press('ArrowLeft');
-        //     await page.keyboard.press('ArrowLeft');
-        //     await page.keyboard.press('ArrowLeft');
-        //     await page.keyboard.press('ArrowLeft');
-        //     await page.keyboard.up('Shift', {delay: 100});
+        await page.keyboard.press(`${ctrlOrCmdKey}+h`);
 
-        //     await page.keyboard.press('Meta+B', {delay: 100});
+        await assertHTML(page, html`
+            <h2 dir="ltr"><span data-lexical-text="true">test</span></h2>
+        `);
 
-        //     // no extra paragraph created
-        //     await assertHTML(page, html`
-        //         "<p dir="ltr"><strong data-lexical-text="true">B</strong></p>"
-        //     `);
-        // });
+        await page.keyboard.press(`${ctrlOrCmdKey}+h`);
+
+        await assertHTML(page, html`
+            <h3 dir="ltr"><span data-lexical-text="true">test</span></h3>
+        `);
+
+        await page.keyboard.press(`${ctrlOrCmdKey}+h`);
+
+        await assertHTML(page, html`
+            <h4 dir="ltr"><span data-lexical-text="true">test</span></h4>
+        `);
+
+        await page.keyboard.press(`${ctrlOrCmdKey}+h`);
+
+        await assertHTML(page, html`
+            <h5 dir="ltr"><span data-lexical-text="true">test</span></h5>
+        `);
+
+        await page.keyboard.press(`${ctrlOrCmdKey}+h`);
+
+        await assertHTML(page, html`
+            <h6 dir="ltr"><span data-lexical-text="true">test</span></h6>
+        `);
+
+        await page.keyboard.press(`${ctrlOrCmdKey}+h`);
+
+        await assertHTML(page, html`
+            <p dir="ltr"><span data-lexical-text="true">test</span></p>
+        `);
     });
 });

--- a/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
+++ b/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
@@ -233,4 +233,23 @@ test.describe('Editor keyboard shortcuts', async () => {
             <h6 dir="ltr"><span data-lexical-text="true">test</span></h6>
         `);
     });
+
+    test('list', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('test');
+        await page.keyboard.press('Control+l');
+
+        await assertHTML(page, html`
+            <ul>
+                <li value="1" dir="ltr"><span data-lexical-text="true">test</span></li>
+            </ul>
+        `);
+
+        await page.keyboard.press('Control+l');
+
+        await assertHTML(page, html`
+            <p dir="ltr"><span data-lexical-text="true">test</span></p>
+        `);
+    });
 });

--- a/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
+++ b/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
@@ -143,7 +143,7 @@ test.describe('Editor keyboard shortcuts', async () => {
         `);
     });
 
-    test('header cycle', async function () {
+    test('heading cycle', async function () {
         await focusEditor(page);
 
         await page.keyboard.type('test');
@@ -182,6 +182,55 @@ test.describe('Editor keyboard shortcuts', async () => {
 
         await assertHTML(page, html`
             <p dir="ltr"><span data-lexical-text="true">test</span></p>
+        `);
+    });
+
+    test('specific heading', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('test');
+
+        await page.keyboard.press(`Control+Alt+1`);
+
+        await assertHTML(page, html`
+            <h1 dir="ltr"><span data-lexical-text="true">test</span></h1>
+        `);
+
+        await page.keyboard.press(`Control+Alt+2`);
+
+        await assertHTML(page, html`
+            <h2 dir="ltr"><span data-lexical-text="true">test</span></h2>
+        `);
+
+        await page.keyboard.press(`Control+Alt+3`);
+
+        await assertHTML(page, html`
+            <h3 dir="ltr"><span data-lexical-text="true">test</span></h3>
+        `);
+
+        await page.keyboard.press(`Control+Alt+4`);
+
+        await assertHTML(page, html`
+            <h4 dir="ltr"><span data-lexical-text="true">test</span></h4>
+        `);
+
+        await page.keyboard.press(`Control+Alt+5`);
+
+        await assertHTML(page, html`
+            <h5 dir="ltr"><span data-lexical-text="true">test</span></h5>
+        `);
+
+        await page.keyboard.press(`Control+Alt+6`);
+
+        await assertHTML(page, html`
+            <h6 dir="ltr"><span data-lexical-text="true">test</span></h6>
+        `);
+
+        // higher levels are ignored
+        await page.keyboard.press(`Control+Alt+7`);
+
+        await assertHTML(page, html`
+            <h6 dir="ltr"><span data-lexical-text="true">test</span></h6>
         `);
     });
 });

--- a/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
+++ b/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
@@ -1,9 +1,9 @@
-import {assertHTML, focusEditor, html, initialize, isMac} from '../utils/e2e';
+import {assertHTML, ctrlOrCmd, focusEditor, html, initialize} from '../utils/e2e';
 import {test} from '@playwright/test';
 
-test.describe('Editor text formatting keyboard shortcuts', async () => {
+test.describe('Editor keyboard shortcuts', async () => {
+    const ctrlOrCmdKey = ctrlOrCmd();
     let page;
-    const ctrlOrCmd = isMac() ? 'Meta' : 'Control';
 
     test.beforeAll(async ({browser}) => {
         page = await browser.newPage();
@@ -30,7 +30,7 @@ test.describe('Editor text formatting keyboard shortcuts', async () => {
             await page.keyboard.press('ArrowLeft');
             await page.keyboard.up('Shift', {delay: 100});
 
-            await page.keyboard.press(`${ctrlOrCmd}+B`, {delay: 100});
+            await page.keyboard.press(`${ctrlOrCmdKey}+B`, {delay: 100});
 
             await assertHTML(page, html`<p dir="ltr"><strong data-lexical-text="true">test</strong></p>`);
         });
@@ -47,7 +47,7 @@ test.describe('Editor text formatting keyboard shortcuts', async () => {
             await page.keyboard.press('ArrowLeft');
             await page.keyboard.up('Shift', {delay: 100});
 
-            await page.keyboard.press(`${ctrlOrCmd}+I`, {delay: 100});
+            await page.keyboard.press(`${ctrlOrCmdKey}+I`, {delay: 100});
 
             await assertHTML(page, html`<p dir="ltr"><em data-lexical-text="true">test</em></p>`);
         });
@@ -64,7 +64,7 @@ test.describe('Editor text formatting keyboard shortcuts', async () => {
             await page.keyboard.press('ArrowLeft');
             await page.keyboard.up('Shift', {delay: 100});
 
-            await page.keyboard.press(`${ctrlOrCmd}+Alt+U`, {delay: 100});
+            await page.keyboard.press(`${ctrlOrCmdKey}+Alt+U`, {delay: 100});
 
             await assertHTML(page, html`<p dir="ltr"><span data-lexical-text="true" class="line-through">test</span></p>`);
         });
@@ -81,7 +81,7 @@ test.describe('Editor text formatting keyboard shortcuts', async () => {
             await page.keyboard.press('ArrowLeft');
             await page.keyboard.up('Shift', {delay: 100});
 
-            await page.keyboard.press(`${ctrlOrCmd}+K`, {delay: 100});
+            await page.keyboard.press(`${ctrlOrCmdKey}+K`, {delay: 100});
 
             await page.keyboard.type('https://example.com');
             await page.keyboard.press('Enter');
@@ -106,32 +106,42 @@ test.describe('Editor text formatting keyboard shortcuts', async () => {
             await page.keyboard.press('ArrowLeft');
             await page.keyboard.up('Shift', {delay: 100});
 
-            await page.keyboard.press(`${ctrlOrCmd}+Shift+K`, {delay: 100});
+            await page.keyboard.press(`${ctrlOrCmdKey}+Shift+K`, {delay: 100});
 
             await assertHTML(page, html`<p dir="ltr"><code data-lexical-text="true"><span>test</span></code></p>`);
         });
+    });
 
-        // TODO : these are currently missing from the editor
+    test('quotes', async function () {
+        await focusEditor(page);
 
-        // test('blockquote', async function () {
-        //     await focusEditor(page);
+        await page.keyboard.type('test');
 
-        //     await page.keyboard.type('test');
+        // paragraph -> blockquote
+        await page.keyboard.press('Control+q');
 
-        //     await page.keyboard.down('Shift');
-        //     await page.keyboard.press('ArrowLeft');
-        //     await page.keyboard.press('ArrowLeft');
-        //     await page.keyboard.press('ArrowLeft');
-        //     await page.keyboard.press('ArrowLeft');
-        //     await page.keyboard.up('Shift', {delay: 100});
+        await assertHTML(page, html`
+            <blockquote dir="ltr">
+                <span data-lexical-text="true">test</span>
+            </blockquote>
+        `);
 
-        //     await page.keyboard.press('Meta+B', {delay: 100});
+        // blockquote -> aside
+        await page.keyboard.press('Control+q');
 
-        //     // no extra paragraph created
-        //     await assertHTML(page, html`
-        //         "<p dir="ltr"><strong data-lexical-text="true">B</strong></p>"
-        //     `);
-        // });
+        await assertHTML(page, html`
+            <aside dir="ltr">
+                <span data-lexical-text="true">test</span>
+            </aside>
+        `);
+
+        // aside -> paragraph
+        await page.keyboard.press('Control+q');
+
+        await assertHTML(page, html`
+            <p dir="ltr"><span data-lexical-text="true">test</span></p>
+        `);
+    });
 
         // test('header (h2)', async function () {
         //     await focusEditor(page);


### PR DESCRIPTION
- 🐛 Added missing Ctrl+Q shortcut for cycling through quote styles
- 🐛 Added missing Ctrl/Cmd+H shortcut for cycling through heading levels
- 🐛 Added missing Ctrl+Alt+[1-6] shortcuts for setting specific heading levels
- 🐛 Added missing Ctrl+L shortcut for toggling unordered list
