### PR TITLE
🐛 Fixed video card thumbnail generation in Safari

### DIFF
--- a/packages/koenig-lexical/src/utils/extractVideoMetadata.js
+++ b/packages/koenig-lexical/src/utils/extractVideoMetadata.js
@@ -5,7 +5,6 @@ export default function extractVideoMetadata(file) {
         let duration, width, height;
 
         const video = document.createElement('video');
-        video.preload = 'metadata';
         video.muted = true;
         video.playsInline = true;
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4127

- using `video.preload = 'metadata'` in Safari was causing issues with Blob resources when populating the video element during thumbnail generation resulting in plain black thumbnails
