### PR TITLE
Skipped header v1 tests

### DIFF
--- a/packages/koenig-lexical/test/e2e/cards/header-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/header-card.test.js
@@ -22,7 +22,7 @@ async function createHeaderCard({page, version = 1}) {
     }
 }
 
-test.describe('Header card V1', async () => {
+test.describe.skip('Header card V1', async () => {
     const ctrlOrCmd = isMac() ? 'Meta' : 'Control';
     let page;
 


### PR DESCRIPTION
no refs
- header v1 is unlisted in the menu and we can retire tests