### PR TITLE
Fixed arrow up/down navigation of inline emoji picker

### DIFF
--- a/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
@@ -10,9 +10,13 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 init({data: emojiData});
 
 const EmojiMenuItem = function ({index, isSelected, onClick, onMouseEnter, emoji}) {
+    // we need to manually set this unless we import the MenuOption type and extend it (see LexicalTypeaheadMenuPlugin)
+    const ref = React.useRef(null);
+    emoji.ref = ref;
     return (
         <li
             key={emoji.id}
+            ref={emoji.ref}
             aria-selected={isSelected}
             className={`mb-0 flex cursor-pointer items-center gap-2 whitespace-nowrap rounded px-2 py-1 font-sans text-sm leading-[1.65] tracking-wide text-grey-800 ${isSelected ? 'bg-grey-100 text-grey-900' : ''}`}
             data-testid={'emoji-option-' + index}


### PR DESCRIPTION
closes TryGhost/Product#4079
- arrow keys were not causing the selected item to scroll into view
- Lexical's plugin expects their Type to be used/class to be defined
- used react ref until we move to typescript