### PR TITLE
Added Escape key shortcut to Unsplash modal

### DIFF
--- a/packages/koenig-lexical/src/components/ui/UnsplashModal.jsx
+++ b/packages/koenig-lexical/src/components/ui/UnsplashModal.jsx
@@ -27,6 +27,18 @@ const UnsplashModal = ({onClose, onImageInsert, unsplashConf}) => {
     }, [zoomedImg, scrollPos, lastScrollPos]);
 
     React.useEffect(() => {
+        const handleKeyDown = (e) => {
+            if (e.key === 'Escape') {
+                onClose();
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [onClose]);
+
+    React.useEffect(() => {
         const ref = galleryRef.current;
         if (!zoomedImg) {
             if (ref) {

--- a/packages/koenig-lexical/test/e2e/modals/UnsplashSelector.test.js
+++ b/packages/koenig-lexical/test/e2e/modals/UnsplashSelector.test.js
@@ -154,5 +154,14 @@ test.describe('Modals', async () => {
         await expect(page.locator('[data-kg-unsplash-zoomed]')).not.toBeVisible();
     });
 
+    test('can close modal with escape key', async () => {
+        await focusEditor(page);
+        await page.click('[data-kg-plus-button]');
+        await page.click('button[data-kg-card-menu-item="Unsplash"]');
+        await expect(page.locator('[data-kg-modal="unsplash"]')).toBeVisible();
+        await page.keyboard.press('Escape');
+        await expect(page.locator('[data-kg-modal="unsplash"]')).not.toBeVisible();
+    });
+
     //test.fixme('can infinite scroll');
 });


### PR DESCRIPTION
closes TryGhost/Product#3780
- added Esc key listener to close the modal