### PR TITLE
🐛 Prevented scroll when selecting cards

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -81,7 +81,9 @@ function $selectCard(editor, nodeKey) {
     // selecting a decorator node does not change the
     // window selection (there's no caret) so we need
     // to manually move focus to the editor element
-    editor.getRootElement().focus();
+    if (document.activeElement !== editor.getRootElement()) {
+        editor.getRootElement().focus({preventScroll: true});
+    }
 }
 
 // remove empty cards when they are deselected


### PR DESCRIPTION
refs 11ed11e076ba56c2fb7b2a83dd4dda282e53b6af
- adding editor focus handling was too permissive
- will not only focus editor if not already focused
- prevented scroll when focusing editor (e.g. from settings panel)