### PR TITLE
Fixed direction attribute for converted nodes

### DIFF
--- a/packages/kg-converters/lib/mobiledoc-to-lexical.js
+++ b/packages/kg-converters/lib/mobiledoc-to-lexical.js
@@ -263,7 +263,7 @@ function createEmptyLexicalNode(tagName, attributes = {}) {
     const nodeParams = TAG_TO_LEXICAL_NODE[tagName];
     const node = {
         children: [],
-        direction: null,
+        direction: 'ltr',
         format: '',
         indent: 0,
         ...nodeParams,

--- a/packages/kg-converters/test/mobiledoc-to-lexical.test.js
+++ b/packages/kg-converters/test/mobiledoc-to-lexical.test.js
@@ -46,7 +46,7 @@ describe('mobiledocToLexical', function () {
                 root: {
                     children: [{
                         children: [],
-                        direction: null,
+                        direction: 'ltr',
                         format: '',
                         indent: 0,
                         type: 'paragraph',
@@ -2099,7 +2099,7 @@ describe('mobiledocToLexical', function () {
                         title: null,
                         version: 1
                     }],
-                    direction: null,
+                    direction: 'ltr',
                     format: '',
                     indent: 0,
                     type: 'paragraph',
@@ -2335,7 +2335,7 @@ describe('mobiledocToLexical', function () {
                         card: 1
                     }, {
                         children: [],
-                        direction: null,
+                        direction: 'ltr',
                         format: '',
                         indent: 0,
                         type: 'paragraph',


### PR DESCRIPTION
no issue

- When converting a published post from mobiledoc to lexical, the editor would enable the 'Update' button as if changes had been made that need to be saved
- During conversion, the direction attribute on e.g. a paragraph node was being set to `null` instead of `'ltr'` as it should have been.
- Upon loading in the editor, `direction: null` was replaced by `direction: 'ltr'` which caused the editor to think the post had been changed and needed to be saved
- This change sets the direction to 'ltr' during conversion so that the editor doesn't think the post has been changed and the Update button is not enabled