### PR TITLE
:bug: Fixed nested editors missing content

### DIFF
--- a/packages/kg-clean-basic-html/lib/clean-basic-html.js
+++ b/packages/kg-clean-basic-html/lib/clean-basic-html.js
@@ -48,6 +48,11 @@ export default function cleanBasicHtml(html = '', _options = {}) {
     if (cleanHtml) {
         let doc = options.createDocument(cleanHtml);
 
+        // don't analyze the document if it's empty (can result in storing <br> tags if allowed)
+        if (doc.body.textContent === '') {
+            return null;
+        }
+
         doc.body.querySelectorAll('*').forEach((element) => {
             // Treat Zero Width Non-Joiner characters as spaces
             if (!element.textContent.trim().replace(/\u200c+/g, '')) {


### PR DESCRIPTION
fixes TryGhost/Product#3646
- empty nested editors were saving an empty <br> tag
- updated cleanHtml to return nothing when there's no textContent