### PR TITLE
Fixed bookmark card email renderer

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/bookmark/bookmark-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/bookmark/bookmark-renderer.js
@@ -39,8 +39,8 @@ function emailTemplate(node, document) {
                         <div class="kg-bookmark-description">${description}</div>
                         <div class="kg-bookmark-metadata">
                             ${icon ? `<img class="kg-bookmark-icon" src="${icon}" alt="">` : ''}
-                            ${publisher ? `<span class="kg-bookmark-publisher" src="${publisher}">${publisher}</span>` : ''}
-                            ${author ? `<span class="kg-bookmark-author" src="${author}">${author}</span>` : ''}
+                            ${publisher ? `<span class="kg-bookmark-author" src="${publisher}">${publisher}</span>` : ''}
+                            ${author ? `<span class="kg-bookmark-publisher" src="${author}">${author}</span>` : ''}
                         </div>
                     </div>
                     ${thumbnail ? `<div class="kg-bookmark-thumbnail" style="background-image: url('${thumbnail}')">


### PR DESCRIPTION
closes TryGhost/Product#3858
- swapped css classes for author and publisher
- while 'incorrect', this would be a breaking change for themes and should remain swapped; see comment