### PR TITLE
:sparkles: Added a new button on image toolbar to reduce the size of an image.

### DIFF
--- a/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
@@ -9,7 +9,8 @@ const CARD_WIDTH_CLASSES = {
         'lg:w-[calc(100%+22rem)] lg:left-[calc(50%-(100%+22rem)/2)]',
         'xl:w-[calc(100%+40rem)] xl:left-[calc(50%-(100%+40rem)/2)]'
     ].join(' '),
-    full: 'inset-x-[-1px] mx-[calc(50%-50vw+(var(--kg-breakout-adjustment)/2))] w-[calc(100vw-var(--kg-breakout-adjustment)+2px)]'
+    full: 'inset-x-[-1px] mx-[calc(50%-50vw+(var(--kg-breakout-adjustment)/2))] w-[calc(100vw-var(--kg-breakout-adjustment)+2px)]',
+    half: 'inset-x-[-1px] w-[calc(50%+2rem)] left-[calc(50%-(50%+2rem)/2)]'
 };
 
 export const CardWrapper = React.forwardRef(({
@@ -70,7 +71,7 @@ CardWrapper.displayName = 'CardWrapper';
 CardWrapper.propTypes = {
     isSelected: PropTypes.bool,
     isEditing: PropTypes.bool,
-    cardWidth: PropTypes.oneOf(['regular', 'wide', 'full']),
+    cardWidth: PropTypes.oneOf(['regular', 'wide', 'full', 'half']),
     icon: PropTypes.string
 };
 

--- a/packages/koenig-lexical/src/components/ui/ToolbarMenu.jsx
+++ b/packages/koenig-lexical/src/components/ui/ToolbarMenu.jsx
@@ -12,6 +12,7 @@ import {ReactComponent as LinkIcon} from '../../assets/icons/kg-link.svg';
 import {ReactComponent as QuoteIcon} from '../../assets/icons/kg-quote.svg';
 import {ReactComponent as QuoteOneIcon} from '../../assets/icons/kg-quote-1.svg';
 import {ReactComponent as QuoteTwoIcon} from '../../assets/icons/kg-quote-2.svg';
+import {ReactComponent as ShrinkIcon} from '../../assets/icons/kg-shrink.svg';
 import {ReactComponent as SnippetIcon} from '../../assets/icons/kg-snippet.svg';
 import {ReactComponent as TrashIcon} from '../../assets/icons/kg-trash.svg';
 
@@ -27,6 +28,7 @@ export const TOOLBAR_ICONS = {
     imgRegular: ImgRegularIcon,
     imgWide: ImgWideIcon,
     imgFull: ImgFullIcon,
+    imgHalf: ShrinkIcon,
     imgReplace: ImgReplaceIcon,
     add: AddIcon,
     edit: EditIcon,

--- a/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
@@ -239,6 +239,13 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, captionE
                         label="Full"
                         onClick={() => handleImageCardResize('full')}
                     />
+                    <ToolbarMenuItem
+                        hide={isGif(src)}
+                        icon="imgHalf"
+                        isActive={cardWidth === 'half'}
+                        label="Half"
+                        onClick={() => handleImageCardResize('half')}
+                    />
                     <ToolbarMenuSeparator hide={isGif(src)} />
                     <ToolbarMenuItem icon="link" isActive={href === true || false} label="Link" onClick = {() => {
                         setShowLink(true);


### PR DESCRIPTION
Hi,
In this PR, the goal is to enhance the display of portrait-format images to provide a more visually appealing and user-friendly experience. I've added a new button to the image toolbar, allowing users to easily reduce the size of portrait images. 
[demo.webm](https://github.com/TryGhost/Koenig/assets/41616/a581d9ff-c07f-4692-8fb8-e7f1aa6ef75d)
