### PR TITLE
🎨 Added missing Unsplash isHidden config

### DIFF
--- a/packages/koenig-lexical/src/nodes/ImageNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNode.jsx
@@ -41,6 +41,7 @@ export class ImageNode extends BaseImageNode {
         insertParams: {
             triggerFileDialog: false
         },
+        isHidden: ({config}) => !config?.unsplash,
         matches: ['unsplash', 'uns'],
         queryParams: ['src'],
         priority: 3


### PR DESCRIPTION
no issue

- It's possible for the Unsplash card to be hidden via the integrations settings. In which case we should be able to hide it from the kgMenu should it be disabled. This is not a breaking change, but relies on a change from within Ghost as well to function as expected.