### PR TITLE
🐛 Fixed handling of root with empty children

### DIFF
--- a/packages/kg-html-to-lexical/src/html-to-lexical.ts
+++ b/packages/kg-html-to-lexical/src/html-to-lexical.ts
@@ -1,5 +1,5 @@
 /* eslint-disable ghost/filenames/match-exported-class */
-import {$createParagraphNode, $getRoot, $getSelection, CreateEditorArgs, type SerializedEditorState} from 'lexical';
+import {$createParagraphNode, $getRoot, CreateEditorArgs, SerializedParagraphNode, type SerializedEditorState} from 'lexical';
 import {createHeadlessEditor} from '@lexical/headless';
 import {$generateNodesFromDOM} from '@lexical/html';
 import {$insertGeneratedNodes} from '@lexical/clipboard';
@@ -9,6 +9,26 @@ import {LinkNode} from '@lexical/link';
 import {DEFAULT_NODES} from '@tryghost/kg-default-nodes';
 import {JSDOM} from 'jsdom';
 import {registerDefaultTransforms} from '@tryghost/kg-default-transforms';
+
+const EMPTY_PARAGRAPH: SerializedParagraphNode = {
+    children: [],
+    direction: null,
+    format: '',
+    indent: 0,
+    type: 'paragraph',
+    version: 1
+};
+
+const BLANK_DOCUMENT: SerializedEditorState = {
+    root: {
+        children: [EMPTY_PARAGRAPH],
+        direction: null,
+        format: '',
+        indent: 0,
+        type: 'root',
+        version: 1
+    }
+};
 
 export interface htmlToLexicalOptions {
     editorConfig: CreateEditorArgs
@@ -27,6 +47,10 @@ const defaultNodes = [
 ];
 
 export function htmlToLexical(html: string, options?: htmlToLexicalOptions): SerializedEditorState {
+    if (!html) {
+        return BLANK_DOCUMENT;
+    }
+
     const defaultEditorConfig = {
         nodes: defaultNodes
     };

--- a/packages/kg-html-to-lexical/test/html-to-lexical.test.ts
+++ b/packages/kg-html-to-lexical/test/html-to-lexical.test.ts
@@ -18,7 +18,36 @@ describe('HTMLtoLexical', function () {
 
             assert.deepEqual(lexical, {
                 root: {
-                    children: [],
+                    children: [{
+                        children: [],
+                        direction: null,
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            });
+        });
+
+        it('can convert null document', function () {
+            const lexical = converter.htmlToLexical(null, editorConfig);
+
+            assert.deepEqual(lexical, {
+                root: {
+                    children: [{
+                        children: [],
+                        direction: null,
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }],
                     direction: null,
                     format: '',
                     indent: 0,
@@ -563,8 +592,8 @@ describe('HTMLtoLexical', function () {
                     <h4 class="kg-toggle-heading-text">
                         <span style="white-space: pre-wrap">toggle header</span>
                     </h4>
-                    <button 
-                        class="kg-toggle-card-icon" 
+                    <button
+                        class="kg-toggle-card-icon"
                         aria-label="Expand toggle to read content"
                     >
                         <svg

--- a/packages/koenig-lexical/src/components/KoenigComposer.jsx
+++ b/packages/koenig-lexical/src/components/KoenigComposer.jsx
@@ -35,9 +35,31 @@ const KoenigComposer = ({
     children
 }) => {
     const initialConfig = React.useMemo(() => {
+        let editorState = initialEditorState;
+
+        // root needs to have at least one paragraph node for the editor to work
+        if (editorState) {
+            if (typeof editorState === 'string') {
+                editorState = JSON.parse(editorState);
+            }
+
+            if (editorState.root?.children?.length === 0) {
+                editorState.root.children.push({
+                    children: [],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'paragraph',
+                    version: 1
+                });
+            }
+
+            editorState = JSON.stringify(editorState);
+        }
+
         return Object.assign({}, defaultConfig, {
             nodes,
-            editorState: enableMultiplayer ? null : initialEditorState,
+            editorState: enableMultiplayer ? null : editorState,
             onError
         });
     }, [enableMultiplayer, initialEditorState, nodes, onError]);


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4179

Lexical doesn't handle an empty root node in it's initial editor state but our html->lexical library was creating that state when parsing a blank document.

- added escape hatch to `koenig-lexical` to insert an empty paragraph to the initial editor state when the root is empty (allows existing bad state content to be opened)
- fixed `kg-html-to-lexical` so it generates a valid state when given a blank document
