### PR TITLE
🐛 Fixed backspace on lines preceded by line breaks

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -15,6 +15,7 @@ import {
     $insertNodes,
     $isDecoratorNode,
     $isElementNode,
+    $isLineBreakNode,
     $isNodeSelection,
     $isParagraphNode,
     $isRangeSelection,
@@ -930,7 +931,8 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
 
                             const atStartOfElement =
                                 selection.anchor.offset === 0 &&
-                                selection.focus.offset === 0;
+                                selection.focus.offset === 0 &&
+                                !$isLineBreakNode(anchorNode.getPreviousSibling());
 
                             // convert empty top level list items to paragraphs
                             if (


### PR DESCRIPTION
closes TryGhost/Product#3986
- backspace on lines preceded by new lines (created by Shift+Enter) could delete previous nodes