### PR TITLE
🐛 Added overlay to Collection card

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/CollectionCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CollectionCard.jsx
@@ -8,6 +8,7 @@ import {DateTime} from 'luxon';
 import {ReactComponent as GridLayoutIcon} from '../../../assets/icons/kg-layout-grid.svg';
 import {ReactComponent as ImgPlaceholderIcon} from '../../../assets/icons/kg-img-placeholder.svg';
 import {ReactComponent as ListLayoutIcon} from '../../../assets/icons/kg-layout-list.svg';
+import {ReadOnlyOverlay} from '../ReadOnlyOverlay';
 import {isEditorEmpty} from '../../../utils/isEditorEmpty';
 
 function PostImage({image, layout, columns, isLoading}) {
@@ -298,6 +299,7 @@ export function CollectionCard({
                     }
                 </SettingsPanel>
             )}
+            {!isEditing && <ReadOnlyOverlay />}
         </>
     );
 }


### PR DESCRIPTION
closes TryGhost/Product#3876
- cursor could select text but not be able to edit it
- added overlay to force edit mode toggle