### PR TITLE
:bug: Fixed delete key in nested editors

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -902,7 +902,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                     }
 
                     // delete selected card if we have one
-                    if (selectedCardKey) {
+                    if (!isNested && selectedCardKey) {
                         event.preventDefault();
                         editor.dispatchCommand(DELETE_CARD_COMMAND, {cardKey: selectedCardKey, direction: 'forward'});
                         return true;

--- a/packages/koenig-lexical/test/e2e/card-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/card-behaviour.test.js
@@ -1590,6 +1590,20 @@ test.describe('Card behaviour', async () => {
     });
 
     test.describe('inner editors', function () {
+        test.only('can use the delete key to remove text', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('/image https://example.com/image.jpg');
+            await page.waitForSelector('[data-kg-card-menu-item="Image"][data-kg-cardmenu-selected="true"]');
+            await page.keyboard.press('Enter');
+            await page.waitForSelector('[data-kg-card="image"]');
+            await page.keyboard.type('Caption value');
+            await page.keyboard.press('ArrowLeft');
+            // await page.keyboard.press('Fn+Backspace'); // note: this is the delete key for macs, but playwright doesn't recognize "Fn" even when running on a mac :(
+            await page.keyboard.press('Delete');
+
+            await expect(page.locator('[data-kg-card="image"] figcaption [data-kg="editor"]')).toHaveText('Caption valu');
+        });
+
         test.describe('codemirror', function () {
             // Skipped because CodeMirror does not pick up the copy/paste properly inside Playwright - manual testing is working
             test.skip('can copy/paste', async function () {


### PR DESCRIPTION
closes TryGhost/Product#3680
- did not previously check for nested editors, would try to delete card