### PR TITLE
🐛 Fixed text having unexpected formats when rendering

### DIFF
--- a/packages/kg-lexical-html-renderer/lib/convert-to-html-string.js
+++ b/packages/kg-lexical-html-renderer/lib/convert-to-html-string.js
@@ -64,7 +64,7 @@ function exportChildren(node, options) {
     const output = [];
     const children = node.getChildren();
 
-    const textContent = new TextContent(options.dom);
+    const textContent = new TextContent(exportChildren, options);
 
     for (const child of children) {
         if (!textContent.isEmpty() && !$isLineBreakNode(child) && !$isTextNode(child) && !$isLinkNode(child)) {
@@ -72,12 +72,8 @@ function exportChildren(node, options) {
             textContent.clear();
         }
 
-        if ($isLineBreakNode(child)) {
-            textContent.addLineBreak();
-        } else if ($isTextNode(child)) {
-            textContent.addTextNode(child, node, options);
-        } else if ($isLinkNode(child)) {
-            textContent.addLinkNode(child, node, exportChildren, options);
+        if ($isLineBreakNode(child) || $isTextNode(child) || $isLinkNode(child)) {
+            textContent.addNode(child);
         } else if ($isElementNode(child)) {
             output.push(exportChildren(child, options));
         }

--- a/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
+++ b/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
@@ -1,5 +1,5 @@
 const {$isLinkNode} = require('@lexical/link');
-const {$isTextNode} = require('lexical');
+const {$isTextNode, $isLineBreakNode} = require('lexical');
 
 const FORMAT_TAG_MAP = {
     bold: 'STRONG',
@@ -14,105 +14,119 @@ const FORMAT_TAG_MAP = {
 // Builds and renders text content, useful to ensure proper format tag opening/closing
 // and html escaping
 class TextContent {
-    constructor(dom) {
-        this.dom = dom;
-        this.doc = this.dom.window.document;
-        this.root = this.doc.createElement('div');
-        this.currentNode = this.root;
-        this.currentFormats = [];
-        this.queuedLineBreaks = 0;
+    constructor(exportChildren, options) {
+        this.exportChildren = exportChildren;
+        this.options = options;
+
+        this.nodes = [];
     }
 
-    addTextNode(node/*, parentNode, options*/) {
-        if (!$isTextNode(node)) {
-            return;
-        }
-
-        // remove formats that shouldn't be applied to this node
-        // NOTE: ensure we're working with a copy of the array otherwise forEach bails early when we use .shift()
-        Array.from(this.currentFormats).forEach((format) => {
-            if (!node.hasFormat(format)) {
-                this.currentFormats.shift();
-                this.currentNode = this.currentFormats[0]
-                    ? this.currentNode.parentNode
-                    : this.root;
-            }
-        });
-
-        if (!this.currentNode) {
-            this.currentNode = this.root;
-        }
-
-        // insert any queued line breaks
-        this._insertQueuedLineBreaks();
-
-        // add any new format tags for this node
-        Object.entries(FORMAT_TAG_MAP).forEach(([format, tag]) => {
-            if (node.hasFormat(format)) {
-                // prevent adding extra wrapping tags if we already have this format
-                if (!this.currentFormats.includes(format)) {
-                    const formatTag = this.doc.createElement(tag);
-                    this.currentNode.append(formatTag);
-                    this.currentNode = formatTag;
-
-                    this.currentFormats.unshift(format);
-                }
-            }
-        });
-
-        // add the actual text content
-        this.currentNode.append(node.getTextContent());
-    }
-
-    addLineBreak() {
-        this.queuedLineBreaks = this.queuedLineBreaks + 1;
-    }
-
-    addLinkNode(node, parentNode, exportChildren, options) {
-        if (!$isLinkNode(node)) {
-            return;
-        }
-
-        // insert any queued line breaks
-        this._insertQueuedLineBreaks();
-
-        const a = this.doc.createElement('a');
-
-        // Only set the href if we have a URL, otherwise we get a link to the current page
-        if (node.getURL()) {
-            a.setAttribute('href', node.getURL());
-        }
-        if (node.getRel()) {
-            a.setAttribute('rel', node.getRel());
-        }
-        a.innerHTML = exportChildren(node, options);
-
-        this.currentNode.append(a);
-    }
-
-    isEmpty() {
-        return this.root.innerHTML === '';
+    addNode(node) {
+        this.nodes.push(node);
     }
 
     render() {
-        this._insertQueuedLineBreaks();
-        return this.root.innerHTML;
+        const document = this.options.dom.window.document;
+        const root = document.createElement('div');
+
+        let currentNode = root;
+        const openFormats = [];
+
+        for (let i = 0; i < this.nodes.length; i++) {
+            const node = this.nodes[i];
+
+            if ($isLineBreakNode(node)) {
+                currentNode.append(document.createElement('BR'));
+                continue;
+            }
+
+            if ($isLinkNode(node)) {
+                const anchor = document.createElement('A');
+                this._buildAnchorElement(anchor, node);
+                currentNode.append(anchor);
+                continue;
+            }
+
+            if ($isTextNode(node)) {
+                // shortcut format code for plain text
+                if (node.getFormat() === 0) {
+                    currentNode.append(node.getTextContent());
+                    continue;
+                }
+
+                // open format tags in correct order
+                const formatsToOpen = [];
+
+                // get base list of formats that need to open
+                Object.entries(FORMAT_TAG_MAP).forEach(([format]) => {
+                    if (node.hasFormat(format) && !openFormats.includes(format)) {
+                        formatsToOpen.push(format);
+                    }
+                });
+
+                // re-order formats to open based on next nodes - we want to make
+                // sure tags that will be kept open for later nodes are opened first
+                const remainingNodes = this.nodes.slice(i + 1);
+                formatsToOpen.sort((a, b) => {
+                    const aIndex = remainingNodes.findIndex(n => n.hasFormat(a));
+                    const bIndex = remainingNodes.findIndex(n => n.hasFormat(b));
+
+                    if (aIndex === -1) {
+                        return 1;
+                    }
+                    if (bIndex === -1) {
+                        return -1;
+                    }
+
+                    return aIndex - bIndex;
+                });
+
+                // open new tags
+                formatsToOpen.forEach((format) => {
+                    const formatTag = document.createElement(FORMAT_TAG_MAP[format]);
+                    currentNode.append(formatTag);
+                    currentNode = formatTag;
+                    openFormats.push(format);
+                });
+
+                // insert text
+                currentNode.append(node.getTextContent());
+
+                // close tags in correct order if next node doesn't have the format
+                const nextNode = remainingNodes.find(n => $isTextNode(n));
+                [...openFormats].forEach((format) => {
+                    if (!nextNode || !nextNode.hasFormat(format)) {
+                        currentNode = currentNode.parentNode;
+                        openFormats.pop();
+                    }
+                });
+
+                continue;
+            }
+        }
+
+        return root.innerHTML;
+    }
+
+    isEmpty() {
+        return this.nodes.length === 0;
     }
 
     clear() {
-        this.root = this.doc.createElement('DIV');
-        this.currentNode = this.root;
-        this.currentFormats = [];
-        this.queuedLineBreaks = 0;
+        this.nodes = [];
     }
 
-    _insertQueuedLineBreaks() {
-        while (this.queuedLineBreaks > 0) {
-            this.currentNode.append(this.doc.createElement('BR'));
-            this.queuedLineBreaks = this.queuedLineBreaks - 1;
-        }
+    // PRIVATE -----------------------------------------------------------------
 
-        this.queuedLineBreaks = 0;
+    _buildAnchorElement(anchor, node) {
+        // Only set the href if we have a URL, otherwise we get a link to the current page
+        if (node.getURL()) {
+            anchor.setAttribute('href', node.getURL());
+        }
+        if (node.getRel()) {
+            anchor.setAttribute('rel', node.getRel());
+        }
+        anchor.innerHTML = this.exportChildren(node, this.options);
     }
 }
 

--- a/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
+++ b/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
@@ -93,9 +93,9 @@ class TextContent {
                 currentNode.append(node.getTextContent());
 
                 // close tags in correct order if next node doesn't have the format
-                const nextNode = remainingNodes.find(n => $isTextNode(n));
+                const nextNode = remainingNodes.find(n => $isTextNode(n) || $isLinkNode(n));
                 [...openFormats].forEach((format) => {
-                    if (!nextNode || !nextNode.hasFormat(format)) {
+                    if (!nextNode || $isLinkNode(nextNode) || !nextNode.hasFormat(format)) {
                         currentNode = currentNode.parentNode;
                         openFormats.pop();
                     }

--- a/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
+++ b/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
@@ -67,9 +67,13 @@ class TextContent {
                 // re-order formats to open based on next nodes - we want to make
                 // sure tags that will be kept open for later nodes are opened first
                 const remainingNodes = this.nodes.slice(i + 1);
+                // avoid checking any nodes after a link node because those cause all formats to close
+                const nextLinkNodeIndex = remainingNodes.findIndex(n => $isLinkNode(n));
+                const remainingSortNodes = nextLinkNodeIndex === -1 ? remainingNodes : remainingNodes.slice(0, nextLinkNodeIndex);
+
                 formatsToOpen.sort((a, b) => {
-                    const aIndex = remainingNodes.findIndex(n => n.hasFormat(a));
-                    const bIndex = remainingNodes.findIndex(n => n.hasFormat(b));
+                    const aIndex = remainingSortNodes.findIndex(n => n.hasFormat(a));
+                    const bIndex = remainingSortNodes.findIndex(n => n.hasFormat(b));
 
                     if (aIndex === -1) {
                         return 1;
@@ -93,6 +97,7 @@ class TextContent {
                 currentNode.append(node.getTextContent());
 
                 // close tags in correct order if next node doesn't have the format
+                // links are their own formatting islands so all formats need to close before a link
                 const nextNode = remainingNodes.find(n => $isTextNode(n) || $isLinkNode(n));
                 [...openFormats].forEach((format) => {
                     if (!nextNode || $isLinkNode(nextNode) || !nextNode.hasFormat(format)) {

--- a/packages/kg-lexical-html-renderer/test/links.test.js
+++ b/packages/kg-lexical-html-renderer/test/links.test.js
@@ -25,4 +25,9 @@ describe('Links', function () {
         input: `{"root":{"children":[{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"test ","type":"text","version":1},{"detail":0,"format":1,"mode":"normal","style":"","text":"bold ","type":"text","version":1},{"detail":0,"format":3,"mode":"normal","style":"","text":"bold+italic","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"https://example.com"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
         output: '<p><a href="https://example.com">test <strong>bold <em>bold+italic</em></strong></a></p>'
     }));
+
+    it('strong - a > italic - strong', shouldRender({
+        input: `{"root":{"children":[{"children":[{"detail":0,"format":1,"mode":"normal","style":"","text":"Strong ","type":"text","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"link plain ","type":"text","version":1},{"detail":0,"format":2,"mode":"normal","style":"","text":"italic","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":"noreferrer","target":null,"title":null,"url":"https://ghost.org"},{"detail":0,"format":1,"mode":"normal","style":"","text":" Strong","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+        output: '<p><strong>Strong </strong><a href="https://ghost.org" rel="noreferrer">link plain <em>italic</em></a><strong> Strong</strong></p>'
+    }));
 });

--- a/packages/kg-lexical-html-renderer/test/text-formats.test.js
+++ b/packages/kg-lexical-html-renderer/test/text-formats.test.js
@@ -73,6 +73,14 @@ describe('Format combinations', function () {
         input: `{"root":{"children":[{"children":[{"detail":0,"format":2,"mode":"normal","style":"","text":"Italic ","type":"text","version":1},{"detail":0,"format":3,"mode":"normal","style":"","text":"Strong","type":"text","version":1},{"detail":0,"format":2,"mode":"normal","style":"","text":" Italic","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
         output: `<p><em>Italic <strong>Strong</strong> Italic</em></p>`
     }));
+
+    // an earlier TextContent implementation was dependent on content formats having a specific order
+    // otherwise we would start tags and close tags in an incorrect order
+    // previous output: <p>(<strong><em>italic+bold</em><em> italic</em></strong>)</p>
+    it('italic+bold different order', shouldRender({
+        input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"(","type":"text","version":1},{"detail":0,"format":3,"mode":"normal","style":"","text":"italic+bold","type":"text","version":1},{"detail":0,"format":2,"mode":"normal","style":"","text":" italic","type":"text","version":1},{"detail":0,"format":0,"mode":"normal","style":"","text":")","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+        output: `<p>(<em><strong>italic+bold</strong> italic</em>)</p>`
+    }));
 });
 
 describe('Formats with linebreaks', function () {


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/4116

Our `TextContent` class was inadvertently tied to needing content format order to match the key order of its `FORMAT_TAG_MAP` object. If content didn't match it would result in tags being opened in the wrong order and then not correctly closed meaning one format would cover much more of the text than it should have.

- re-worked the class to have two methods `addNode()` and `render()`
  - `addNode()` is much simpler as it now only builds up an array of the text content nodes ready for rendering rather than trying to build up DOM as nodes are added
  - `render()` now contains the meat of the DOM creation. By deferring DOM creation until rendering we are able to walk forwards through the node array for each format to correctly order the opening and closing of elements
