### PR TITLE
🐛 Fixed collection header rendering

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/collection/CollectionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/collection/CollectionNode.js
@@ -9,7 +9,7 @@ export class CollectionNode extends generateDecoratorNode({nodeType: 'collection
         {name: 'postCount', default: 3},
         {name: 'layout', default: 'grid'},
         {name: 'columns', default: 3},
-        {name: 'header', default: 'Latest', wordCount: true}
+        {name: 'header', default: '', wordCount: true}
     ]}
 ) {
     static importDOM() {

--- a/packages/kg-default-nodes/lib/nodes/collection/collection-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/collection/collection-renderer.js
@@ -35,7 +35,7 @@ function cardTemplate(node, posts) {
 
     return (
         `<div class="${cardClass}" data-kg-collection-slug="${collection.slug}" data-kg-collection-limit="${postCount}">
-            <h4 class="${headerClass}">${header}</h4>
+            ${header ? `<h4 class="${headerClass}">${header}</h4>` : ''}
             <div class="${collectionClass}">
                 ${posts.map(post => postTemplate(post, layout, columns)).join('')}
             </div>

--- a/packages/koenig-lexical/src/components/ui/cards/CollectionCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CollectionCard.jsx
@@ -217,8 +217,8 @@ export function CollectionCard({
         if (value !== 'latest' && value !== 'featured') {
             return;
         }
-        const header = headerEditor.getEditorState().read(() => ($getRoot().getTextContent()));
-        if (value === 'latest' && header === 'Featured') {
+        const header = headerEditor.getEditorState().read(() => ($getRoot().getTextContent())).toLowerCase(); // we use block lettering so we can't differentiate between latest and Latest
+        if (value === 'latest' && header === 'featured') {
             headerEditor.update(() => {
                 const newHeader = $createParagraphNode().append($createTextNode('Latest'));
                 const root = $getRoot();
@@ -227,7 +227,7 @@ export function CollectionCard({
                 root.selectEnd();
             });
         }
-        if (value === 'featured' && header === 'Latest') {
+        if (value === 'featured' && header === 'latest') {
             headerEditor.update(() => {
                 const newHeader = $createParagraphNode().append($createTextNode('Featured'));
                 const root = $getRoot();

--- a/packages/koenig-lexical/src/nodes/CollectionNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CollectionNode.jsx
@@ -22,7 +22,8 @@ export class CollectionNode extends BaseCollectionNode {
         matches: ['collection', 'post'],
         priority: 18,
         postType: 'page',
-        isHidden: ({config}) => !config?.feature?.collectionsCard || !config?.feature?.collections // hide if missing collections or collectionsCard flags
+        isHidden: ({config}) => !config?.feature?.collectionsCard || !config?.feature?.collections, // hide if missing collections or collectionsCard flags
+        insertParams: () => ({header: 'Latest'})
     }];
 
     constructor(dataset = {}, key) {


### PR DESCRIPTION
closes TryGhost/Product#3872
- renderer was always rendering a header tag, even if empty
- empty headers were rendering a default value
- block lettering for header hid flaky default behaviour