### PR TITLE
🐛 Fixed collection card snippet entering edit mode

### DIFF
--- a/packages/koenig-lexical/src/nodes/CollectionNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CollectionNodeComponent.jsx
@@ -108,7 +108,7 @@ export function CollectionNodeComponent({
 
             <ActionToolbar
                 data-kg-card-toolbar="collection"
-                isVisible={isSelected && !isEditing}
+                isVisible={isSelected && !isEditing && !showSnippetToolbar}
             >
                 <ToolbarMenu>
                     <ToolbarMenuItem dataTestId="edit-collection-card" icon="edit" isActive={false} label="Edit" onClick={handleToolbarEdit} />


### PR DESCRIPTION
closes TryGhost/Product#3919
- toolbar was not closing when snippet entry became active