### PR TITLE
Added KoenigFocusPlugin to ComposableEditor

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigComposableEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigComposableEditor.jsx
@@ -13,6 +13,7 @@ import {EditorPlaceholder} from './ui/EditorPlaceholder';
 import {ExternalControlPlugin} from '../plugins/ExternalControlPlugin';
 import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
 import {KoenigBlurPlugin} from '../plugins/KoenigBlurPlugin';
+import {KoenigFocusPlugin} from '../plugins/KoenigFocusPlugin';
 import {LinkPlugin} from '@lexical/react/LexicalLinkPlugin';
 import {OnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
 import {RestrictContentPlugin} from '../index.js';
@@ -25,6 +26,7 @@ import {useSharedOnChangeContext} from '../context/SharedOnChangeContext';
 const KoenigComposableEditor = ({
     onChange,
     onBlur,
+    onFocus,
     markdownTransformers,
     registerAPI,
     cursorDidExitAtTop,
@@ -110,6 +112,7 @@ const KoenigComposableEditor = ({
             {isDragReorderEnabled && <DragDropReorderPlugin containerElem={editorContainerRef} />}
             {singleParagraph && <RestrictContentPlugin paragraphs={1} />}
             {onBlur && <KoenigBlurPlugin onBlur={onBlur} />}
+            {onFocus && <KoenigFocusPlugin onFocus={onFocus} />}
             <MarkdownPastePlugin />
             {children}
         </div>

--- a/packages/koenig-lexical/src/plugins/KoenigFocusPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigFocusPlugin.jsx
@@ -1,0 +1,18 @@
+import {COMMAND_PRIORITY_EDITOR, FOCUS_COMMAND} from 'lexical';
+import {useEffect} from 'react';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+
+export const KoenigFocusPlugin = ({onFocus}) => {
+    const [editor] = useLexicalComposerContext();
+    useEffect(() => {
+        editor.registerCommand(
+            FOCUS_COMMAND,
+            () => {
+                onFocus?.();
+            },
+            COMMAND_PRIORITY_EDITOR
+        );
+    }, [editor, onFocus]);
+
+    return null;
+};


### PR DESCRIPTION
no issue

- In AdminX we need an onFocus helper to determine when it's in focus for enhanced UX.
- This adds an onFocus prop to the ComposableEditor and a new FocusPlugin