### PR TITLE
Improved emoji typeahead matching

### DIFF
--- a/packages/koenig-lexical/src/hooks/useTypeaheadTriggerMatch.js
+++ b/packages/koenig-lexical/src/hooks/useTypeaheadTriggerMatch.js
@@ -1,0 +1,38 @@
+import {useCallback} from 'react';
+
+// adapted from lexical-react/src/LexicalTypeaheadMenuPlugin
+//  we need the ability to match on punctuation, as well as a leading space, which was not possible using lexical's version
+
+export default function useBasicTypeaheadTriggerMatch(trigger,{minLength = 1, maxLength = 75}) {
+    return useCallback(
+        (text) => {
+            const invalidChars = '[^' + trigger + '\\s]'; // escaped set - these cannot be present in the matched string
+            const TypeaheadTriggerRegex = new RegExp(
+                // '(^|\\s|\\()(' +
+                '(' +
+            '[' +
+            trigger +
+            ']' +
+            '((?:' +
+            invalidChars +
+            '){0,' +
+            maxLength +
+            '})' +
+            ')$', // returns end of string
+            );
+            const match = TypeaheadTriggerRegex.exec(text);
+            if (match !== null) {
+                const matchingString = match[2];
+                if (matchingString.length >= minLength) {
+                    return {
+                        leadOffset: match.index,
+                        matchingString,
+                        replaceableString: match[1]
+                    };
+                }
+            }
+            return null;
+        },
+        [maxLength, minLength, trigger],
+    );
+}

--- a/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
@@ -1,11 +1,9 @@
 import Portal from '../components/ui/Portal';
 import React from 'react';
 import emojiData from '@emoji-mart/data';
+import useTypeaheadTriggerMatch from '../hooks/useTypeaheadTriggerMatch';
 import {$createTextNode, $getSelection, $isRangeSelection} from 'lexical';
-import {
-    LexicalTypeaheadMenuPlugin,
-    useBasicTypeaheadTriggerMatch
-} from '@lexical/react/LexicalTypeaheadMenuPlugin';
+import {LexicalTypeaheadMenuPlugin} from '@lexical/react/LexicalTypeaheadMenuPlugin';
 import {SearchIndex, init} from 'emoji-mart';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
@@ -34,7 +32,7 @@ export function EmojiPickerPlugin() {
     const [queryString, setQueryString] = React.useState(null);
     const [searchResults, setSearchResults] = React.useState(null);
 
-    const checkForTriggerMatch = useBasicTypeaheadTriggerMatch(':', {minLength: 1});
+    const checkForTriggerMatch = useTypeaheadTriggerMatch(':', {minLength: 1});
 
     React.useEffect(() => {
         if (!queryString) {


### PR DESCRIPTION
closes TryGhost/Product#4069, closes TryGhost/Product#4070
- created our own version of the lexical trigger match function
- needed to allow punctuation and allow no spaces between emoji