### PR TITLE
:bug: Fixed floating toolbar display issues

### DIFF
--- a/packages/koenig-lexical/src/components/ui/FloatingFormatToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/FloatingFormatToolbar.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {$getSelection, $isRangeSelection} from 'lexical';
 import {LinkActionToolbar} from './LinkActionToolbar.jsx';
 import {SnippetActionToolbar} from './SnippetActionToolbar';
+import {debounce} from 'lodash-es';
 
 export const toolbarItemTypes = {
     snippet: 'snippet',
@@ -33,11 +34,12 @@ export function FloatingFormatToolbar({
     // shouldn't display until selection via mouse is complete to avoid toolbar re-positioning while dragging
     const toggleVisibility = React.useCallback(() => {
         if (toolbarItemType && toolbarRef.current.style.opacity === '0') {
-            console.log(`making visible`);
             toolbarRef.current.style.opacity = '1';
             updateArrowStyles();
         }
     }, [toolbarItemType, updateArrowStyles]);
+
+    // TODO: Arrow not updating position on selection change (select all)
 
     React.useEffect(() => {
         document.addEventListener('mouseup', toggleVisibility); // desktop
@@ -58,7 +60,6 @@ export function FloatingFormatToolbar({
             // should not show floating toolbar when we don't have a text selection
             editor.getEditorState().read(() => {
                 const selection = $getSelection();
-                console.log(`onMouseMove`, selection.getTextContent());
                 if (selection === null || !$isRangeSelection(selection)) {
                     return;
                 }
@@ -67,10 +68,10 @@ export function FloatingFormatToolbar({
                 }
             });
         };
-        // note: debouncing this has conflicts >10ms or so, not sure it's worth it
-        document.addEventListener('mousemove', onMouseMove);
+        const debouncedOnMouseMove = debounce(onMouseMove, 10);
+        document.addEventListener('mousemove', debouncedOnMouseMove);
         return () => {
-            document.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mousemove', debouncedOnMouseMove);
         };
     }, [editor, toggleVisibility]);
 

--- a/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
@@ -18,7 +18,6 @@ function useFloatingFormatToolbar(editor, anchorElem, isSnippetsEnabled, hiddenF
     const [href, setHref] = React.useState(null);
 
     const setToolbarType = React.useCallback(() => {
-        console.log(`setting toolbar type from selection change`);
         editor.getEditorState().read(() => {
             // Should not to pop up the floating toolbar when using IME input
             if (editor.isComposing()) {
@@ -72,31 +71,14 @@ function useFloatingFormatToolbar(editor, anchorElem, isSnippetsEnabled, hiddenF
         });
     }, [editor, toolbarItemType]);
 
-    useEffect(() => {
-        // Add a listener if the text toolbar is active. It helps to prevent events bubbling
-        // when a user is interacting with inputs in the link/snippets toolbar
-        if (!!toolbarItemType && toolbarItemType !== toolbarItemTypes.text) {
-            return;
-        }
-        console.log(`...adding listener for selection change`);
-        document.addEventListener('selectionchange', setToolbarType);
-        return () => {
-            console.log(`...removing listener for selection change`);
-            document.removeEventListener('selectionchange', setToolbarType);
-        };
-    }, [setToolbarType, toolbarItemType]);
-
     React.useEffect(() => {
+        // we need to attach the listener to the editor because it intercepts some events (like keyboard selection)
         return editor.registerUpdateListener(() => {
             editor.getEditorState().read(() => {
-                const selection = $getSelection();
-                // save selection range rect to calculate toolbar arrow position
-                if (toolbarItemType) {
-                    setSelectionRangeRect($getSelectionRangeRect({selection, editor}));
-                }
+                setToolbarType();
             });
         });
-    }, [editor, toolbarItemType]);
+    }, [editor, setToolbarType, toolbarItemType]);
 
     React.useEffect(() => {
         editor.registerCommand(

--- a/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import {$getSelection, $isParagraphNode, $isRangeSelection, $isTextNode, COMMAND_PRIORITY_LOW, FORMAT_TEXT_COMMAND, KEY_MODIFIER_COMMAND} from 'lexical';
 import {$getSelectionRangeRect} from '../utils/$getSelectionRangeRect';
 import {$isLinkNode} from '@lexical/link';

--- a/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
@@ -18,6 +18,7 @@ function useFloatingFormatToolbar(editor, anchorElem, isSnippetsEnabled, hiddenF
     const [href, setHref] = React.useState(null);
 
     const setToolbarType = React.useCallback(() => {
+        console.log(`setting toolbar type from selection change`);
         editor.getEditorState().read(() => {
             // Should not to pop up the floating toolbar when using IME input
             if (editor.isComposing()) {
@@ -77,8 +78,10 @@ function useFloatingFormatToolbar(editor, anchorElem, isSnippetsEnabled, hiddenF
         if (!!toolbarItemType && toolbarItemType !== toolbarItemTypes.text) {
             return;
         }
+        console.log(`...adding listener for selection change`);
         document.addEventListener('selectionchange', setToolbarType);
         return () => {
+            console.log(`...removing listener for selection change`);
             document.removeEventListener('selectionchange', setToolbarType);
         };
     }, [setToolbarType, toolbarItemType]);


### PR DESCRIPTION
closes TryGhost/Product#2231, closes TryGhost/Product#3733
- only show text toolbar when moving cursor
- listen to editor updates, not browser, as lexical intercepts some events