### PR TITLE
Fixed blockquote rendering single quotes for class attribute

### DIFF
--- a/packages/kg-lexical-html-renderer/lib/transformers/element/aside.js
+++ b/packages/kg-lexical-html-renderer/lib/transformers/element/aside.js
@@ -6,6 +6,6 @@ module.exports = {
             return null;
         }
 
-        return `<blockquote class='kg-blockquote-alt'>${exportChildren(node)}</blockquote>`;
+        return `<blockquote class="kg-blockquote-alt">${exportChildren(node)}</blockquote>`;
     }
 };

--- a/packages/kg-lexical-html-renderer/test/quotes.test.js
+++ b/packages/kg-lexical-html-renderer/test/quotes.test.js
@@ -15,6 +15,6 @@ describe('Quotes', function () {
         const renderer = new Renderer({nodes: [AsideNode]});
         const html = await renderer.render(editorState);
 
-        html.should.eql(`<blockquote class='kg-blockquote-alt'>Aside with <strong>formatting</strong></blockquote>`);
+        html.should.eql(`<blockquote class="kg-blockquote-alt">Aside with <strong>formatting</strong></blockquote>`);
     });
 });


### PR DESCRIPTION
no issue

- no functional difference here, just a style change...this was being flagged as a difference between mobiledoc and lexical rendering behavior — only fixing this to reduce some of that noise