### PR TITLE
Removed newlines between lexical nodes when rendering html

### DIFF
--- a/packages/kg-lexical-html-renderer/lib/convert-to-html-string.js
+++ b/packages/kg-lexical-html-renderer/lib/convert-to-html-string.js
@@ -31,7 +31,7 @@ function $convertToHtmlString(options = {}) {
         output.pop();
     }
 
-    return output.join('\n');
+    return output.join('');
 }
 
 function exportTopLevelElementOrDecorator(node, options) {

--- a/packages/kg-lexical-html-renderer/test/cards.test.js
+++ b/packages/kg-lexical-html-renderer/test/cards.test.js
@@ -76,9 +76,7 @@ describe('Cards', function () {
 
         const output = await Prettier.format(renderedInput, {parser: 'html'});
 
-        const expected =
-`<!--members-only-->
-`;
+        const expected = `<!--members-only-->\n`;
         output.should.equal(expected);
     });
 
@@ -93,7 +91,7 @@ describe('Cards', function () {
                     format: 0,
                     mode: 'normal',
                     style: '',
-                    text: 'Testing',
+                    text: 'Testing this',
                     type: 'text',
                     version: 1
                 }
@@ -111,13 +109,7 @@ describe('Cards', function () {
         const renderer = new Renderer({nodes});
         const renderedInput = await renderer.render(JSON.stringify(lexicalState), options);
 
-        const output = await Prettier.format(renderedInput, {parser: 'html'});
-
-        const expected =
-`<div style="color: red">
-  <p>Testing</p>
-</div>
-`;
-        output.should.equal(expected);
+        const expected = `<div style="color: red"><p>Testing this</p></div>`;
+        renderedInput.should.equal(expected);
     });
 });

--- a/packages/kg-lexical-html-renderer/test/headings.test.js
+++ b/packages/kg-lexical-html-renderer/test/headings.test.js
@@ -3,12 +3,7 @@ const {shouldRender} = require('./utils');
 describe('Headings', function () {
     it('h1-h6', shouldRender({
         input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Heading 1","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"heading","version":1,"tag":"h1"},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Heading 2","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"heading","version":1,"tag":"h2"},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Heading 3","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"heading","version":1,"tag":"h3"},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Heading 4","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"heading","version":1,"tag":"h4"},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Heading 5","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"heading","version":1,"tag":"h5"},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Heading 6","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"heading","version":1,"tag":"h6"}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
-        output: `<h1 id="heading-1">Heading 1</h1>
-<h2 id="heading-2">Heading 2</h2>
-<h3 id="heading-3">Heading 3</h3>
-<h4 id="heading-4">Heading 4</h4>
-<h5 id="heading-5">Heading 5</h5>
-<h6 id="heading-6">Heading 6</h6>`
+        output: `<h1 id="heading-1">Heading 1</h1><h2 id="heading-2">Heading 2</h2><h3 id="heading-3">Heading 3</h3><h4 id="heading-4">Heading 4</h4><h5 id="heading-5">Heading 5</h5><h6 id="heading-6">Heading 6</h6>`
     }));
 
     it('containing text formats', shouldRender({
@@ -18,10 +13,6 @@ describe('Headings', function () {
 
     it('duplicate headings', shouldRender({
         input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"heading one","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"heading","version":1,"tag":"h1"},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"heading one","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"heading","version":1,"tag":"h1"},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"heading two","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"heading","version":1,"tag":"h1"},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"heading one","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"heading","version":1,"tag":"h1"},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"heading two","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"heading","version":1,"tag":"h1"}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
-        output: `<h1 id="heading-one">heading one</h1>
-<h1 id="heading-one-1">heading one</h1>
-<h1 id="heading-two">heading two</h1>
-<h1 id="heading-one-2">heading one</h1>
-<h1 id="heading-two-1">heading two</h1>`
+        output: `<h1 id="heading-one">heading one</h1><h1 id="heading-one-1">heading one</h1><h1 id="heading-two">heading two</h1><h1 id="heading-one-2">heading one</h1><h1 id="heading-two-1">heading two</h1>`
     }));
 });

--- a/packages/kg-lexical-html-renderer/test/render.test.js
+++ b/packages/kg-lexical-html-renderer/test/render.test.js
@@ -9,8 +9,7 @@ describe('render()', function () {
 
         const html = await renderer.render(editorState);
 
-        html.should.eql(`<p>First paragraph</p>
-<p>Second paragraph</p>`);
+        html.should.eql(`<p>First paragraph</p><p>Second paragraph</p>`);
     });
 
     it('escapes text content', shouldRender({


### PR DESCRIPTION
closes TryGhost/Product#3913
- removed \n between rendered lexical nodes
- updated tests
- note: prettier adds \n to end of strings in tests