### PR TITLE
Added handling for emoji completion matching inserting emoji

### DIFF
--- a/packages/koenig-lexical/src/hooks/useTypeaheadTriggerMatch.js
+++ b/packages/koenig-lexical/src/hooks/useTypeaheadTriggerMatch.js
@@ -7,17 +7,14 @@ export default function useBasicTypeaheadTriggerMatch(trigger,{minLength = 1, ma
     return useCallback(
         (text) => {
             const invalidChars = '[^' + trigger + '\\s]'; // escaped set - these cannot be present in the matched string
-            // const TypeaheadTriggerRegex = new RegExp(
-            //     '[' + trigger + ']' +
-            //     '(' +
-            //         '(?:' + invalidChars + ')' +
-            //         '{0,' + maxLength + '}' +
-            //     ')$',
-            // );
-            const TypeaheadTriggerRegex = new RegExp(/[:]((?:[^:\s]){0,75}[:]?)$/);
+            const TypeaheadTriggerRegex = new RegExp(
+                '[' + trigger + ']' +
+                '(' +
+                    '(?:' + invalidChars + ')' +
+                    '{0,' + maxLength + '}' +
+                ')$',
+            );
             const match = TypeaheadTriggerRegex.exec(text);
-            console.log(`replaceableString`,match?.[0]);
-            console.log(`match`,match);
             if (match !== null) {
                 const matchingString = match[1];
                 if (matchingString.length >= minLength) {

--- a/packages/koenig-lexical/src/hooks/useTypeaheadTriggerMatch.js
+++ b/packages/koenig-lexical/src/hooks/useTypeaheadTriggerMatch.js
@@ -7,27 +7,24 @@ export default function useBasicTypeaheadTriggerMatch(trigger,{minLength = 1, ma
     return useCallback(
         (text) => {
             const invalidChars = '[^' + trigger + '\\s]'; // escaped set - these cannot be present in the matched string
-            const TypeaheadTriggerRegex = new RegExp(
-                // '(^|\\s|\\()(' +
-                '(' +
-            '[' +
-            trigger +
-            ']' +
-            '((?:' +
-            invalidChars +
-            '){0,' +
-            maxLength +
-            '})' +
-            ')$', // returns end of string
-            );
+            // const TypeaheadTriggerRegex = new RegExp(
+            //     '[' + trigger + ']' +
+            //     '(' +
+            //         '(?:' + invalidChars + ')' +
+            //         '{0,' + maxLength + '}' +
+            //     ')$',
+            // );
+            const TypeaheadTriggerRegex = new RegExp(/[:]((?:[^:\s]){0,75}[:]?)$/);
             const match = TypeaheadTriggerRegex.exec(text);
+            console.log(`replaceableString`,match?.[0]);
+            console.log(`match`,match);
             if (match !== null) {
-                const matchingString = match[2];
+                const matchingString = match[1];
                 if (matchingString.length >= minLength) {
                     return {
                         leadOffset: match.index,
                         matchingString,
-                        replaceableString: match[1]
+                        replaceableString: match[0]
                     };
                 }
             }

--- a/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
@@ -92,7 +92,6 @@ export function EmojiPickerPlugin() {
         }
 
         async function searchEmojis() {
-            console.log(`searchEmojis`,queryString);
             let filteredEmojis = [];
             if ([')','-)'].includes(queryString)) {
                 filteredEmojis = await SearchIndex.search('smile');

--- a/packages/koenig-lexical/test/e2e/plugins/EmojiPickerPlugin.test.js
+++ b/packages/koenig-lexical/test/e2e/plugins/EmojiPickerPlugin.test.js
@@ -254,4 +254,20 @@ test.describe('Emoji Picker Plugin', async function () {
         </div>
         `);
     });
+
+    test.describe('Completion matching', async function () {
+        test('can insert emojis by providing the whole :shortcode:', async function () {
+            await focusEditor(page);
+
+            await page.keyboard.type(':taco:');
+            await assertHTML(page, '<p dir="ltr"><span data-lexical-text="true">🌮</span></p>');
+        });
+
+        test('a whole :shortcode: with no emojis matches inserts nothing', async function () {
+            await focusEditor(page);
+
+            await page.keyboard.type(':tac:');
+            await assertHTML(page, '<p dir="ltr"><span data-lexical-text="true">:tac:</span></p>');
+        });
+    });
 });


### PR DESCRIPTION
closes TryGhost/Product#4072
- have to manually handle the insertion because the lexical menu component doesn't expose necessary behaviour
- added key down command handler to intercept `queryString` before further updates, this allows undo to work properly