### PR TITLE
Fixed mobiledocToLexical crash on empty 'a' markup

### DIFF
--- a/packages/kg-converters/lib/mobiledoc-to-lexical.js
+++ b/packages/kg-converters/lib/mobiledoc-to-lexical.js
@@ -165,6 +165,7 @@ function populateLexicalNodeWithMarkers(lexicalNode, markers, mobiledoc) {
     let openMarkups = []; // tracks which markup tags are open for the current marker
     let linkNode = undefined; // tracks current link node or undefined if no a tag is open
     let href = undefined; // tracks the href for the current link node or undefined if no a tag is open
+    let openLinkMarkup = false; // tracks whether the current node is a link node
 
     // loop over markers and convert each one to lexical
     for (let i = 0; i < markers.length; i++) {
@@ -193,7 +194,10 @@ function populateLexicalNodeWithMarkers(lexicalNode, markers, mobiledoc) {
             const markup = markups[markupIndex];
             // Extract the href from the markup if it's a link
             if (markup[0] === 'a') {
-                href = markup[1][1];
+                openLinkMarkup = true;
+                if (markup[1] && markup[1][0] === 'href') {
+                    href = markup[1][1];
+                }
             }
             // Add the markup to the list of open markups
             openMarkups.push(markup);
@@ -205,7 +209,7 @@ function populateLexicalNodeWithMarkers(lexicalNode, markers, mobiledoc) {
 
             // If there is an open link tag, add the text to the link node
             // Otherwise add the text to the parent node
-            if (href) { // link is open
+            if (openLinkMarkup) { // link is open
                 // Create an empty link node if it doesn't exist already
                 linkNode = linkNode !== undefined ? linkNode : createEmptyLexicalNode('a', {url: href});
 
@@ -228,6 +232,7 @@ function populateLexicalNodeWithMarkers(lexicalNode, markers, mobiledoc) {
             // Reset href and linkNode for the next markup
             if (markup[0] === 'a') {
                 embedChildNode(lexicalNode, linkNode);
+                openLinkMarkup = false;
                 href = undefined;
                 linkNode = undefined;
             }

--- a/packages/kg-converters/test/mobiledoc-to-lexical.test.js
+++ b/packages/kg-converters/test/mobiledoc-to-lexical.test.js
@@ -2062,6 +2062,56 @@ describe('mobiledocToLexical', function () {
                 }
             }));
         });
+
+        it('converts successfully when mobiledoc has missing values', function () {
+            const result = mobiledocToLexical(JSON.stringify({version: '0.3.1',
+                atoms: [],
+                cards: [],
+                markups: [
+                    ['a']
+                ],
+                sections: [
+                    [1,'p',[
+                        [0,[0],1,'Blah Blah']
+                    ]]
+                ],
+                ghostVersion: '3.0'}
+            ));
+
+            assert.equal(result, JSON.stringify({root: {
+                children: [{
+                    children: [{
+                        children: [{
+                            detail: 0,
+                            format: 0,
+                            mode: 'normal',
+                            style: '',
+                            text: 'Blah Blah',
+                            type: 'text',
+                            version: 1
+                        }],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'link',
+                        rel: null,
+                        target: null,
+                        title: null,
+                        version: 1
+                    }],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'paragraph',
+                    version: 1
+                }],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }}));
+        });
     });
 
     describe('cards', function () {


### PR DESCRIPTION
closes TryGhost/Product#3766

- Added test for empty 'a' markup
- Fixed crash behavior for mobiledoc strings with an empty 'a' markup