### PR TITLE
🐛 Fixed drag-to-select text inside text container cards triggering the card re-order overlay

### DIFF
--- a/packages/koenig-lexical/src/components/ui/CardCaptionEditor.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardCaptionEditor.jsx
@@ -8,6 +8,7 @@ function CaptionInput({captionEditor, captionEditorInitialState, placeholder, da
         <div
             className={`m-0 w-full px-9 text-center`}
             data-testid={dataTestId}
+            data-kg-allow-clickthrough
         >
             <KoenigCaptionEditor
                 captionEditor={captionEditor}

--- a/packages/koenig-lexical/src/plugins/DragDropReorderPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/DragDropReorderPlugin.jsx
@@ -14,7 +14,7 @@ function preventDefault(event) {
 
 function useDragDropReorder(editor, isEditable) {
     const koenig = React.useContext(KoenigComposerContext);
-    const {setIsDragging} = useKoenigSelectedCardContext();
+    const {setIsDragging, isEditingCard} = useKoenigSelectedCardContext();
 
     const cardContainer = React.useRef(null);
     const skipOnDropEnd = React.useRef(false);
@@ -36,8 +36,6 @@ function useDragDropReorder(editor, isEditable) {
             const cardNode = $getNearestNodeFromDOMNode(draggableElement);
 
             if (cardNode) {
-                // TODO: payload should probably contain everything here as well as the
-                // card payload so that draggableInfo has a consistent shape
                 draggableInfo = {
                     type: 'card',
                     nodeKey: cardNode.getKey(),
@@ -230,6 +228,15 @@ function useDragDropReorder(editor, isEditable) {
             prevRootElement?.removeEventListener('dragstart', preventDefault);
         });
     }, [editor]);
+
+    // Disable drag-drop-reorder when editing a card
+    React.useEffect(() => {
+        if (isEditingCard) {
+            cardContainer.current?.disableDrag();
+        } else {
+            cardContainer.current?.enableDrag();
+        }
+    }, [isEditingCard]);
 }
 
 export default function DragDropReorderPlugin() {

--- a/packages/koenig-lexical/test/e2e/cards/bookmark-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/bookmark-card.test.js
@@ -61,7 +61,7 @@ test.describe('Bookmark card', async () => {
                             <div></div>
                         </div>
                         <figcaption>
-                            <div>
+                            <div data-kg-allow-clickthrough="true">
                                 <div>
                                     <div data-kg="editor">
                                         <div
@@ -278,7 +278,7 @@ test.describe('Bookmark card', async () => {
                             <div></div>
                         </div>
                         <figcaption>
-                            <div>
+                            <div data-kg-allow-clickthrough="true">
                                 <div>
                                     <div data-kg="editor">
                                         <div

--- a/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
@@ -44,7 +44,7 @@ test.describe('Code Block card', async () => {
                         <div><span>javascript</span></div>
                     </div>
                     <figcaption>
-                        <div>
+                        <div data-kg-allow-clickthrough="true">
                             <div>
                                 <div data-kg="editor">
                                     <div
@@ -188,7 +188,7 @@ test.describe('Code Block card', async () => {
                         <div><span>javascript</span></div>
                     </div>
                     <figcaption>
-                        <div>
+                        <div data-kg-allow-clickthrough="true">
                             <div>
                                 <div data-kg="editor">
                                     <div
@@ -236,7 +236,7 @@ test.describe('Code Block card', async () => {
                         <div><span>javascript</span></div>
                     </div>
                     <figcaption>
-                        <div>
+                        <div data-kg-allow-clickthrough="true">
                             <div>
                                 <div data-kg="editor">
                                     <div

--- a/packages/koenig-lexical/test/e2e/cards/embed-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/embed-card.test.js
@@ -62,7 +62,7 @@ test.describe('Embed card', async () => {
                             <div></div>
                         </div>
                         <figcaption>
-                            <div>
+                            <div data-kg-allow-clickthrough="true">
                                 <div>
                                     <div data-kg="editor">
                                         <div
@@ -315,7 +315,7 @@ test.describe('Embed card', async () => {
                             <div></div>
                         </div>
                         <figcaption>
-                            <div>
+                            <div data-kg-allow-clickthrough="true">
                                 <div>
                                     <div data-kg="editor">
                                         <div

--- a/packages/koenig-lexical/test/e2e/cards/gallery-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/gallery-card.test.js
@@ -131,7 +131,7 @@ test.describe('Gallery card', async () => {
                             </form>
                         </div>
                         <figcaption>
-                            <div>
+                            <div data-kg-allow-clickthrough="true">
                                 <div>
                                     <div data-kg="editor">
                                         <div contenteditable="true" role="textbox" spellcheck="true" data-lexical-editor="true">
@@ -192,7 +192,7 @@ test.describe('Gallery card', async () => {
                             </form>
                         </div>
                         <figcaption>
-                            <div>
+                            <div data-kg-allow-clickthrough="true">
                                 <div>
                                     <div data-kg="editor">
                                         <div contenteditable="true" role="textbox" spellcheck="true" data-lexical-editor="true">
@@ -375,7 +375,7 @@ test.describe('Gallery card', async () => {
                             </form>
                         </div>
                         <figcaption>
-                          <div>
+                          <div data-kg-allow-clickthrough="true">
                             <div>
                               <div data-kg="editor">
                                 <div

--- a/packages/koenig-lexical/test/e2e/cards/image-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/image-card.test.js
@@ -64,7 +64,7 @@ test.describe('Image card', async () => {
                     <figure data-kg-card-width="wide">
                         <div><img alt="" src="/content/images/2022/11/koenig-lexical.jpg" /></div>
                         <figcaption>
-                            <div>
+                            <div data-kg-allow-clickthrough="true">
                                 <div>
                                     <div data-kg="editor">
                                         <div
@@ -242,7 +242,7 @@ test.describe('Image card', async () => {
                             <img alt="" src="blob:...">
                         </div>
                         <figcaption>
-                            <div data-testid="image-caption-editor">
+                            <div data-testid="image-caption-editor" data-kg-allow-clickthrough="true">
                                 <div>
                                     <div data-kg="editor">
                                         <div contenteditable="true" role="textbox" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true">
@@ -413,7 +413,7 @@ test.describe('Image card', async () => {
                             <img alt="" src="blob:...">
                         </div>
                         <figcaption>
-                            <div data-testid="image-caption-editor">
+                            <div data-testid="image-caption-editor" data-kg-allow-clickthrough="true">
                                 <div>
                                     <div data-kg="editor">
                                         <div contenteditable="true" role="textbox" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true" role="textbox">
@@ -685,7 +685,7 @@ test.describe('Image card', async () => {
                                 src="http://127.0.0.1:5173/Koenig-editor-1.png" />
                         </div>
                         <figcaption>
-                            <div data-testid="image-caption-editor">
+                            <div data-testid="image-caption-editor" data-kg-allow-clickthrough="true">
                                 <div>
                                     <div data-kg="editor">
                                         <div contenteditable="true" role="textbox" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true">
@@ -737,7 +737,7 @@ test.describe('Image card', async () => {
                                 src="https://media.tenor.com/ocbMLlwniWQAAAAC/steve-harvey-oh.gif" />
                         </div>
                         <figcaption>
-                            <div data-testid="image-caption-editor">
+                            <div data-testid="image-caption-editor" data-kg-allow-clickthrough="true">
                                 <div>
                                     <div data-kg="editor">
                                         <div contenteditable="true" role="textbox" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true">
@@ -783,7 +783,7 @@ test.describe('Image card', async () => {
                                 src="https://media.tenor.com/Sm9aylrzSyMAAAAC/cats-animals.gif" />
                         </div>
                         <figcaption>
-                            <div data-testid="image-caption-editor">
+                            <div data-testid="image-caption-editor" data-kg-allow-clickthrough="true">
                                 <div>
                                     <div data-kg="editor">
                                         <div contenteditable="true" role="textbox" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true">

--- a/packages/koenig-lexical/test/e2e/cards/video-card.firefox.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/video-card.firefox.test.js
@@ -87,7 +87,7 @@ test.describe('Video card', async () => {
                           <div></div>
                         </div>
                         <figcaption>
-                          <div>
+                          <div data-kg-allow-clickthrough="true">
                             <div>
                               <div data-kg="editor">
                                 <div
@@ -458,7 +458,7 @@ test.describe('Video card', async () => {
                           <div></div>
                         </div>
                         <figcaption>
-                          <div>
+                          <div data-kg-allow-clickthrough="true">
                             <div>
                               <div data-kg="editor">
                                 <div

--- a/packages/koenig-lexical/test/e2e/plugins/DragDropReorderPlugin.test.js
+++ b/packages/koenig-lexical/test/e2e/plugins/DragDropReorderPlugin.test.js
@@ -155,7 +155,7 @@ test.describe('Drag Drop Reorder Plugin', async function () {
         const paragraphBBox = await page.locator('p:not(figure p)').boundingBox();
         const toBBox = {
             x: paragraphBBox.x,
-            y: paragraphBBox.y + paragraphBBox.height + 45,
+            y: paragraphBBox.y + paragraphBBox.height + 45 + 40, // 40 = height of the caption that appears on mousedown
             width: paragraphBBox.width,
             height: paragraphBBox.height
         };
@@ -209,7 +209,7 @@ test.describe('Drag Drop Reorder Plugin', async function () {
         const paragraphBBox = await page.locator('p:not(figure p)').boundingBox();
         const toBBox = {
             x: paragraphBBox.x,
-            y: paragraphBBox.y + paragraphBBox.height + 35,
+            y: paragraphBBox.y + paragraphBBox.height + 35 + 40, // 40 = height of the caption that appears on mousedown
             width: paragraphBBox.width,
             height: paragraphBBox.height
         };
@@ -218,7 +218,7 @@ test.describe('Drag Drop Reorder Plugin', async function () {
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="image"></div>
+                <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="image"></div>
             </div>
             <div data-lexical-decorator="true" contenteditable="false">
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule"></div>


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/3487

- disabled the reorder drag-drop behaviour when a card is in edit mode
- added mousedown handling to `<KoenigCardWrapper>` so cards get selected immediately on mousedown, this matches the  mobiledoc editor behaviour and allows for immediate drag-to-reorder when another card is in edit mode
- added missing `data-kg-allow-clickthrough` attribute on caption editors which meant clicks on them were being prevented by the mousedown-to-select behaviour
- updated demo app's "focus editor" behaviour to skip the focus if the mousedown before the click was initiated on a card
  - fixes unexpected issues (especially in tests) where mousedown on a card below another card that was in selected/edit mode would cause a content jump from it being deselected meaning the click event fired outside of the editor root element despite being initiated on a card and focus then moving off of the newly selected card