### PR TITLE
🐛 Fixed double-insert when pasting plain text in Firefox

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -1187,15 +1187,15 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
             ),
             editor.registerCommand(
                 PASTE_COMMAND,
-                (clipboard) => {
+                (clipboardEvent) => {
                     // avoid Koenig behaviours when an inner element (e.g. a card input) has focus
                     // and event wasn't triggered from nested editor
                     if (document.activeElement !== editor.getRootElement() && !isNested) {
                         return false;
                     }
 
-                    const text = clipboard?.clipboardData?.getData(MIME_TEXT_PLAIN);
-                    const html = clipboard?.clipboardData?.getData(MIME_TEXT_HTML);
+                    const text = clipboardEvent?.clipboardData?.getData(MIME_TEXT_PLAIN);
+                    const html = clipboardEvent?.clipboardData?.getData(MIME_TEXT_HTML);
                     // TODO: replace with better regex to include more protocols like mailto, ftp, etc
                     const linkMatch = text?.match(/^(https?:\/\/[^\s]+)$/);
 
@@ -1213,6 +1213,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                     }
 
                     if (text && !html) {
+                        clipboardEvent?.preventDefault();
                         editor.dispatchCommand(PASTE_MARKDOWN_COMMAND, {text, allowBr: true});
 
                         return true;

--- a/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
@@ -16,6 +16,18 @@ test.describe('Paste behaviour', async () => {
         await page.close();
     });
 
+    test.describe('Text', function () {
+        test('converts line breaks to paragraphs', async function () {
+            await focusEditor(page);
+            await pasteText(page, 'One\n\nTwo\n\nThree');
+            await assertHTML(page, html`
+                <p dir="ltr"><span data-lexical-text="true">One</span></p>
+                <p dir="ltr"><span data-lexical-text="true">Two</span></p>
+                <p dir="ltr"><span data-lexical-text="true">Three</span></p>
+            `);
+        });
+    });
+
     test.describe('URLs', function () {
         test('pasted at start of populated paragraph creates a link', async function () {
             await focusEditor(page);


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/3500

- Firefox requires the paste event to be prevented when pasting plain-text otherwise we'll convert the plain text as markdown and insert that and then the default paste insertion happens resulting in content appearing twice
- no Firefox-specific regression test because it doesn't allow you to emulate paste events via JS
