### PR TITLE
Fixed image toolbar items order

### DIFF
--- a/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
@@ -256,15 +256,6 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, captionE
                         label="Replace"
                         onClick={() => openFileSelection({fileInputRef: toolbarFileInputRef})}
                     />
-                    <ToolbarMenuSeparator hide={!cardConfig.createSnippet} />
-                    <ToolbarMenuItem
-                        dataTestId="create-snippet"
-                        hide={!cardConfig.createSnippet}
-                        icon="snippet"
-                        isActive={false}
-                        label="Create snippet"
-                        onClick={() => setShowSnippetToolbar(true)}
-                    />
                     <ToolbarMenuSeparator hide={!isPinturaEnabled} />
                     <ToolbarMenuItem
                         hide={!isPinturaEnabled}
@@ -281,6 +272,15 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, captionE
                                 });
                             }
                         })}
+                    />
+                    <ToolbarMenuSeparator hide={!cardConfig.createSnippet} />
+                    <ToolbarMenuItem
+                        dataTestId="create-snippet"
+                        hide={!cardConfig.createSnippet}
+                        icon="snippet"
+                        isActive={false}
+                        label="Create snippet"
+                        onClick={() => setShowSnippetToolbar(true)}
                     />
                 </ToolbarMenu>
             </ActionToolbar>


### PR DESCRIPTION
No ref
- Switched around image editing and snippet icons, as snippet icon should always come last