### PR TITLE
🐛 Fixed invalid background color in callout cards breaking rendering + copy/paste

### DIFF
--- a/packages/kg-converters/lib/mobiledoc-to-lexical.js
+++ b/packages/kg-converters/lib/mobiledoc-to-lexical.js
@@ -82,6 +82,16 @@ const CARD_PROPERTY_MAP = {
     }
 };
 
+const CARD_FIXES_MAP = {
+    callout: (payload) => {
+        if (payload.backgroundColor && !payload.backgroundColor.match(/^[a-zA-Z\d-]+$/)) {
+            payload.backgroundColor = 'white';
+        }
+
+        return payload;
+    }
+};
+
 export function mobiledocToLexical(serializedMobiledoc) {
     if (serializedMobiledoc === null || serializedMobiledoc === undefined || serializedMobiledoc === '') {
         return JSON.stringify(BLANK_DOC);
@@ -329,6 +339,11 @@ function convertCardSectionToLexical(child, mobiledoc) {
             payload[newName] = payload[oldName];
             delete payload[oldName];
         }
+    }
+
+    // run any payload fixes
+    if (CARD_FIXES_MAP[cardName]) {
+        payload = CARD_FIXES_MAP[cardName](payload);
     }
 
     delete payload.type;

--- a/packages/kg-converters/test/mobiledoc-to-lexical.test.js
+++ b/packages/kg-converters/test/mobiledoc-to-lexical.test.js
@@ -1357,7 +1357,7 @@ describe('mobiledocToLexical', function () {
                         [1, `h${i}`, [[0, [], 0, `Heading ${i}`]]]
                     ]
                 }));
-    
+
                 assert.equal(result, JSON.stringify({
                     root: {
                         children: [
@@ -2303,6 +2303,43 @@ describe('mobiledocToLexical', function () {
                             type: 'embed',
                             version: 1,
                             embedType: 'twitter'
+                        }
+                    ],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            }));
+        });
+
+        it('fixes payload properties', function () {
+            const result = mobiledocToLexical(JSON.stringify({
+                version: MOBILEDOC_VERSION,
+                ghostVersion: GHOST_VERSION,
+                atoms: [],
+                cards: [
+                    ['callout', {
+                        version: 1,
+                        backgroundColor: 'rgba(0, 0, 0, 0.05)',
+                        calloutText: '<strong>Test</strong>'
+                    }]
+                ],
+                markups: [],
+                sections: [
+                    [10, 0]
+                ]
+            }));
+
+            assert.equal(result, JSON.stringify({
+                root: {
+                    children: [
+                        {
+                            type: 'callout',
+                            version: 1,
+                            backgroundColor: 'white',
+                            calloutText: '<strong>Test</strong>'
                         }
                     ],
                     direction: null,

--- a/packages/kg-default-nodes/lib/nodes/callout/callout-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/callout/callout-renderer.js
@@ -5,6 +5,14 @@ export function renderCalloutNode(node, options = {}) {
     addCreateDocumentOption(options);
     const document = options.createDocument();
     const element = document.createElement('div');
+
+    // backgroundColor can end up with `rgba(0, 0, 0, 0)` from old mobiledoc copy/paste
+    // that is invalid when used in a class name so fall back to `white` when we don't have
+    // something that looks like a valid class
+    if (!node.backgroundColor || !node.backgroundColor.match(/^[a-zA-Z\d-]+$/)) {
+        node.backgroundColor = 'white';
+    }
+
     element.classList.add('kg-card', 'kg-callout-card', `kg-callout-card-${node.backgroundColor}`);
 
     if (node.calloutEmoji) {

--- a/packages/kg-default-nodes/test/nodes/callout.test.js
+++ b/packages/kg-default-nodes/test/nodes/callout.test.js
@@ -151,6 +151,24 @@ describe('CalloutNode', function () {
                 </div>
                 `);
         }));
+
+        it('can render to HTML with invalid backgroundColor', editorTest(function () {
+            dataset.backgroundColor = 'rgba(124, 139, 154, 0.13)';
+
+            const node = $createCalloutNode(dataset);
+            const {element} = node.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-callout-card kg-callout-card-white">
+                    <div class="kg-callout-emoji">💡</div>
+                    <div class="kg-callout-text">
+                        <b><strong>Hello!</strong></b
+                        >Check<i><em class="italic">this</em></i
+                        ><a href="https://ghost.org" rel="noopener">out</a>.
+                    </div>
+                </div>
+            `);
+        }));
     });
 
     describe('importDOM', function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4008

Copy/paste of callout cards in the old editor could result in the `backgroundColor` property containing a non-class value like `rgba(124, 139, 154, 0.13)` which would then error when we attempted to use that as a class name during rendering.

- added regex to validate the `backgroundColor` value when rendering, if it's not present or doesn't match a class-like string then we fall back to using `'white'`
- added a similar fix to `mobiledocToLexical()` so we can fix bad values when converting so there's less likelihood of known bad values ending up in converted content
