### PR TITLE
Fixed `type` property in mobiledoc-to-lexical converter

### DIFF
--- a/packages/kg-converters/lib/mobiledoc-to-lexical.js
+++ b/packages/kg-converters/lib/mobiledoc-to-lexical.js
@@ -199,7 +199,7 @@ function populateLexicalNodeWithMarkers(lexicalNode, markers, mobiledoc) {
             openMarkups.push(markup);
         });
 
-        if (value) {
+        if (value !== undefined) {
             // Convert the open markups to a bitmask compatible with Lexical
             const format = convertMarkupTagsToLexicalFormatBitmask(openMarkups);
 
@@ -226,7 +226,7 @@ function populateLexicalNodeWithMarkers(lexicalNode, markers, mobiledoc) {
 
             // If we're closing a link tag, add the linkNode to the node
             // Reset href and linkNode for the next markup
-            if (markup[0] === 'a') {
+            if (markup && markup[0] === 'a') {
                 embedChildNode(lexicalNode, linkNode);
                 href = undefined;
                 linkNode = undefined;
@@ -265,11 +265,15 @@ function createEmptyLexicalNode(tagName, attributes = {}) {
 
 // Adds a child node to a parent node
 function embedChildNode(parentNode, childNode) {
+    // If there is no child node, do nothing
+    if (!childNode) {
+        return;
+    }
     // Add textNode to node's children
     parentNode.children.push(childNode);
 
     // If there is any text (e.g. not a blank text node), set the direction to ltr
-    if ('text' in childNode && childNode.text) {
+    if (childNode && 'text' in childNode && childNode.text) {
         parentNode.direction = 'ltr';
     }
 }
@@ -317,6 +321,7 @@ function convertCardSectionToLexical(child, mobiledoc) {
         }
     }
 
+    delete payload.type;
     const decoratorNode = {type: cardName, ...payload};
 
     return decoratorNode;

--- a/packages/kg-converters/test/mobiledoc-to-lexical.test.js
+++ b/packages/kg-converters/test/mobiledoc-to-lexical.test.js
@@ -2219,6 +2219,38 @@ describe('mobiledocToLexical', function () {
                 }
             }));
         });
+
+        it('does not overwrite the type property', function () {
+            const result = mobiledocToLexical(JSON.stringify({
+                version: '0.3.2',
+                atoms: [],
+                cards: [
+                    ['image',{src: 'https://media.tenor.com/images/90daac539a399e176dd7c69def020b1f/tenor.gif',width: 398,height: 224,caption: '',type: 'gif',href: 'https://dailyposter.outpost.pub/gift_subscription#/'}]
+                ],
+                markups: [],
+                sections: [
+                    [10, 0]
+                ]
+            }));
+
+            assert.equal(result, JSON.stringify({
+                root: {
+                    children: [{
+                        type: 'image',
+                        src: 'https://media.tenor.com/images/90daac539a399e176dd7c69def020b1f/tenor.gif',
+                        width: 398,
+                        height: 224,
+                        caption: '',
+                        href: 'https://dailyposter.outpost.pub/gift_subscription#/'
+                    }],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            }));
+        });
     });
 
     describe('card specifics', function () {


### PR DESCRIPTION
closes TryGhost/Product#3764

- In mobiledoc, there are some image cards that have a payload property `type="gif"`
- In the converter, we blindly copy the card payloads from mobiledoc to lexical
- In lexical though, the `type` property is reserved for the type of card, e.g. `image`, `markdown`, `html`
- Using the example of a gif, the converter was creating a lexical card where `type="gif"` which wasn't recognize, so it was being omitted from the rendered output
- This change prevents the converter from overwriting the `type` property in the lexical payload upon conversion from mobiledoc