### PR TITLE
🐛 Fixed pasting URLs on `/card [url]` shortcuts

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -1188,16 +1188,25 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
             editor.registerCommand(
                 PASTE_COMMAND,
                 (clipboard) => {
-                    // avoid Koenig behaviours when an inner element (e.g. a card input) has focus and event wasn't triggered from nested editor
+                    // avoid Koenig behaviours when an inner element (e.g. a card input) has focus
+                    // and event wasn't triggered from nested editor
                     if (document.activeElement !== editor.getRootElement() && !isNested) {
                         return false;
                     }
 
                     const text = clipboard?.clipboardData?.getData(MIME_TEXT_PLAIN);
                     const html = clipboard?.clipboardData?.getData(MIME_TEXT_HTML);
-                    const linkMatch = text?.match(/^(https?:\/\/[^\s]+)$/); // replace with better regex to include more protocols like mailto, ftp, etc
+                    // TODO: replace with better regex to include more protocols like mailto, ftp, etc
+                    const linkMatch = text?.match(/^(https?:\/\/[^\s]+)$/);
 
                     if (linkMatch) {
+                        // avoid any conversion if we're pasting onto a card shortcut
+                        const node = $getSelection().anchor.getNode();
+                        if (node.getTextContent().startsWith('/')) {
+                            return false;
+                        }
+
+                        // we're pasting a URL, convert it to an embed/bookmark/link
                         editor.dispatchCommand(PASTE_LINK_COMMAND, {linkMatch});
 
                         return true;

--- a/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
@@ -95,8 +95,8 @@ test.describe('Paste behaviour', async () => {
         test('pasted on blank paragraph creates embed/bookmark', async function () {
             await focusEditor(page);
             await pasteText(page, 'https://ghost.org/');
-            await expect(await page.getByTestId('embed-url-loading-container')).toBeVisible();
-            await expect(await page.getByTestId('embed-url-loading-container')).toBeHidden();
+            await expect(page.getByTestId('embed-url-loading-container')).toBeVisible();
+            await expect(page.getByTestId('embed-url-loading-container')).toBeHidden();
             await expect(page.getByTestId('embed-iframe')).toBeVisible();
         });
 
@@ -113,6 +113,24 @@ test.describe('Paste behaviour', async () => {
                     </a>
                 </p>
             `);
+        });
+
+        test('pasted on a card shortcut avoids conversion', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('/embed ');
+            await pasteText(page, 'https://ghost.org/');
+
+            await assertHTML(page, html`
+                <p dir="ltr">
+                    <span data-lexical-text="true">/embed https://ghost.org/</span>
+                </p>
+            `);
+
+            await page.keyboard.press('Enter');
+
+            await expect(page.getByTestId('embed-url-loading-container')).toBeVisible();
+            await expect(page.getByTestId('embed-url-loading-container')).toBeHidden();
+            await expect(page.getByTestId('embed-iframe')).toBeVisible();
         });
     });
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/3972

- added skip of URL->link conversion when the node being pasted to starts with a `/`
