### PR TITLE
🐛 Fixed relative url parsing in card button components

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/bookmark/bookmark-parser.js
+++ b/packages/kg-default-nodes/lib/nodes/bookmark/bookmark-parser.js
@@ -5,7 +5,7 @@ export function parseBookmarkNode(BookmarkNode) {
             if (nodeElem.tagName === 'FIGURE' && isKgBookmarkCard) {
                 return {
                     conversion(domNode) {
-                        const url = domNode?.querySelector('.kg-bookmark-container')?.href;
+                        const url = domNode?.querySelector('.kg-bookmark-container')?.getAttribute('href');
                         const icon = domNode?.querySelector('.kg-bookmark-icon')?.src;
                         const title = domNode?.querySelector('.kg-bookmark-title')?.textContent;
                         const description = domNode?.querySelector('.kg-bookmark-description')?.textContent;
@@ -47,7 +47,7 @@ export function parseBookmarkNode(BookmarkNode) {
                         domNode.querySelector('br').remove();
 
                         // Grab individual values from the elements
-                        const url = anchorElement.href;
+                        const url = anchorElement.getAttribute('href');
                         let title = '';
                         let description = '';
                         let thumbnail = '';

--- a/packages/kg-default-nodes/lib/nodes/button/button-parser.js
+++ b/packages/kg-default-nodes/lib/nodes/button/button-parser.js
@@ -14,7 +14,7 @@ export function parseButtonNode(ButtonNode) {
 
                         const buttonNode = domNode?.querySelector('.kg-btn');
                         const buttonUrl = buttonNode.getAttribute('href');
-                        const buttonText = buttonNode.getTextContent();
+                        const buttonText = buttonNode.textContent;
 
                         const payload = {
                             buttonText: buttonText,

--- a/packages/kg-default-nodes/lib/nodes/button/button-parser.js
+++ b/packages/kg-default-nodes/lib/nodes/button/button-parser.js
@@ -13,8 +13,8 @@ export function parseButtonNode(ButtonNode) {
                         }
 
                         const buttonNode = domNode?.querySelector('.kg-btn');
-                        const buttonUrl = buttonNode.href;
-                        const buttonText = buttonNode.textContent;
+                        const buttonUrl = buttonNode.getAttribute('href');
+                        const buttonText = buttonNode.getTextContent();
 
                         const payload = {
                             buttonText: buttonText,

--- a/packages/kg-default-nodes/lib/nodes/embed/embed-parser.js
+++ b/packages/kg-default-nodes/lib/nodes/embed/embed-parser.js
@@ -32,7 +32,7 @@ export function parseEmbedNode(EmbedNode) {
                                 return null;
                             }
 
-                            let url = link.href;
+                            let url = link.getAttribute('href');
 
                             // If we don't have a url, or it's not an absolute URL, we can't handle this
                             if (!url || !url.match(/^https?:\/\//i)) {

--- a/packages/kg-default-nodes/lib/nodes/product/product-parser.js
+++ b/packages/kg-default-nodes/lib/nodes/product/product-parser.js
@@ -39,7 +39,7 @@ export function parseProductNode(ProductNode) {
                         const button = domNode.querySelector('a');
 
                         if (button) {
-                            const buttonUrl = button.href;
+                            const buttonUrl = button.getAttribute('href');
                             const buttonText = getButtonText(button);
 
                             if (buttonUrl && buttonText) {

--- a/packages/kg-default-nodes/test/nodes/button.test.js
+++ b/packages/kg-default-nodes/test/nodes/button.test.js
@@ -216,6 +216,19 @@ describe('ButtonNode', function () {
             nodes[0].buttonText.should.equal('click me');
             nodes[0].alignment.should.equal('center');
         }));
+
+        it('preserves relative urls in content', editorTest(function () {
+            const dom = (new JSDOM(html`
+                <div class="kg-card kg-button-card kg-align-center">
+                    <a href="#/portal/signup" class="kg-btn kg-btn-accent">Subscribe 1</a>
+                </div>
+            `)).window.document;
+            const nodes = $generateNodesFromDOM(editor, dom);
+            nodes.length.should.equal(1);
+            nodes[0].buttonUrl.should.equal('#/portal/signup');
+            nodes[0].buttonText.should.equal('Subscribe 1');
+            nodes[0].alignment.should.equal('center');
+        }));
     });
 
     describe('getTextContent', function () {

--- a/packages/kg-default-nodes/test/nodes/product.test.js
+++ b/packages/kg-default-nodes/test/nodes/product.test.js
@@ -550,6 +550,40 @@ describe('ProductNode', function () {
             productNode.productUrl.should.equal('https://example.com/product/ok');
         }));
 
+        it('handles relative urls', editorTest(function () {
+            const dom = (new JSDOM(html`
+                <div class="kg-card kg-product-card">
+                    <div class="kg-product-card-container">
+                        <img src="https://example.com/images/ok.jpg" class="kg-product-card-image" />
+                        <div class="kg-product-card-header">
+                            <div class="kg-product-card-title-container">
+                                <h4 class="kg-product-card-title">Product title!</h4>
+                            </div>
+                        </div>
+                        <p class="kg-product-card-description">This product is ok</p>
+                        <a href="#/portal/signup" class="kg-btn kg-btn-accent kg-product-card-button" target="_blank" rel="noopener noreferrer">
+                            <span>
+                                Click me
+                            </span>
+                        </a>
+                    </div>
+                </div>
+            `)).window.document;
+            const nodes = $generateNodesFromDOM(editor, dom);
+            nodes.length.should.equal(1);
+
+            const productNode = nodes[0];
+            $isProductNode(productNode).should.be.exactly(true);
+
+            productNode.productImageSrc.should.equal('https://example.com/images/ok.jpg');
+            productNode.productTitle.should.equal('Product title!');
+            productNode.productDescription.should.equal('This product is ok');
+            productNode.productRatingEnabled.should.be.exactly(false);
+            productNode.productButtonEnabled.should.be.exactly(true);
+            productNode.productButton.should.equal('Click me');
+            productNode.productUrl.should.equal('#/portal/signup');
+        }));
+
         it('falls through if title, description, button and image are missing', editorTest(function () {
             const dom = (new JSDOM(html`
                 <div class="kg-card kg-product-card"><div class="kg-product-card-container"><div class="kg-product-card-header"><div class="kg-product-card-title-container"></div><div class="kg-product-card-rating"><span class="kg-product-card-rating-active kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"/></svg></span><span class="kg-product-card-rating-active kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"/></svg></span><span class="kg-product-card-rating-active kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"/></svg></span><span class=" kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"/></svg></span><span class=" kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"/></svg></span></div></div></div></div>


### PR DESCRIPTION
refs TryGhost/Product#4033
- references to the HTMLElement href prop add about:blank to hrefs
- changed all parser references to use getAttribute('href')
- we should only use relative urls for buttons, but updated refs in embed and bookmark just in case