### PR TITLE
🐛 Fixed browser focus on editor when clicking card

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/signup/signup-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/signup-renderer.js
@@ -5,6 +5,8 @@ import {addCreateDocumentOption} from '../../utils/add-create-document-option';
 function cardTemplate(nodeData) {
     const cardClasses = getCardClasses(nodeData).join(' ');
 
+    // console.log(`nodeData`, nodeData);
+
     const backgroundAccent = nodeData.backgroundColor === 'accent' ? 'kg-style-accent' : '';
     const buttonAccent = nodeData.buttonColor === 'accent' ? 'kg-style-accent' : '';
     const buttonStyle = nodeData.buttonColor !== 'accent' ? `background-color: ${nodeData.buttonColor};` : ``;

--- a/packages/kg-default-nodes/lib/nodes/signup/signup-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/signup-renderer.js
@@ -5,8 +5,6 @@ import {addCreateDocumentOption} from '../../utils/add-create-document-option';
 function cardTemplate(nodeData) {
     const cardClasses = getCardClasses(nodeData).join(' ');
 
-    // console.log(`nodeData`, nodeData);
-
     const backgroundAccent = nodeData.backgroundColor === 'accent' ? 'kg-style-accent' : '';
     const buttonAccent = nodeData.buttonColor === 'accent' ? 'kg-style-accent' : '';
     const buttonStyle = nodeData.buttonColor !== 'accent' ? `background-color: ${nodeData.buttonColor};` : ``;

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -74,10 +74,14 @@ const SPECIAL_MARKUPS = {
     strikethrough: '~~'
 };
 
-function $selectCard(nodeKey) {
+function $selectCard(editor, nodeKey) {
     const selection = $createNodeSelection();
     selection.add(nodeKey);
     $setSelection(selection);
+    // selecting a decorator node does not change the
+    // window selection (there's no caret) so we need
+    // to manually move focus to the editor element
+    editor.getRootElement().focus();
 }
 
 // remove empty cards when they are deselected
@@ -279,7 +283,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                         $deselectCard(editor, selectedCardKey);
                     }
 
-                    $selectCard(cardKey);
+                    $selectCard(editor, cardKey);
 
                     setSelectedCardKey(cardKey);
                     setIsEditingCard(false);
@@ -292,7 +296,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                     if (selectedCardKey && selectedCardKey !== cardKey) {
                         $deselectCard(editor, selectedCardKey);
                     }
-                    $selectCard(cardKey);
+                    $selectCard(editor, cardKey);
 
                     setSelectedCardKey(cardKey);
 
@@ -393,7 +397,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                                         paragraph.select();
                                     } else {
                                         // reselect card to ensure we have a selection for the next steps
-                                        $selectCard(selectedCardKey);
+                                        $selectCard(editor, selectedCardKey);
 
                                         // select the next paragraph or card
                                         editor.dispatchCommand(KEY_ARROW_DOWN_COMMAND);
@@ -403,7 +407,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                                 } else {
                                     // re-create the node selection because the focus will place the cursor at
                                     // the beginning of the doc
-                                    $selectCard(selectedCardKey);
+                                    $selectCard(editor, selectedCardKey);
                                 }
 
                                 setIsEditingCard(false);
@@ -504,7 +508,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
 
                     // if we're in a nested editor, we need to move selection back to the parent editor
                     if (event?._fromCaptionEditor) {
-                        $selectCard(selectedCardKey);
+                        $selectCard(editor, selectedCardKey);
                     }
 
                     // avoid processing card behaviours when an inner element has focus (e.g. nested editors)
@@ -626,7 +630,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
 
                     // if we're in a nested editor, we need to move selection back to the parent editor
                     if (event?._fromCaptionEditor) {
-                        $selectCard(selectedCardKey);
+                        $selectCard(editor, selectedCardKey);
                     }
 
                     // avoid processing card behaviours when an inner element has focus (e.g. nested editors)
@@ -1324,7 +1328,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                         //   cards have their own click handlers
                         event.preventDefault();
                         const cardNode = $getNearestNodeFromDOMNode(event.target);
-                        $selectCard(cardNode.getKey());
+                        $selectCard(editor, cardNode.getKey());
                         return true;
                     }
 

--- a/packages/koenig-lexical/test/e2e/card-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/card-behaviour.test.js
@@ -160,7 +160,6 @@ test.describe('Card behaviour', async () => {
             expect(editorHasFocus).toEqual(true);
         });
 
-
         test('clicking outside the empty edit mode card removes the card', async function () {
             await focusEditor(page);
             await page.keyboard.type('```javascript ');

--- a/packages/koenig-lexical/test/e2e/card-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/card-behaviour.test.js
@@ -144,6 +144,23 @@ test.describe('Card behaviour', async () => {
             expect(await page.locator('[data-kg-card-editing="false"]'));
         });
 
+        test('clicking outside the editor and then on a card focuses the editor', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('```javascript ');
+            await page.keyboard.type('import React from "react"');
+
+            const title = page.getByTestId('post-title');
+            await title.click();
+            let titleHasFocus = await title.evaluate(node => document.activeElement === node);
+            expect(titleHasFocus).toEqual(true);
+
+            await page.click('div[data-kg-card="codeblock"]');
+            const editor = await page.locator('div.kg-prose').first();
+            let editorHasFocus = await editor.evaluate(node => document.activeElement === node);
+            expect(editorHasFocus).toEqual(true);
+        });
+
+
         test('clicking outside the empty edit mode card removes the card', async function () {
             await focusEditor(page);
             await page.keyboard.type('```javascript ');


### PR DESCRIPTION
closes TryGhost/Issues#18752
- cards do not have a caret and require manual editor focus when clicking them