### PR TITLE
✨Added shift arrow key selection handling

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -18,6 +18,7 @@ import {
     $isNodeSelection,
     $isParagraphNode,
     $isRangeSelection,
+    $isRootNode,
     $isTextNode,
     $setSelection,
     CLICK_COMMAND,
@@ -453,8 +454,48 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
             editor.registerCommand(
                 KEY_ARROW_UP_COMMAND,
                 (event) => {
-                    // stick to default behaviour if a selection is being made
+                    const selection = $getSelection();
+
+                    // if a selection is being made, we need to handle it ourselves (lexical does not handle decorator nodes at this time)
                     if (event?.shiftKey) {
+                        if ($isRangeSelection(selection)) {
+                            let anchorNode = selection.anchor.getNode();
+
+                            if (!$isRootNode(anchorNode)) {
+                                anchorNode = anchorNode.getTopLevelElement();
+                                let focusNode = selection.focus.getNode().getTopLevelElement();
+
+                                // treat text nodes as normal
+                                let previousSibling = focusNode.getTopLevelElement().getPreviousSibling();
+                                if ($isTextNode(focusNode) && $isTextNode(previousSibling)) {
+                                    return false;
+                                }
+                                // if on or about to move to decorator node selection, select the entire current node using root node offsets
+                                if ($isDecoratorNode(anchorNode) || $isDecoratorNode(previousSibling)) {
+                                    // if at the start of the line, treat that line/node as not selected
+                                    if (selection.anchor.offset === 0) {
+                                        selection.focus.set('root', focusNode.getIndexWithinParent() - 1, 'element');
+                                        selection.anchor.set('root', anchorNode.getIndexWithinParent(), 'element');
+                                    } else {
+                                        selection.focus.set('root', focusNode.getIndexWithinParent(), 'element');
+                                        selection.anchor.set('root', anchorNode.getIndexWithinParent() + 1, 'element');
+                                    }
+                                    event.preventDefault(); 
+                                    return true;
+                                }
+                            }
+
+                            // if using the root node, simply add the card above
+                            if ($isRootNode(anchorNode)) {
+                                const offset = selection.focus.offset;
+                                if (offset > 0) {
+                                    selection.focus.set('root', selection.focus.offset - 1, 'element');
+                                }
+                                event.preventDefault();
+                                return true;
+                            }
+                        }
+                        // use default behavior for other selection
                         return false;
                     }
 
@@ -467,8 +508,6 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                     if (document.activeElement !== editor.getRootElement()) {
                         return true;
                     }
-
-                    const selection = $getSelection();
 
                     if ($isNodeSelection(selection)) {
                         const currentNode = selection.getNodes()[0];
@@ -537,8 +576,48 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
             editor.registerCommand(
                 KEY_ARROW_DOWN_COMMAND,
                 (event) => {
-                    // stick to default behaviour if shift key is pressed
+                    const selection = $getSelection();
+
+                    // if a selection is being made, we need to handle it ourselves (lexical does not handle decorator nodes at this time)
                     if (event?.shiftKey) {
+                        if ($isRangeSelection(selection)) {
+                            let anchorNode = selection.anchor.getNode();
+
+                            if (!$isRootNode(anchorNode)) {
+                                anchorNode = anchorNode.getTopLevelElement();
+                                let focusNode = selection.focus.getNode().getTopLevelElement();
+
+                                // treat text nodes as normal
+                                let nextSibling = focusNode.getTopLevelElement().getNextSibling();
+                                if ($isTextNode(focusNode) && $isTextNode(nextSibling)) {
+                                    return false;
+                                }
+                                // if on or about to move to decorator node selection, select the entire current node using root node offsets
+                                if ($isDecoratorNode(anchorNode) || $isDecoratorNode(nextSibling)) {
+                                    // if at end of a line, treat it as if that line/node is not selected
+                                    if (selection.anchor.offset === anchorNode.getTextContentSize()) {
+                                        selection.anchor.set('root', anchorNode.getIndexWithinParent() + 1, 'element');
+                                        selection.focus.set('root', focusNode.getIndexWithinParent() + 2, 'element');
+                                    } else {
+                                        selection.anchor.set('root', anchorNode.getIndexWithinParent(), 'element');
+                                        selection.focus.set('root', focusNode.getIndexWithinParent() + 1, 'element');
+                                    }
+                                    event.preventDefault(); 
+                                    return true;
+                                }
+                            }
+
+                            // if using the root node, simply add the card below
+                            if ($isRootNode(anchorNode)) {
+                                const offset = selection.focus.offset;
+                                if (offset <= anchorNode.getLastChildOrThrow().getIndexWithinParent()) {
+                                    selection.focus.set('root', selection.focus.offset + 1, 'element');
+                                }
+                                event.preventDefault();
+                                return true;
+                            }
+                        }
+                        // use default behavior for other selection
                         return false;
                     }
 
@@ -551,8 +630,6 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                     if (document.activeElement !== editor.getRootElement()) {
                         return true;
                     }
-
-                    const selection = $getSelection();
 
                     if ($isNodeSelection(selection)) {
                         const currentNode = selection.getNodes()[0];

--- a/packages/koenig-lexical/test/e2e/card-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/card-behaviour.test.js
@@ -1405,13 +1405,14 @@ test.describe('Card behaviour', async () => {
             await page.keyboard.press('ArrowDown');
             await page.keyboard.up('Shift');
 
+            // offsets are based on the root node offset
             await assertSelection(page, {
-                anchorPath: [0, 0, 0],
+                anchorPath: [],
                 anchorOffset: 0,
-                focusPath: [2, 0, 0],
-                focusOffset: 6
+                focusPath: [],
+                focusOffset: 2
             });
-
+            // this is a range selection, so the card is not explicitly selected
             await expect(page.locator('[data-kg-card-selected="true"]')).not.toBeVisible();
         });
 
@@ -1435,13 +1436,14 @@ test.describe('Card behaviour', async () => {
             await page.keyboard.press('ArrowUp');
             await page.keyboard.up('Shift');
 
+            // offsets are based on the root node offset
             await assertSelection(page, {
-                anchorPath: [2, 0, 0],
-                anchorOffset: 6,
-                focusPath: [0, 0, 0],
-                focusOffset: 0
+                anchorPath: [],
+                anchorOffset: 3,
+                focusPath: [],
+                focusOffset: 1
             });
-
+            // this is a range selection, so the card is not explicitly selected
             await expect(page.locator('[data-kg-card-selected="true"]')).not.toBeVisible();
         });
     });


### PR DESCRIPTION
closes TryGhost/Product#3087
- arrow keys will do block selection when encountering decorator nodes (cards)
- dependent on lexical 0.12.2
- handling not in native lexical