### PR TITLE
Fixed mobiledocToLexical rel attribute handling on links

### DIFF
--- a/packages/kg-converters/lib/mobiledoc-to-lexical.js
+++ b/packages/kg-converters/lib/mobiledoc-to-lexical.js
@@ -165,6 +165,7 @@ function populateLexicalNodeWithMarkers(lexicalNode, markers, mobiledoc) {
     let openMarkups = []; // tracks which markup tags are open for the current marker
     let linkNode = undefined; // tracks current link node or undefined if no a tag is open
     let href = undefined; // tracks the href for the current link node or undefined if no a tag is open
+    let rel = undefined; //tracks the rel attribute for the current link node or undefined if no a tag is open
     let openLinkMarkup = false; // tracks whether the current node is a link node
 
     // loop over markers and convert each one to lexical
@@ -198,6 +199,10 @@ function populateLexicalNodeWithMarkers(lexicalNode, markers, mobiledoc) {
                 if (markup[1] && markup[1][0] === 'href') {
                     href = markup[1][1];
                 }
+
+                if (markup[1] && markup[1][2] === 'rel') {
+                    rel = markup[1][3];
+                }
             }
             // Add the markup to the list of open markups
             openMarkups.push(markup);
@@ -211,7 +216,7 @@ function populateLexicalNodeWithMarkers(lexicalNode, markers, mobiledoc) {
             // Otherwise add the text to the parent node
             if (openLinkMarkup) { // link is open
                 // Create an empty link node if it doesn't exist already
-                linkNode = linkNode !== undefined ? linkNode : createEmptyLexicalNode('a', {url: href});
+                linkNode = linkNode !== undefined ? linkNode : createEmptyLexicalNode('a', {url: href, rel: rel || null});
 
                 // Create a text node and add it to the link node
                 const textNode = createTextNode(value, format);

--- a/packages/kg-converters/test/mobiledoc-to-lexical.test.js
+++ b/packages/kg-converters/test/mobiledoc-to-lexical.test.js
@@ -2112,6 +2112,86 @@ describe('mobiledocToLexical', function () {
                 version: 1
             }}));
         });
+
+        it('converts a paragraph with a link with a rel attribute', function () {
+            const result = mobiledocToLexical(JSON.stringify({
+                version: MOBILEDOC_VERSION,
+                ghostVersion: GHOST_VERSION,
+                atoms: [],
+                cards: [],
+                markups: [
+                    ['a', ['href', 'https://koenig.ghost.org', 'rel', 'noopener noreferrer']]
+                ],
+                sections: [
+                    [1, 'p', [
+                        [0, [], 0, 'Hello, '],
+                        [0, [0], 1, 'world'],
+                        [0, [], 0, '!']
+                    ]]
+                ]
+            }));
+
+            assert.equal(result, JSON.stringify({
+                root: {
+                    children: [
+                        {
+                            children: [
+                                {
+                                    detail: 0,
+                                    format: 0,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: 'Hello, ',
+                                    type: 'text',
+                                    version: 1
+                                },
+                                {
+                                    children: [
+                                        {
+                                            detail: 0,
+                                            format: 0,
+                                            mode: 'normal',
+                                            style: '',
+                                            text: 'world',
+                                            type: 'text',
+                                            version: 1
+                                        }
+                                    ],
+                                    direction: 'ltr',
+                                    format: '',
+                                    indent: 0,
+                                    type: 'link',
+                                    rel: 'noopener noreferrer',
+                                    target: null,
+                                    title: null,
+                                    url: 'https://koenig.ghost.org',
+                                    version: 1
+                                },
+                                {
+                                    detail: 0,
+                                    format: 0,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: '!',
+                                    type: 'text',
+                                    version: 1
+                                }
+                            ],
+                            direction: 'ltr',
+                            format: '',
+                            indent: 0,
+                            type: 'paragraph',
+                            version: 1
+                        }
+                    ],
+                    direction: 'ltr',
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            }));
+        });
     });
 
     describe('cards', function () {


### PR DESCRIPTION
closes TryGhost/Product#3767

- previously the mobiledocToLexical converter would ignore rel attributes on links in the source mobiledoc, leading to differences in rendering between mobiledoc and lexical
- this change adds a test for the rel attribute, and fixes the converter to include it in the output