### PR TITLE
Fixed lexical rendering for links with no href set

### DIFF
--- a/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
+++ b/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
@@ -75,7 +75,10 @@ class TextContent {
 
         const a = this.doc.createElement('a');
 
-        a.setAttribute('href', node.getURL());
+        // Only set the href if we have a URL, otherwise we get a link to the current page
+        if (node.getURL()) {
+            a.setAttribute('href', node.getURL());            
+        }
         a.innerHTML = exportChildren(node, options);
 
         this.currentNode.append(a);

--- a/packages/kg-lexical-html-renderer/test/links.test.js
+++ b/packages/kg-lexical-html-renderer/test/links.test.js
@@ -6,6 +6,11 @@ describe('Links', function () {
         output: `<p><a href="https://example.com">test</a></p>`
     }));
 
+    it('a without an href', shouldRender({
+        input: `{"root":{"children":[{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"test","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":null}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+        output: `<p><a>test</a></p>`
+    }));
+
     it('a > strong italic', shouldRender({
         input: `{"root":{"children":[{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"test ","type":"text","version":1},{"detail":0,"format":1,"mode":"normal","style":"","text":"bold","type":"text","version":1},{"detail":0,"format":0,"mode":"normal","style":"","text":" ","type":"text","version":1},{"detail":0,"format":2,"mode":"normal","style":"","text":"italic","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"https://example.com"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
         output: '<p><a href="https://example.com">test <strong>bold</strong> <em>italic</em></a></p>'


### PR DESCRIPTION
closes TryGhost/Product#3760

- When converting from mobiledoc or pasting HTML into lexical, there can be links that don't have an href/url attribute in their payload
- Previously the lexical renderer would render an <a href=""></a> tag in this case, which results in a link to the current page and differs from mobiledoc's rendering behavior
- This change will omit the href attribute entirely if the link has no url set