### PR TITLE
Fixed lexical renderer including empty trailing paragraphs

### DIFF
--- a/packages/kg-lexical-html-renderer/lib/convert-to-html-string.js
+++ b/packages/kg-lexical-html-renderer/lib/convert-to-html-string.js
@@ -2,6 +2,7 @@ const {
     $getRoot,
     $isElementNode,
     $isLineBreakNode,
+    $isParagraphNode,
     $isTextNode
 } = require('lexical');
 const {$isLinkNode} = require('@lexical/link');
@@ -21,6 +22,13 @@ function $convertToHtmlString(options = {}) {
         if (result !== null) {
             output.push(result);
         }
+    }
+
+    // Koenig keeps a blank paragraph at the end of a doc but we want to
+    // make sure it doesn't get rendered
+    const lastChild = children[children.length - 1];
+    if (lastChild && $isParagraphNode(lastChild) && lastChild.getTextContent().trim() === '') {
+        output.pop();
     }
 
     return output.join('\n');

--- a/packages/kg-lexical-html-renderer/test/render.test.js
+++ b/packages/kg-lexical-html-renderer/test/render.test.js
@@ -17,6 +17,16 @@ describe('render()', function () {
         input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"<test>","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
         output: '<p>&lt;test&gt;</p>'
     }));
+
+    it('removes a trailing empty paragraph if present', shouldRender({
+        input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+        output: ''
+    }));
+
+    it('removes a trailing paragraph with only whitespace if present', shouldRender({
+        input: `{"root":{"children":[{"children":[{"type":"linebreak","version":1}],"direction":null,"format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+        output: ''
+    }));
 });
 
 describe('Special elements', function () {


### PR DESCRIPTION
closes TryGhost/Product#3764

- The lexical editor keeps a trailing paragraph in the doc almost always
- The mobiledoc editor did this too, but then it stripped the trailing paragraph before rendering to html
- This fix makes the lexical renderer do the same thing