### PR TITLE
🐛 Fixed ordering of links and linebreaks when rendering

### DIFF
--- a/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
+++ b/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
@@ -73,11 +73,14 @@ class TextContent {
             return;
         }
 
+        // insert any queued line breaks
+        this._insertQueuedLineBreaks();
+
         const a = this.doc.createElement('a');
 
         // Only set the href if we have a URL, otherwise we get a link to the current page
         if (node.getURL()) {
-            a.setAttribute('href', node.getURL());            
+            a.setAttribute('href', node.getURL());
         }
         if (node.getRel()) {
             a.setAttribute('rel', node.getRel());

--- a/packages/kg-lexical-html-renderer/test/render.test.js
+++ b/packages/kg-lexical-html-renderer/test/render.test.js
@@ -49,4 +49,14 @@ describe('Special elements', function () {
         input: `{"root":{"children":[{"children":[{"detail":0,"format":1,"mode":"normal","style":"","text":"One","type":"text","version":1},{"type":"linebreak","version":1},{"type":"linebreak","version":1},{"detail":0,"format":0,"mode":"normal","style":"","text":"Two","type":"text","version":1},{"type":"linebreak","version":1},{"type":"linebreak","version":1},{"detail":0,"format":1,"mode":"normal","style":"","text":"Three","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
         output: `<p><strong>One</strong><br><br>Two<br><br><strong>Three</strong></p>`
     }));
+
+    it('linebreaks with links', shouldRender ({
+        input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Test","type":"text","version":1},{"type":"linebreak","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"a link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"title":null,"url":"https://ghost.org"},{"detail":0,"format":0,"mode":"normal","style":"","text":" some text","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+        output: `<p>Test<br><a href="https://ghost.org">a link</a> some text</p>`
+    }));
+
+    it('multiple linebreaks with links', shouldRender ({
+        input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Test","type":"text","version":1},{"type":"linebreak","version":1},{"type":"linebreak","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"a link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"title":null,"url":"https://ghost.org"},{"detail":0,"format":0,"mode":"normal","style":"","text":" some text","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+        output: `<p>Test<br><br><a href="https://ghost.org">a link</a> some text</p>`
+    }));
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3827

- we weren't rendering any queued line breaks when inserting a link node which meant links were being rendered before line breaks rather than after them
