### PR TITLE
🐛 Fixed missing support for dragging an image card onto an empty gallery

### DIFF
--- a/packages/koenig-lexical/.eslintrc.cjs
+++ b/packages/koenig-lexical/.eslintrc.cjs
@@ -4,7 +4,7 @@ module.exports = {
     extends: ['react-app', 'plugin:ghost/browser', 'plugin:react/recommended', 'plugin:storybook/recommended'],
     plugins: ['ghost', 'tailwindcss'],
     rules: {
-    // sort multiple import lines into alphabetical groups
+        // sort multiple import lines into alphabetical groups
         'ghost/sort-imports-es6-autofix/sort-imports-es6': ['error', {
             memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple']
         }],

--- a/packages/koenig-lexical/src/components/ui/cards/GalleryCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/GalleryCard.jsx
@@ -76,7 +76,7 @@ function GalleryImage({image, deleteImage, position, isDragging}) {
     );
 }
 
-function PopulatedGalleryCard({filesDropper, images, deleteImage, reorderHandler, isDragging}) {
+function PopulatedGalleryCard({images, deleteImage, reorderHandler, isDragging}) {
     const rows = [];
     const noOfImages = images.length;
 
@@ -113,14 +113,15 @@ function PopulatedGalleryCard({filesDropper, images, deleteImage, reorderHandler
     );
 }
 
-function EmptyGalleryCard({filesDropper, openFilePicker}) {
+function EmptyGalleryCard({openFilePicker, isDraggedOver, reorderHandler}) {
     return (
         <MediaPlaceholder
             desc="Click to select up to 9 images"
             filePicker={openFilePicker}
             icon='gallery'
-            isDraggedOver={filesDropper.isDraggedOver}
+            isDraggedOver={isDraggedOver}
             multiple={true}
+            placeholderRef={reorderHandler.setContainerRef}
             size='large'
         />
     );
@@ -176,8 +177,8 @@ export function GalleryCard({
         <figure className="not-kg-prose">
             <div ref={filesDropper.setRef} className="relative" data-testid="gallery-container">
                 {images.length
-                    ? <PopulatedGalleryCard deleteImage={deleteImage} filesDropper={filesDropper} images={images} isDragging={isDragging} reorderHandler={reorderHandler} />
-                    : <EmptyGalleryCard filesDropper={filesDropper} openFilePicker={openFilePicker} />
+                    ? <PopulatedGalleryCard deleteImage={deleteImage} images={images} isDragging={isDragging} reorderHandler={reorderHandler} />
+                    : <EmptyGalleryCard isDraggedOver={isDragging} openFilePicker={openFilePicker} reorderHandler={reorderHandler} />
                 }
 
                 {isLoading ? <UploadOverlay progress={progress} /> : null}
@@ -240,8 +241,9 @@ PopulatedGalleryCard.propTypes = {
 };
 
 EmptyGalleryCard.propTypes = {
-    filesDropper: PropTypes.object,
-    openFilePicker: PropTypes.func
+    openFilePicker: PropTypes.func,
+    isDraggedOver: PropTypes.bool,
+    reorderHandler: PropTypes.object
 };
 
 UploadOverlay.propTypes = {

--- a/packages/koenig-lexical/src/components/ui/cards/GalleryCard.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/GalleryCard.stories.jsx
@@ -1,3 +1,4 @@
+import CardContext from '../../../context/CardContext';
 import React from 'react';
 import populateEditor from '../../../utils/storybook/populate-storybook-editor';
 import {CardWrapper} from './../CardWrapper';
@@ -43,9 +44,11 @@ const Template = ({display, caption, ...args}) => {
     return (
         <div className="kg-prose">
             <div className="mx-auto my-8 w-[1170px] min-w-[initial]">
-                <CardWrapper {...display} {...args}>
-                    <GalleryCard {...display} {...args} captionEditor={captionEditor} />
-                </CardWrapper>
+                <CardContext.Provider value={{setCaptionHasFocus: () => {}}}>
+                    <CardWrapper {...display} {...args}>
+                        <GalleryCard {...display} {...args} captionEditor={captionEditor} />
+                    </CardWrapper>
+                </CardContext.Provider>
             </div>
         </div>
     );


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/2721

- passed `reorderHandler` into `<EmptyGalleryCard>` and used it to set the container ref, with that the `useGalleryReorder` hook handles image cards being dropped on the empty gallery component
- swapped `filesDropper` for `isDraggedOver` so the base `<GalleryCard>` component can amalgamate the file+card dragged over states into one prop
