### PR TITLE
Removed unnecessary select all command

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -228,14 +228,6 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                 }
             }),
             editor.registerCommand(
-                SELECT_ALL_COMMAND,
-                () => {
-                    $selectAll();
-                    return true;
-                },
-                COMMAND_PRIORITY_LOW
-            ),
-            editor.registerCommand(
                 INSERT_CARD_COMMAND,
                 ({cardNode, openInEditMode}) => {
                     let focusNode;

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -18,7 +18,6 @@ import {
     $isParagraphNode,
     $isRangeSelection,
     $isTextNode,
-    $selectAll,
     $setSelection,
     COMMAND_PRIORITY_LOW,
     DELETE_LINE_COMMAND,
@@ -35,7 +34,6 @@ import {
     KEY_MODIFIER_COMMAND,
     KEY_TAB_COMMAND,
     PASTE_COMMAND,
-    SELECT_ALL_COMMAND,
     createCommand
 } from 'lexical';
 import {$insertAndSelectNode} from '../utils/$insertAndSelectNode';


### PR DESCRIPTION
refs TryGhost/Product#3709
-removed duplicate command registration
-SELECT_ALL_COMMAND is registered by RichTextPlugin, which we will likely always use