### PR TITLE
Changed z-index of selected card cardWrapper component

### DIFF
--- a/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
@@ -36,7 +36,7 @@ export const CardWrapper = React.forwardRef(({
 
     const className = [
         'relative border-transparent caret-grey-800',
-        isSelected ? 'z-10' : '', // ensure setting panels sit above other cards
+        isSelected ? 'z-20' : '', // ensure setting panels sit above other cards
         isSelected && !isDragging ? 'shadow-[0_0_0_2px] shadow-green' : '',
         !isSelected && !isDragging ? 'hover:shadow-[0_0_0_1px] hover:shadow-green' : '',
         CARD_WIDTH_CLASSES[cardWidth] || '',


### PR DESCRIPTION
Refs https://github.com/TryGhost/Ghost/issues/18754
- By doing so, we avoid the snippet menu appearing behind subsequent cards