### PR TITLE
Updated `EmojiPickerPortal` to pass through all `Picker` props

### DIFF
--- a/packages/koenig-lexical/src/components/ui/EmojiPickerPortal.jsx
+++ b/packages/koenig-lexical/src/components/ui/EmojiPickerPortal.jsx
@@ -1,10 +1,11 @@
 import KoenigComposerContext from '../../context/KoenigComposerContext';
 import Picker from '@emoji-mart/react';
 import Portal from './Portal';
+import PropTypes from 'prop-types';
 import React from 'react';
 import data from '@emoji-mart/data';
 
-const EmojiPickerPortal = ({onEmojiClick, buttonRef}) => {
+const EmojiPickerPortal = ({onEmojiClick, buttonRef, ...props}) => {
     const [position, setPosition] = React.useState(null);
     const {darkMode} = React.useContext(KoenigComposerContext);
 
@@ -16,17 +17,17 @@ const EmojiPickerPortal = ({onEmojiClick, buttonRef}) => {
             const scrollY = document.documentElement.scrollTop;
             const windowHeight = window.innerHeight;
             const pickerHeight = 352; // Approximate height of the emoji picker, adjust if needed
-    
+
             let adjustedTop = rect.top + scrollY;
-    
+
             if (adjustedTop + pickerHeight > windowHeight) {
                 adjustedTop = rect.top - pickerHeight - shiftPixels + scrollY;
             }
-    
+
             setPosition({x: (rect.left + scrollX) / 1.5, y: adjustedTop});
         }
     }, [buttonRef]);
-    
+
     React.useEffect(() => {
         handleScroll();
         document.addEventListener('scroll', handleScroll, true); // Use true for capture phase
@@ -34,35 +35,43 @@ const EmojiPickerPortal = ({onEmojiClick, buttonRef}) => {
             document.removeEventListener('scroll', handleScroll, true);
         };
     }, [handleScroll]);
-    
+
     if (!position) {
         return null;
     }
     const {x, y} = position;
-  
+
     const handleClick = (e) => {
         e.stopPropagation();
     };
-  
+
     const style = {
         left: x,
         top: y,
         position: 'fixed'
     };
+
+    // https://github.com/missive/emoji-mart#options--props
+    const defaultProps = {
+        autoFocus: true,
+        icons: 'outline',
+        maxFrequentRows: 1,
+        navPosition: 'bottom',
+        noResultsEmoji: 'cry',
+        previewPosition: 'none',
+        theme: darkMode ? 'dark' : 'light'
+    };
+
+    const mergedProps = {...defaultProps, ...props};
+
     return (
         <Portal>
             <div className='z-10 mr-9 mt-10 rounded-md bg-white' data-testid="emoji-picker-container" style={style} onClick={handleClick}>
                 <div className=''>
-                    <Picker
-                        autoFocus='true'
+                    <Picker // https://github.com/missive/emoji-mart#-picker
                         data={data}
-                        icons='outline'
-                        maxFrequentRows='1'
-                        navPosition='bottom'
-                        noResultsEmoji='cry'
-                        previewPosition='none'
-                        theme={darkMode ? 'dark' : 'light'}
                         onEmojiSelect={onEmojiClick}
+                        {...mergedProps}
                     />
                 </div>
             </div>
@@ -71,3 +80,52 @@ const EmojiPickerPortal = ({onEmojiClick, buttonRef}) => {
 };
 
 export default EmojiPickerPortal;
+
+EmojiPickerPortal.propTypes = {
+    onEmojiClick: PropTypes.func.isRequired,
+    buttonRef: PropTypes.object,
+    autoFocus: PropTypes.bool,
+    dynamicWidth: PropTypes.bool,
+    emojiButtonColors: PropTypes.arrayOf(PropTypes.string),
+    emojiButtonRadius: PropTypes.string,
+    emojiButtonSize: PropTypes.number,
+    emojiSize: PropTypes.number,
+    emojiVersion: PropTypes.oneOf([1, 2, 3, 4, 5, 11, 12, 12.1, 13, 13.1, 14]),
+    exceptEmojis: PropTypes.arrayOf(PropTypes.string),
+    icons: PropTypes.oneOf(['auto', 'outline', 'solid']),
+    locale: PropTypes.oneOf(['en','ar','be','cs','de','es','fa','fi','fr','hi','it','ja','kr','nl','pl','pt','ru','sa','tr','uk','vi','zh']),
+    maxFrequentRows: PropTypes.number,
+    navPosition: PropTypes.oneOf(['top', 'bottom', 'none']),
+    noCountryFlags: PropTypes.bool,
+    noResultsEmoji: PropTypes.string,
+    perLine: PropTypes.number,
+    previewEmoji: PropTypes.string,
+    previewPosition: PropTypes.oneOf(['top', 'bottom', 'none']),
+    searchPosition: PropTypes.oneOf(['sticky', 'static', 'none']),
+    set: PropTypes.oneOf(['native', 'apple', 'facebook', 'google', 'twitter']),
+    skin: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
+    skinTonePosition: PropTypes.oneOf(['preview', 'search', 'none']),
+    theme: PropTypes.oneOf(['auto', 'light', 'dark'])
+};
+
+EmojiPickerPortal.defaultProps = {
+    autoFocus: true,
+    dynamicWidth: false,
+    emojiButtonRadius: '100%',
+    emojiButtonSize: 36,
+    emojiSize: 24,
+    icons: 'outline',
+    locale: 'en',
+    maxFrequentRows: 1,
+    navPosition: 'bottom',
+    noCountryFlags: false,
+    noResultsEmoji: 'cry',
+    perLine: 9,
+    previewEmoji: null,
+    previewPosition: 'none',
+    searchPosition: 'sticky',
+    set: 'native',
+    skin: 1,
+    skinTonePosition: 'preview',
+    theme: 'light'
+};


### PR DESCRIPTION
no issue

- allows for customising the emoji picker display for different use cases
- added capture and pass-through of all props with override of defaults
- added prop-type definitions
