### PR TITLE
Added "saveable" demo content to make testing across refreshes easier

### DIFF
--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -197,6 +197,13 @@ function DemoComposer({editorType, isMultiplayer, setWordCount}) {
         setSearchParams(searchParams);
     }
 
+    function saveContent() {
+        const serializedState = editorAPI.serialize();
+        const encodedContent = encodeURIComponent(serializedState);
+        searchParams.set('content', encodedContent);
+        setSearchParams(searchParams);
+    }
+
     React.useEffect(() => {
         const handleFileDrag = (event) => {
             event.preventDefault();
@@ -258,7 +265,7 @@ function DemoComposer({editorType, isMultiplayer, setWordCount}) {
                 editorType={editorType || 'full'}
             />
             <div className="absolute z-20 flex h-full flex-col items-end sm:relative">
-                <Sidebar isOpen={isSidebarOpen} view={sidebarView} />
+                <Sidebar isOpen={isSidebarOpen} saveContent={saveContent} view={sidebarView} />
                 <FloatingButton isOpen={isSidebarOpen} onClick={openSidebar} />
             </div>
         </KoenigComposer>

--- a/packages/koenig-lexical/demo/components/Sidebar.jsx
+++ b/packages/koenig-lexical/demo/components/Sidebar.jsx
@@ -1,11 +1,17 @@
 import SerializedStateTextarea from './SerializedStateTextarea';
 import TreeView from './TreeView';
 
-const Sidebar = ({isOpen, view}) => {
+const Sidebar = ({isOpen, view, saveContent}) => {
     return (
         <div className={`h-full grow overflow-hidden border-grey-100 bg-black pb-16 transition-all ease-in-out ${isOpen ? 'right-0 w-full opacity-100 sm:w-[440px]' : 'right-[-100%] w-0 opacity-0'}`}>
             {view === 'json' && <SerializedStateTextarea isOpen={isOpen} />}
             {view === 'tree' && <TreeView isOpen={isOpen} />}
+
+            {view === 'json' && (
+                <div className="absolute bottom-[1.1em] left-[1em]">
+                    <button type="button" onClick={saveContent}>💾</button>
+                </div>
+            )}
         </div>
     );
 };

--- a/packages/koenig-lexical/src/plugins/ExternalControlPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/ExternalControlPlugin.jsx
@@ -19,6 +19,9 @@ export const ExternalControlPlugin = ({registerAPI}) => {
             // give access to the editor instance so the Lexical API can be used directly if needed
             editorInstance: editor,
             // simplified API methods for typical consumer app actions
+            serialize() {
+                return JSON.stringify(editor.getEditorState());
+            },
             editorIsEmpty() {
                 let isEmpty;
                 editor.update(() => {

--- a/packages/koenig-lexical/test/e2e/card-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/card-behaviour.test.js
@@ -194,7 +194,6 @@ test.describe('Card behaviour', async () => {
             // Click the card that's not currently editing (second card)
             await page.click('div[data-kg-card-editing="false"]');
             // Now neither card should be editing
-            //await page.pause();
             await expect(await page.locator('[data-kg-card-editing="true"]')).toHaveCount(0);
 
             await assertHTML(page, html`
@@ -280,7 +279,7 @@ test.describe('Card behaviour', async () => {
                     </div>
                 </div>
             `, {ignoreCardContents: true});
-            
+
             await page.mouse.click(275, 275);
 
             await assertHTML(page, html`


### PR DESCRIPTION
no issue

Needing to continually set up complex editor state to test functionality whilst you're working on it is tedious and annoying because almost every code change requires a refresh which would lose your content.

- added `serialize()` to the return value of `<ExternalControlPlugin>` so it's possible for consumers to serialize editor state
- added button to the demo app's sidebar when the JSON view is shown that saves the current editor state to the `?content=` query param when clicked so the content persists across refreshes
