### PR TITLE
🐛 Fixed backspace behaviour at start of aside/quote

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -981,8 +981,24 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                                 }
                             }
 
-                            // delete any previous card keeping caret in place
                             const anchorNodeParent = anchorNode.getParent();
+
+                            // convert to paragraph if backspace is at start of the quote/aside block
+                            if (
+                                atStartOfElement &&
+                                ($isQuoteNode(anchorNodeParent) || $isAsideNode(anchorNodeParent))
+                            ) {
+                                const paragraph = $createParagraphNode();
+                                anchorNodeParent.getChildren().forEach((child) => {
+                                    paragraph.append(child);
+                                });
+                                anchorNodeParent.replace(paragraph);
+                                paragraph.selectStart();
+                                event.preventDefault();
+                                return true;
+                            }
+
+                            // delete any previous card keeping caret in place
                             if (
                                 atStartOfElement &&
                                 $isDecoratorNode(previousSibling) &&

--- a/packages/koenig-lexical/test/e2e/card-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/card-behaviour.test.js
@@ -1075,6 +1075,99 @@ test.describe('Card behaviour', async () => {
                 focusPath: [1, 0, 0]
             });
         });
+
+        test('at start of list after a card', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('---');
+            await page.keyboard.type('* Test');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <ul>
+                    <li value="1" dir="ltr"><span data-lexical-text="true">Test</span></li>
+                </ul>
+            `);
+
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('Backspace');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <p dir="ltr"><span data-lexical-text="true">Test</span></p>
+            `);
+        });
+
+        test('at start of a quote block after a card', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('---');
+            await page.keyboard.type('> Test');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <blockquote dir="ltr"><span data-lexical-text="true">Test</span></blockquote>
+            `);
+
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('Backspace');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <p dir="ltr"><span data-lexical-text="true">Test</span></p>
+            `);
+        });
+
+        test('at start of an aside after a card', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('---');
+            await page.keyboard.type('> Test');
+            await page.keyboard.press('Control+q');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <aside dir="ltr"><span data-lexical-text="true">Test</span></aside>
+            `);
+
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('Backspace');
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="horizontalrule">
+                        <hr>
+                    </div>
+                </div>
+                <p dir="ltr"><span data-lexical-text="true">Test</span></p>
+            `);
+        });
     });
 
     test.describe('DELETE', function () {


### PR DESCRIPTION
closes TryGhost/Ghost#18753
- needed new handling for quote and aside, which block level like paragraphs
- backspace now removes the quote/aside formatting and goes to paragraph
- this is consistent with the general behaviour when there's no neighboring text