### PR TITLE
Updated code and strikethrough shortcuts

### DIFF
--- a/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
@@ -111,16 +111,6 @@ function useFloatingFormatToolbar(editor, anchorElem, isSnippetsEnabled, hiddenF
                         return true;
                     }
                 }
-                // ctrl/cmd shift K should format text as code
-                if (shiftKey && keyCode === 75 && (ctrlKey || metaKey)) {
-                    editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
-                    return true;
-                }
-                // ctrl/cmd alt U should strikethrough
-                if (altKey && keyCode === 85 && (ctrlKey || metaKey)) {
-                    editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough');
-                    return true;
-                }
                 return false;
             },
             COMMAND_PRIORITY_LOW

--- a/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {$getSelection, $isParagraphNode, $isRangeSelection, $isTextNode, COMMAND_PRIORITY_LOW, FORMAT_TEXT_COMMAND, KEY_MODIFIER_COMMAND} from 'lexical';
+import {$getSelection, $isParagraphNode, $isRangeSelection, $isTextNode, COMMAND_PRIORITY_LOW, KEY_MODIFIER_COMMAND} from 'lexical';
 import {$getSelectionRangeRect} from '../utils/$getSelectionRangeRect';
 import {$isLinkNode} from '@lexical/link';
 import {FloatingFormatToolbar, toolbarItemTypes} from '../components/ui/FloatingFormatToolbar';
@@ -101,7 +101,7 @@ function useFloatingFormatToolbar(editor, anchorElem, isSnippetsEnabled, hiddenF
         editor.registerCommand(
             KEY_MODIFIER_COMMAND,
             (event) => {
-                const {keyCode, ctrlKey, metaKey, shiftKey, altKey} = event;
+                const {keyCode, ctrlKey, metaKey, shiftKey} = event;
                 // ctrl/cmd K with selected text should prompt for link insertion
                 if (!shiftKey && keyCode === 75 && (ctrlKey || metaKey)) {
                     const selection = $getSelection();

--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -792,7 +792,7 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
             editor.registerCommand(
                 KEY_MODIFIER_COMMAND,
                 (event) => {
-                    const {altKey, ctrlKey, metaKey, code, key} = event;
+                    const {altKey, ctrlKey, metaKey, shiftKey, code, key} = event;
                     const isArrowUp = key === 'ArrowUp' || event.keyCode === 38;
                     const isArrowDown = key === 'ArrowDown' || event.keyCode === 40;
 
@@ -855,12 +855,24 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
 
                     // Ctrl+Option+H to toggle highlight
                     if ((ctrlKey || metaKey) && altKey && code === 'KeyH') {
-                        // highlight
                         event.preventDefault();
                         editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'highlight');
                         return true;
                     }
 
+                    // ctrl shift K should format text as code
+                    if (ctrlKey && shiftKey && code === 'KeyK') {
+                        editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
+                        return true;
+                    }
+
+                    // ctrl alt U should strikethrough (cmd alt U launches the browser source view)
+                    if (ctrlKey && altKey && code === 'KeyU') {
+                        editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough');
+                        return true;
+                    }
+
+                    // ctrl alt 1-6 should create headings
                     if (ctrlKey && altKey && key.match(/^[1-6]$/)) {
                         event.preventDefault();
 

--- a/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
+++ b/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
@@ -94,7 +94,7 @@ test.describe('Editor keyboard shortcuts', async () => {
             </p>`);
         });
 
-        test('inline code', async function () {
+        test.only('inline code', async function () {
             await focusEditor(page);
 
             await page.keyboard.type('test');
@@ -106,7 +106,7 @@ test.describe('Editor keyboard shortcuts', async () => {
             await page.keyboard.press('ArrowLeft');
             await page.keyboard.up('Shift', {delay: 100});
 
-            await page.keyboard.press(`${ctrlOrCmdKey}+Shift+K`, {delay: 100});
+            await page.keyboard.press(`Control+Shift+K`, {delay: 100});
 
             await assertHTML(page, html`<p dir="ltr"><code spellcheck="false" data-lexical-text="true"><span>test</span></code></p>`);
         });

--- a/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
+++ b/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
@@ -94,7 +94,7 @@ test.describe('Editor keyboard shortcuts', async () => {
             </p>`);
         });
 
-        test.only('inline code', async function () {
+        test('inline code', async function () {
             await focusEditor(page);
 
             await page.keyboard.type('test');


### PR DESCRIPTION
refs TryGhost/Product#4160
- removed cmd shift k for code
- removed cmd alt u for strike
- these shortcuts were doubled up with os/browser behaviours
- moved shortcuts to koenigbehaviourplugin where they should be