### PR TITLE
🐛 Fixed card icon spacing

### DIFF
--- a/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
@@ -47,7 +47,7 @@ export const CardWrapper = React.forwardRef(({
     return (
         <>
             {IndicatorIcon &&
-                <div className="sticky top-6 mb-6">
+                <div className="sticky mb-[0.3rem]">
                     <IndicatorIcon className="absolute left-[-6rem] top-[.6rem] h-6 w-6 text-grey" />
                 </div>
             }

--- a/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
@@ -138,7 +138,7 @@ test.describe('Email card', async () => {
 
             await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
-                <div class="sticky top-6 mb-6"><svg></svg></div>
+                <div class="sticky mb-[0.3rem]"><svg></svg></div>
                 <div class="relative border-transparent caret-grey-800 hover:shadow-[0_0_0_1px] hover:shadow-green hover:-mx-3 hover:px-3"
                     data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="email-cta">
                     <div class="w-full pb-6">


### PR DESCRIPTION
closes TryGhost/Product#3779
- card icons were increasing in distance from their associated card with each added card
- might be caused by our change from margin to padding with cardwrapper