### PR TITLE
🐛 Fixed galleries not saving last image

### DIFF
--- a/packages/kg-default-nodes/test/nodes/gallery.test.js
+++ b/packages/kg-default-nodes/test/nodes/gallery.test.js
@@ -805,6 +805,105 @@ describe('GalleryNode', function () {
             output.should.match(/height="1800"/);
         }));
 
+        it('renders all 9 images in a 3x3 grid', editorTest(function () {
+            const galleryNode = $createGalleryNode({
+                type: 'gallery',
+                version: 1,
+                images: [
+                    {
+                        row: 0,
+                        src: '/content/images/2018/08/NatGeo01-1.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-1.jpg'
+                    },
+                    {
+                        row: 0,
+                        src: '/content/images/2018/08/NatGeo01-2.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-2.jpg'
+                    },
+                    {
+                        row: 0,
+                        src: '/content/images/2018/08/NatGeo01-3.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-3.jpg'
+                    },
+                    {
+                        row: 1,
+                        src: '/content/images/2018/08/NatGeo01-4.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-4.jpg'
+                    },
+                    {
+                        row: 1,
+                        src: '/content/images/2018/08/NatGeo01-5.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-5.jpg'
+                    },
+                    {
+                        row: 1,
+                        src: '/content/images/2018/08/NatGeo01-6.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-6.jpg'
+                    },
+                    {
+                        row: 2,
+                        src: '/content/images/2018/08/NatGeo01-7.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-7.jpg'
+                    },
+                    {
+                        row: 2,
+                        src: '/content/images/2018/08/NatGeo01-8.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-8.jpg'
+                    },
+                    {
+                        row: 2,
+                        src: '/content/images/2018/08/NatGeo01-9.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-9.jpg'
+                    }
+                ],
+                caption: ''
+            });
+
+            // skip srcset
+            delete exportOptions.imageOptimization.contentImageSizes;
+            const {element} = galleryNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(html`
+                <figure class="kg-card kg-gallery-card kg-width-wide">
+                    <div class="kg-gallery-container">
+                        <div class="kg-gallery-row">
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-1.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-2.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-3.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                        </div>
+                        <div class="kg-gallery-row">
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-4.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-5.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-6.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                        </div>
+                        <div class="kg-gallery-row">
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-7.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-8.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-9.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                        </div>
+                    </div>
+                </figure>
+            `);
+        }));
+
         describe('srcset', function () {
             it('is included when image src is relative or Unsplash', editorTest(function () {
                 const galleryNode = $createGalleryNode({

--- a/packages/koenig-lexical/src/nodes/GalleryNode.jsx
+++ b/packages/koenig-lexical/src/nodes/GalleryNode.jsx
@@ -96,7 +96,7 @@ export class GalleryNode extends BaseGalleryNode {
     // TODO: move to kg-default-nodes?
     setImages(images) {
         const datasetImages = images
-            .slice(0, MAX_IMAGES - 1)
+            .slice(0, MAX_IMAGES)
             .map(image => pick(image, ALLOWED_IMAGE_PROPS));
 
         recalculateImageRows(datasetImages);
@@ -105,7 +105,7 @@ export class GalleryNode extends BaseGalleryNode {
 
     addImages(images) {
         const datasetImages = [...this.images, ...images]
-            .slice(0, MAX_IMAGES - 1)
+            .slice(0, MAX_IMAGES)
             .map(image => pick(image, ALLOWED_IMAGE_PROPS));
 
         recalculateImageRows(datasetImages);

--- a/packages/koenig-lexical/test/e2e/cards/gallery-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/gallery-card.test.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import {assertHTML, createDataTransfer, ctrlOrCmd, focusEditor, html, initialize, insertCard} from '../../utils/e2e';
+import {assertHTML, createDataTransfer, ctrlOrCmd, focusEditor, getEditorState, html, initialize, insertCard} from '../../utils/e2e';
 import {expect, test} from '@playwright/test';
 import {fileURLToPath} from 'url';
 const __filename = fileURLToPath(import.meta.url);
@@ -424,4 +424,29 @@ test.describe('Gallery card', async () => {
     //     await assertHTML(page, `
     //     `, {ignoreCardContents: true});
     // });
+
+    test('exports all 9 images', async function () {
+        // necessary to check the saved data because the gallery card state is not
+        // directly synchronized with the editor state at time of testing
+        // (it keeps it's own state for easier handling of loading states, etc.)
+
+        await test.step('insert and upload images to gallery card', async () => {
+            const filePaths = Array.from(Array(9).keys()).map(n => path.relative(process.cwd(), __dirname + `/../fixtures/large-image-${n}.png`));
+            const fileChooserPromise = page.waitForEvent('filechooser');
+
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'gallery'});
+            await page.click('[name="placeholder-button"]');
+
+            const fileChooser = await fileChooserPromise;
+            await fileChooser.setFiles(filePaths);
+
+            await expect(page.locator('[data-testid="gallery-image"]')).toHaveCount(9);
+        });
+
+        const editorState = await getEditorState(page);
+
+        expect(editorState.root.children[0].type).toEqual('gallery');
+        expect(editorState.root.children[0].images).toHaveLength(9);
+    });
 });

--- a/packages/koenig-lexical/test/utils/e2e.js
+++ b/packages/koenig-lexical/test/utils/e2e.js
@@ -412,3 +412,9 @@ export async function createDataTransfer(page, data = []) {
         return dt;
     }, filesData);
 }
+
+export async function getEditorState(page) {
+    return await page.evaluate(() => {
+        return window.lexicalEditor.getEditorState().toJSON();
+    });
+}


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/3866
refs https://github.com/TryGhost/Koenig/pull/866

- previous PR adding gallery conversion feature added some util methods to the editor's `GalleryNode` for setting/adding images but it contained an off-by-one bug that meant the last image was skipped when creating the node's dataset
- this wasn't obvious in the editor itself because the gallery card component has it's own state that is only derived from the node's state on first render
