### PR TITLE
Added `TKPlugin` to exports

### DIFF
--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -15,6 +15,7 @@ import {
     KoenigComposer, KoenigEditor, MINIMAL_NODES, MINIMAL_TRANSFORMERS,
     MobiledocCopyPlugin,
     RestrictContentPlugin,
+    TKPlugin,
     WordCountPlugin
 } from '../src';
 import {defaultHeaders as defaultUnsplashHeaders} from './utils/unsplashConfig';
@@ -45,8 +46,7 @@ const cardConfig = {
     feature: {
         collections: true,
         collectionsCard: true,
-        emojiPicker: true,
-        tkReminders: true
+        emojiPicker: true
     },
     deprecated: {
         headerV1: process.env.NODE_ENV === 'test' ? false : true // show header v1 only for tests
@@ -104,6 +104,7 @@ function DemoEditor({editorType, registerAPI, cursorDidExitAtTop, darkMode, setW
         >
             <MobiledocCopyPlugin />
             <WordCountPlugin onChange={setWordCount} />
+            <TKPlugin />
         </KoenigEditor>
     );
 }

--- a/packages/koenig-lexical/src/index.js
+++ b/packages/koenig-lexical/src/index.js
@@ -30,6 +30,7 @@ import PlusCardMenuPlugin from './plugins/PlusCardMenuPlugin';
 import RestrictContentPlugin from './plugins/RestrictContentPlugin';
 import SignupPlugin from './plugins/SignupPlugin';
 import SlashCardMenuPlugin from './plugins/SlashCardMenuPlugin';
+import TKPlugin from './plugins/TKPlugin';
 import TogglePlugin from './plugins/TogglePlugin';
 import VideoPlugin from './plugins/VideoPlugin';
 import WordCountPlugin from './plugins/WordCountPlugin';
@@ -89,6 +90,7 @@ export {
     VideoPlugin,
     WordCountPlugin,
     CollectionPlugin,
+    TKPlugin,
 
     AllDefaultPlugins,
 

--- a/packages/koenig-lexical/src/plugins/AllDefaultPlugins.jsx
+++ b/packages/koenig-lexical/src/plugins/AllDefaultPlugins.jsx
@@ -25,7 +25,6 @@ import {SignupPlugin} from '../plugins/SignupPlugin';
 // import {TabIndentationPlugin} from '@lexical/react/LexicalTabIndentationPlugin';
 import KoenigComposerContext from '../context/KoenigComposerContext';
 import {EmojiPickerPlugin} from './EmojiPickerPlugin';
-import {TKPlugin} from '../plugins/TKPlugin';
 import {TogglePlugin} from '../plugins/TogglePlugin';
 import {VideoPlugin} from '../plugins/VideoPlugin';
 
@@ -68,8 +67,6 @@ export const AllDefaultPlugins = () => {
 
             {/* Snippet Plugins */}
             <KoenigSnippetPlugin />
-
-            {cardConfig.feature?.tkReminders ? <TKPlugin /> : null}
         </>
     );
 };

--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -5,7 +5,7 @@ import {useLexicalTextEntity} from '../hooks/useExtendedTextEntity';
 
 const REGEX = new RegExp(/(?<!\w)TK(?!\w)/);
 
-export function TKPlugin() {
+export default function TKPlugin() {
     const [editor] = useLexicalComposerContext();
 
     useEffect(() => {


### PR DESCRIPTION
refs TryGhost/Product#4172
- removed feature toggle as plugin is removed from the default plugins
- plugin needs to be used when loading the composer like WordCountPlugin