### PR TITLE
🐛 Fixed populated embed/bookmark cards re-fetching oembed on render

### DIFF
--- a/packages/koenig-lexical/demo/utils/fetchEmbed.js
+++ b/packages/koenig-lexical/demo/utils/fetchEmbed.js
@@ -1,4 +1,5 @@
 export async function fetchEmbed(url, {type}) {
+    console.log('fetchEmbed', {url, type}); // eslint-disable-line no-console
     let urlObject = new URL(url);
     if (!urlObject) {
         throw new Error('No URL specified.');

--- a/packages/koenig-lexical/src/nodes/BookmarkNode.jsx
+++ b/packages/koenig-lexical/src/nodes/BookmarkNode.jsx
@@ -33,7 +33,7 @@ export class BookmarkNode extends BaseBookmarkNode {
     constructor(dataset = {}, key) {
         super(dataset, key);
 
-        this.__createdWithUrl = !!dataset.url;
+        this.__createdWithUrl = !!dataset.url && !dataset.metadata;
 
         // set up nested editor instances
         setupNestedEditor(this, '__captionEditor', {editor: dataset.captionEditor, nodes: MINIMAL_NODES});

--- a/packages/koenig-lexical/src/nodes/EmbedNode.jsx
+++ b/packages/koenig-lexical/src/nodes/EmbedNode.jsx
@@ -106,7 +106,7 @@ export class EmbedNode extends BaseEmbedNode {
     constructor(dataset = {}, key) {
         super(dataset, key);
 
-        this.__createdWithUrl = !!dataset.url;
+        this.__createdWithUrl = !!dataset.url && !dataset.html;
 
         setupNestedEditor(this, '__captionEditor', {editor: dataset.captionEditor, nodes: MINIMAL_NODES});
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/4009

- the bookmark and embed cards are set up with an effect that fetches their oembed data when they have a "created with url" state set so they auto-populate when links etc are pasted
- we were setting the "created with url" state based on the dataset containing a URL irrespective of whether we already had the other data needed for card display which meant for every populated card we were unnecessarily re-fetching the oembed endpoint on initial render which was hammering the API when content contained a lot of embeds
- added logging of the `fetchEmbed` calls in the demo app for more visibility
