### PR TITLE
Moved click-above-card behaviour inside editor

### DIFF
--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -9,7 +9,7 @@ import WordCount from './components/WordCount';
 import basicContent from './content/basic-content.json';
 import content from './content/content.json';
 import minimalContent from './content/minimal-content.json';
-import {$createNodeSelection, $getNearestNodeFromDOMNode, $getRoot, $isDecoratorNode, $setSelection} from 'lexical';
+import {$getRoot, $isDecoratorNode} from 'lexical';
 import {
     BASIC_NODES, BASIC_TRANSFORMERS, KoenigComposableEditor,
     KoenigComposer, KoenigEditor, MINIMAL_NODES, MINIMAL_TRANSFORMERS,
@@ -186,19 +186,6 @@ function DemoComposer({editorType, isMultiplayer, setWordCount}) {
                 //scroll to the bottom of the container
                 containerRef.current.scrollTop = containerRef.current.scrollHeight;
             }
-        }
-
-        // when clicking between cards, put focus on the next card
-        const clickedOnKoenigCard = (event.target.closest('[data-kg-card]') !== null) || event.target.hasAttribute('data-kg-card');
-        if (editorAPI && clickedOnDecorator && !clickedOnKoenigCard) {
-            let editor = editorAPI.editorInstance;
-            event.preventDefault();
-            editor.update(() => {
-                const node = $getNearestNodeFromDOMNode(event.target);
-                const nodeSelection = $createNodeSelection();
-                nodeSelection.add(node.getKey());
-                $setSelection(nodeSelection);
-            });
         }
     }
 

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -8,6 +8,7 @@ import {
     $createNodeSelection,
     $createParagraphNode,
     $createTextNode,
+    $getNearestNodeFromDOMNode,
     $getNodeByKey,
     $getRoot,
     $getSelection,
@@ -19,6 +20,7 @@ import {
     $isRangeSelection,
     $isTextNode,
     $setSelection,
+    CLICK_COMMAND,
     COMMAND_PRIORITY_LOW,
     DELETE_LINE_COMMAND,
     INSERT_PARAGRAPH_COMMAND,
@@ -1051,7 +1053,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                     if (selectedCardKey && isEditingCard) {
                         (editor._parentEditor || editor).dispatchCommand(SELECT_CARD_COMMAND, {cardKey: selectedCardKey});
                     }
-                    
+
                     if (editor._parentEditor) {
                         editor._parentEditor.getRootElement().focus();
                     }
@@ -1130,6 +1132,23 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                         const url = linkMatch[1];
                         const embedNode = $createEmbedNode({url});
                         editor.dispatchCommand(INSERT_CARD_COMMAND, {cardNode: embedNode, createdWithUrl: true});
+                        return true;
+                    }
+
+                    return false;
+                },
+                COMMAND_PRIORITY_LOW
+            ),
+            editor.registerCommand(
+                CLICK_COMMAND,
+                (event) => {
+                    if (event.target.matches('[data-lexical-decorator="true"]')) {
+                        // clicked on a decorator node, select it
+                        // - only occurs when the padding above a card is clicked as our
+                        //   cards have their own click handlers
+                        event.preventDefault();
+                        const cardNode = $getNearestNodeFromDOMNode(event.target);
+                        $selectCard(cardNode.getKey());
                         return true;
                     }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3472

- clicking above a card to select it is general editor behaviour, we shouldn't expect consumers of the editor to re-implement that themselves
- added handling to `<KoenigBehaviourPlugin />` so it's in place by default
