### PR TITLE
🐛 Fixed deselecting code/md cards on editor blur

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/CodeBlockCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CodeBlockCard.jsx
@@ -12,7 +12,7 @@ import {minimalSetup} from '@uiw/codemirror-extensions-basic-setup';
 import {standardKeymap} from '@codemirror/commands';
 import {tags as t} from '@lezer/highlight';
 
-export function CodeEditor({code, language, updateCode, updateLanguage, onBlur}) {
+export function CodeEditor({code, language, updateCode, updateLanguage}) {
     const [showLanguage, setShowLanguage] = React.useState(true);
     const {darkMode} = React.useContext(KoenigComposerContext);
 
@@ -188,7 +188,6 @@ export function CodeEditor({code, language, updateCode, updateLanguage, onBlur})
                 basicSetup={false} // basic setup includes unnecessary extensions
                 extensions={extensions}
                 value={code}
-                onBlur={onBlur}
                 onChange={onChange}
             />
             <input
@@ -222,7 +221,7 @@ export function CodeBlock({code, darkMode, language}) {
     );
 }
 
-export function CodeBlockCard({captionEditor, captionEditorInitialState, code, darkMode, isEditing, isSelected, language, updateCode, updateLanguage, onBlur}) {
+export function CodeBlockCard({captionEditor, captionEditorInitialState, code, darkMode, isEditing, isSelected, language, updateCode, updateLanguage}) {
     if (isEditing) {
         return (
             <CodeEditor
@@ -231,7 +230,6 @@ export function CodeBlockCard({captionEditor, captionEditorInitialState, code, d
                 language={language}
                 updateCode={updateCode}
                 updateLanguage={updateLanguage}
-                onBlur={onBlur}
             />
         );
     } else {
@@ -254,8 +252,7 @@ CodeEditor.propTypes = {
     code: PropTypes.string,
     language: PropTypes.string,
     updateCode: PropTypes.func,
-    updateLanguage: PropTypes.func,
-    onBlur: PropTypes.func
+    updateLanguage: PropTypes.func
 };
 
 CodeBlock.propTypes = {
@@ -273,6 +270,5 @@ CodeBlockCard.propTypes = {
     isEditing: PropTypes.bool,
     isSelected: PropTypes.bool,
     updateCode: PropTypes.func,
-    updateLanguage: PropTypes.func,
-    onBlur: PropTypes.func
+    updateLanguage: PropTypes.func
 };

--- a/packages/koenig-lexical/src/components/ui/cards/HtmlCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/HtmlCard.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {sanitizeHtml} from '../../../utils/sanitize-html';
 
-export function HtmlCard({html, updateHtml, isEditing, darkMode, onBlur}) {
+export function HtmlCard({html, updateHtml, isEditing, darkMode}) {
     return (
         <>
             {isEditing
@@ -13,7 +13,6 @@ export function HtmlCard({html, updateHtml, isEditing, darkMode, onBlur}) {
                         darkMode={darkMode}
                         html={html}
                         updateHtml={updateHtml}
-                        onBlur={onBlur}
                     />
                 )
                 : <div><HtmlDisplay html={html} /><div className="absolute inset-0 z-50 mt-0"></div></div>
@@ -36,6 +35,5 @@ HtmlCard.propTypes = {
     html: PropTypes.string,
     updateHtml: PropTypes.func,
     isEditing: PropTypes.bool,
-    darkMode: PropTypes.bool,
-    onBlur: PropTypes.func
+    darkMode: PropTypes.bool
 };

--- a/packages/koenig-lexical/src/nodes/CodeBlockNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CodeBlockNodeComponent.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import {$getNodeByKey} from 'lexical';
 import {ActionToolbar} from '../components/ui/ActionToolbar.jsx';
 import {CodeBlockCard} from '../components/ui/cards/CodeBlockCard';
-import {DESELECT_CARD_COMMAND} from '../plugins/KoenigBehaviourPlugin';
 import {SnippetActionToolbar} from '../components/ui/SnippetActionToolbar.jsx';
 import {ToolbarMenu, ToolbarMenuItem, ToolbarMenuSeparator} from '../components/ui/ToolbarMenu.jsx';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
@@ -35,19 +34,6 @@ export function CodeBlockNodeComponent({nodeKey, captionEditor, captionEditorIni
         setEditing(true);
     };
 
-    const onBlur = (event) => {
-        // ignore if clicking on the language selection input
-        const relatedTarget = event?.relatedTarget;
-        if (relatedTarget?.ariaLabel === 'Code card language') {
-            return;
-        }
-        // deselect if clicking outside the card
-        //  this check results in deferring to the Cmd+Enter handling in KoenigBehaviourPlugin when the cause of the blur
-        if (relatedTarget?.className !== 'kg-prose') {
-            editor.dispatchCommand(DESELECT_CARD_COMMAND, {cardKey: nodeKey});
-        }
-    };
-
     return (
         <>
             <CodeBlockCard
@@ -62,7 +48,6 @@ export function CodeBlockNodeComponent({nodeKey, captionEditor, captionEditorIni
                 nodeKey={nodeKey}
                 updateCode={updateCode}
                 updateLanguage={updateLanguage}
-                onBlur={onBlur}
             />
             <ActionToolbar
                 data-kg-card-toolbar="button"

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -135,14 +135,18 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                 return;
             }
 
+            // clicks outside of editor should deselect cards
+            //  this more generic handling prevents the need to handle blur for codemirror cards (and likely others)
             if (containerElem.current && !containerElem.current.contains(event.target)) {
-                editor.update(() => {
+                editor.getEditorState().read(() => {
                     const selection = $getSelection();
-
                     if ($isNodeSelection(selection)) {
-                        $setSelection(null);
+                        const selectedNode = selection.getNodes()[0];
+                        if ($isKoenigCard(selectedNode)) {
+                            editor.dispatchCommand(DESELECT_CARD_COMMAND, {cardKey: selectedNode.getKey()});
+                        }
                     }
-                }, {tag: 'history-merge'});
+                });
             }
         };
 

--- a/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
@@ -263,8 +263,10 @@ test.describe('Code Block card', async () => {
         await page.keyboard.type('```javascript ');
         await page.waitForSelector('[data-kg-card="codeblock"] .cm-editor');
 
+        // Types slower. Codemirror can be slow and needs some time to place the cursor after entering text.
         await page.keyboard.type('Here are some words');
-        await page.getByTestId('post-title').fill('post title'); // move focus outside of the editor
+        await page.getByTestId('post-title').click();
+        await page.keyboard.type('post title'); // click outside of the editor
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">

--- a/packages/koenig-lexical/test/e2e/cards/html-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/html-card.test.js
@@ -112,7 +112,7 @@ test.describe('Html card', async () => {
         await expect(page.getByText('Here are some words')).toBeVisible();
     });
 
-    test.only('goes into display mode when losing focus', async function () {
+    test('goes into display mode when losing focus', async function () {
         await focusEditor(page);
         // insert new card
         await page.keyboard.type('/html');

--- a/packages/koenig-lexical/test/e2e/cards/html-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/html-card.test.js
@@ -112,7 +112,7 @@ test.describe('Html card', async () => {
         await expect(page.getByText('Here are some words')).toBeVisible();
     });
 
-    test('goes into display mode when losing focus', async function () {
+    test.only('goes into display mode when losing focus', async function () {
         await focusEditor(page);
         // insert new card
         await page.keyboard.type('/html');
@@ -124,7 +124,8 @@ test.describe('Html card', async () => {
 
         // Types slower. Codemirror can be slow and needs some time to place the cursor after entering text.
         await page.keyboard.type('Here are some words');
-        await page.getByTestId('post-title').fill('post title'); // move focus outside of the editor
+        await page.getByTestId('post-title').click();
+        await page.keyboard.type('post title'); // click outside of the editor
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">


### PR DESCRIPTION
closes TryGhost/Product#3410
- moved to card deselection command on editor blur
- refactored existing code/html card handling