### PR TITLE
🐛 Supported parsing images nested in anchor tags

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/image/image-parser.js
+++ b/packages/kg-default-nodes/lib/nodes/image/image-parser.js
@@ -46,6 +46,21 @@ export function parseImageNode(ImageNode) {
                 };
             }
             return null;
+        },
+        a: (nodeElem) => {
+            const img = nodeElem.querySelector('img');
+            if (img) {
+                return {
+                    conversion(domNode) {
+                        const href = domNode.getAttribute('href');
+                        const {src, width, height, alt, title} = readImageAttributesFromElement(img);
+
+                        const node = new ImageNode({alt, src, title, width, height, href});
+                        return {node};
+                    },
+                    priority: 0
+                };
+            }
         }
     };
 }

--- a/packages/kg-default-nodes/lib/nodes/image/image-parser.js
+++ b/packages/kg-default-nodes/lib/nodes/image/image-parser.js
@@ -6,9 +6,9 @@ export function parseImageNode(ImageNode) {
         img: () => ({
             conversion(domNode) {
                 if (domNode.tagName === 'IMG') {
-                    const {src, width, height, alt, title} = readImageAttributesFromElement(domNode);
+                    const {src, width, height, alt, title, href} = readImageAttributesFromElement(domNode);
 
-                    const node = new ImageNode({alt, src, title, width, height});
+                    const node = new ImageNode({alt, src, title, width, height, href});
                     return {node};
                 }
 
@@ -46,21 +46,6 @@ export function parseImageNode(ImageNode) {
                 };
             }
             return null;
-        },
-        a: (nodeElem) => {
-            const img = nodeElem.querySelector('img');
-            if (img) {
-                return {
-                    conversion(domNode) {
-                        const href = domNode.getAttribute('href');
-                        const {src, width, height, alt, title} = readImageAttributesFromElement(img);
-
-                        const node = new ImageNode({alt, src, title, width, height, href});
-                        return {node};
-                    },
-                    priority: 0
-                };
-            }
         }
     };
 }

--- a/packages/kg-default-nodes/test/nodes/image.test.js
+++ b/packages/kg-default-nodes/test/nodes/image.test.js
@@ -435,6 +435,19 @@ describe('ImageNode', function () {
             nodes[0].src.should.equal('http://example.com/test.png');
             nodes[0].href.should.equal('https://example.com/link');
         }));
+
+        it('extracts href when img wrapped in anchor tag not within figure', editorTest(function () {
+            const dom = (new JSDOM(html`
+                <a href="https://example.com/link">
+                    <img src="http://example.com/test.png">
+                </a>
+            `)).window.document;
+            const nodes = $generateNodesFromDOM(editor, dom);
+
+            nodes.length.should.equal(1);
+            nodes[0].src.should.equal('http://example.com/test.png');
+            nodes[0].href.should.equal('https://example.com/link');
+        }));
     });
 
     describe('exportJSON', function () {


### PR DESCRIPTION
closes TryGhost/Product#4035
- added support for images wrapped in an anchor tag
- previously only supported this if additionally wrapped in a figure