### PR TITLE
Added close-on-Escape behaviour to emoji picker

### DIFF
--- a/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
@@ -98,7 +98,6 @@ export function EmojiPickerPlugin() {
             options={searchResults}
             triggerFn={checkForTriggerMatch}
             onQueryChange={setQueryString}
-            // TODO: add a way to close the emoji picker when the user presses escape
             // TODO: select the emoji on enter
         />
     );

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -1162,7 +1162,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                         const hasIndentedNode = nodes.some((node) => {
                             return node.getIndent && node.getIndent() > 0;
                         });
-                        
+
                         if (!hasIndentedNode) {
                             event.preventDefault();
                             cursorDidExitAtTop();
@@ -1216,15 +1216,16 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                 KEY_ESCAPE_COMMAND,
                 (event) => {
                     if (selectedCardKey && isEditingCard) {
+                        event.preventDefault();
                         (editor._parentEditor || editor).dispatchCommand(SELECT_CARD_COMMAND, {cardKey: selectedCardKey});
+                        return true;
                     }
 
                     if (editor._parentEditor) {
+                        event.preventDefault();
                         editor._parentEditor.getRootElement().focus();
+                        return true;
                     }
-
-                    event.preventDefault();
-                    return true;
                 },
                 COMMAND_PRIORITY_LOW
             ),


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/4063

- `<LexicalMenu>` has close-on-Escape behaviour but we were preventing that by having our own `ESCAPE_COMMAND` handling that always prevented both default behaviour and Lexical's behaviour
- updated our `ESCAPE_COMMAND` handler to only prevent default in the situations where we do something specific with it
