### PR TITLE
Fixed toolbar position console error

### DIFF
--- a/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
@@ -90,7 +90,7 @@ function useFloatingFormatToolbar(editor, anchorElem, isSnippetsEnabled, hiddenF
             editor.getEditorState().read(() => {
                 const selection = $getSelection();
                 // save selection range rect to calculate toolbar arrow position
-                if (toolbarItemType) {
+                if (toolbarItemType && $isRangeSelection(selection)) {
                     setSelectionRangeRect($getSelectionRangeRect({selection, editor}));
                 }
             });

--- a/packages/koenig-lexical/src/utils/$getSelectionRangeRect.js
+++ b/packages/koenig-lexical/src/utils/$getSelectionRangeRect.js
@@ -1,7 +1,8 @@
+import {$isRangeSelection} from 'lexical';
 import {createDOMRange, createRectsFromDOMRange} from '@lexical/selection';
 
 export function $getSelectionRangeRect({selection, editor}) {
-    if (!selection) {
+    if (!selection || !$isRangeSelection(selection)) {
         return null;
     }
     const anchor = selection.anchor;


### PR DESCRIPTION
no refs
- added validation to a method that should only take a `RangeSelection` as input and was getting a `NodeSelection` in some cases