### PR TITLE
🐛 Fixed email content card help link

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/EmailCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/EmailCard.jsx
@@ -21,7 +21,7 @@ export function EmailCard({htmlEditor, htmlEditorInitialState, isEditing}) {
             {isEditing &&
                 <div className="!-mx-3 !mt-3 flex items-center justify-center bg-grey-100 p-2 font-sans text-sm font-normal leading-none text-grey-600 dark:bg-grey-950 dark:text-grey-800">
                     Only visible when delivered by email, this card will not be published on your site.
-                    <a href="https://ghost.org/help/email-newsletters/#email-cards" rel="noopener noreferrer" target="_blank">
+                    <a href="https://ghost.org/help/cards/#email-content" rel="noopener noreferrer" target="_blank">
                         <HelpIcon className="ml-1 mt-[1px] h-4 w-4 stroke-[1.2px] text-grey-600 dark:text-grey-800" />
                     </a>
                 </div>

--- a/packages/koenig-lexical/test/e2e/cards/email-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/email-card.test.js
@@ -86,7 +86,7 @@ test.describe('Email card', async () => {
                     </div>
                     <div>
                         Only visible when delivered by email, this card will not be published on your site.
-                        <a href="https://ghost.org/help/email-newsletters/#email-cards" rel="noopener noreferrer" target="_blank">
+                        <a href="https://ghost.org/help/cards/#email-content" rel="noopener noreferrer" target="_blank">
                             <svg></svg>
                         </a>
                     </div>
@@ -221,7 +221,7 @@ test.describe('Email card', async () => {
                         </div>
                         <div>
                             Only visible when delivered by email, this card will not be published on your site.
-                            <a href="https://ghost.org/help/email-newsletters/#email-cards" rel="noopener noreferrer" target="_blank">
+                            <a href="https://ghost.org/help/cards/#email-content" rel="noopener noreferrer" target="_blank">
                                 <svg></svg>
                             </a>
                         </div>
@@ -258,7 +258,7 @@ test.describe('Email card', async () => {
                         </div>
                         <div>
                             Only visible when delivered by email, this card will not be published on your site.
-                            <a href="https://ghost.org/help/email-newsletters/#email-cards" rel="noopener noreferrer" target="_blank">
+                            <a href="https://ghost.org/help/cards/#email-content" rel="noopener noreferrer" target="_blank">
                                 <svg></svg>
                             </a>
                         </div>


### PR DESCRIPTION
no issue

- links help icon to email content section of cards help docs