### PR TITLE
Added rel attributes to link renderer

### DIFF
--- a/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
+++ b/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
@@ -79,6 +79,9 @@ class TextContent {
         if (node.getURL()) {
             a.setAttribute('href', node.getURL());            
         }
+        if (node.getRel()) {
+            a.setAttribute('rel', node.getRel());
+        }
         a.innerHTML = exportChildren(node, options);
 
         this.currentNode.append(a);

--- a/packages/kg-lexical-html-renderer/test/links.test.js
+++ b/packages/kg-lexical-html-renderer/test/links.test.js
@@ -11,6 +11,11 @@ describe('Links', function () {
         output: `<p><a>test</a></p>`
     }));
 
+    it('a with rel attribute', shouldRender({
+        input: `{"root":{"children":[{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"test","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":"noopener noreferrer","target":null,"url":"https://example.com"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+        output: `<p><a href="https://example.com" rel="noopener noreferrer">test</a></p>`
+    }));
+
     it('a > strong italic', shouldRender({
         input: `{"root":{"children":[{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"test ","type":"text","version":1},{"detail":0,"format":1,"mode":"normal","style":"","text":"bold","type":"text","version":1},{"detail":0,"format":0,"mode":"normal","style":"","text":" ","type":"text","version":1},{"detail":0,"format":2,"mode":"normal","style":"","text":"italic","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"https://example.com"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
         output: '<p><a href="https://example.com">test <strong>bold</strong> <em>italic</em></a></p>'


### PR DESCRIPTION
closes TryGhost/Product#3763

- Before this change, the lexical renderer would not add rel attributes to links, even if they were present in the lexical payload
- This change adds the rel attributes to <a></a> tags if present in the payload