### PR TITLE
:bug: Fixed onBlur handler for code and html cards

### DIFF
--- a/packages/koenig-lexical/src/nodes/CodeBlockNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CodeBlockNodeComponent.jsx
@@ -38,12 +38,12 @@ export function CodeBlockNodeComponent({nodeKey, captionEditor, captionEditorIni
     const onBlur = (event) => {
         // ignore if clicking on the language selection input
         const relatedTarget = event?.relatedTarget;
-        if (relatedTarget.ariaLabel === 'Code card language') {
+        if (relatedTarget?.ariaLabel === 'Code card language') {
             return;
         }
         // deselect if clicking outside the card
         //  this check results in deferring to the Cmd+Enter handling in KoenigBehaviourPlugin when the cause of the blur
-        if (relatedTarget.className !== 'kg-prose') {
+        if (relatedTarget?.className !== 'kg-prose') {
             editor.dispatchCommand(DESELECT_CARD_COMMAND, {cardKey: nodeKey});
         }
     };

--- a/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
@@ -257,4 +257,24 @@ test.describe('Code Block card', async () => {
             </div>
         `, {ignoreCardContents: false, ignoreCardToolbarContents: true});
     });
+
+    test('goes into display mode when losing focus', async function () {
+        await focusEditor(page);
+        await page.keyboard.type('```javascript ');
+        await page.waitForSelector('[data-kg-card="codeblock"] .cm-editor');
+
+        await page.keyboard.type('Here are some words');
+        await page.getByTestId('post-title').fill('post title'); // move focus outside of the editor
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="codeblock">
+                    <div>
+                        <pre><code>Here are some words</code></pre>
+                        <div><span>javascript</span></div>
+                    </div>
+                </div>
+            </div>
+        `);
+    });
 });

--- a/packages/koenig-lexical/test/e2e/cards/html-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/html-card.test.js
@@ -111,4 +111,35 @@ test.describe('Html card', async () => {
         await page.keyboard.press('Escape');
         await expect(page.getByText('Here are some words')).toBeVisible();
     });
+
+    test('goes into display mode when losing focus', async function () {
+        await focusEditor(page);
+        // insert new card
+        await page.keyboard.type('/html');
+        await page.waitForSelector('[data-kg-card-menu-item="HTML"][data-kg-cardmenu-selected="true"]');
+        await page.keyboard.press('Enter');
+        await expect(await page.locator('[data-kg-card="html"][data-kg-card-editing="true"]')).toBeVisible();
+        // waiting for html editor
+        await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
+
+        // Types slower. Codemirror can be slow and needs some time to place the cursor after entering text.
+        await page.keyboard.type('Here are some words');
+        await page.getByTestId('post-title').fill('post title'); // move focus outside of the editor
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div><svg></svg></div>
+                <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="html">
+                    <div>
+                        <div class="min-h-[3.5vh] whitespace-normal">
+                            Here are some words
+                        </div>
+                        <div class="absolute inset-0 z-50 mt-0">
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <p><br /></p>
+        `);
+    });
 });


### PR DESCRIPTION
refs TryGhost/Product#3410
- console error was being thrown when checking for nonexistent prop