### PR TITLE
Added first pass of emoji picker plugin

### DIFF
--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -44,7 +44,8 @@ const cardConfig = {
     membersEnabled: true,
     feature: {
         collections: true,
-        collectionsCard: true
+        collectionsCard: true,
+        emojiPicker: true
     },
     deprecated: {
         headerV1: process.env.NODE_ENV === 'test' ? false : true // show header v1 only for tests

--- a/packages/koenig-lexical/src/components/ui/EmojiPicker.jsx
+++ b/packages/koenig-lexical/src/components/ui/EmojiPicker.jsx
@@ -1,0 +1,27 @@
+import React, {useEffect, useRef} from 'react';
+import {Picker} from 'emoji-mart';
+
+export default function EmojiPicker({setInstanceRef, ...props}) {
+    const ref = useRef(null);
+    const instance = useRef(null);
+
+    function setInstance(newInstance) {
+        instance.current = newInstance;
+        setInstanceRef?.(newInstance);
+    }
+
+    if (instance.current) {
+        instance.current.update(props);
+    }
+
+    useEffect(() => {
+        setInstance(new Picker({...props, ref}));
+
+        return () => {
+            setInstance(null);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return React.createElement('div', {ref});
+}

--- a/packages/koenig-lexical/src/components/ui/EmojiPickerPortal.jsx
+++ b/packages/koenig-lexical/src/components/ui/EmojiPickerPortal.jsx
@@ -1,5 +1,5 @@
 import KoenigComposerContext from '../../context/KoenigComposerContext';
-import Picker from '@emoji-mart/react';
+import Picker from './EmojiPicker';
 import Portal from './Portal';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -104,6 +104,7 @@ EmojiPickerPortal.propTypes = {
     previewPosition: PropTypes.oneOf(['top', 'bottom', 'none']),
     searchPosition: PropTypes.oneOf(['sticky', 'static', 'none']),
     set: PropTypes.oneOf(['native', 'apple', 'facebook', 'google', 'twitter']),
+    setInstanceRef: PropTypes.func,
     skin: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
     skinTonePosition: PropTypes.oneOf(['preview', 'search', 'none']),
     theme: PropTypes.oneOf(['auto', 'light', 'dark'])

--- a/packages/koenig-lexical/src/components/ui/EmojiPickerPortal.jsx
+++ b/packages/koenig-lexical/src/components/ui/EmojiPickerPortal.jsx
@@ -3,16 +3,16 @@ import Picker from '@emoji-mart/react';
 import Portal from './Portal';
 import PropTypes from 'prop-types';
 import React from 'react';
-import data from '@emoji-mart/data';
+import defaultData from '@emoji-mart/data';
 
-const EmojiPickerPortal = ({onEmojiClick, buttonRef, ...props}) => {
+const EmojiPickerPortal = ({onEmojiClick, positionRef, data = defaultData, ...props}) => {
     const [position, setPosition] = React.useState(null);
     const {darkMode} = React.useContext(KoenigComposerContext);
 
     const shiftPixels = 35; // how many pixels we want to move it up when it's at the bottom of the screen
     const handleScroll = React.useCallback(() => {
-        if (buttonRef.current) {
-            const rect = buttonRef.current.getBoundingClientRect();
+        if (positionRef.current) {
+            const rect = positionRef.current.getBoundingClientRect();
             const scrollX = document.documentElement.scrollLeft;
             const scrollY = document.documentElement.scrollTop;
             const windowHeight = window.innerHeight;
@@ -26,7 +26,7 @@ const EmojiPickerPortal = ({onEmojiClick, buttonRef, ...props}) => {
 
             setPosition({x: (rect.left + scrollX) / 1.5, y: adjustedTop});
         }
-    }, [buttonRef]);
+    }, [positionRef]);
 
     React.useEffect(() => {
         handleScroll();
@@ -83,7 +83,8 @@ export default EmojiPickerPortal;
 
 EmojiPickerPortal.propTypes = {
     onEmojiClick: PropTypes.func.isRequired,
-    buttonRef: PropTypes.object,
+    positionRef: PropTypes.object,
+    data: PropTypes.array,
     autoFocus: PropTypes.bool,
     dynamicWidth: PropTypes.bool,
     emojiButtonColors: PropTypes.arrayOf(PropTypes.string),

--- a/packages/koenig-lexical/src/components/ui/cards/CalloutCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CalloutCard.jsx
@@ -124,7 +124,7 @@ export function CalloutCard({
                         {
                             isEditing && showEmojiPicker && (
                                 <EmojiPickerPortal
-                                    buttonRef={emojiButtonRef}
+                                    positionRef={emojiButtonRef}
                                     togglePortal={toggleEmojiPicker}
                                     onEmojiClick={changeEmoji} />
                             )

--- a/packages/koenig-lexical/src/plugins/AllDefaultPlugins.jsx
+++ b/packages/koenig-lexical/src/plugins/AllDefaultPlugins.jsx
@@ -23,10 +23,14 @@ import {PaywallPlugin} from '../plugins/PaywallPlugin';
 import {ProductPlugin} from '../plugins/ProductPlugin';
 import {SignupPlugin} from '../plugins/SignupPlugin';
 // import {TabIndentationPlugin} from '@lexical/react/LexicalTabIndentationPlugin';
+import KoenigComposerContext from '../context/KoenigComposerContext';
+import {EmojiPickerPlugin} from './EmojiPickerPlugin';
 import {TogglePlugin} from '../plugins/TogglePlugin';
 import {VideoPlugin} from '../plugins/VideoPlugin';
 
 export const AllDefaultPlugins = () => {
+    const {cardConfig} = React.useContext(KoenigComposerContext);
+
     return (
         <>
             {/* Lexical Plugins */}
@@ -35,6 +39,7 @@ export const AllDefaultPlugins = () => {
 
             {/* Koenig Plugins */}
             <CardMenuPlugin />
+            {cardConfig.feature?.emojiPicker ? <EmojiPickerPlugin /> : null}
 
             {/* Card Plugins */}
             <AudioPlugin />

--- a/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
@@ -82,6 +82,7 @@ export function EmojiPickerPlugin() {
 
                 return (
                     <EmojiPickerPortal
+                        navPosition='none' // hide the category tabs, they're disabled when searching
                         positionRef={anchorElementRef}
                         searchPosition='none'
                         setInstanceRef={setPickerInstance}

--- a/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
@@ -1,0 +1,72 @@
+import EmojiPickerPortal from '../components/ui/EmojiPickerPortal';
+import React from 'react';
+import emojiData from '@emoji-mart/data';
+import {$createTextNode, $getSelection, $isRangeSelection} from 'lexical';
+import {
+    LexicalTypeaheadMenuPlugin,
+    useBasicTypeaheadTriggerMatch
+} from '@lexical/react/LexicalTypeaheadMenuPlugin';
+import {SearchIndex, init} from 'emoji-mart';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+
+init({data: emojiData});
+
+export function EmojiPickerPlugin() {
+    const [editor] = useLexicalComposerContext();
+    const [queryString, setQueryString] = React.useState(null);
+    const [emojis, setEmojis] = React.useState(null);
+
+    const checkForTriggerMatch = useBasicTypeaheadTriggerMatch(':', {minLength: 1});
+
+    React.useEffect(() => {
+        if (!queryString) {
+            setEmojis(null);
+        }
+
+        async function searchEmojis() {
+            const filteredEmojis = await SearchIndex.search(queryString);
+            console.log(filteredEmojis);
+            setEmojis(filteredEmojis);
+        }
+
+        searchEmojis();
+    }, [queryString]);
+
+    const onEmojiSelect = React.useCallback((emoji, event) => {
+        editor.update(() => {
+            const selection = $getSelection();
+
+            if (!$isRangeSelection(selection) || emoji === null) {
+                return;
+            }
+
+            selection.insertNodes([$createTextNode(emoji.native)]);
+
+            setEmojis([]); // closes the emoji picker
+        });
+    }, [editor]);
+
+    return (
+        <LexicalTypeaheadMenuPlugin
+            menuRenderFn={(
+                anchorElementRef
+            ) => {
+                if (anchorElementRef.current === null || emojis.length === 0) {
+                    return null;
+                }
+
+                return (
+                    <EmojiPickerPortal
+                        data={emojis}
+                        positionRef={anchorElementRef}
+                        searchPosition='none'
+                        onEmojiClick={onEmojiSelect}
+                    />
+                );
+            }}
+            options={emojis}
+            triggerFn={checkForTriggerMatch}
+            onQueryChange={setQueryString}
+        />
+    );
+}

--- a/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
@@ -1,7 +1,7 @@
 import EmojiPickerPortal from '../components/ui/EmojiPickerPortal';
 import React from 'react';
 import emojiData from '@emoji-mart/data';
-import {$createTextNode, $getSelection, $isRangeSelection} from 'lexical';
+import {$getSelection, $isRangeSelection} from 'lexical';
 import {
     LexicalTypeaheadMenuPlugin,
     useBasicTypeaheadTriggerMatch
@@ -44,7 +44,6 @@ export function EmojiPickerPlugin() {
                 row.push(emoji);
             }
 
-            console.log(pickerInstance.current);
             pickerInstance.current?.component.setState({searchResults: grid, pos: [0, 0]});
             setSearchResults(grid);
         }
@@ -99,6 +98,8 @@ export function EmojiPickerPlugin() {
             options={searchResults}
             triggerFn={checkForTriggerMatch}
             onQueryChange={setQueryString}
+            // TODO: add a way to close the emoji picker when the user presses escape
+            // TODO: select the emoji on enter
         />
     );
 }

--- a/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
@@ -14,19 +14,39 @@ init({data: emojiData});
 export function EmojiPickerPlugin() {
     const [editor] = useLexicalComposerContext();
     const [queryString, setQueryString] = React.useState(null);
-    const [emojis, setEmojis] = React.useState(null);
+    const [searchResults, setSearchResults] = React.useState(null);
+    const pickerInstance = React.useRef(null);
 
     const checkForTriggerMatch = useBasicTypeaheadTriggerMatch(':', {minLength: 1});
 
     React.useEffect(() => {
         if (!queryString) {
-            setEmojis(null);
+            pickerInstance.current?.component.setState({searchResults: null, pos: [-1, -1]});
+            return;
         }
 
         async function searchEmojis() {
             const filteredEmojis = await SearchIndex.search(queryString);
-            console.log(filteredEmojis);
-            setEmojis(filteredEmojis);
+
+            const grid = [];
+            grid.setsize = filteredEmojis.length;
+            let row = null;
+
+            for (const emoji of filteredEmojis) {
+                // 9 = EmojiPickerPortal default perLine
+                if (!grid.length || row.length === 9) {
+                    row = [];
+                    row.__categoryId = 'search';
+                    row.__index = grid.length;
+                    grid.push(row);
+                }
+
+                row.push(emoji);
+            }
+
+            console.log(pickerInstance.current);
+            pickerInstance.current?.component.setState({searchResults: grid, pos: [0, 0]});
+            setSearchResults(grid);
         }
 
         searchEmojis();
@@ -42,29 +62,34 @@ export function EmojiPickerPlugin() {
 
             selection.insertNodes([$createTextNode(emoji.native)]);
 
-            setEmojis([]); // closes the emoji picker
+            pickerInstance.current?.component.setState({searchResults: null, pos: [-1, -1]});
+            setSearchResults(null); // closes the emoji picker
         });
     }, [editor]);
+
+    const setPickerInstance = function (instance) {
+        pickerInstance.current = instance;
+    };
 
     return (
         <LexicalTypeaheadMenuPlugin
             menuRenderFn={(
                 anchorElementRef
             ) => {
-                if (anchorElementRef.current === null || emojis.length === 0) {
+                if (anchorElementRef.current === null || searchResults === null || searchResults.length === 0) {
                     return null;
                 }
 
                 return (
                     <EmojiPickerPortal
-                        data={emojis}
                         positionRef={anchorElementRef}
                         searchPosition='none'
+                        setInstanceRef={setPickerInstance}
                         onEmojiClick={onEmojiSelect}
                     />
                 );
             }}
-            options={emojis}
+            options={searchResults}
             triggerFn={checkForTriggerMatch}
             onQueryChange={setQueryString}
         />

--- a/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
@@ -60,8 +60,14 @@ export function EmojiPickerPlugin() {
                 return;
             }
 
-            selection.insertNodes([$createTextNode(emoji.native)]);
+            // replace the text with the emoji
+            const node = selection.anchor.getNode();
+            const nodeText = node.getTextContent();
+            const cursorPosition = selection.anchor.offset;
+            const startPosition = nodeText.lastIndexOf(':', cursorPosition);
+            node.spliceText(startPosition, cursorPosition - startPosition, emoji.native, true);
 
+            // reset the emoji picker
             pickerInstance.current?.component.setState({searchResults: null, pos: [-1, -1]});
             setSearchResults(null); // closes the emoji picker
         });


### PR DESCRIPTION
no issue

- added `<EmojiPickerPlugin>` component
  - uses `<LexicalTypeaheadMenuPlugin>` to update `searchQuery` state and render our `EmojiPickerPortal` component when we have matches
  - uses "headless search" of `emoji-mart` to filter emojis based on the search query
- added new plugin to `<AllDefaultPlugins>` with a conditional on the `feature.emojiPicker` flag
