### PR TITLE
Fixed h6 tags in mobiledoc converting to h5 tags in lexical

### DIFF
--- a/packages/kg-converters/lib/mobiledoc-to-lexical.js
+++ b/packages/kg-converters/lib/mobiledoc-to-lexical.js
@@ -35,7 +35,7 @@ const TAG_TO_LEXICAL_NODE = {
     },
     h6: {
         type: 'heading',
-        tag: 'h5'
+        tag: 'h6'
     },
     blockquote: {
         type: 'quote'

--- a/packages/kg-converters/test/mobiledoc-to-lexical.test.js
+++ b/packages/kg-converters/test/mobiledoc-to-lexical.test.js
@@ -1279,92 +1279,50 @@ describe('mobiledocToLexical', function () {
             }));
         });
 
-        it('converts H1s', function () {
-            const result = mobiledocToLexical(JSON.stringify({
-                version: MOBILEDOC_VERSION,
-                ghostVersion: GHOST_VERSION,
-                atoms: [],
-                cards: [],
-                markups: [],
-                sections: [
-                    [1, 'h1', [[0, [], 0, 'Heading 1']]]
-                ]
-            }));
-
-            assert.equal(result, JSON.stringify({
-                root: {
-                    children: [
-                        {
-                            children: [
-                                {
-                                    detail: 0,
-                                    format: 0,
-                                    mode: 'normal',
-                                    style: '',
-                                    text: 'Heading 1',
-                                    type: 'text',
-                                    version: 1
-                                }
-                            ],
-                            direction: 'ltr',
-                            format: '',
-                            indent: 0,
-                            type: 'heading',
-                            tag: 'h1',
-                            version: 1
-                        }
-                    ],
-                    direction: 'ltr',
-                    format: '',
-                    indent: 0,
-                    type: 'root',
-                    version: 1
-                }
-            }));
-        });
-
-        it('converts H2s', function () {
-            const result = mobiledocToLexical(JSON.stringify({
-                version: MOBILEDOC_VERSION,
-                ghostVersion: GHOST_VERSION,
-                atoms: [],
-                cards: [],
-                markups: [],
-                sections: [
-                    [1, 'h2', [[0, [], 0, 'Heading 2']]]
-                ]
-            }));
-
-            assert.equal(result, JSON.stringify({
-                root: {
-                    children: [
-                        {
-                            children: [
-                                {
-                                    detail: 0,
-                                    format: 0,
-                                    mode: 'normal',
-                                    style: '',
-                                    text: 'Heading 2',
-                                    type: 'text',
-                                    version: 1
-                                }
-                            ],
-                            direction: 'ltr',
-                            format: '',
-                            indent: 0,
-                            type: 'heading',
-                            tag: 'h2',
-                            version: 1
-                        }
-                    ],
-                    direction: 'ltr',
-                    format: '',
-                    indent: 0,
-                    type: 'root',
-                    version: 1
-                }
-            }));
+        it('converts all headings', function () {
+            for (let i = 1; i < 7; i++) {
+                const result = mobiledocToLexical(JSON.stringify({
+                    version: MOBILEDOC_VERSION,
+                    ghostVersion: GHOST_VERSION,
+                    atoms: [],
+                    cards: [],
+                    markups: [],
+                    sections: [
+                        [1, `h${i}`, [[0, [], 0, `Heading ${i}`]]]
+                    ]
+                }));
+    
+                assert.equal(result, JSON.stringify({
+                    root: {
+                        children: [
+                            {
+                                children: [
+                                    {
+                                        detail: 0,
+                                        format: 0,
+                                        mode: 'normal',
+                                        style: '',
+                                        text: `Heading ${i}`,
+                                        type: 'text',
+                                        version: 1
+                                    }
+                                ],
+                                direction: 'ltr',
+                                format: '',
+                                indent: 0,
+                                type: 'heading',
+                                tag: `h${i}`,
+                                version: 1
+                            }
+                        ],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'root',
+                        version: 1
+                    }
+                }));
+            }
         });
 
         it('converts headings with links and formatting', function () {


### PR DESCRIPTION
- closes TryGhost/Product#3759

- added a test for all 6 headings, and fixed the bad mapping that was causing this issue