### PR TITLE
Improved `matches` for embed cards

### DIFF
--- a/packages/koenig-lexical/src/nodes/EmbedNode.jsx
+++ b/packages/koenig-lexical/src/nodes/EmbedNode.jsx
@@ -38,7 +38,7 @@ export class EmbedNode extends BaseEmbedNode {
         Icon: YouTubeIcon,
         insertCommand: INSERT_EMBED_COMMAND,
         queryParams: ['url'],
-        matches: ['youtube'],
+        matches: ['embed','youtube','video'],
         priority: 1
     },
     {
@@ -48,7 +48,7 @@ export class EmbedNode extends BaseEmbedNode {
         Icon: TwitterIcon,
         insertCommand: INSERT_EMBED_COMMAND,
         queryParams: ['url'],
-        matches: ['twitter'],
+        matches: ['embed','twitter'],
         priority: 2
     },
     {
@@ -58,7 +58,7 @@ export class EmbedNode extends BaseEmbedNode {
         Icon: VimeoIcon,
         insertCommand: INSERT_EMBED_COMMAND,
         queryParams: ['url'],
-        matches: ['vimeo'],
+        matches: ['embed','vimeo','video'],
         priority: 4
     },
     {
@@ -68,7 +68,7 @@ export class EmbedNode extends BaseEmbedNode {
         Icon: CodePenIcon,
         insertCommand: INSERT_EMBED_COMMAND,
         queryParams: ['url'],
-        matches: ['codepen'],
+        matches: ['embed','codepen'],
         priority: 5
     },
     {
@@ -78,7 +78,7 @@ export class EmbedNode extends BaseEmbedNode {
         Icon: SpotifyIcon,
         insertCommand: INSERT_EMBED_COMMAND,
         queryParams: ['url'],
-        matches: ['spotify'],
+        matches: ['embed','spotify'],
         priority: 6
     },
     {
@@ -88,7 +88,7 @@ export class EmbedNode extends BaseEmbedNode {
         Icon: SoundCloudIcon,
         insertCommand: INSERT_EMBED_COMMAND,
         queryParams: ['url'],
-        matches: ['soundcloud'],
+        matches: ['embed','soundcloud'],
         priority: 7
     }];
 

--- a/packages/koenig-lexical/src/nodes/EmbedNode.jsx
+++ b/packages/koenig-lexical/src/nodes/EmbedNode.jsx
@@ -48,7 +48,7 @@ export class EmbedNode extends BaseEmbedNode {
         Icon: TwitterIcon,
         insertCommand: INSERT_EMBED_COMMAND,
         queryParams: ['url'],
-        matches: ['embed','twitter'],
+        matches: ['embed','twitter','x'],
         priority: 2
     },
     {


### PR DESCRIPTION
- All embed cards now match "embed"

![Ghost Koenig Editor - All embed cards now match "embed"](https://github.com/TryGhost/Koenig/assets/5418178/e3ec39b4-8bea-45b1-9331-e61fa15604bf)

- YouTube and Vimeo now match "video"

![Ghost Koenig Editor - YouTube and Vimeo now match "video"](https://github.com/TryGhost/Koenig/assets/5418178/63e92c51-bffd-4d0f-ba08-a0d19ccfbf4c)


---

This allows for much faster embed card selection since you don't need to use the mouse to easily find embed cards or video embed cards.