### PR TITLE
🐛 Fixed broken IME input in alt text and other plain-text setting inputs

### DIFF
--- a/packages/koenig-lexical/src/components/ui/Input.jsx
+++ b/packages/koenig-lexical/src/components/ui/Input.jsx
@@ -1,15 +1,9 @@
 import React from 'react';
-import useInputSelection from '../../hooks/useInputSelection';
 
 export const INPUT_CLASSES = 'rounded border border-grey-300 py-2 px-3 font-sans text-sm font-normal text-grey-900 focus:border-green focus:shadow-insetgreen focus-visible:outline-none dark:border-grey-900 dark:bg-grey-900 dark:text-white dark:placeholder:text-grey-700 dark:selection:bg-grey-800';
 
 export function Input({dataTestId, value, placeholder, onChange, onFocus, onBlur}) {
-    const {setRef, saveSelectionRange} = useInputSelection({value});
-
     const onChangeWrapper = (e) => {
-        // Fixes cursor jumping to the end of the input when typing
-        saveSelectionRange(e);
-
         if (onChange) {
             onChange(e);
         }
@@ -19,11 +13,10 @@ export function Input({dataTestId, value, placeholder, onChange, onFocus, onBlur
         <>
             <div className="relative">
                 <input
-                    ref={setRef}
                     className={`relative w-full ${INPUT_CLASSES}`}
                     data-testid={dataTestId}
+                    defaultValue={value}
                     placeholder={placeholder}
-                    value={value}
                     onBlur={onBlur}
                     onChange={onChangeWrapper}
                     onFocus={onFocus}

--- a/packages/koenig-lexical/src/components/ui/SubscribeForm.jsx
+++ b/packages/koenig-lexical/src/components/ui/SubscribeForm.jsx
@@ -1,15 +1,9 @@
 import React from 'react';
 import clsx from 'clsx';
-import useInputSelection from '../../hooks/useInputSelection';
 import {Button} from './Button';
 
 export function SubscribeForm({dataTestId, placeholder, value, buttonSize, buttonText, buttonStyle, onChange, onFocus, onBlur, disabled}) {
-    const {setRef, saveSelectionRange} = useInputSelection({value});
-
     const onChangeWrapper = (e) => {
-        // Fixes cursor jumping to the end of the input when typing
-        saveSelectionRange(e);
-
         if (onChange) {
             onChange(e);
         }
@@ -21,16 +15,15 @@ export function SubscribeForm({dataTestId, placeholder, value, buttonSize, butto
             buttonSize === 'large' ? 'p-[3px]' : 'p-[2px]',
         )}>
             <input
-                ref={setRef}
                 className={clsx(
                     'relative w-full bg-white px-4 py-2 font-sans font-normal text-grey-900 focus-visible:outline-none',
                     buttonSize === 'small' && 'h-10 text-md leading-[4rem]',
                     buttonSize === 'medium' && 'h-11 text-[1.6rem] leading-[4.4rem]',
                     buttonSize === 'large' && 'h-12 text-lg leading-[4.8rem]',
                 )}
+                defaultValue={value}
                 placeholder={placeholder}
                 tabIndex={disabled ? '-1' : ''}
-                value={value}
                 readOnly
                 onBlur={onBlur}
                 onChange={onChangeWrapper}

--- a/packages/koenig-lexical/src/components/ui/TextInput.jsx
+++ b/packages/koenig-lexical/src/components/ui/TextInput.jsx
@@ -1,18 +1,13 @@
 import React from 'react';
-import useInputSelection from '../../hooks/useInputSelection';
 
 export function TextInput({value, onChange, ...args}) {
-    const {setRef, saveSelectionRange} = useInputSelection({value});
-
     const handleOnChange = (e) => {
-        saveSelectionRange(e);
         onChange(e);
     };
 
     return (
         <input
-            ref={setRef}
-            value={value}
+            defaultValue={value}
             onChange={handleOnChange}
             {...args}
         />


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/3894

- removes 2-way binding from input fields so the caret-position hack to work around React's re-rendering of fields that was interfering with IME input isn't needed
- removing 2-way binding does have implications for future collaboration work so we'll need to investigate a different approach for that
- no specific IME tests as Playwright has no support for testing IME
