### PR TITLE
🐛 Fixed highlight format not being rendered

### DIFF
--- a/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
+++ b/packages/kg-lexical-html-renderer/lib/utils/TextContent.js
@@ -8,7 +8,8 @@ const FORMAT_TAG_MAP = {
     underline: 'U',
     code: 'CODE',
     subscript: 'SUB',
-    superscript: 'SUP'
+    superscript: 'SUP',
+    highlight: 'MARK'
 };
 
 // Builds and renders text content, useful to ensure proper format tag opening/closing

--- a/packages/kg-lexical-html-renderer/test/text-formats.test.js
+++ b/packages/kg-lexical-html-renderer/test/text-formats.test.js
@@ -36,6 +36,11 @@ describe('Basic formats', function () {
         input: `{"root":{"children":[{"children":[{"detail":0,"format":64,"mode":"normal","style":"","text":"Superscript","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
         output: `<p><sup>Superscript</sup></p>`
     }));
+
+    it('highlight', shouldRender({
+        input: `{"root":{"children":[{"children":[{"detail":0,"format":128,"mode":"normal","style":"","text":"Highlight","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"highlight","indent":0,"type":"root","version":1}}`,
+        output: `<p><mark>Highlight</mark></p>`
+    }));
 });
 
 describe('Format combinations', function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4144

- our renderer was missing the highlight format in it's format tag map meaning highlights weren't being output despite being shown in the editor
