### PR TITLE
✨ Added `Ctrl+Alt+H` shortcut for toggling highlight formatting

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -26,6 +26,7 @@ import {
     COMMAND_PRIORITY_LOW,
     CUT_COMMAND,
     DELETE_LINE_COMMAND,
+    FORMAT_TEXT_COMMAND,
     INSERT_PARAGRAPH_COMMAND,
     KEY_ARROW_DOWN_COMMAND,
     KEY_ARROW_LEFT_COMMAND,
@@ -846,25 +847,33 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                         }
                     }
 
+                    // Ctrl/Cmd+H to toggle heading
+                    // Ctrl+Option+H to toggle highlight
                     if ((metaKey || ctrlKey) && code === 'KeyH') {
                         // avoid hide behaviour
                         event.preventDefault();
 
-                        const selection = $getSelection();
-                        if ($isRangeSelection(selection)) {
-                            const firstNode = selection.anchor.getNode().getTopLevelElement();
+                        // highlight
+                        if (ctrlKey && altKey) {
+                            editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'highlight');
+                        // heading
+                        } else {
+                            const selection = $getSelection();
+                            if ($isRangeSelection(selection)) {
+                                const firstNode = selection.anchor.getNode().getTopLevelElement();
 
-                            if ($isParagraphNode(firstNode)) {
-                                $setBlocksType(selection, () => $createHeadingNode('h2'));
-                            } else if ($isHeadingNode(firstNode)) {
-                                const tag = firstNode.getTag();
-                                const level = parseInt(tag.slice(1), 10);
-                                const newLevel = level + 1;
+                                if ($isParagraphNode(firstNode)) {
+                                    $setBlocksType(selection, () => $createHeadingNode('h2'));
+                                } else if ($isHeadingNode(firstNode)) {
+                                    const tag = firstNode.getTag();
+                                    const level = parseInt(tag.slice(1), 10);
+                                    const newLevel = level + 1;
 
-                                if (newLevel > 6) {
-                                    $setBlocksType(selection, () => $createParagraphNode());
-                                } else {
-                                    $setBlocksType(selection, () => $createHeadingNode(`h${newLevel}`));
+                                    if (newLevel > 6) {
+                                        $setBlocksType(selection, () => $createParagraphNode());
+                                    } else {
+                                        $setBlocksType(selection, () => $createHeadingNode(`h${newLevel}`));
+                                    }
                                 }
                             }
                         }

--- a/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
+++ b/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
@@ -110,6 +110,23 @@ test.describe('Editor keyboard shortcuts', async () => {
 
             await assertHTML(page, html`<p dir="ltr"><code spellcheck="false" data-lexical-text="true"><span>test</span></code></p>`);
         });
+
+        test('highlight', async function () {
+            await focusEditor(page);
+
+            await page.keyboard.type('test');
+
+            await page.keyboard.down('Shift');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.up('Shift', {delay: 100});
+
+            await page.keyboard.press(`Control+Alt+H`, {delay: 100});
+
+            await assertHTML(page, html`<p dir="ltr"><mark data-lexical-text="true"><span>test</span></mark></p>`);
+        });
     });
 
     test('quotes', async function () {


### PR DESCRIPTION
no issue

- highlight was possible using `==text==` markdown formatting but didn't have an associated key shortcut
