### PR TITLE
🐛 Fixed code/html/markdown cards being removed when cutting content inside their editors

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -22,6 +22,7 @@ import {
     $setSelection,
     CLICK_COMMAND,
     COMMAND_PRIORITY_LOW,
+    CUT_COMMAND,
     DELETE_LINE_COMMAND,
     INSERT_PARAGRAPH_COMMAND,
     KEY_ARROW_DOWN_COMMAND,
@@ -1153,6 +1154,18 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                         event.preventDefault();
                         const cardNode = $getNearestNodeFromDOMNode(event.target);
                         $selectCard(cardNode.getKey());
+                        return true;
+                    }
+
+                    return false;
+                },
+                COMMAND_PRIORITY_LOW
+            ),
+            editor.registerCommand(
+                CUT_COMMAND,
+                (event) => {
+                    // prevent cut events inside card editors triggering lexical behaviour
+                    if (shouldIgnoreEvent(event)) {
                         return true;
                     }
 

--- a/packages/koenig-lexical/src/utils/shouldIgnoreEvent.js
+++ b/packages/koenig-lexical/src/utils/shouldIgnoreEvent.js
@@ -15,7 +15,7 @@ export const shouldIgnoreEvent = (event) => {
         return false;
     }
 
-    const isFromCardEditor = target.matches('input, textarea') || !!target.closest('.cm-editor');
+    const isFromCardEditor = target.matches('input, textarea') || target.cmView || !!target.closest('.cm-editor');
 
     return isFromCardEditor;
 };


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/3785

- we were preventing default Lexical behaviour for <kbd>Cmd+X</kbd> in our `KEY_MODIFIER_COMMAND` handler but that still leaves the browser's `cut` event which meant it was being handled by the CodeMirror editor and then bubbling up to Lexical which then cut the card
- added a `CUT_COMMAND` handler that uses the same `shouldIgnoreEvent()` function to prevent default behaviour when the event occurred inside a card's editor/input
- updated `shouldIgnoreEvent()` to look for `target.cmView` when determining if the event was intended for a nested editor to handle the case where CodeMirror marker highlighting was breaking the `.closest('.cm-editor')` check
