### PR TITLE
Added detection & indicator for TKs

### DIFF
--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -1,4 +1,5 @@
 import {$createTKNode, TKNode} from '@tryghost/kg-default-nodes';
+import {$getNodeByKey, $getRoot, $isElementNode, $isTextNode} from 'lexical';
 import {useCallback, useEffect} from 'react';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalTextEntity} from '../hooks/useExtendedTextEntity';
@@ -13,6 +14,98 @@ export default function TKPlugin() {
             throw new Error('TKPlugin: TKNode not registered on editor');
         }
     }, [editor]);
+
+    // get the first TK node for each direct child of the root element
+    const getTKNodesForIndicators = useCallback((editorState) => {
+        let foundNodes = [];
+        if (!editorState) {
+            return foundNodes;
+        }
+        editorState.read(() => {
+            const root = $getRoot();
+            const children = root.getChildren();
+            // need to loop over all leaf nodes and check if they are TKNodes
+
+            // TODO: right now doesn't handle children of children of children (e.g. list > listitem > text, or list > listitem > list > listitem > text)
+            for (let child of children) {
+                if ($isElementNode(child)) {
+                    // need to export children
+                    const childChildren = child.getChildren();
+                    for (let childChild of childChildren) {
+                        if (childChild instanceof TKNode) {
+                            foundNodes.push(childChild);
+                            break; // only need to find one child per parent element
+                        }
+                    }
+                } else if ($isTextNode(child)) {
+                    if (child.getType instanceof TKNode) {
+                        foundNodes.push(child);
+                    }
+                }
+            }
+        });
+        return foundNodes;
+    }, []);
+
+    // TODO: may be some competition with the listener for clicking outside the editor since clicking on the indicator sometimes focuses the document body
+    const indicatorOnClick = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        editor.update(() => {
+            const node = $getNodeByKey(e.target.dataset.key);
+            node.select(0,0);
+        });
+    };
+
+    const renderIndicators = useCallback((tkNodes) => {
+        // clean up existing indicators
+        document.body.querySelectorAll('.tk-indicator').forEach((el) => {
+            el.remove(); 
+        });
+
+        // add indicators to the dom
+        tkNodes.forEach((node) => {
+            const element = editor.getElementByKey(node.getKey());
+            const editorParent = editor.getRootElement().parentElement;
+            const editorParentTop = editorParent.getBoundingClientRect().top;
+            const tkParentTop = element.parentElement.getBoundingClientRect().top;
+            const editorWidth = editorParent.offsetWidth;
+
+            // create an element
+            const indicator = document.createElement('div');
+            indicator.style.position = 'absolute';
+            indicator.style.left = `${editorWidth + 10}px`;
+            indicator.style.top = `${tkParentTop - editorParentTop}px`;
+            indicator.style.marginTop = '3px';
+            indicator.textContent = 'TK';
+            indicator.classList.add('tk-indicator');
+            indicator.dataset.key = node.getKey();
+
+            indicator.onclick = indicatorOnClick;
+
+            // add to the editor parent (adding to editor triggers an infinite loop)
+            editorParent.appendChild(indicator);
+        });
+    }, [editor]);
+
+    // run once on mount and then let the editor state listener handle updates
+    useEffect(() => {
+        const foundNodes = getTKNodesForIndicators(editor.getEditorState());
+        renderIndicators(foundNodes);
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+    }, []);
+
+    // update TKs on editor state updates
+    useEffect(() => {
+        const removeListener = editor.registerUpdateListener(({editorState}) => {
+            const foundNodes = getTKNodesForIndicators(editorState);
+            renderIndicators(foundNodes);
+        });
+
+        return () => {
+            removeListener();
+        };
+    }, [editor, renderIndicators, getTKNodesForIndicators]);
 
     const createTKNode = useCallback((textNode) => {
         return $createTKNode(textNode.getTextContent());

--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -54,7 +54,7 @@ export default function TKPlugin() {
         e.stopPropagation();
         editor.update(() => {
             const node = $getNodeByKey(e.target.dataset.key);
-            node.select(0,0);
+            node.select(0, node.getTextContentSize());
         });
     };
 
@@ -73,6 +73,7 @@ export default function TKPlugin() {
             const editorWidth = editorParent.offsetWidth;
 
             // create an element
+            // TODO: styles can migrated to use tailwind/themes
             const indicator = document.createElement('div');
             indicator.style.position = 'absolute';
             indicator.style.left = `${editorWidth + 10}px`;


### PR DESCRIPTION
refs TryGhost/Product#4173
- added `TKNode` detection
- added indicator to right side of editor for any TK node present in the first child of the root node
- doesn't work for nested nodes or decorators at the moment
- clicking the indicator will focus the first TK in the respective parent