### PR TITLE
🐛 Fixed HTML->Lexical conversion not handling paragraphs inside blockquotes

### DIFF
--- a/packages/kg-default-nodes/lib/kg-default-nodes.js
+++ b/packages/kg-default-nodes/lib/kg-default-nodes.js
@@ -22,6 +22,7 @@ import * as signup from './nodes/signup/SignupNode';
 import * as collection from './nodes/collection/CollectionNode';
 import * as textnode from './nodes/ExtendedTextNode';
 import * as headingnode from './nodes/ExtendedHeadingNode';
+import * as quotenode from './nodes/ExtendedQuoteNode';
 
 // re-export everything for easier importing
 export * from './KoenigDecoratorNode';
@@ -49,6 +50,7 @@ export * from './nodes/signup/SignupNode';
 export * from './nodes/collection/CollectionNode';
 export * from './nodes/ExtendedTextNode';
 export * from './nodes/ExtendedHeadingNode';
+export * from './nodes/ExtendedQuoteNode';
 
 // export convenience objects for use elsewhere
 export const DEFAULT_NODES = [
@@ -56,6 +58,8 @@ export const DEFAULT_NODES = [
     textnode.extendedTextNodeReplacement,
     headingnode.ExtendedHeadingNode,
     headingnode.extendedHeadingNodeReplacement,
+    quotenode.ExtendedQuoteNode,
+    quotenode.extendedQuoteNodeReplacement,
     codeblock.CodeBlockNode,
     image.ImageNode,
     markdown.MarkdownNode,

--- a/packages/kg-default-nodes/lib/nodes/ExtendedQuoteNode.js
+++ b/packages/kg-default-nodes/lib/nodes/ExtendedQuoteNode.js
@@ -1,0 +1,79 @@
+/* eslint-disable ghost/filenames/match-exported-class */
+import {QuoteNode} from '@lexical/rich-text';
+import {$createLineBreakNode, $isParagraphNode} from 'lexical';
+
+// Since the QuoteNode is foundational to Lexical rich-text, only using a
+// custom QuoteNode is undesirable as it means every package would need to
+// be updated to work with the custom node. Instead we can use Lexical's node
+// override/replacement mechanism to extend the default with our custom parsing
+// logic.
+//
+// https://lexical.dev/docs/concepts/serialization#handling-extended-html-styling
+
+export const extendedQuoteNodeReplacement = {replace: QuoteNode, with: () => new ExtendedQuoteNode()};
+
+export class ExtendedQuoteNode extends QuoteNode {
+    constructor(key) {
+        super(key);
+    }
+
+    static getType() {
+        return 'extended-quote';
+    }
+
+    static clone(node) {
+        return new ExtendedQuoteNode(node.__key);
+    }
+
+    static importDOM() {
+        const importers = QuoteNode.importDOM();
+        return {
+            ...importers,
+            blockquote: convertBlockquoteElement
+        };
+    }
+
+    static importJSON(serializedNode) {
+        return QuoteNode.importJSON(serializedNode);
+    }
+
+    exportJSON() {
+        const json = super.exportJSON();
+        json.type = 'extended-quote';
+        return json;
+    }
+}
+
+function convertBlockquoteElement() {
+    return {
+        conversion: () => {
+            const node = new ExtendedQuoteNode();
+            return {
+                node,
+                after: (childNodes) => {
+                    // Blockquotes can have nested paragraphs. In our original mobiledoc
+                    // editor we parsed all of the nested paragraphs into a single blockquote
+                    // separating each paragraph with two line breaks. We replicate that
+                    // here so we don't have a breaking change in conversion behaviour.
+                    const newChildNodes = [];
+
+                    childNodes.forEach((child) => {
+                        if ($isParagraphNode(child)) {
+                            if (newChildNodes.length > 0) {
+                                newChildNodes.push($createLineBreakNode());
+                                newChildNodes.push($createLineBreakNode());
+                            }
+
+                            newChildNodes.push(...child.getChildren());
+                        } else {
+                            newChildNodes.push(child);
+                        }
+                    });
+
+                    return newChildNodes;
+                }
+            };
+        },
+        priority: 1
+    };
+}

--- a/packages/kg-html-to-lexical/test/html-to-lexical.test.ts
+++ b/packages/kg-html-to-lexical/test/html-to-lexical.test.ts
@@ -351,9 +351,32 @@ describe('HTMLtoLexical', function () {
 
             assert.ok(lexical.root);
             assert.equal(lexical.root.children.length, 1);
-            assert.equal(lexical.root.children[0].type, 'quote');
+            assert.equal(lexical.root.children[0].type, 'extended-quote');
             assert.equal(lexical.root.children[0].children.length, 1);
             assert.equal(lexical.root.children[0].children[0].text, 'Hello World');
+        });
+
+        it('can convert blockquote with nested paragraph', function () {
+            const lexical = converter.htmlToLexical('<blockquote><p>Hello World</p></blockquote>', editorConfig);
+
+            assert.ok(lexical.root);
+            assert.equal(lexical.root.children.length, 1);
+            assert.equal(lexical.root.children[0].type, 'extended-quote');
+            assert.equal(lexical.root.children[0].children.length, 1);
+            assert.equal(lexical.root.children[0].children[0].text, 'Hello World');
+        });
+
+        it('can convert blockquote with nested paragraphs (paragraphs separated by line breaks)', function () {
+            const lexical = converter.htmlToLexical('<blockquote><p>Hello</p><p>World</p></blockquote>', editorConfig);
+
+            assert.ok(lexical.root);
+            assert.equal(lexical.root.children.length, 1);
+            assert.equal(lexical.root.children[0].type, 'extended-quote');
+            assert.equal(lexical.root.children[0].children.length, 4);
+            assert.equal(lexical.root.children[0].children[0].text, 'Hello');
+            assert.equal(lexical.root.children[0].children[1].type, 'linebreak');
+            assert.equal(lexical.root.children[0].children[2].type, 'linebreak');
+            assert.equal(lexical.root.children[0].children[3].text, 'World');
         });
     });
 
