### PR TITLE
Allowed blank placeholder text

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigComposableEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigComposableEditor.jsx
@@ -33,7 +33,7 @@ const KoenigComposableEditor = ({
     children,
     placeholder,
     singleParagraph,
-    placeholderText = '',
+    placeholderText,
     placeholderClassName = '',
     className = '',
     readOnly = false,

--- a/packages/koenig-lexical/src/components/ui/EditorPlaceholder.jsx
+++ b/packages/koenig-lexical/src/components/ui/EditorPlaceholder.jsx
@@ -2,6 +2,6 @@ export function EditorPlaceholder({className, text}) {
     return (
         <div
             className={`pointer-events-none absolute left-0 top-0 min-w-full cursor-text font-serif text-xl text-grey-500 dark:text-grey-800 ${className}`}
-        >{text || 'Begin writing your post...'}</div>
+        >{typeof text === 'string' ? text : 'Begin writing your post...'}</div>
     );
 }


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/0ffe4dd1444944bb8822e95a50580bf30ef6c7b3

- in some cases consumers want to hide the placeholder completely but that wasn't easy because we did a basic `text || "Default..."` assignment meaning explicitly passing in a blank string meant you got the default placeholder
- adjusted the behaviour to check if we have a string and to always display that if we do, this required removing the default value of the `placeholderText` prop to ensure we still show the default placeholder when no placeholder is provided
