### PR TITLE
🐛 Fixed floating toolbar positioning with inline nodes

### DIFF
--- a/packages/koenig-lexical/src/utils/$getSelectionRangeRect.js
+++ b/packages/koenig-lexical/src/utils/$getSelectionRangeRect.js
@@ -8,5 +8,19 @@ export function $getSelectionRangeRect({selection, editor}) {
     const focus = selection.focus;
     const selectionRange = createDOMRange(editor, anchor.getNode(), selection.anchor.offset, focus.getNode(), selection.focus.offset);
     const selectionRects = createRectsFromDOMRange(editor, selectionRange);
-    return selectionRects[0];
+
+    const returnRect = selectionRects[0];
+
+    // we can get multiple rects if the selection spans multiple lines or has inline nodes like links
+    if (selectionRects.length > 1) {
+        // add up the widths of all rects using the first top position
+        for (let i = 1; i < selectionRects.length; i++) {
+            const rect = selectionRects[i];
+            if (rect.top === returnRect.top) {
+                returnRect.width += rect.width;
+            }
+        }
+    }
+
+    return returnRect;
 }


### PR DESCRIPTION
closes TryGhost/Product#3992, closes TryGhost/Product#3993
- toolbar position was based on the first `DOMRect`, which is problematic with inline nodes
- toolbar position also didn't update when clicking the link node edit (which causes the link node to become selected)