### PR TITLE
🎨 Improved tab/indent behaviour

### DIFF
--- a/packages/koenig-lexical/src/plugins/AllDefaultPlugins.jsx
+++ b/packages/koenig-lexical/src/plugins/AllDefaultPlugins.jsx
@@ -22,7 +22,7 @@ import {ListPlugin} from '@lexical/react/LexicalListPlugin';
 import {PaywallPlugin} from '../plugins/PaywallPlugin';
 import {ProductPlugin} from '../plugins/ProductPlugin';
 import {SignupPlugin} from '../plugins/SignupPlugin';
-import {TabIndentationPlugin} from '@lexical/react/LexicalTabIndentationPlugin';
+// import {TabIndentationPlugin} from '@lexical/react/LexicalTabIndentationPlugin';
 import {TogglePlugin} from '../plugins/TogglePlugin';
 import {VideoPlugin} from '../plugins/VideoPlugin';
 
@@ -31,7 +31,7 @@ export const AllDefaultPlugins = () => {
         <>
             {/* Lexical Plugins */}
             <ListPlugin /> {/* adds indent/outdent/remove etc support */}
-            <TabIndentationPlugin /> {/* tab/shift+tab triggers indent/outdent */}
+            {/* <TabIndentationPlugin /> tab/shift+tab triggers indent/outdent */}
 
             {/* Koenig Plugins */}
             <CardMenuPlugin />

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -1140,6 +1140,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                         return true;
                     }
 
+                    // exit the editor if we're shift tabbing on an element that isn't tabbed
                     if (event.shiftKey && cursorDidExitAtTop) {
                         const selection = $getSelection();
 
@@ -1161,10 +1162,8 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                         const hasIndentedNode = nodes.some((node) => {
                             return node.getIndent && node.getIndent() > 0;
                         });
-
-                        if (hasIndentedNode) {
-                            return false;
-                        } else {
+                        
+                        if (!hasIndentedNode) {
                             event.preventDefault();
                             cursorDidExitAtTop();
                             return true;
@@ -1190,6 +1189,25 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                                 return true;
                             }
                         }
+
+                        // handle indent behavior
+                        if ($isListItemNode(currentNode) || ($isTextNode(currentNode) && $isListItemNode(currentNode.getParent()))) {
+                            event.preventDefault();
+                            let node = $isTextNode(currentNode) ? currentNode.getParent() : currentNode;
+                            const indent = node.getIndent();
+                            if (event.shiftKey) {
+                                if (indent > 0) {
+                                    node.setIndent(indent - 1);
+                                }
+                            } else {
+                                node.setIndent(indent + 1);
+                            }
+                            return true;
+                        }
+
+                        // generally prevent tabs from leaving the editor/interacting with the browser
+                        event.preventDefault();
+                        return true;
                     }
                 },
                 COMMAND_PRIORITY_LOW

--- a/packages/koenig-lexical/test/e2e/list-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/list-behaviour.test.js
@@ -1,5 +1,5 @@
 import {assertHTML, assertSelection, focusEditor, html, initialize} from '../utils/e2e';
-import {test} from '@playwright/test';
+import {expect, test} from '@playwright/test';
 
 test.describe('List behaviour', async () => {
     let page;
@@ -211,6 +211,62 @@ test.describe('List behaviour', async () => {
                 </ul>
                 <p><br /></p>
             `);
+        });
+    });
+
+    test.describe('TAB', function () {
+        test('indents on tab', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('*');
+            await page.keyboard.press('Space');
+            await page.keyboard.type('list item');
+            await page.keyboard.press('Tab');
+
+            await assertHTML(page, html`
+                <ul data-koenig-dnd-droppable="true">
+                    <li value="1" class="!list-none">
+                        <ul>
+                            <li value="1" dir="ltr">
+                                <span data-lexical-text="true">list item</span>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            `);
+        });
+
+        test('dedents on shift+tab as long as indent is > 0', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('*');
+            await page.keyboard.press('Space');
+            await page.keyboard.type('list item');
+            await page.keyboard.press('Tab');
+            await page.keyboard.press('Tab');
+            await page.keyboard.press('Shift+Tab');
+
+            await assertHTML(page, html`
+                <ul data-koenig-dnd-droppable="true">
+                    <li value="1" class="!list-none">
+                        <ul>
+                            <li value="1" dir="ltr">
+                                <span data-lexical-text="true">list item</span>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            `);
+        });
+
+        test('shift+tab moves to header if indent is 0', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('*');
+            await page.keyboard.press('Space');
+            await page.keyboard.type('list item');
+            await page.keyboard.press('Shift+Tab');
+
+            const title = page.getByTestId('post-title');
+            let titleHasFocus = await title.evaluate(node => document.activeElement === node);
+            expect(titleHasFocus).toEqual(true);
         });
     });
 

--- a/packages/koenig-lexical/test/e2e/title-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/title-behaviour.test.js
@@ -422,25 +422,6 @@ test.describe('Title behaviour (ExternalControlPlugin)', async () => {
                 let titleHasFocus = await title.evaluate(node => document.activeElement === node);
                 expect(titleHasFocus).toEqual(true);
             });
-
-            test('does not move cursor to title if a range selection would outdent something', async function () {
-                await focusEditor(page);
-                await page.keyboard.type('Test');
-                await page.keyboard.press('Enter');
-                await page.keyboard.press('Tab');
-                await page.keyboard.type('Test');
-                await page.keyboard.press('Shift+ArrowUp');
-                await page.keyboard.press('Shift+Tab');
-
-                const title = page.getByTestId('post-title');
-                let titleHasFocus = await title.evaluate(node => document.activeElement === node);
-                expect(titleHasFocus).toEqual(false);
-
-                await assertHTML(page, html`
-                    <p dir="ltr"><span data-lexical-text="true">Test</span></p>
-                    <p dir="ltr"><span data-lexical-text="true">Test</span></p>
-                `);
-            });
         });
     });
 });


### PR DESCRIPTION
closes TryGhost/Product#3737, closes TryGhost/Product#4039
- tab indenting behaviour now works with the cursor anywhere in a list item
- tab no longer indents paragraphs (these are not rendered anyways)