### PR TITLE
:bug: Prevented focus jumping to start of editor

### DIFF
--- a/packages/koenig-lexical/src/components/ui/SnippetActionToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/SnippetActionToolbar.jsx
@@ -34,6 +34,7 @@ export function SnippetActionToolbar({onClose, ...props}) {
             }
 
             onClose?.();
+            editor.getRootElement().focus(); // don't force focus to be handled in each implementation
         });
     };
 


### PR DESCRIPTION
closes TryGhost/Product#3755
- stripped out manually focusing the editor root element when selecting a card creating competing foci
- this seemed like it was necessary in the past, perhaps no longer necessary due to lexical upgrades
- required changes in other commands that were depending on this