### PR TITLE
Enabled tests for deprecated cards

### DIFF
--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -46,9 +46,8 @@ const cardConfig = {
         collections: true,
         collectionsCard: true
     },
-    // we keep header v1 visible in the demo to ensure it remains tested till we full deprecate it in the future
-    depreciated: {
-        headerV1: false // if false, shows header v1 in the menu
+    deprecated: {
+        headerV1: process.env.NODE_ENV === 'test' ? false : true // show header v1 only for tests
     }
 };
 

--- a/packages/koenig-lexical/package.json
+++ b/packages/koenig-lexical/package.json
@@ -30,7 +30,7 @@
     "test": "yarn test:unit && yarn test:e2e",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
-    "test:e2e": "NODE_OPTIONS='--experimental-specifier-resolution=node --no-warnings' VITE_TEST=true playwright test",
+    "test:e2e": "NODE_ENV=test NODE_OPTIONS='--experimental-specifier-resolution=node --no-warnings' VITE_TEST=true playwright test",
     "test:slowmo": "TIMEOUT=100000 PLAYWRIGHT_SLOWMO=100 yarn test:e2e --headed",
     "test:storybook": "test-storybook",
     "pretest:watch": "yarn pretest",

--- a/packages/koenig-lexical/src/nodes/HeaderNode.jsx
+++ b/packages/koenig-lexical/src/nodes/HeaderNode.jsx
@@ -23,6 +23,21 @@ export class HeaderNode extends BaseHeaderNode {
     // we keep it hidden in the Menu in Ghost but visible in the Demo to ensure it remains tested till we full deprecate it in the future
     static kgMenu = [
         {
+            label: 'Header1',
+            desc: 'Add a header',
+            Icon: HeaderCardIcon,
+            insertCommand: INSERT_HEADER_COMMAND,
+            matches: ['v1_header', 'v1_heading'],
+            priority: 17,
+            insertParams: () => ({
+                version: 1
+            }),
+            isHidden: ({config}) => {
+                return config?.deprecated?.headerV1;
+            },
+            shortcut: '/header'
+        },
+        {
             label: 'Header',
             desc: 'Add a header',
             Icon: HeaderCardIcon,

--- a/packages/koenig-lexical/test/e2e/cards/header-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/header-card.test.js
@@ -22,7 +22,7 @@ async function createHeaderCard({page, version = 1}) {
     }
 }
 
-test.describe.skip('Header card V1', async () => {
+test.describe.only('Header card V1', async () => {
     const ctrlOrCmd = isMac() ? 'Meta' : 'Control';
     let page;
 

--- a/packages/koenig-lexical/test/e2e/cards/header-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/header-card.test.js
@@ -22,7 +22,7 @@ async function createHeaderCard({page, version = 1}) {
     }
 }
 
-test.describe.only('Header card V1', async () => {
+test.describe('Header card V1', async () => {
     const ctrlOrCmd = isMac() ? 'Meta' : 'Control';
     let page;
 


### PR DESCRIPTION
no refs
- moved to using `NODE_ENV=test` for tests
- we can default to deprecated for deprecated cards w/o env flag being set
- tests should still run on deprecated cards because they could still be in use