### PR TITLE
🐛 Fixed slash menu having fixed position when scrolling

### DIFF
--- a/packages/koenig-lexical/src/components/ui/CardMenu.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardMenu.jsx
@@ -29,14 +29,15 @@ export const CardMenuSection = ({label, children, ...props}) => {
     );
 };
 
-export const CardMenuItem = ({label, shortcut, desc, isSelected, onClick, Icon, ...props}) => {
+export const CardMenuItem = ({label, shortcut, desc, isSelected, scrollToItem, onClick, Icon, ...props}) => {
     const buttonRef = React.useRef(null);
 
     React.useEffect(() => {
-        if (isSelected) {
+        if (scrollToItem) {
             buttonRef.current.scrollIntoView({behavior: 'smooth', block: 'nearest', inline: 'nearest'});
         }
-    }, [isSelected]);
+    }, [scrollToItem]);
+
     // browsers will move focus on mouseDown but we don't want that because it
     // removes focus from the editor meaning key commands don't work as
     // expected after a card is inserted
@@ -69,14 +70,15 @@ export const CardMenuItem = ({label, shortcut, desc, isSelected, onClick, Icon, 
     );
 };
 
-export const CardSnippetItem = ({label, isSelected, Icon, onRemove, closeMenu, ...props}) => {
+export const CardSnippetItem = ({label, isSelected, scrollToItem, Icon, onRemove, closeMenu, ...props}) => {
     const itemRef = React.useRef(null);
 
     React.useEffect(() => {
-        if (isSelected) {
+        if (scrollToItem) {
             itemRef.current.scrollIntoView({behavior: 'smooth', block: 'nearest', inline: 'nearest'});
         }
-    }, [isSelected]);
+    }, [scrollToItem]);
+
     const handleSnippetRemove = (event) => {
         event.stopPropagation(); // prevent snippet insertion
         onRemove();
@@ -115,7 +117,7 @@ export const CardSnippetItem = ({label, isSelected, Icon, onRemove, closeMenu, .
     );
 };
 
-export const CardMenu = ({menu = new Map(), insert = () => {}, selectedItemIndex, closeMenu}) => {
+export const CardMenu = ({menu = new Map(), insert = () => {}, selectedItemIndex, scrollToSelectedItem, closeMenu}) => {
     // build up the children arrays from the passed in menu Map
     const CardMenuSections = [];
 
@@ -142,6 +144,7 @@ export const CardMenu = ({menu = new Map(), insert = () => {}, selectedItemIndex
                         Icon={item.Icon}
                         isSelected={isSelected}
                         label={item.label}
+                        scrollToItem={isSelected && scrollToSelectedItem}
                         shortcut={item.shortcut}
                         onClick={onClick}
                     />
@@ -155,6 +158,7 @@ export const CardMenu = ({menu = new Map(), insert = () => {}, selectedItemIndex
                         Icon={item.Icon}
                         isSelected={isSelected}
                         label={item.label}
+                        scrollToItem={isSelected && scrollToSelectedItem}
                         onClick={onClick}
                         onRemove={item.onRemove}
                     />


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/4112

- slash menu was using fixed positioning which meant scrolling whilst the menu was open caused a visual disconnect between the insertion point and the menu
- switched positioning style to absolute
  - updated position calculation to work with relative top/bottom positioning
  - when using absolute positioning the "scroll into view when selected" behaviour for card menu items was causing random scrolling when the menu opened due to the render+reposition timing. Adjusted menu item component to only scroll into view when explicitly told to and updated the keyboard navigation in the slash menu to enable the scroll behaviour to avoid any initial-render scroll problems
