### PR TITLE
Fixed exports filename for bundled package

### DIFF
--- a/packages/koenig-lexical/package.json
+++ b/packages/koenig-lexical/package.json
@@ -10,12 +10,12 @@
     "README.md",
     "dist/"
   ],
-  "main": "./dist/koenig-lexical.umd.cjs",
+  "main": "./dist/koenig-lexical.umd.js",
   "module": "./dist/koenig-lexical.js",
   "exports": {
     ".": {
       "import": "./dist/koenig-lexical.js",
-      "require": "./dist/koenig-lexical.umd.cjs"
+      "require": "./dist/koenig-lexical.umd.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1696235735259489?thread_ts=1695035790.122589&cid=C02G9E68C

- this updates the filenames that are designated as the exports of the package, so `require.resolve` works correctly for `@tryghost/koenig-lexical`