### PR TITLE
🐛 Fixed line breaks being removed on editor save

### DIFF
--- a/packages/kg-clean-basic-html/lib/clean-basic-html.js
+++ b/packages/kg-clean-basic-html/lib/clean-basic-html.js
@@ -10,6 +10,15 @@ function removeCodeWrappers(html) {
 }
 
 /* global DOMParser, window */
+/**
+ * Parses an html string and returns a cleaned version
+ * @param {string} html 
+ * @param {Object} _options
+ * @param {boolean} [_options.allowBr] - if true, <br> tags will be kept
+ * @param {boolean} [_options.firstChildInnerContent] - if true, only the innerHTML of the first element will be returned
+ * @param {boolean} [_options.removeCodeWrappers] - if true, <code> wrappers around replacement strings {foo} will be removed
+ * @returns {string}
+ */
 export default function cleanBasicHtml(html = '', _options = {}) {
     const defaults = {};
     const options = Object.assign({}, defaults, _options);

--- a/packages/koenig-lexical/src/nodes/EmailCtaNode.jsx
+++ b/packages/koenig-lexical/src/nodes/EmailCtaNode.jsx
@@ -61,7 +61,7 @@ export class EmailCtaNode extends BaseEmailCtaNode {
         if (this.__htmlEditor) {
             this.__htmlEditor.getEditorState().read(() => {
                 const html = $generateHtmlFromNodes(this.__htmlEditor, null);
-                const cleanedHtml = cleanBasicHtml(html, {removeCodeWrappers: true});
+                const cleanedHtml = cleanBasicHtml(html, {removeCodeWrappers: true, allowBr: true});
                 json.html = cleanedHtml;
             });
         }

--- a/packages/koenig-lexical/src/nodes/EmailNode.jsx
+++ b/packages/koenig-lexical/src/nodes/EmailNode.jsx
@@ -61,7 +61,7 @@ export class EmailNode extends BaseEmailNode {
         if (this.__htmlEditor) {
             this.__htmlEditor.getEditorState().read(() => {
                 const html = $generateHtmlFromNodes(this.__htmlEditor, null);
-                const cleanedHtml = cleanBasicHtml(html, {removeCodeWrappers: true});
+                const cleanedHtml = cleanBasicHtml(html, {removeCodeWrappers: true, allowBr: true});
                 json.html = cleanedHtml;
             });
         }

--- a/packages/koenig-lexical/src/nodes/ProductNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ProductNode.jsx
@@ -74,7 +74,7 @@ export class ProductNode extends BaseProductNode {
         if (this.__productDescriptionEditor) {
             this.__productDescriptionEditor.getEditorState().read(() => {
                 const html = $generateHtmlFromNodes(this.__productDescriptionEditor, null);
-                const cleanedHtml = cleanBasicHtml(html);
+                const cleanedHtml = cleanBasicHtml(html, {allowBr: true});
                 json.productDescription = cleanedHtml;
             });
         }


### PR DESCRIPTION
closes TryGhost/Product#3778
- email cta, email, and product cards were stripping br's from content
- added allowBr prop to cleanBasicHtml for these nested editors