### PR TITLE
Fixed ordered list shortcut creating unordered list

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -51,7 +51,7 @@ import {
     getTopLevelNativeElement
 } from '../utils/';
 import {$isKoenigCard, ImageNode} from '@tryghost/kg-default-nodes';
-import {$isListItemNode, $isListNode, INSERT_UNORDERED_LIST_COMMAND, ListNode} from '@lexical/list';
+import {$isListItemNode, $isListNode, INSERT_ORDERED_LIST_COMMAND, INSERT_UNORDERED_LIST_COMMAND, ListNode} from '@lexical/list';
 import {$setBlocksType} from '@lexical/selection';
 import {MIME_TEXT_HTML, MIME_TEXT_PLAIN, PASTE_MARKDOWN_COMMAND} from './MarkdownPastePlugin.jsx';
 import {mergeRegister} from '@lexical/utils';
@@ -905,7 +905,11 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                                     pNode.setIndent(0);
                                 });
                             } else {
-                                editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined);
+                                if (altKey) {
+                                    editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined);
+                                } else {
+                                    editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined);
+                                }
                             }
                         }
                     }

--- a/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
+++ b/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
@@ -251,7 +251,7 @@ test.describe('Editor keyboard shortcuts', async () => {
         `);
     });
 
-    test('list', async function () {
+    test('unordered list', async function () {
         await focusEditor(page);
 
         await page.keyboard.type('test');
@@ -261,6 +261,25 @@ test.describe('Editor keyboard shortcuts', async () => {
             <ul>
                 <li value="1" dir="ltr"><span data-lexical-text="true">test</span></li>
             </ul>
+        `);
+
+        await page.keyboard.press('Control+l');
+
+        await assertHTML(page, html`
+            <p dir="ltr"><span data-lexical-text="true">test</span></p>
+        `);
+    });
+
+    test('ordered list', async function () {
+        await focusEditor(page);
+
+        await page.keyboard.type('test');
+        await page.keyboard.press('Control+Alt+l');
+
+        await assertHTML(page, html`
+            <ol>
+                <li value="1" dir="ltr"><span data-lexical-text="true">test</span></li>
+            </ol>
         `);
 
         await page.keyboard.press('Control+l');


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/3979

- added conditional for ordered vs unordered toggle when Alt is pressed with the Ctrl+L shortcut
