### PR TITLE
✨ Added conversion of image to gallery when image cards are dropped on each other

### DIFF
--- a/packages/koenig-lexical/package.json
+++ b/packages/koenig-lexical/package.json
@@ -84,6 +84,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.22.15",
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@etchteam/storybook-addon-status": "^4.2.4",
     "@playwright/test": "^1.33.0",
     "@prettier/sync": "^0.3.0",

--- a/packages/koenig-lexical/src/components/ui/cards/GalleryCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/GalleryCard.jsx
@@ -15,7 +15,7 @@ function GalleryRow({index, images, deleteImage, isDragging}) {
                     idx === images.length - 1 ? 'last' :
                         'middle';
 
-        return <GalleryImage key={image.fileName} deleteImage={deleteImage} image={image} isDragging={isDragging} position={position} />;
+        return <GalleryImage key={image.src} deleteImage={deleteImage} image={image} isDragging={isDragging} position={position} />;
     });
 
     return (

--- a/packages/koenig-lexical/src/components/ui/cards/ImageCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/ImageCard.jsx
@@ -2,11 +2,11 @@ import ImageUploadForm from '../ImageUploadForm';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {CardCaptionEditor} from '../CardCaptionEditor';
-import {MediaPlaceholder} from '../MediaPlaceholder';
+import {CardText, MediaPlaceholder} from '../MediaPlaceholder';
 import {ProgressBar} from '../ProgressBar';
 import {openFileSelection} from '../../../utils/openFileSelection';
 
-function PopulatedImageCard({src, alt, previewSrc, imageUploader}) {
+function PopulatedImageCard({src, alt, previewSrc, imageUploader, imageCardDragHandler}) {
     const progressStyle = {
         width: `${imageUploader.progress?.toFixed(0)}%`
     };
@@ -14,7 +14,7 @@ function PopulatedImageCard({src, alt, previewSrc, imageUploader}) {
     const progressAlt = imageUploader.progress.toFixed(0) < 100 ? `upload in progress, ${imageUploader.progress}` : '';
 
     return (
-        <div className="not-kg-prose">
+        <div ref={imageCardDragHandler?.setRef} className="not-kg-prose relative">
             <img
                 alt={alt ? alt : progressAlt}
                 className={`mx-auto block ${previewSrc ? 'opacity-40' : ''}`}
@@ -27,11 +27,16 @@ function PopulatedImageCard({src, alt, previewSrc, imageUploader}) {
                 </div>
                 : <></>
             }
+            {imageCardDragHandler?.isDraggedOver ? (
+                <div className={`absolute inset-0 flex items-center justify-center border border-grey/20 bg-black/80 dark:border-grey/10 dark:bg-grey-950`}>
+                    <CardText text="Drop to convert to a gallery" />
+                </div>
+            ) : null}
         </div>
     );
 }
 
-function EmptyImageCard({onFileChange, setFileInputRef, imageDragHandler, errors}) {
+function EmptyImageCard({onFileChange, setFileInputRef, imageFileDragHandler, errors}) {
     const fileInputRef = React.useRef(null);
 
     const onFileInputRef = (element) => {
@@ -46,8 +51,8 @@ function EmptyImageCard({onFileChange, setFileInputRef, imageDragHandler, errors
                 errors={errors}
                 filePicker={() => openFileSelection({fileInputRef})}
                 icon='image'
-                isDraggedOver={imageDragHandler.isDraggedOver}
-                placeholderRef={imageDragHandler.setRef}
+                isDraggedOver={imageFileDragHandler?.isDraggedOver}
+                placeholderRef={imageFileDragHandler?.setRef}
             />
             <ImageUploadForm
                 fileInputRef={onFileInputRef}
@@ -65,12 +70,14 @@ const ImageHolder = ({
     imageUploader,
     onFileChange,
     setFileInputRef,
-    imageDragHandler
+    imageCardDragHandler,
+    imageFileDragHandler
 }) => {
     if (previewSrc || src) {
         return (
             <PopulatedImageCard
                 alt={altText}
+                imageCardDragHandler={imageCardDragHandler}
                 imageUploader={imageUploader}
                 previewSrc={previewSrc}
                 src={src}
@@ -80,7 +87,7 @@ const ImageHolder = ({
         return (
             <EmptyImageCard
                 errors={imageUploader.errors}
-                imageDragHandler={imageDragHandler}
+                imageFileDragHandler={imageFileDragHandler}
                 setFileInputRef={setFileInputRef}
                 onFileChange={onFileChange}
             />
@@ -101,7 +108,8 @@ export function ImageCard({
     cardWidth,
     previewSrc,
     imageUploader,
-    imageDragHandler
+    imageCardDragHandler,
+    imageFileDragHandler
 }) {
     const figureRef = React.useRef(null);
 
@@ -121,7 +129,8 @@ export function ImageCard({
             <figure ref={figureRef} data-kg-card-width={cardWidth}>
                 <ImageHolder
                     altText={altText}
-                    imageDragHandler={imageDragHandler}
+                    imageCardDragHandler={imageCardDragHandler}
+                    imageFileDragHandler={imageFileDragHandler}
                     imageUploader={imageUploader}
                     previewSrc={previewSrc}
                     setFileInputRef={setFileInputRef}
@@ -151,21 +160,23 @@ ImageHolder.propTypes = {
     imageUploader: PropTypes.object,
     onFileChange: PropTypes.func,
     setFileInputRef: PropTypes.func,
-    imageDragHandler: PropTypes.object
+    imageFileDragHandler: PropTypes.object,
+    imageCardDragHandler: PropTypes.object
 };
 
 PopulatedImageCard.propTypes = {
     src: PropTypes.string,
     alt: PropTypes.string,
     previewSrc: PropTypes.string,
-    imageUploader: PropTypes.object
+    imageUploader: PropTypes.object,
+    imageCardDragHandler: PropTypes.object
 };
 
 EmptyImageCard.propTypes = {
     onFileChange: PropTypes.func,
     setFileInputRef: PropTypes.func,
-    imageDragHandler: PropTypes.object,
-    errors: PropTypes.array
+    errors: PropTypes.array,
+    imageFileDragHandler: PropTypes.object
 };
 
 ImageCard.propTypes = {
@@ -181,5 +192,6 @@ ImageCard.propTypes = {
     cardWidth: PropTypes.string,
     previewSrc: PropTypes.string,
     imageUploader: PropTypes.object,
-    imageDragHandler: PropTypes.object
+    imageFileDragHandler: PropTypes.object,
+    imageCardDragHandler: PropTypes.object
 };

--- a/packages/koenig-lexical/src/components/ui/cards/ImageCard.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/ImageCard.stories.jsx
@@ -65,7 +65,7 @@ Empty.args = {
         isLoading: false,
         progress: 100
     },
-    imageDragHandler: {
+    imageFileDragHandler: {
         isDraggedOver: false
     }
 };
@@ -83,7 +83,7 @@ Uploading.args = {
         progress: 50,
         isLoading: true
     },
-    imageDragHandler: {
+    imageFileDragHandler: {
         isDraggedOver: false
     }
 };
@@ -100,7 +100,7 @@ Populated.args = {
         isLoading: false,
         progress: 100
     },
-    imageDragHandler: {
+    imageFileDragHandler: {
         isDraggedOver: false
     }
 };
@@ -115,7 +115,7 @@ Errors.args = {
     imageUploader: {
         errors: [{message: 'The file type you uploaded is not supported. Please use .GIF, .JPG, .JPEG, .PNG, .SVG, .SVGZ, .WEBP'}]
     },
-    imageDragHandler: {
+    imageFileDragHandler: {
         isDraggedOver: false
     }
 };
@@ -130,7 +130,7 @@ DraggedOver.args = {
     imageUploader: {
         errors: [{message: 'The file type you uploaded is not supported. Please use .GIF, .JPG, .JPEG, .PNG, .SVG, .SVGZ, .WEBP'}]
     },
-    imageDragHandler: {
+    imageFileDragHandler: {
         isDraggedOver: true
     }
 };

--- a/packages/koenig-lexical/src/hooks/useCardDragAndDrop.js
+++ b/packages/koenig-lexical/src/hooks/useCardDragAndDrop.js
@@ -1,0 +1,109 @@
+import KoenigComposerContext from '../context/KoenigComposerContext';
+import React from 'react';
+
+export default function useCardDragAndDrop({
+    enabled = true,
+    canDrop,
+    onDrop,
+    onDropEnd,
+    getDraggableInfo,
+    getIndicatorPosition,
+    draggableSelector,
+    droppableSelector
+}) {
+    const koenig = React.useContext(KoenigComposerContext);
+
+    const [containerRef, setContainerRef] = React.useState(null);
+    const [isDraggedOver, setIsDraggedOver] = React.useState(false);
+    const dragDropContainer = React.useRef(null);
+
+    const onDragStart = React.useCallback((draggableInfo) => {
+        if (canDrop(draggableInfo)) {
+            dragDropContainer.current.enableDrag();
+        } else {
+            dragDropContainer.current.disableDrag();
+        }
+    }, [canDrop]);
+
+    const onDragEnd = React.useCallback(() => {
+        setIsDraggedOver(false);
+    }, [setIsDraggedOver]);
+
+    const onDragEnterContainer = React.useCallback((draggableInfo) => {
+        setIsDraggedOver(canDrop(draggableInfo));
+    }, [setIsDraggedOver, canDrop]);
+
+    const onDragLeaveContainer = React.useCallback(() => {
+        setIsDraggedOver(false);
+    }, [setIsDraggedOver]);
+
+    const _onDrop = React.useCallback((draggableInfo) => {
+        return onDrop?.(draggableInfo) || false;
+    }, [onDrop]);
+
+    const _onDropEnd = React.useCallback((draggableInfo, success) => {
+        onDropEnd?.(draggableInfo, success);
+    }, [onDropEnd]);
+
+    // returns {
+    //   direction: 'horizontal' TODO: use a constant?
+    //   position: 'left'/'right' TODO: use constants?
+    //   beforeElems: array of elems to left of indicator
+    //   afterElems: array of elems to right of indicator
+    //   droppableIndex:
+    // }
+    const _getIndicatorPosition = React.useCallback((draggableInfo) => {
+        return getIndicatorPosition?.(draggableInfo) || false;
+    }, [getIndicatorPosition]);
+
+    const _getDraggableInfo = React.useCallback((draggableElement) => {
+        return getDraggableInfo?.(draggableElement) || {};
+    }, [getDraggableInfo]);
+
+    React.useEffect(() => {
+        if (enabled) {
+            dragDropContainer.current?.enableDrag();
+        } else {
+            dragDropContainer.current?.disableDrag();
+        }
+    }, [enabled, containerRef]);
+
+    React.useEffect(() => {
+        if (!containerRef || !koenig.dragDropHandler) {
+            return;
+        }
+
+        dragDropContainer.current = koenig.dragDropHandler.registerContainer(
+            containerRef,
+            {
+                draggableSelector,
+                droppableSelector,
+                isDragEnabled: enabled,
+                onDragStart,
+                onDragEnd,
+                onDragEnterContainer,
+                onDragLeaveContainer,
+                getDraggableInfo: _getDraggableInfo,
+                getIndicatorPosition: _getIndicatorPosition,
+                onDrop: _onDrop,
+                onDropEnd: _onDropEnd
+            }
+        );
+    }, [
+        _getDraggableInfo,
+        _getIndicatorPosition,
+        _onDrop,
+        _onDropEnd,
+        containerRef,
+        draggableSelector,
+        droppableSelector,
+        enabled,
+        koenig.dragDropHandler,
+        onDragEnd,
+        onDragEnterContainer,
+        onDragLeaveContainer,
+        onDragStart
+    ]);
+
+    return {setRef: setContainerRef, isDraggedOver};
+}

--- a/packages/koenig-lexical/src/hooks/useGalleryReorder.js
+++ b/packages/koenig-lexical/src/hooks/useGalleryReorder.js
@@ -16,8 +16,6 @@ export default function useGalleryReorder({images, updateImages, isSelected = fa
         if (isImageDrag && draggableInfo.dataset.src && images.length !== maxImages) {
             dragDropContainer.current.enableDrag();
         }
-
-        setIsDraggedOver(true);
     };
 
     const onDragEnd = () => {

--- a/packages/koenig-lexical/src/nodes/GalleryNode.jsx
+++ b/packages/koenig-lexical/src/nodes/GalleryNode.jsx
@@ -5,9 +5,22 @@ import {ReactComponent as GalleryCardIcon} from '../assets/icons/kg-card-type-ga
 import {GalleryNodeComponent} from './GalleryNodeComponent';
 import {KoenigCardWrapper, MINIMAL_NODES} from '../index.js';
 import {createCommand} from 'lexical';
+import {pick} from 'lodash-es';
 import {populateNestedEditor, setupNestedEditor} from '../utils/nested-editors';
 
 export const INSERT_GALLERY_COMMAND = createCommand();
+
+export const MAX_IMAGES = 9;
+export const MAX_PER_ROW = 3;
+
+// ensure we don't save client-side only properties such as preview blob urls to the server
+export const ALLOWED_IMAGE_PROPS = ['row', 'src', 'width', 'height', 'alt', 'caption', 'fileName'];
+
+export function recalculateImageRows(images) {
+    images.forEach((image, idx) => {
+        image.row = Math.ceil((idx + 1) / MAX_PER_ROW) - 1;
+    });
+}
 
 export class GalleryNode extends BaseGalleryNode {
     __captionEditor;
@@ -79,6 +92,25 @@ export class GalleryNode extends BaseGalleryNode {
             </KoenigCardWrapper>
         );
     }
+
+    // TODO: move to kg-default-nodes?
+    setImages(images) {
+        const datasetImages = images
+            .slice(0, MAX_IMAGES - 1)
+            .map(image => pick(image, ALLOWED_IMAGE_PROPS));
+
+        recalculateImageRows(datasetImages);
+        this.images = datasetImages;
+    }
+
+    addImages(images) {
+        const datasetImages = [...this.images, ...images]
+            .slice(0, MAX_IMAGES - 1)
+            .map(image => pick(image, ALLOWED_IMAGE_PROPS));
+
+        recalculateImageRows(datasetImages);
+        this.images = datasetImages;
+    }
 }
 
 export const $createGalleryNode = (dataset) => {
@@ -88,4 +120,3 @@ export const $createGalleryNode = (dataset) => {
 export function $isGalleryNode(node) {
     return node instanceof GalleryNode;
 }
-

--- a/packages/koenig-lexical/src/nodes/GalleryNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/GalleryNodeComponent.jsx
@@ -5,24 +5,12 @@ import useGalleryReorder from '../hooks/useGalleryReorder';
 import {$getNodeByKey} from 'lexical';
 import {ActionToolbar} from '../components/ui/ActionToolbar';
 import {GalleryCard} from '../components/ui/cards/GalleryCard';
+import {MAX_IMAGES, recalculateImageRows} from './GalleryNode';
 import {SnippetActionToolbar} from '../components/ui/SnippetActionToolbar';
 import {ToolbarMenu, ToolbarMenuItem, ToolbarMenuSeparator} from '../components/ui/ToolbarMenu';
 import {getImageDimensions} from '../utils/getImageDimensions';
-import {pick} from 'lodash-es';
 import {useKoenigSelectedCardContext} from '../context/KoenigSelectedCardContext';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
-
-const MAX_IMAGES = 9;
-const MAX_PER_ROW = 3;
-
-// ensure we don't save client-side only properties such as preview blob urls to the server
-const ALLOWED_IMAGE_PROPS = ['row', 'src', 'width', 'height', 'alt', 'caption', 'fileName'];
-
-function recalculateImageRows(images) {
-    images.forEach((image, idx) => {
-        image.row = Math.ceil((idx + 1) / MAX_PER_ROW) - 1;
-    });
-}
 
 export function GalleryNodeComponent({nodeKey, captionEditor, captionEditorInitialState}) {
     const [editor] = useLexicalComposerContext();
@@ -55,9 +43,7 @@ export function GalleryNodeComponent({nodeKey, captionEditor, captionEditorIniti
     function setNodeImages(newImages) {
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
-            const datasetImages = newImages.map(image => pick(image, ALLOWED_IMAGE_PROPS));
-            recalculateImageRows(datasetImages);
-            node.images = datasetImages;
+            node.setImages(newImages);
         });
     }
 

--- a/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
@@ -1,8 +1,10 @@
 import CardContext from '../context/CardContext';
 import KoenigComposerContext from '../context/KoenigComposerContext';
 import React from 'react';
+import useCardDragAndDrop from '../hooks/useCardDragAndDrop';
 import useFileDragAndDrop from '../hooks/useFileDragAndDrop';
 import usePinturaEditor from '../hooks/usePinturaEditor';
+import {$createGalleryNode} from './GalleryNode';
 import {$createNodeSelection, $getNodeByKey, $setSelection} from 'lexical';
 import {ActionToolbar} from '../components/ui/ActionToolbar';
 import {ImageCard} from '../components/ui/cards/ImageCard';
@@ -26,8 +28,38 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, captionE
     const [showSnippetToolbar, setShowSnippetToolbar] = React.useState(false);
 
     const imageUploader = fileUploader.useFileUpload('image');
-    const imageDragHandler = useFileDragAndDrop({handleDrop: handleImageDrop});
-    const {isEnabled: isPinturaEnabled, openEditor: openImageEditor} = usePinturaEditor({config: cardConfig.pinturaConfig});
+    const imageFileDragHandler = useFileDragAndDrop({handleDrop: handleImageDrop});
+
+    // stable fn refs to avoid excessive re-inits of the drag/drop handler effects
+    // which can cause unexpected side-effects with event handling
+    const canDropImageCard = React.useCallback((draggable) => {
+        return draggable.type === 'card'
+            && draggable.cardName === 'image'
+            && draggable.nodeKey !== nodeKey;
+    }, [nodeKey]);
+    const onDropImageCard = React.useCallback((draggable) => {
+        const {type, cardName, nodeKey: draggedNodeKey, dataset} = draggable;
+
+        if (type === 'card' && cardName === 'image' && draggedNodeKey && dataset) {
+            editor.update(() => {
+                const targetImageNode = $getNodeByKey(nodeKey);
+                const droppedImageNode = $getNodeByKey(draggedNodeKey);
+                const galleryNode = $createGalleryNode();
+
+                galleryNode.addImages([targetImageNode.getDataset(), dataset]);
+
+                targetImageNode.replace(galleryNode);
+                droppedImageNode.remove();
+            });
+        }
+    }, [editor, nodeKey]);
+    const imageCardDragHandler = useCardDragAndDrop({
+        canDrop: canDropImageCard,
+        onDrop: onDropImageCard
+    });
+
+    const {isEnabled: isPinturaEnabled, openEditor: openImageEditor}
+        = usePinturaEditor({config: cardConfig.pinturaConfig});
 
     React.useEffect(() => {
         if (!src?.startsWith('data:') || imageUploader.isLoading) {
@@ -145,7 +177,8 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, captionE
                 captionEditorInitialState={captionEditorInitialState}
                 cardWidth={cardWidth}
                 fileInputRef={fileInputRef}
-                imageDragHandler={imageDragHandler}
+                imageCardDragHandler={imageCardDragHandler}
+                imageFileDragHandler={imageFileDragHandler}
                 imageUploader={imageUploader}
                 isSelected={isSelected}
                 previewSrc={previewSrc}

--- a/packages/koenig-lexical/src/utils/draggable/DragDropHandler.jsx
+++ b/packages/koenig-lexical/src/utils/draggable/DragDropHandler.jsx
@@ -376,7 +376,7 @@ export class DragDropHandler {
         const isOverDroppable = overDroppableElem;
 
         if (isLeavingContainer) {
-            this._currentOverContainer.onDragLeaveContainer();
+            this._currentOverContainer.onDragLeaveContainer(this.draggableInfo);
             this._currentOverContainer = null;
             this._currentOverContainerElem = null;
             this._hideDropIndicator();
@@ -385,7 +385,7 @@ export class DragDropHandler {
         if (isOverContainer) {
             const container = this.containers.find(c => c.element === overContainerElem);
             if (!this._currentOverContainer) {
-                container.onDragEnterContainer();
+                container.onDragEnterContainer(this.draggableInfo);
             }
 
             this._currentOverContainer = container;

--- a/packages/koenig-lexical/test/e2e/cards/gallery-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/gallery-card.test.js
@@ -397,4 +397,31 @@ test.describe('Gallery card', async () => {
             <p><br /></p>
         `, {ignoreCardToolbarContents: true, ignoreInnerSVG: true});
     });
+
+    // Skipped test because I couldn't get the drag to initiate with the image
+    // rather than the whole gallery.
+    //
+    // test('can drag image card out of gallery card', async function () {
+    //     await test.step('insert and upload images to gallery card', async () => {
+    //         const filePaths = Array.from(Array(2).keys()).map(n => path.relative(process.cwd(), __dirname + `/../fixtures/large-image-${n}.png`));
+    //         const fileChooserPromise = page.waitForEvent('filechooser');
+
+    //         await focusEditor(page);
+    //         await insertCard(page, {cardName: 'gallery'});
+    //         await page.click('[name="placeholder-button"]');
+
+    //         const fileChooser = await fileChooserPromise;
+    //         await fileChooser.setFiles(filePaths);
+
+    //         await expect(page.locator('[data-testid="gallery-image"]')).toHaveCount(2);
+    //     });
+
+    //     const firstImageBBox = await page.locator('[data-testid="gallery-image"]').nth(0).boundingBox();
+    //     const paragraphBBox = await page.locator('p:not(figure p)').boundingBox();
+
+    //     await dragMouse(page, firstImageBBox, paragraphBBox, 'middle', 'start', true, 100, 100);
+
+    //     await assertHTML(page, `
+    //     `, {ignoreCardContents: true});
+    // });
 });

--- a/packages/koenig-lexical/test/e2e/plugins/DragDropReorderPlugin.test.js
+++ b/packages/koenig-lexical/test/e2e/plugins/DragDropReorderPlugin.test.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import {assertHTML, dragMouse, focusEditor, html, initialize} from '../../utils/e2e';
+import {assertHTML, dragMouse, focusEditor, html, initialize, insertCard} from '../../utils/e2e';
 import {expect, test} from '@playwright/test';
 import {fileURLToPath} from 'url';
 const __filename = fileURLToPath(import.meta.url);
@@ -232,8 +232,5 @@ test.describe('Drag Drop Reorder Plugin', async function () {
 });
 
 async function insertDivider(page) {
-    await page.keyboard.type('/divider');
-    await expect(page.locator(`[data-kg-card-menu-item="Divider"][data-kg-cardmenu-selected="true"]`)).toBeVisible();
-    await page.keyboard.press('Enter');
-    await expect(page.locator(`[data-kg-card="horizontalrule"]`)).toBeVisible();
+    await insertCard(page, {cardName: 'divider'});
 }

--- a/packages/koenig-lexical/test/utils/e2e.js
+++ b/packages/koenig-lexical/test/utils/e2e.js
@@ -343,16 +343,16 @@ export function ctrlOrCmd() {
 }
 
 // note: we always use lowercase for the cardName but we use start case for the menu item attribute
-export async function insertCard(page, {cardName}) {
+export async function insertCard(page, {cardName, nth = 0}) {
     let card = startCase(cardName);
     await page.keyboard.type(`/${cardName}`);
     await expect(page.locator(`[data-kg-card-menu-item="${card}" i][data-kg-cardmenu-selected="true"]`)).toBeVisible();
     await page.keyboard.press('Enter');
     // hr is the one case we don't match the card name to the data attribute
     if (card === 'Divider') {
-        await expect(page.locator(`[data-kg-card="horizontalrule"]`)).toBeVisible();
+        await expect(page.locator(`[data-kg-card="horizontalrule"]`).nth(nth)).toBeVisible();
     } else {
-        await expect(page.locator(`[data-kg-card="${cardName}" i]`)).toBeVisible();
+        await expect(page.locator(`[data-kg-card="${cardName}" i]`).nth(nth)).toBeVisible();
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,7 +85,7 @@
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
 
-"@babel/helper-annotate-as-pure@^7.22.5":
+"@babel/helper-annotate-as-pure@^7.18.6", "@babel/helper-annotate-as-pure@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz#e7f06737b197d580a01edf75d97e2c8be99d3882"
   integrity sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==
@@ -119,6 +119,21 @@
     "@babel/helper-environment-visitor" "^7.22.5"
     "@babel/helper-function-name" "^7.22.5"
     "@babel/helper-member-expression-to-functions" "^7.22.5"
+    "@babel/helper-optimise-call-expression" "^7.22.5"
+    "@babel/helper-replace-supers" "^7.22.9"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    semver "^6.3.1"
+
+"@babel/helper-create-class-features-plugin@^7.21.0":
+  version "7.22.15"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.15.tgz#97a61b385e57fe458496fad19f8e63b63c867de4"
+  integrity sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.22.5"
+    "@babel/helper-environment-visitor" "^7.22.5"
+    "@babel/helper-function-name" "^7.22.5"
+    "@babel/helper-member-expression-to-functions" "^7.22.15"
     "@babel/helper-optimise-call-expression" "^7.22.5"
     "@babel/helper-replace-supers" "^7.22.9"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.22.5"
@@ -164,6 +179,13 @@
   integrity sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==
   dependencies:
     "@babel/types" "^7.22.5"
+
+"@babel/helper-member-expression-to-functions@^7.22.15":
+  version "7.22.15"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.22.15.tgz#b95a144896f6d491ca7863576f820f3628818621"
+  integrity sha512-qLNsZbgrNh0fDQBCPocSL8guki1hcPvltGDv/NxvUoABwFq7GkKSu1nRXeJkVZc+wJvne2E0RKQz+2SQrz6eAA==
+  dependencies:
+    "@babel/types" "^7.22.15"
 
 "@babel/helper-member-expression-to-functions@^7.22.5":
   version "7.22.5"
@@ -360,6 +382,16 @@
   version "7.21.0-placeholder-for-preset-env.2"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz#7844f9289546efa9febac2de4cfe358a050bd703"
   integrity sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==
+
+"@babel/plugin-proposal-private-property-in-object@^7.21.11":
+  version "7.21.11"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz#69d597086b6760c4126525cfa154f34631ff272c"
+  integrity sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-create-class-features-plugin" "^7.21.0"
+    "@babel/helper-plugin-utils" "^7.20.2"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/2721

- added `useCardDragAndDrop` hook that can be used for handling cards being dragged over and dropped on components
- updated `ImageNodeComponent` and it's associated `ImageCard` component to use `useCardDragAndDrop` hook to allow an image card to be dragged and dropped onto an image card to convert it to a gallery
  - renamed `imageDragHandler` to `imageFileDragHandler` to be more explicit about the type of drag and drop it's handling