### PR TITLE
🐛 Fixed occasional unexpected render output by preventing bad node nesting

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -1358,12 +1358,13 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
         );
     }, [editor]);
 
-    // any child non-inline nodes should be moved to the top level
+    // validate child nodes of ParagraphNode - e.g. no headings, lists, horizontal rules, etc
     React.useEffect(() => {
         return mergeRegister(
             editor.registerNodeTransform(ParagraphNode, (node) => {
-                let incorrectChildIndex = false; // use this to move all children after the first incorrect one to the parent level
+                let incorrectChildIndex = false;
                 const children = node.getChildren();
+                // check for incorrect child node
                 children.forEach((child) => {
                     if (!incorrectChildIndex && ($isDecoratorNode(child) || $isHeadingNode(child) || $isListNode(child) || $isHorizontalRuleNode(child))) {
                         incorrectChildIndex = child.getIndexWithinParent();

--- a/packages/koenig-lexical/test/e2e/cards/paragraph.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/paragraph.test.js
@@ -1,0 +1,146 @@
+import {assertHTML, html, initialize} from '../../utils/e2e';
+// import {calloutColorPicker} from '../../../src/components/ui/cards/CalloutCardx';
+import {test} from '@playwright/test';
+
+test.describe('Callout Card', async () => {
+    let page;
+
+    test.beforeAll(async ({browser}) => {
+        page = await browser.newPage();
+    });
+
+    test.beforeEach(async () => {
+        await initialize({page});
+    });
+
+    test.afterAll(async () => {
+        await page.close();
+    });
+
+    test('test bad nodes', async function () {
+        await page.evaluate(() => {
+            const serializedState = JSON.stringify({
+                root: {
+                    children: [
+                        {
+                            children: [
+                                {
+                                    children: [
+                                        {
+                                            detail: 0,
+                                            format: 0,
+                                            mode: 'normal',
+                                            style: '',
+                                            text: 'Hello Fintech Friends,',
+                                            type: 'text',
+                                            version: 1
+                                        }
+                                    ],
+                                    direction: 'ltr',
+                                    format: '',
+                                    indent: 0,
+                                    type: 'paragraph',
+                                    version: 1
+                                },
+                                {
+                                    type: 'horizontalrule',
+                                    version: 1
+                                }
+                            ],
+                            direction: 'ltr',
+                            format: '',
+                            indent: 0,
+                            type: 'paragraph',
+                            version: 1
+                        }
+                    ],
+                    direction: 'ltr',
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            });
+            const editor = window.lexicalEditor;
+            const editorState = editor.parseEditorState(serializedState);
+            editor.setEditorState(editorState);
+        });
+        await assertHTML(page, html`
+            <p></p>
+            <p dir="ltr"><span data-lexical-text="true">Hello Fintech Friends,</span></p>
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                </div>
+            </div>
+            <p></p>
+        `, {ignoreCardContents: true});
+    });
+
+    test('test bad nodes2', async function () {
+        await page.evaluate(() => {
+            const serializedState = JSON.stringify({
+                root: {
+                    children: [
+                        {
+                            children: [
+                                {
+                                    detail: 0,
+                                    format: 0,
+                                    mode: 'normal',
+                                    style: '',
+                                    text: 'Hello Fintech Friends,',
+                                    type: 'text',
+                                    version: 1
+                                }
+                            ],
+                            direction: 'ltr',
+                            format: '',
+                            indent: 0,
+                            type: 'paragraph',
+                            version: 1
+                        },
+                        {
+                            children: [
+                                {
+                                    children: [],
+                                    direction: 'ltr',
+                                    format: '',
+                                    indent: 0,
+                                    type: 'paragraph',
+                                    version: 1
+                                },
+                                {
+                                    type: 'horizontalrule',
+                                    version: 1
+                                }
+                            ],
+                            direction: 'ltr',
+                            format: '',
+                            indent: 0,
+                            type: 'paragraph',
+                            version: 1
+                        }
+                    ],
+                    direction: 'ltr',
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            });
+            const editor = window.lexicalEditor;
+            const editorState = editor.parseEditorState(serializedState);
+            editor.setEditorState(editorState);
+        });
+        await assertHTML(page, html`
+            <p dir="ltr"><span data-lexical-text="true">Hello Fintech Friends,</span></p>
+            <p></p>
+            <p><br /></p>
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                </div>
+            </div>
+            <p></p>
+        `, {ignoreCardContents: true});
+    });
+});

--- a/packages/koenig-lexical/test/e2e/node-transforms.test.js
+++ b/packages/koenig-lexical/test/e2e/node-transforms.test.js
@@ -1,8 +1,8 @@
-import {assertHTML, html, initialize} from '../../utils/e2e';
+import {assertHTML, html, initialize} from '../utils/e2e';
 // import {calloutColorPicker} from '../../../src/components/ui/cards/CalloutCardx';
 import {test} from '@playwright/test';
 
-test.describe('Callout Card', async () => {
+test.describe('Node transforms', async () => {
     let page;
 
     test.beforeAll(async ({browser}) => {
@@ -17,7 +17,7 @@ test.describe('Callout Card', async () => {
         await page.close();
     });
 
-    test('test bad nodes', async function () {
+    test('nested elements in paragraph nodes 1', async function () {
         await page.evaluate(() => {
             const serializedState = JSON.stringify({
                 root: {
@@ -76,7 +76,7 @@ test.describe('Callout Card', async () => {
         `, {ignoreCardContents: true});
     });
 
-    test('test bad nodes2', async function () {
+    test('nested elements in paragraph nodes 2', async function () {
         await page.evaluate(() => {
             const serializedState = JSON.stringify({
                 root: {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4006

We've seen a few examples of bad document structure with improper nesting of element nodes inside paragraph nodes. This has knock-on effects of selection and deletion not behaving correctly and render output not being correct because styling expects all content elements to be top-level.

- added a node transform for `ParagraphNode` that detects any non-inline elements and moves them to be top-level