### PR TITLE
🐛 Fixed broken gallery re-ordering

### DIFF
--- a/packages/koenig-lexical/src/hooks/useGalleryReorder.js
+++ b/packages/koenig-lexical/src/hooks/useGalleryReorder.js
@@ -201,7 +201,7 @@ export default function useGalleryReorder({images, updateImages, isSelected = fa
     React.useEffect(() => {
         const galleryElem = containerRef;
 
-        if (!galleryElem) {
+        if (!galleryElem || !koenig?.dragDropHandler) {
             return;
         }
 
@@ -232,7 +232,7 @@ export default function useGalleryReorder({images, updateImages, isSelected = fa
         // we want to be specific about when we want the drag/drop handler to
         // be set up or refreshed so we disable the exhaustive-deps rule here
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [containerRef, images]);
+    }, [containerRef, images, koenig.dragDropHandler]);
 
     return {setContainerRef, isDraggedOver};
 }


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4170

If something caused the `koenig` context to be torn down and re-created (e.g. a re-render higher in the component tree) then any gallery component's re-order effect was not re-registering its drag and drop container so re-ordering would cease to work.

- added the top-level drag-drop handler instance to the effect that registers the gallery re-order container so we don't lose containers on re-renders
- no tests because I was unable to find a way to initiate individual image drag from within galleries using Playwright, any drag would always initiate a whole-card drag rather than an image drag
