### PR TITLE
🐛 Fixed text formats being lost when copy/pasting from Google Docs

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/ExtendedTextNode.js
+++ b/packages/kg-default-nodes/lib/nodes/ExtendedTextNode.js
@@ -92,23 +92,23 @@ function convertSpanElement(lexicalNode, domNode) {
     // Word uses span tags + "Highlight" class for highlighted text
     const hasHighlightClass = span.classList.contains('Highlight') || span.parentElement?.classList.contains('Highlight');
 
-    if (hasBoldFontWeight) {
+    if (hasBoldFontWeight && !lexicalNode.hasFormat('bold')) {
         lexicalNode = lexicalNode.toggleFormat('bold');
     }
 
-    if (hasItalicFontStyle) {
+    if (hasItalicFontStyle && !lexicalNode.hasFormat('italic')) {
         lexicalNode = lexicalNode.toggleFormat('italic');
     }
 
-    if (hasUnderlineTextDecoration) {
+    if (hasUnderlineTextDecoration && !lexicalNode.hasFormat('underline')) {
         lexicalNode = lexicalNode.toggleFormat('underline');
     }
 
-    if (hasStrikethroughClass) {
+    if (hasStrikethroughClass && !lexicalNode.hasFormat('strikethrough')) {
         lexicalNode = lexicalNode.toggleFormat('strikethrough');
     }
 
-    if (hasHighlightClass) {
+    if (hasHighlightClass && !lexicalNode.hasFormat('highlight')) {
         lexicalNode = lexicalNode.toggleFormat('highlight');
     }
 

--- a/packages/kg-html-to-lexical/test/sources/google-docs.test.ts
+++ b/packages/kg-html-to-lexical/test/sources/google-docs.test.ts
@@ -1,0 +1,237 @@
+import assert from 'assert/strict';
+const converter = require('../../');
+
+const editorConfig = {
+    onError(e: Error) {
+        throw e;
+    }
+};
+
+interface LexicalNode {
+    type: string;
+}
+
+const wrapperMap = {
+    normal: {
+        tag: 'p',
+        style: 'line-height: 1.38; margin-top: 0pt; margin-bottom: 0pt'
+    }
+};
+
+function googleHtml(html: string, type: keyof typeof wrapperMap): string {
+    const {tag, style} = wrapperMap[type];
+
+    return `<b style="font-weight: normal" id="docs-internal-guid-7898193f-7fff-3086-7f10-dc328c4061a8"><${tag} dir="ltr" style="${style}">${html}</${tag}></b>`;
+}
+
+describe('HTMLtoLexical: Google Docs', function () {
+    it('can convert plain text', function () {
+        const html = googleHtml('<span style="font-size: 11pt; font-family: Arial, sans-serif; color: #000000; background-color: transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration: none; vertical-align: baseline; white-space: pre; white-space: pre-wrap;">Plain</span>', 'normal');
+        const lexical = converter.htmlToLexical(html, editorConfig);
+
+        assert.deepEqual(lexical, {
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                detail: 0,
+                                format: 0,
+                                mode: 'normal',
+                                style: '',
+                                text: 'Plain',
+                                type: 'extended-text',
+                                version: 1
+                            }
+                        ],
+                        direction: null,
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        });
+    });
+
+    it('can convert bold', function () {
+        const html = googleHtml('<span style="font-size: 11pt; font-family: Arial, sans-serif; color: #000000; background-color: transparent; font-weight: 700; font-style: normal; font-variant: normal; text-decoration: none; vertical-align: baseline; white-space: pre; white-space: pre-wrap;">Bold</span>', 'normal');
+        const lexical = converter.htmlToLexical(html, editorConfig);
+
+        assert.deepEqual(lexical, {
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                detail: 0,
+                                format: 1,
+                                mode: 'normal',
+                                style: '',
+                                text: 'Bold',
+                                type: 'extended-text',
+                                version: 1
+                            }
+                        ],
+                        direction: null,
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        });
+    });
+
+    it('can convert italic', function () {
+        const html = googleHtml('<span style="font-size: 11pt; font-family: Arial, sans-serif; color: #000000; background-color: transparent; font-weight: 400; font-style: italic; font-variant: normal; text-decoration: none; vertical-align: baseline; white-space: pre; white-space: pre-wrap;">Italic</span>', 'normal');
+        const lexical = converter.htmlToLexical(html, editorConfig);
+
+        assert.deepEqual(lexical, {
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                detail: 0,
+                                format: 2,
+                                mode: 'normal',
+                                style: '',
+                                text: 'Italic',
+                                type: 'extended-text',
+                                version: 1
+                            }
+                        ],
+                        direction: null,
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        });
+    });
+
+    it('can convert bold+italic', function () {
+        const html = googleHtml('<span style="font-size: 11pt; font-family: Arial, sans-serif; color: #000000; background-color: transparent; font-weight: 700; font-style: italic; font-variant: normal; text-decoration: none; vertical-align: baseline; white-space: pre; white-space: pre-wrap;">Bold+Italic</span>', 'normal');
+        const lexical = converter.htmlToLexical(html, editorConfig);
+
+        assert.deepEqual(lexical, {
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                detail: 0,
+                                format: 3,
+                                mode: 'normal',
+                                style: '',
+                                text: 'Bold+Italic',
+                                type: 'extended-text',
+                                version: 1
+                            }
+                        ],
+                        direction: null,
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        });
+    });
+
+    it('can convert underline', function () {
+        const html = googleHtml('<span style="font-size: 11pt; font-family: Arial, sans-serif; color: #000000; background-color: transparent; font-weight: 400; font-style: normal; font-variant: normal; text-decoration: underline; -webkit-text-decoration-skip: none; text-decoration-skip-ink: none; vertical-align: baseline; white-space: pre; white-space: pre-wrap;">Underline</span>', 'normal');
+        const lexical = converter.htmlToLexical(html, editorConfig);
+
+        assert.deepEqual(lexical, {
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                detail: 0,
+                                format: 8,
+                                mode: 'normal',
+                                style: '',
+                                text: 'Underline',
+                                type: 'extended-text',
+                                version: 1
+                            }
+                        ],
+                        direction: null,
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        });
+    });
+
+    it('can convert italic+underline', function () {
+        const html = googleHtml('<span style="font-size: 11pt; font-family: Arial, sans-serif; color: #000000; background-color: transparent; font-weight: 400; font-style: italic; font-variant: normal; text-decoration: underline; -webkit-text-decoration-skip: none; text-decoration-skip-ink: none; vertical-align: baseline; white-space: pre; white-space: pre-wrap;">Italic+Underline</span>', 'normal');
+        const lexical = converter.htmlToLexical(html, editorConfig);
+
+        assert.deepEqual(lexical, {
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                detail: 0,
+                                format: 10,
+                                mode: 'normal',
+                                style: '',
+                                text: 'Italic+Underline',
+                                type: 'extended-text',
+                                version: 1
+                            }
+                        ],
+                        direction: null,
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        });
+    });
+});


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/4104

When we added support for parsing Word formatting we used `node.toggleFormat()` but that lead to an issue with Google Docs because the default conversions ran first and set appropriate formats which we were then toggling back off when Google Docs and Word shared similar styling.

- added checks in our patched conversions to ensure text doesn't already have the appropriate format applied before toggling
