### PR TITLE
Added support for dynamic data in rendering

### DIFF
--- a/packages/kg-default-nodes/lib/generate-decorator-node.js
+++ b/packages/kg-default-nodes/lib/generate-decorator-node.js
@@ -172,6 +172,13 @@ export function generateDecoratorNode({nodeType, properties = [], version = 1}) 
         /* c8 ignore stop */
 
         /**
+         * Defines whether a node has dynamic data that needs to be fetched from the server when rendering
+         */
+        hasDynamicData() {
+            return false;
+        }
+
+        /**
          * Defines whether a node has an edit mode in the editor UI
          */
         hasEditMode() {

--- a/packages/kg-lexical-html-renderer/lib/get-dynamic-data-nodes.js
+++ b/packages/kg-lexical-html-renderer/lib/get-dynamic-data-nodes.js
@@ -1,0 +1,23 @@
+const {$getRoot} = require('lexical');
+const {$isKoenigCard} = require('@tryghost/kg-default-nodes');
+
+function getDynamicDataNodes(editorState) {
+    let dynamicNodes = [];
+
+    editorState.read(() => {
+        const root = $getRoot();
+        const nodes = root.getChildren();
+
+        nodes.forEach((node) => {
+            if ($isKoenigCard(node) && node.hasDynamicData?.()) {
+                dynamicNodes.push(node);
+            }
+        });
+    });
+
+    return dynamicNodes;
+}
+
+module.exports = {
+    getDynamicDataNodes
+};


### PR DESCRIPTION
closes TryGhost/Product#3884
- added `hasDynamicData` method to decorator nodes
- nodes with dynamic data should override `hasDynamicData` and implement a `getDynamicData` method