### PR TITLE
Fixed mobiledoc to lexical conversion of underline tags

### DIFF
--- a/packages/kg-converters/lib/mobiledoc-to-lexical.js
+++ b/packages/kg-converters/lib/mobiledoc-to-lexical.js
@@ -65,6 +65,7 @@ const MARKUP_TO_FORMAT = {
     em: 1 << 1,
     i: 1 << 1,
     s: 1 << 2,
+    u: 1 << 3,
     code: 1 << 4,
     sub: 1 << 5,
     sup: 1 << 6

--- a/packages/kg-converters/test/lexical-to-mobiledoc.test.js
+++ b/packages/kg-converters/test/lexical-to-mobiledoc.test.js
@@ -315,6 +315,73 @@ describe('lexicalToMobiledoc', function () {
             }));
         });
 
+        it('converts a paragraph with underlined text', function () {
+            const result = lexicalToMobiledoc(JSON.stringify({
+                root: {
+                    children: [
+                        {
+                            children: [
+                                {
+                                    detail: 0,
+                                    format: 0,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: 'Hello, ',
+                                    type: 'text',
+                                    version: 1
+                                },
+                                {
+                                    detail: 0,
+                                    format: 8,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: 'world',
+                                    type: 'text',
+                                    version: 1
+                                },
+                                {
+                                    detail: 0,
+                                    format: 0,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: '!',
+                                    type: 'text',
+                                    version: 1
+                                }
+                            ],
+                            direction: 'ltr',
+                            format: '',
+                            indent: 0,
+                            type: 'paragraph',
+                            version: 1
+                        }
+                    ],
+                    direction: 'ltr',
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            }));
+
+            assert.equal(result, JSON.stringify({
+                version: MOBILEDOC_VERSION,
+                ghostVersion: GHOST_VERSION,
+                atoms: [],
+                cards: [],
+                markups: [
+                    ['u']
+                ],
+                sections: [
+                    [1, 'p', [
+                        [0, [], 0, 'Hello, '],
+                        [0, [0], 1, 'world'],
+                        [0, [], 0, '!']
+                    ]]
+                ]
+            }));
+        });
+
         it('converts a paragraph with strong and italic text', function () {
             const result = lexicalToMobiledoc(JSON.stringify({
                 root: {

--- a/packages/kg-converters/test/mobiledoc-to-lexical.test.js
+++ b/packages/kg-converters/test/mobiledoc-to-lexical.test.js
@@ -271,6 +271,72 @@ describe('mobiledocToLexical', function () {
             }));
         });
 
+        it('converts a paragraph with underlined text', function () {
+            const result = mobiledocToLexical(JSON.stringify({
+                version: MOBILEDOC_VERSION,
+                ghostVersion: GHOST_VERSION,
+                atoms: [],
+                cards: [],
+                markups: [
+                    ['u']
+                ],
+                sections: [
+                    [1, 'p', [
+                        [0, [], 0, 'Hello, '],
+                        [0, [0], 1, 'world'],
+                        [0, [], 0, '!']
+                    ]]
+                ]
+            }));
+            assert.equal(result, JSON.stringify({
+                root: {
+                    children: [
+                        {
+                            children: [
+                                {
+                                    detail: 0,
+                                    format: 0,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: 'Hello, ',
+                                    type: 'text',
+                                    version: 1
+                                },
+                                {
+                                    detail: 0,
+                                    format: 8,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: 'world',
+                                    type: 'text',
+                                    version: 1
+                                },
+                                {
+                                    detail: 0,
+                                    format: 0,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: '!',
+                                    type: 'text',
+                                    version: 1
+                                }
+                            ],
+                            direction: 'ltr',
+                            format: '',
+                            indent: 0,
+                            type: 'paragraph',
+                            version: 1
+                        }
+                    ],
+                    direction: 'ltr',
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            }));
+        });
+
         it('converts a paragraph with strong and italic text', function () {
             const result = mobiledocToLexical(JSON.stringify({
                 version: MOBILEDOC_VERSION,


### PR DESCRIPTION
closes TryGhost/Product#3761

- The mobiledocToLexical converter was ignoring underline tags, falling back to unstyled text
- This change fixes that, and adds a test for both mobiledocToLexical and lexicalToMobiledoc to ensure underline tags are preserved both ways