### PR TITLE
🎨 Added placeholder formatting to email cards

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/email-cta/email-cta-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/email-cta/email-cta-renderer.js
@@ -28,7 +28,7 @@ export function renderEmailCtaNode(node, options = {}) {
         element.appendChild(document.createElement('hr'));
     }
 
-    const cleanedHtml = wrapReplacementStrings(removeCodeWrappersFromHelpers(removeSpaces(html)));
+    const cleanedHtml = wrapReplacementStrings(removeCodeWrappersFromHelpers(removeSpaces(html),document));
     element.innerHTML = element.innerHTML + cleanedHtml;
 
     if (hasButton) {
@@ -47,7 +47,7 @@ export function renderEmailCtaNode(node, options = {}) {
             <p></p>
         `; // the inline <p> element is so we get a line break if there's no separators/hr used
 
-        const cleanedButton = wrapReplacementStrings(removeCodeWrappersFromHelpers(removeSpaces(buttonTemplate)));
+        const cleanedButton = wrapReplacementStrings(removeCodeWrappersFromHelpers(removeSpaces(buttonTemplate),document));
         element.innerHTML = element.innerHTML + cleanedButton;
     }
 

--- a/packages/kg-default-nodes/lib/nodes/email-cta/email-cta-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/email-cta/email-cta-renderer.js
@@ -1,5 +1,5 @@
 import {addCreateDocumentOption} from '../../utils/add-create-document-option';
-import {removeSpaces, wrapReplacementStrings} from '../../utils/replacement-strings';
+import {removeCodeWrappersFromHelpers, removeSpaces, wrapReplacementStrings} from '../../utils/replacement-strings';
 import {escapeHtml} from '../../utils/escape-html';
 import {renderEmptyContainer} from '../../utils/render-empty-container';
 
@@ -28,7 +28,7 @@ export function renderEmailCtaNode(node, options = {}) {
         element.appendChild(document.createElement('hr'));
     }
 
-    const cleanedHtml = wrapReplacementStrings(removeSpaces(html));
+    const cleanedHtml = wrapReplacementStrings(removeCodeWrappersFromHelpers(removeSpaces(html)));
     element.innerHTML = element.innerHTML + cleanedHtml;
 
     if (hasButton) {
@@ -47,7 +47,7 @@ export function renderEmailCtaNode(node, options = {}) {
             <p></p>
         `; // the inline <p> element is so we get a line break if there's no separators/hr used
 
-        const cleanedButton = wrapReplacementStrings(removeSpaces(buttonTemplate));
+        const cleanedButton = wrapReplacementStrings(removeCodeWrappersFromHelpers(removeSpaces(buttonTemplate)));
         element.innerHTML = element.innerHTML + cleanedButton;
     }
 

--- a/packages/koenig-lexical/src/components/KoenigNestedEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigNestedEditor.jsx
@@ -1,6 +1,5 @@
 import KoenigNestedEditorPlugin from '../plugins/KoenigNestedEditorPlugin.jsx';
 import React from 'react';
-import ReplacementStringsPlugin from '../plugins/ReplacementStringsPlugin.jsx';
 import {BASIC_NODES, BASIC_TRANSFORMERS, KoenigComposableEditor, KoenigNestedComposer, MINIMAL_NODES, MINIMAL_TRANSFORMERS, RestrictContentPlugin} from '../index.js';
 
 const Placeholder = ({text = 'Type here', className = ''}) => {
@@ -24,9 +23,9 @@ const KoenigNestedEditor = ({
     singleParagraph = false,
     hasSettingsPanel = false,
     defaultKoenigEnterBehaviour = false,
-    useReplacementStrings = false,
     hiddenFormats = [],
-    dataTestId
+    dataTestId,
+    children
 }) => {
     const initialNodes = nodes === 'minimal' ? MINIMAL_NODES : BASIC_NODES;
     const markdownTransformers = nodes === 'minimal' ? MINIMAL_TRANSFORMERS : BASIC_TRANSFORMERS;
@@ -48,7 +47,7 @@ const KoenigNestedEditor = ({
             >
                 {singleParagraph && <RestrictContentPlugin paragraphs={1} />}
 
-                {useReplacementStrings && <ReplacementStringsPlugin />}
+                {children}
 
                 <KoenigNestedEditorPlugin
                     autoFocus={autoFocus}

--- a/packages/koenig-lexical/src/components/KoenigNestedEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigNestedEditor.jsx
@@ -1,5 +1,6 @@
 import KoenigNestedEditorPlugin from '../plugins/KoenigNestedEditorPlugin.jsx';
 import React from 'react';
+import ReplacementStringsPlugin from '../plugins/ReplacementStringsPlugin.jsx';
 import {BASIC_NODES, BASIC_TRANSFORMERS, KoenigComposableEditor, KoenigNestedComposer, MINIMAL_NODES, MINIMAL_TRANSFORMERS, RestrictContentPlugin} from '../index.js';
 
 const Placeholder = ({text = 'Type here', className = ''}) => {
@@ -23,6 +24,7 @@ const KoenigNestedEditor = ({
     singleParagraph = false,
     hasSettingsPanel = false,
     defaultKoenigEnterBehaviour = false,
+    useReplacementStrings = false,
     hiddenFormats = [],
     dataTestId
 }) => {
@@ -45,6 +47,9 @@ const KoenigNestedEditor = ({
                 placeholder={<Placeholder className={placeholderClassName} text={placeholderText} />}
             >
                 {singleParagraph && <RestrictContentPlugin paragraphs={1} />}
+
+                {useReplacementStrings && <ReplacementStringsPlugin />}
+
                 <KoenigNestedEditorPlugin
                     autoFocus={autoFocus}
                     defaultKoenigEnterBehaviour={defaultKoenigEnterBehaviour}

--- a/packages/koenig-lexical/src/components/ui/cards/EmailCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/EmailCard.jsx
@@ -13,6 +13,7 @@ export function EmailCard({htmlEditor, htmlEditorInitialState, isEditing}) {
                 initialEditorState={htmlEditorInitialState}
                 nodes='basic'
                 textClassName='kg-email-html whitespace-normal pb-1'
+                useReplacementStrings={true}
             />
 
             {isEditing &&

--- a/packages/koenig-lexical/src/components/ui/cards/EmailCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/EmailCard.jsx
@@ -1,6 +1,7 @@
 import KoenigNestedEditor from '../../KoenigNestedEditor';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReplacementStringsPlugin from '../../../plugins/ReplacementStringsPlugin';
 import {ReactComponent as HelpIcon} from '../../../assets/icons/kg-help.svg';
 import {ReadOnlyOverlay} from '../ReadOnlyOverlay';
 
@@ -13,8 +14,9 @@ export function EmailCard({htmlEditor, htmlEditorInitialState, isEditing}) {
                 initialEditorState={htmlEditorInitialState}
                 nodes='basic'
                 textClassName='kg-email-html whitespace-normal pb-1'
-                useReplacementStrings={true}
-            />
+            >
+                <ReplacementStringsPlugin />
+            </KoenigNestedEditor>
 
             {isEditing &&
                 <div className="!-mx-3 !mt-3 flex items-center justify-center bg-grey-100 p-2 font-sans text-sm font-normal leading-none text-grey-600 dark:bg-grey-950 dark:text-grey-800">

--- a/packages/koenig-lexical/src/components/ui/cards/EmailCtaCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/EmailCtaCard.jsx
@@ -1,6 +1,7 @@
 import KoenigNestedEditor from '../../KoenigNestedEditor';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReplacementStringsPlugin from '../../../plugins/ReplacementStringsPlugin';
 import {Button} from '../Button';
 import {ButtonGroupSetting, DropdownSetting, InputSetting, InputUrlSetting, SettingsDivider, SettingsPanel, ToggleSetting} from '../SettingsPanel';
 import {ReactComponent as CenterAlignIcon} from '../../../assets/icons/kg-align-center.svg';
@@ -70,8 +71,9 @@ export function EmailCtaCard({
                     placeholderClassName={`bg-transparent whitespace-normal font-serif text-xl !text-grey-500 !dark:text-grey-800 ` }
                     placeholderText="Email only text... (optional)"
                     textClassName={`w-full bg-transparent whitespace-normal font-serif text-xl text-grey-900 dark:text-grey-200 ${alignment === 'left' ? 'text-left' : 'text-center mx-auto [&:has(.placeholder)]:w-fit [&:has(.placeholder)]:text-left'} ` }
-                    useReplacementStrings={true}
-                />
+                >
+                    <ReplacementStringsPlugin />
+                </KoenigNestedEditor>
 
                 {/* Button */}
                 { (showButton && (isEditing || (buttonText && buttonUrl))) &&

--- a/packages/koenig-lexical/src/components/ui/cards/EmailCtaCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/EmailCtaCard.jsx
@@ -70,6 +70,7 @@ export function EmailCtaCard({
                     placeholderClassName={`bg-transparent whitespace-normal font-serif text-xl !text-grey-500 !dark:text-grey-800 ` }
                     placeholderText="Email only text... (optional)"
                     textClassName={`w-full bg-transparent whitespace-normal font-serif text-xl text-grey-900 dark:text-grey-200 ${alignment === 'left' ? 'text-left' : 'text-center mx-auto [&:has(.placeholder)]:w-fit [&:has(.placeholder)]:text-left'} ` }
+                    useReplacementStrings={true}
                 />
 
                 {/* Button */}

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -999,7 +999,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                                         const markup = SPECIAL_MARKUPS[tag];
                                         // for replacement strings e.g. {{variable}} we shouldn't add the markup (assumes use of ReplacementStringsPlugin)
                                         let newText = textContent;
-                                        if (tag === 'code' && textContent.match(/{{.*?}}(?![A-Za-z\s])/)) {
+                                        if (tag === 'code' && textContent.match(/{.*?}(?![A-Za-z\s])/)) {
                                             newText = newText.slice(0,-1);
                                         } else {
                                             newText = markup + newText + markup;

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -997,8 +997,14 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                                 for (const tag of Object.keys(SPECIAL_MARKUPS)) {
                                     if (anchorNode.hasFormat(tag)) {
                                         const markup = SPECIAL_MARKUPS[tag];
-                                        let newText = markup + textContent + markup;
-                                        newText = newText.slice(0,-1); // remove last markup character
+                                        // for placeholders {{variable}} we shouldn't add the markup
+                                        let newText = textContent;
+                                        if (tag === 'code' && textContent.match(/{{.*?}}(?!\s)/)) {
+                                            newText = newText.slice(0,-1);
+                                        } else {
+                                            newText = markup + newText + markup;
+                                            newText = newText.slice(0,-1); // remove last markup character
+                                        }
 
                                         // manually clear formatting and push offset to accommodate for the added markup
                                         anchorNode.setFormat(0);

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -997,9 +997,9 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                                 for (const tag of Object.keys(SPECIAL_MARKUPS)) {
                                     if (anchorNode.hasFormat(tag)) {
                                         const markup = SPECIAL_MARKUPS[tag];
-                                        // for placeholders {{variable}} we shouldn't add the markup
+                                        // for replacement strings e.g. {{variable}} we shouldn't add the markup (assumes use of ReplacementStringsPlugin)
                                         let newText = textContent;
-                                        if (tag === 'code' && textContent.match(/{{.*?}}(?!\s)/)) {
+                                        if (tag === 'code' && textContent.match(/{{.*?}}(?![A-Za-z\s])/)) {
                                             newText = newText.slice(0,-1);
                                         } else {
                                             newText = markup + newText + markup;

--- a/packages/koenig-lexical/src/plugins/ReplacementStringsPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/ReplacementStringsPlugin.jsx
@@ -7,7 +7,9 @@ function replacementStringTransform(node) {
         return;
     }
     const textContent = node.getTextContent();
-    const replacementString = textContent.match(/{.*?}/)?.[0];
+    // const replacementString = textContent.match(/{.*?}/)?.[0];
+    const replacementString = textContent.match(/\{(\w*?)(?:,? *"(.*?)")?\}/)?.[0];
+
     if (!replacementString) {
         return;
     }

--- a/packages/koenig-lexical/src/plugins/ReplacementStringsPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/ReplacementStringsPlugin.jsx
@@ -1,0 +1,46 @@
+import {ExtendedTextNode} from '@tryghost/kg-default-nodes';
+// import {TextNode} from 'lexical';
+import {useEffect} from 'react';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+
+function replacementStringTransform(node) {
+    if (node.hasFormat('code')) { // prevent infinite loop
+        return;
+    }
+    const regex = /{{.*?}}/g;
+    const textContent = node.getTextContent();
+    // replace {{placeholder}} with a new text node that has the code format applied
+    const replacementString = textContent.match(regex);
+    console.log(`replacementString`,replacementString);
+    if (replacementString) {        
+        const replacementTextNode = new ExtendedTextNode(replacementString);
+        replacementTextNode.setFormat('code');
+
+        // todo: split node in case someone puts placeholder in the middle of the string
+        node.setTextContent(node.getTextContent().replace(replacementString, ''));
+        node.insertAfter(replacementTextNode);
+        // todo: fix selection not going to end....
+        replacementTextNode.select();
+    }
+}
+
+function useReplacementStrings(editor) {
+    useEffect(() => {
+        const removeTransform = editor.registerNodeTransform(ExtendedTextNode, replacementStringTransform);
+        return () => {
+            removeTransform();
+        };
+    }, [editor]);
+
+    // useEffect(() => {
+    //     const removeTransform = editor.registerNodeTransform(TextNode, replacementStringTransform);
+    //     return () => {
+    //         removeTransform();
+    //     };
+    // }, [editor]);
+}
+
+export default function ReplacementStringsPlugin() {
+    const [editor] = useLexicalComposerContext();
+    return useReplacementStrings(editor);
+}

--- a/packages/koenig-lexical/src/plugins/ReplacementStringsPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/ReplacementStringsPlugin.jsx
@@ -8,12 +8,12 @@ function replacementStringTransform(node) {
         return;
     }
     const textContent = node.getTextContent();
-    const replacementString = textContent.match(/{{.*?}}/)?.[0];
+    const replacementString = textContent.match(/{.*?}/)?.[0];
     if (!replacementString) {
         return;
     }
     // split the text content into an array including the matched string
-    const splitContent = textContent.split(/({{.*?}})/g).filter(e => e !== '');
+    const splitContent = textContent.split(/({.*?})/g).filter(e => e !== '');
 
     // create a new text node for each string in the array
     splitContent.reverse().forEach((text) => {

--- a/packages/koenig-lexical/src/plugins/ReplacementStringsPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/ReplacementStringsPlugin.jsx
@@ -1,5 +1,4 @@
-import {ExtendedTextNode} from '@tryghost/kg-default-nodes';
-// import {TextNode} from 'lexical';
+import {TextNode} from 'lexical';
 import {useEffect} from 'react';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
@@ -17,7 +16,7 @@ function replacementStringTransform(node) {
 
     // create a new text node for each string in the array
     splitContent.reverse().forEach((text) => {
-        const newNode = new ExtendedTextNode(text);
+        const newNode = new TextNode(text);
         if (text === replacementString) {
             newNode.setFormat('code');
             newNode.select();
@@ -29,18 +28,11 @@ function replacementStringTransform(node) {
 
 function useReplacementStrings(editor) {
     useEffect(() => {
-        const removeTransform = editor.registerNodeTransform(ExtendedTextNode, replacementStringTransform);
+        const removeTransform = editor.registerNodeTransform(TextNode, replacementStringTransform);
         return () => {
             removeTransform();
         };
     }, [editor]);
-
-    // useEffect(() => {
-    //     const removeTransform = editor.registerNodeTransform(TextNode, replacementStringTransform);
-    //     return () => {
-    //         removeTransform();
-    //     };
-    // }, [editor]);
 }
 
 export default function ReplacementStringsPlugin() {

--- a/packages/koenig-lexical/src/plugins/ReplacementStringsPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/ReplacementStringsPlugin.jsx
@@ -8,7 +8,7 @@ function replacementStringTransform(node) {
         return;
     }
     const textContent = node.getTextContent();
-    const replacementString = textContent.match(/{{.*?}}/);
+    const replacementString = textContent.match(/{{.*?}}/)?.[0];
     if (!replacementString) {
         return;
     }
@@ -18,7 +18,7 @@ function replacementStringTransform(node) {
     // create a new text node for each string in the array
     splitContent.reverse().forEach((text) => {
         const newNode = new ExtendedTextNode(text);
-        if (text === replacementString[0]) {
+        if (text === replacementString) {
             newNode.setFormat('code');
             newNode.select();
         }

--- a/packages/koenig-lexical/src/plugins/ReplacementStringsPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/ReplacementStringsPlugin.jsx
@@ -7,21 +7,24 @@ function replacementStringTransform(node) {
     if (node.hasFormat('code')) { // prevent infinite loop
         return;
     }
-    const regex = /{{.*?}}/g;
     const textContent = node.getTextContent();
-    // replace {{placeholder}} with a new text node that has the code format applied
-    const replacementString = textContent.match(regex);
-    console.log(`replacementString`,replacementString);
-    if (replacementString) {        
-        const replacementTextNode = new ExtendedTextNode(replacementString);
-        replacementTextNode.setFormat('code');
-
-        // todo: split node in case someone puts placeholder in the middle of the string
-        node.setTextContent(node.getTextContent().replace(replacementString, ''));
-        node.insertAfter(replacementTextNode);
-        // todo: fix selection not going to end....
-        replacementTextNode.select();
+    const replacementString = textContent.match(/{{.*?}}/);
+    if (!replacementString) {
+        return;
     }
+    // split the text content into an array including the matched string
+    const splitContent = textContent.split(/({{.*?}})/g).filter(e => e !== '');
+
+    // create a new text node for each string in the array
+    splitContent.reverse().forEach((text) => {
+        const newNode = new ExtendedTextNode(text);
+        if (text === replacementString[0]) {
+            newNode.setFormat('code');
+            newNode.select();
+        }
+        node.insertAfter(newNode);
+    });
+    node.remove();
 }
 
 function useReplacementStrings(editor) {

--- a/packages/koenig-lexical/test/e2e/cards/email-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/email-card.test.js
@@ -185,4 +185,87 @@ test.describe('Email card', async () => {
         const emailCard = page.locator('[data-kg-card="email"] ul > li:first-child');
         await expect(emailCard).toHaveText('List item 1');
     });
+
+    // placeholders like {test} or {test, "string"} should be formatted as code
+    test('formats typed placeholders', async function () {
+        await focusEditor(page);
+        await insertEmailCard(page);
+
+        await page.keyboard.press(`Enter`);
+        await page.keyboard.type(`testing {this}?`);
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div><svg></svg></div>
+                <div data-kg-card-editing="true" data-kg-card-selected="true" data-kg-card="email">
+                    <div>
+                        <div>
+                            <div data-kg="editor">
+                                <div contenteditable="true" role="textbox" spellcheck="true" data-lexical-editor="true">
+                                    <p dir="ltr">
+                                        <span data-lexical-text="true">Hey</span>
+                                        <code spellcheck="false" data-lexical-text="true">
+                                        <span>{first_name, "there"}</span>
+                                        </code>
+                                        <span data-lexical-text="true">,</span>
+                                    </p>
+                                    <p dir="ltr">
+                                        <span data-lexical-text="true">testing </span>
+                                        <code spellcheck="false" data-lexical-text="true">
+                                            <span>{this}</span>
+                                        </code>
+                                        <span data-lexical-text="true">?</span>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            Only visible when delivered by email, this card will not be published on your site.
+                            <a href="https://ghost.org/help/email-newsletters/#email-cards" rel="noopener noreferrer" target="_blank">
+                                <svg></svg>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <p><br /></p>
+    `, {ignoreInnerSVG: true, ignoreCardToolbarContents: true});
+
+        // remove the formatting using backspace
+        await page.keyboard.press('Backspace');
+        await page.keyboard.press('Backspace');
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div><svg></svg></div>
+                <div data-kg-card-editing="true" data-kg-card-selected="true" data-kg-card="email">
+                    <div>
+                        <div>
+                            <div data-kg="editor">
+                                <div contenteditable="true" role="textbox" spellcheck="true" data-lexical-editor="true">
+                                    <p dir="ltr">
+                                        <span data-lexical-text="true">Hey</span>
+                                        <code spellcheck="false" data-lexical-text="true">
+                                        <span>{first_name, "there"}</span>
+                                        </code>
+                                        <span data-lexical-text="true">,</span>
+                                    </p>
+                                    <p dir="ltr">
+                                        <span data-lexical-text="true">testing {this</span>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            Only visible when delivered by email, this card will not be published on your site.
+                            <a href="https://ghost.org/help/email-newsletters/#email-cards" rel="noopener noreferrer" target="_blank">
+                                <svg></svg>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <p><br /></p>
+    `, {ignoreInnerSVG: true, ignoreCardToolbarContents: true});
+    });
 });

--- a/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
@@ -473,4 +473,73 @@ test.describe('Email card', async () => {
             <p><br /></p>
             `, {ignoreInnerSVG: true, ignoreCardToolbarContents: true});
     });
+
+    // placeholders like {test} or {test, "string"} should be formatted as code
+    test('formats typed placeholders', async function () {
+        await focusEditor(page);
+        await insertEmailCard(page);
+
+        await page.keyboard.type(`testing {this}?`);
+        await page.keyboard.press('Escape'); // use escape to avoid the settings panel
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div><svg></svg></div>
+                <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="email-cta">
+                    <div>
+                        <div>Free members</div>
+                        <hr />
+                        <div>
+                            <div data-kg="editor">
+                                <div contenteditable="false" role="textbox" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none" aria-readonly="true">
+                                    <p dir="ltr">
+                                        <span data-lexical-text="true">testing </span>
+                                        <code spellcheck="false" data-lexical-text="true">
+                                            <span>{this}</span>
+                                        </code>
+                                        <span data-lexical-text="true">?</span>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <hr />
+                        <div></div>
+                    </div>
+                    <div data-kg-card-toolbar="email-cta"></div>
+                </div>
+            </div>
+            <p><br /></p>
+        `, {ignoreInnerSVG: true, ignoreCardToolbarContents: true});
+
+        // remove the formatting using backspace
+        await page.keyboard.press(`${ctrlOrCmd}+Enter`);
+        await page.keyboard.press('Backspace');
+        await page.keyboard.press('Backspace');
+        await page.keyboard.press('Escape'); // avoid settings panel
+        
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div><svg></svg></div>
+                <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="email-cta">
+                    <div>
+                        <div>Free members</div>
+                        <hr />
+                        <div>
+                            <div data-kg="editor">
+                                <div contenteditable="false" role="textbox" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none" aria-readonly="true">
+                                    <p dir="ltr">
+                                        <span data-lexical-text="true">testing {this</span>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <hr />
+                        <div></div>
+                    </div>
+                    <div data-kg-card-toolbar="email-cta"></div>
+                </div>
+            </div>
+            <p><br /></p>
+        `, {ignoreInnerSVG: true, ignoreCardToolbarContents: true});
+    });
 });


### PR DESCRIPTION
closes TryGhost/Product#3984
- placeholder strings like {variable} will now be formatted as code in the editor so users can know they are supported
- code formatting is stripped out in the renderer
- created new `ReplacementStringsPlugin` for use in the nested editors