### PR TITLE
🐛 Fixed image card not indicating when it has a link

### DIFF
--- a/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
@@ -246,7 +246,7 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, captionE
                         onClick={() => handleImageCardResize('full')}
                     />
                     <ToolbarMenuSeparator hide={isGif(src)} />
-                    <ToolbarMenuItem icon="link" isActive={href === true || false} label="Link" onClick = {() => {
+                    <ToolbarMenuItem icon="link" isActive={href || false} label="Link" onClick = {() => {
                         setShowLink(true);
                     }} />
                     <ToolbarMenuItem


### PR DESCRIPTION
closes TryGhost/Product#4013
- toolbar icon was not turning green when a link was applied