### PR TITLE
Fixed email card rendering placeholders

### DIFF
--- a/packages/kg-clean-basic-html/lib/clean-basic-html.js
+++ b/packages/kg-clean-basic-html/lib/clean-basic-html.js
@@ -6,7 +6,7 @@
  * @returns {string}
  */
 function removeCodeWrappers(html) {
-    return html.replace(/<code>((.*?){.*?}(.*?))<\/code>/gi, '$1');
+    return html.replace(/<code\b[^>]*>((.*?){.*?}(.*?))<\/code>/gi, '$1');
 }
 
 /* global DOMParser, window */

--- a/packages/kg-default-nodes/lib/nodes/email/email-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/email/email-renderer.js
@@ -1,5 +1,5 @@
 import {addCreateDocumentOption} from '../../utils/add-create-document-option';
-import {removeSpaces, removeCodeWrappers, wrapReplacementStrings} from '../../utils/replacement-strings';
+import {removeSpaces, removeCodeWrappersFromHelpers, wrapReplacementStrings} from '../../utils/replacement-strings';
 import {renderEmptyContainer} from '../../utils/render-empty-container';
 
 export function renderEmailNode(node, options = {}) {
@@ -12,7 +12,7 @@ export function renderEmailNode(node, options = {}) {
         return renderEmptyContainer(document);
     }
 
-    const cleanedHtml = wrapReplacementStrings(removeCodeWrappers(removeSpaces(html)));
+    const cleanedHtml = wrapReplacementStrings(removeCodeWrappersFromHelpers(removeSpaces(html),document));
 
     const element = document.createElement('div');
     element.innerHTML = cleanedHtml;

--- a/packages/kg-default-nodes/lib/nodes/email/email-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/email/email-renderer.js
@@ -1,5 +1,5 @@
 import {addCreateDocumentOption} from '../../utils/add-create-document-option';
-import {removeSpaces, wrapReplacementStrings} from '../../utils/replacement-strings';
+import {removeSpaces, removeCodeWrappers, wrapReplacementStrings} from '../../utils/replacement-strings';
 import {renderEmptyContainer} from '../../utils/render-empty-container';
 
 export function renderEmailNode(node, options = {}) {
@@ -12,7 +12,7 @@ export function renderEmailNode(node, options = {}) {
         return renderEmptyContainer(document);
     }
 
-    const cleanedHtml = wrapReplacementStrings(removeSpaces(html));
+    const cleanedHtml = wrapReplacementStrings(removeCodeWrappers(removeSpaces(html)));
 
     const element = document.createElement('div');
     element.innerHTML = cleanedHtml;

--- a/packages/kg-default-nodes/lib/utils/replacement-strings.js
+++ b/packages/kg-default-nodes/lib/utils/replacement-strings.js
@@ -17,3 +17,14 @@ export function removeSpaces(html) {
 export function wrapReplacementStrings(html) {
     return html.replace(/\{(\w*?)(?:,? *"(.*?)")?\}/g, '%%$&%%');
 }
+
+/**
+ * Removes any <code> wrappers around replacement strings {foo}
+ * Example input:  <code><span>{foo}</span></code>
+ * Example output:       <span>{foo}</span>
+ * @param {string} html
+ * @returns {string}
+ */
+export function removeCodeWrappers(html) {
+    return html.replace(/<code\b[^>]*>((.*?){.*?}(.*?))<\/code>/gi, '$1');
+}

--- a/packages/kg-default-nodes/lib/utils/replacement-strings.js
+++ b/packages/kg-default-nodes/lib/utils/replacement-strings.js
@@ -25,6 +25,21 @@ export function wrapReplacementStrings(html) {
  * @param {string} html
  * @returns {string}
  */
-export function removeCodeWrappers(html) {
-    return html.replace(/<code\b[^>]*>((.*?){.*?}(.*?))<\/code>/gi, '$1');
+export function removeCodeWrappersFromHelpers(html,document) {
+    // parse html to make patterns easier to match
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = html;
+
+    const codeElements = tempDiv.querySelectorAll('code');
+    codeElements.forEach((codeElement) => {
+        const codeTextContent = codeElement.textContent;
+        // extract the content of the code element if it follows the helper pattern (e.g. {foo})
+        if (codeTextContent.match(/((.*?){.*?}(.*?))/gi)) {
+            const codeContent = codeElement.innerHTML; 
+            codeElement.parentNode.replaceChild(document.createRange().createContextualFragment(codeContent), codeElement);
+        }
+    });
+
+    const cleanedHtml = tempDiv.innerHTML;
+    return cleanedHtml;
 }

--- a/packages/kg-default-nodes/test/nodes/email.test.js
+++ b/packages/kg-default-nodes/test/nodes/email.test.js
@@ -400,7 +400,7 @@ describe('EmailNode', function () {
 
         it(`leaves <code> elements when not used with a placeholder`, editorTest(function () {
             const payload = {
-                html: '<p>First paragraph</p><code>Some code</code><p>Third paragraph</p>'
+                html: '<p>First paragraph</p><code>Some code</code><p>Third paragraph</p><code>{helper, "test"}</code>'
             };
 
             const options = {
@@ -415,6 +415,7 @@ describe('EmailNode', function () {
                 <p>First paragraph</p>
                 <code>Some code</code>
                 <p>Third paragraph</p>
+                %%{helper, "test"}%%
             `);
         }));
     });

--- a/packages/kg-default-nodes/test/nodes/email.test.js
+++ b/packages/kg-default-nodes/test/nodes/email.test.js
@@ -377,6 +377,46 @@ describe('EmailNode', function () {
                 <p>Third paragraph</p>
             `);
         }));
+
+        it('strips out <code> elements with placeholders', editorTest(function () {
+            const payload = {
+                html: '<p>First paragraph</p><code>{placeholder}</code><p>Third paragraph</p>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p>First paragraph</p>
+                %%{placeholder}%%
+                <p>Third paragraph</p>
+            `);
+        }));
+
+        it(`leaves <code> elements when not used with a placeholder`, editorTest(function () {
+            const payload = {
+                html: '<p>First paragraph</p><code>Some code</code><p>Third paragraph</p>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p>First paragraph</p>
+                <code>Some code</code>
+                <p>Third paragraph</p>
+            `);
+        }));
     });
 
     describe('getTextContent', function () {

--- a/packages/koenig-lexical/src/nodes/EmailNode.jsx
+++ b/packages/koenig-lexical/src/nodes/EmailNode.jsx
@@ -62,7 +62,7 @@ export class EmailNode extends BaseEmailNode {
         if (this.__htmlEditor) {
             this.__htmlEditor.getEditorState().read(() => {
                 const html = $generateHtmlFromNodes(this.__htmlEditor, null);
-                const cleanedHtml = cleanBasicHtml(html, {removeCodeWrappers: true, allowBr: true});
+                const cleanedHtml = cleanBasicHtml(html, {removeCodeWrappers: false, allowBr: true});
                 json.html = cleanedHtml;
             });
         }


### PR DESCRIPTION
closes TryGhost/Product#3983
- stripped code elements from the rendered email output when using a placeholder
- retained code elements within `exportJSON` so that formatting looks appropriate across editor save/loads
- needed to expand regex to cover props, as a recent Lexical upgrade added these to most elements
- added tests to cover these cases