### PR TITLE
🐛 Fixed styles in HTML card content interfering with editor display

### DIFF
--- a/packages/koenig-lexical/src/utils/sanitize-html.js
+++ b/packages/koenig-lexical/src/utils/sanitize-html.js
@@ -15,5 +15,10 @@ export function sanitizeHtml(html = '', options = {}) {
     }
 
     // sanitize html
-    return DOMPurify.sanitize(html, {ALLOWED_URI_REGEXP: /^https?:|^\/|blob:/, ADD_ATTR: ['id']});
+    return DOMPurify.sanitize(html, {
+        ALLOWED_URI_REGEXP: /^https?:|^\/|blob:/,
+        ADD_ATTR: ['id'],
+        FORBID_TAGS: ['style'],
+        FORBID_ATTR: ['style']
+    });
 }

--- a/packages/koenig-lexical/test/e2e/cards/html-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/html-card.test.js
@@ -46,7 +46,40 @@ test.describe('Html card', async () => {
                     </div>
                 </div>
             </div>
-        `);
+        `, {ignoreCardContents: false});
+    });
+
+    test('renders without style elements and attributes', async function () {
+        await page.evaluate(() => {
+            const serializedState = JSON.stringify({
+                root: {
+                    children: [{
+                        type: 'html',
+                        html: '<div id="fullscreen"><span style="fullscreen-inner">Loading...</span></div><style>.fullscreen {position: fixed;}</style>'
+                    }],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            });
+            const editor = window.lexicalEditor;
+            const editorState = editor.parseEditorState(serializedState);
+            editor.setEditorState(editorState);
+        });
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div><svg></svg></div>
+                <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="html">
+                    <div>
+                        <div><div><span>Loading...</span></div></div>
+                        <div></div>
+                    </div>
+                </div>
+            </div>
+        `, {ignoreCardContents: false, ignoreInlineStyles: false});
     });
 
     test('renders html card node from slash entry', async function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4027

- added removal of `<style>` elements and `style` attributes to our `sanitizeHtml` function
- matches behaviour of previous editor
