### PR TITLE
🐛 Fixed renderer error when line break nodes follow text with multiple formats

### DIFF
--- a/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
+++ b/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
@@ -69,7 +69,10 @@ class TextContent {
                 const remainingNodes = this.nodes.slice(i + 1);
                 // avoid checking any nodes after a link node because those cause all formats to close
                 const nextLinkNodeIndex = remainingNodes.findIndex(n => $isLinkNode(n));
-                const remainingSortNodes = nextLinkNodeIndex === -1 ? remainingNodes : remainingNodes.slice(0, nextLinkNodeIndex);
+                let remainingSortNodes = nextLinkNodeIndex === -1 ? remainingNodes : remainingNodes.slice(0, nextLinkNodeIndex);
+
+                // ensure we're only working with text nodes as they're the only ones that can open/close formats
+                remainingSortNodes = remainingSortNodes.filter(n => $isTextNode(n));
 
                 formatsToOpen.sort((a, b) => {
                     const aIndex = remainingSortNodes.findIndex(n => n.hasFormat(a));

--- a/packages/kg-lexical-html-renderer/test/render.test.js
+++ b/packages/kg-lexical-html-renderer/test/render.test.js
@@ -58,6 +58,11 @@ describe('Special elements', function () {
         input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Test","type":"text","version":1},{"type":"linebreak","version":1},{"type":"linebreak","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"a link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"title":null,"url":"https://ghost.org"},{"detail":0,"format":0,"mode":"normal","style":"","text":" some text","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
         output: `<p>Test<br><br><a href="https://ghost.org">a link</a> some text</p>`
     }));
+
+    it('linebreaks after multiple formats', shouldRender ({
+        input: `{"root":{"children":[{"children":[{"detail":0,"format":3,"mode":"normal","style":"","text":"Test","type":"text","version":1},{"detail":0,"format":0,"mode":"normal","style":"","text":" test","type":"text","version":1},{"type":"linebreak","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+        output: `<p><strong><em>Test</em></strong> test<br></p>`
+    }));
 });
 
 describe('Unexpected input', function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4146

- when sorting nodes that follow a text node with formats we weren't taking into account line break or link nodes that don't have a `.hasFormat()` method causing an error when we hit one and returning blank render output
