### PR TITLE
🐛 Fixed gallery rendering when created from image nodes

### DIFF
--- a/packages/koenig-lexical/src/hooks/useGalleryReorder.js
+++ b/packages/koenig-lexical/src/hooks/useGalleryReorder.js
@@ -1,5 +1,6 @@
 import KoenigComposerContext from '../context/KoenigComposerContext';
 import React from 'react';
+import {getImageFilenameFromSrc} from '../utils/getImageFilenameFromSrc';
 import {pick} from 'lodash-es';
 
 export default function useGalleryReorder({images, updateImages, isSelected = false, maxImages = 9, disabled = false}) {
@@ -54,11 +55,7 @@ export default function useGalleryReorder({images, updateImages, isSelected = fa
                 // image card datasets may not have all of the details we need but we can fill them in
                 dataset.width = dataset.width || img.naturalWidth;
                 dataset.height = dataset.height || img.naturalHeight;
-                if (!dataset.fileName) {
-                    const url = new URL(dataset.src || img.src);
-                    const fileName = url.pathname.match(/\/([^/]*)$/)[1];
-                    dataset.fileName = fileName;
-                }
+                dataset.fileName = dataset?.fileName || getImageFilenameFromSrc(dataset.src);
 
                 updatedImages.splice(insertIndex, 0, dataset);
             } else {

--- a/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
@@ -13,6 +13,7 @@ import {LinkInput} from '../components/ui/LinkInput';
 import {SnippetActionToolbar} from '../components/ui/SnippetActionToolbar';
 import {ToolbarMenu, ToolbarMenuItem, ToolbarMenuSeparator} from '../components/ui/ToolbarMenu';
 import {dataSrcToFile} from '../utils/dataSrcToFile.js';
+import {getImageFilenameFromSrc} from '../utils/getImageFilenameFromSrc';
 import {imageUploadHandler} from '../utils/imageUploadHandler';
 import {isGif} from '../utils/isGif';
 import {openFileSelection} from '../utils/openFileSelection';
@@ -46,7 +47,12 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, captionE
                 const droppedImageNode = $getNodeByKey(draggedNodeKey);
                 const galleryNode = $createGalleryNode();
 
-                galleryNode.addImages([targetImageNode.getDataset(), dataset]);
+                // images don't contain the filename dataset property so we need to add it
+                dataset.fileName = dataset?.fileName || getImageFilenameFromSrc(dataset.src);
+                const targetImageDataset = targetImageNode.getDataset();
+                targetImageDataset.fileName = targetImageDataset?.fileName || getImageFilenameFromSrc(targetImageDataset.src);
+
+                galleryNode.addImages([targetImageDataset, dataset]);
 
                 targetImageNode.replace(galleryNode);
                 droppedImageNode.remove();

--- a/packages/koenig-lexical/src/utils/getImageFilenameFromSrc.js
+++ b/packages/koenig-lexical/src/utils/getImageFilenameFromSrc.js
@@ -1,0 +1,5 @@
+export function getImageFilenameFromSrc(src) {
+    const url = new URL(src);
+    const fileName = url.pathname.match(/\/([^/]*)$/)[1];
+    return fileName;
+}


### PR DESCRIPTION
closes TryGhost/Product#3922
- image nodes weren't getting fileName set which the renderer saw as invalid
- we may want to set fileName on creation of image nodes