@@ -415,7 +438,7 @@ describe('HTMLtoLexical', function () {
 
             assert.ok(lexical.root);
             assert.equal(lexical.root.children.length, 1);
-            assert.equal(lexical.root.children[0].type, 'quote');
+            assert.equal(lexical.root.children[0].type, 'extended-quote');
             assert.equal(lexical.root.children[0].children.length, 1);
             assert.equal(lexical.root.children[0].children[0].text, 'Hello World');
         });

--- a/packages/kg-lexical-html-renderer/test/quotes.test.js
+++ b/packages/kg-lexical-html-renderer/test/quotes.test.js
@@ -1,7 +1,5 @@
 const {shouldRender} = require('./utils');
-const {AsideNode} = require('@tryghost/kg-default-nodes');
-
-const Renderer = require('../');
+const {AsideNode, ExtendedQuoteNode} = require('@tryghost/kg-default-nodes');
 
 describe('Quotes', function () {
     it('quote', shouldRender({
@@ -9,12 +7,15 @@ describe('Quotes', function () {
         output: `<blockquote>Blockquote with <strong>formatting</strong></blockquote>`
     }));
 
-    it('big quote', async function () {
-        const editorState = `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Aside with ","type":"text","version":1},{"detail":0,"format":1,"mode":"normal","style":"","text":"formatting","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"aside","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`;
+    it('extended-quote', shouldRender({
+        options: {nodes: [ExtendedQuoteNode]},
+        input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Blockquote with ","type":"text","version":1},{"detail":0,"format":1,"mode":"normal","style":"","text":"formatting","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"extended-quote","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+        output: `<blockquote>Blockquote with <strong>formatting</strong></blockquote>`
+    }));
 
-        const renderer = new Renderer({nodes: [AsideNode]});
-        const html = await renderer.render(editorState);
-
-        html.should.eql(`<blockquote class="kg-blockquote-alt">Aside with <strong>formatting</strong></blockquote>`);
-    });
+    it('big quote', shouldRender({
+        options: {nodes: [AsideNode]},
+        input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Aside with ","type":"text","version":1},{"detail":0,"format":1,"mode":"normal","style":"","text":"formatting","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"aside","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+        output: `<blockquote class="kg-blockquote-alt">Aside with <strong>formatting</strong></blockquote>`
+    }));
 });

--- a/packages/koenig-lexical/src/nodes/DefaultNodes.js
+++ b/packages/koenig-lexical/src/nodes/DefaultNodes.js
@@ -1,7 +1,9 @@
 import {
     ExtendedHeadingNode,
+    ExtendedQuoteNode,
     ExtendedTextNode,
     extendedHeadingNodeReplacement,
+    extendedQuoteNodeReplacement,
     extendedTextNodeReplacement
 } from '@tryghost/kg-default-nodes';
 
@@ -36,6 +38,8 @@ const DEFAULT_NODES = [
     extendedTextNodeReplacement,
     ExtendedHeadingNode,
     extendedHeadingNodeReplacement,
+    ExtendedQuoteNode,
+    extendedQuoteNodeReplacement,
     HeadingNode,
     ListNode,
     ListItemNode,

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -1184,7 +1184,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                         const hasIndentedNode = nodes.some((node) => {
                             return node.getIndent && node.getIndent() > 0;
                         });
-                        
+
                         if (!hasIndentedNode) {
                             event.preventDefault();
                             cursorDidExitAtTop();


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/18844

The default `LexicalQuoteNode` DOM importer doesn't do anything with paragraph node children resulting in the nested paragraphs being parsed as top-level paragraphs rather than blockquote text. This is a deviation from our previous mobiledoc editor's HTML conversion and was resulting in imported content losing it's blockquote semantics.

- extended `LexicalQuoteNode` with an improved `importDOM()` method
  - after conversion we loop over the parsed children and extract paragraph children out into the top-level child list so the text contents end up being part of the blockquote
  - for multiple nested paragraphs we separate the text contents by two line breaks as blockquotes don't support element nodes as children and we don't want to render as two separate blockquotes
