### PR TITLE
Fixed emoji picker menu not re-positioning to stay on screen

### DIFF
--- a/packages/koenig-lexical/src/components/ui/Portal.jsx
+++ b/packages/koenig-lexical/src/components/ui/Portal.jsx
@@ -2,7 +2,7 @@ import KoenigComposerContext from '../../context/KoenigComposerContext';
 import React from 'react';
 import {createPortal} from 'react-dom';
 
-function Portal({children, to}) {
+function Portal({children, to, className}) {
     const {darkMode} = React.useContext(KoenigComposerContext);
 
     const container = to || document.body;
@@ -16,8 +16,8 @@ function Portal({children, to}) {
     }
 
     return createPortal(
-        <div className="koenig-lexical" onMouseDown={cancelEvents}>
-            <div className={darkMode ? 'dark' : ''}>
+        <div className="koenig-lexical" style={{width: 'fit-content'}} onMouseDown={cancelEvents}>
+            <div className={`${darkMode ? 'dark' : ''} ${className}`}>
                 {children}
             </div>
         </div>,

--- a/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
@@ -157,7 +157,7 @@ export function EmojiPickerPlugin() {
         const rangeRect = selectedRange.getBoundingClientRect();
 
         return {
-            top: `${rangeRect.height}px`
+            marginTop: `${rangeRect.height}px`
         };
     }
 
@@ -172,8 +172,8 @@ export function EmojiPickerPlugin() {
                 }
 
                 return (
-                    <Portal to={anchorElementRef.current}>
-                        <ul className="absolute z-10 max-h-[214px] w-[240px] list-none overflow-y-auto bg-white p-1 shadow" data-testid="emoji-menu" style={getPositionStyles()}>
+                    <Portal className="w-[240px]" to={anchorElementRef.current}>
+                        <ul className="relative z-10 max-h-[214px] list-none overflow-y-auto bg-white p-1 shadow" data-testid="emoji-menu" style={getPositionStyles()}>
                             {searchResults.map((emoji, index) => (
                                 <div key={emoji.id}>
                                     <EmojiMenuItem


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/4091

- adjusted our portal/menu styling so that the top-level element rendered inside the LexicalMenu anchor ref matches the content width and height so the positioning code in `<LexicalMenu>` has the correct values to work with
