### PR TITLE
🎨 Re-enabled `style` attributes when displaying HTML cards in the editor

### DIFF
--- a/packages/koenig-lexical/src/utils/sanitize-html.js
+++ b/packages/koenig-lexical/src/utils/sanitize-html.js
@@ -18,7 +18,6 @@ export function sanitizeHtml(html = '', options = {}) {
     return DOMPurify.sanitize(html, {
         ALLOWED_URI_REGEXP: /^https?:|^\/|blob:/,
         ADD_ATTR: ['id'],
-        FORBID_TAGS: ['style'],
-        FORBID_ATTR: ['style']
+        FORBID_TAGS: ['style']
     });
 }

--- a/packages/koenig-lexical/test/e2e/cards/html-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/html-card.test.js
@@ -74,7 +74,7 @@ test.describe('Html card', async () => {
                 <div><svg></svg></div>
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="html">
                     <div>
-                        <div><div><span>Loading...</span></div></div>
+                        <div><div><span style="fullscreen-inner">Loading...</span></div></div>
                         <div></div>
                     </div>
                 </div>

--- a/packages/koenig-lexical/test/unit/utils/sanitize-html.test.js
+++ b/packages/koenig-lexical/test/unit/utils/sanitize-html.test.js
@@ -1,14 +1,19 @@
 import {describe, expect, test} from 'vitest';
 import {sanitizeHtml} from '../../../src/utils/sanitize-html';
 
-describe('Utils: sanitize-html', async () => {
-    test('can replace scripts', async function () {
+describe('Utils: sanitize-html', () => {
+    test('can replace scripts', function () {
         const sanitizedHtml = sanitizeHtml('<span>Hey</span><script>alert("hello");</script>');
         expect(sanitizedHtml).toEqual('<span>Hey</span><pre class="js-embed-placeholder">Embedded JavaScript</pre>');
     });
 
-    it('can render html', async function () {
+    it('can render html', function () {
         const sanitizedHtml = sanitizeHtml('<strong>bold</strong>');
         expect(sanitizedHtml).toEqual('<strong>bold</strong>');
+    });
+
+    it('strips style elements but keeps style attributes', function () {
+        const sanitizedHtml = sanitizeHtml('<span style="color: red;">Hey</span><style>span {color: blue;}</style>');
+        expect(sanitizedHtml).toEqual('<span style="color: red;">Hey</span>');
     });
 });

--- a/packages/koenig-lexical/vite.config.js
+++ b/packages/koenig-lexical/vite.config.js
@@ -99,7 +99,7 @@ export default (function viteConfig({mode}) {
             globals: true, // required for @testing-library/jest-dom extensions
             environment: 'jsdom',
             setupFiles: './test/test-setup.js',
-            include: ['./test/unit/*'],
+            include: ['./test/unit/**/*.test.{js,jsx,ts,tsx}'],
             testTimeout: process.env.TIMEOUT ? parseInt(process.env.TIMEOUT) : 10000,
             ...(process.env.CI && { // https://github.com/vitest-dev/vitest/issues/1674
                 minThreads: 1,


### PR DESCRIPTION
refs https://github.com/TryGhost/Koenig/pull/1000

- fully matches old editor behaviour
- inline styles typically don't have editor-breaking styles in them but are useful to preview inside the editor
