### PR TITLE
Added cycle through multiple TK nodes when clicking indicator

### DIFF
--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -1,5 +1,5 @@
-import {$createTKNode, TKNode} from '@tryghost/kg-default-nodes';
-import {$getNodeByKey, $nodesOfType} from 'lexical';
+import {$createTKNode, $isTKNode, TKNode} from '@tryghost/kg-default-nodes';
+import {$getNodeByKey, $getSelection, $isRangeSelection, $nodesOfType} from 'lexical';
 import {useCallback, useEffect, useLayoutEffect, useState} from 'react';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalTextEntity} from '../hooks/useExtendedTextEntity';
@@ -32,24 +32,44 @@ export default function TKPlugin({setTkCount = () => {}}) {
     }, []);
 
     // TODO: may be some competition with the listener for clicking outside the editor since clicking on the indicator sometimes focuses the document body
-    const indicatorOnClick = (e) => {
+    const indicatorOnClick = useCallback((e) => {
         e.preventDefault();
         e.stopPropagation();
         editor.update(() => {
-            const node = $getNodeByKey(e.target.dataset.key);
+            const tkNodeKeys = JSON.parse(e.target.dataset.keys);
+            let nodeKeyToSelect = tkNodeKeys[0];
+
+            // if there is a selection, and it is a TK node, select the next one
+            const selection = $getSelection();
+            if ($isRangeSelection(selection) && $isTKNode(selection.getNodes()[0])) {
+                const selectedIndex = tkNodeKeys.indexOf(selection.getNodes()[0].getKey());
+                if (selectedIndex === tkNodeKeys.length - 1) {
+                    nodeKeyToSelect = tkNodeKeys[0];
+                } else {
+                    nodeKeyToSelect = tkNodeKeys[selectedIndex + 1];
+                }
+            }
+
+            const node = $getNodeByKey(nodeKeyToSelect);
             node.select(0, node.getTextContentSize());
         });
-    };
+    }, [editor]);
 
-    const indicatorOnMouseEnter = (e) => {
+    const indicatorOnMouseEnter = useCallback((e) => {
         const classes = editor._config.theme.tkHighlighted?.split(' ') || [];
-        editor.getElementByKey(e.target.dataset.key).classList.add(classes);
-    };
+        const keys = JSON.parse(e.target.dataset.keys);
+        keys.forEach((key) => {
+            editor.getElementByKey(key).classList.add(...classes);
+        });
+    }, [editor]);
 
-    const indicatorOnMouseLeave = (e) => {
+    const indicatorOnMouseLeave = useCallback((e) => {
         const classes = editor._config.theme.tkHighlighted?.split(' ') || [];
-        editor.getElementByKey(e.target.dataset.key).classList.remove(classes);
-    };
+        const keys = JSON.parse(e.target.dataset.keys);
+        keys.forEach((key) => {
+            editor.getElementByKey(key).classList.remove(...classes);
+        });
+    }, [editor]);
 
     const renderIndicators = useCallback((nodes) => {
         // clean up existing indicators
@@ -57,39 +77,47 @@ export default function TKPlugin({setTkCount = () => {}}) {
             el.remove();
         });
 
-        // pull only the first child for each parent for the indicator as this is what we link to on click
-        const parentKeys = new Set();
-        const firstTks = nodes.filter((node) => {
-            if (parentKeys.has(node.__parent)) {
-                return false;
-            }
-            parentKeys.add(node.__parent);
-            return true;
-        });
+        const tkIndicators = {};
 
         // add indicators to the dom
-        firstTks.forEach((node) => {
-            const element = editor.getElementByKey(node.getKey());
-            const editorParent = editor.getRootElement().parentElement;
-            const editorParentTop = editorParent.getBoundingClientRect().top;
-            const tkParentTop = element.parentElement.getBoundingClientRect().top;
+        editor.getEditorState().read(() => {
+            nodes.forEach((node) => {
+                const parentKey = node.getParent().getKey();
 
-            // create an element
-            const indicator = document.createElement('div');
-            indicator.style.top = `${tkParentTop - editorParentTop + 4}px`;
-            indicator.textContent = 'TK';
-            indicator.classList.add('absolute', '-right-14', 'p-1', 'text-xs', 'text-grey-600', 'font-medium', 'cursor-pointer');
-            indicator.dataset.hasTk = true;
-            indicator.dataset.key = node.getKey();
+                if (tkIndicators[parentKey]) {
+                    const keys = JSON.parse(tkIndicators[parentKey].dataset.keys);
+                    keys.push(node.getKey());
+                    tkIndicators[parentKey].dataset.keys = JSON.stringify(keys);
+                    tkIndicators[parentKey].dataset.count = keys.length;
+                    tkIndicators[parentKey].textContent = `TK ● ${keys.length}`;
+                    return;
+                }
 
-            indicator.onclick = indicatorOnClick;
-            indicator.onmouseenter = indicatorOnMouseEnter;
-            indicator.onmouseleave = indicatorOnMouseLeave;
+                const element = editor.getElementByKey(node.getKey());
+                const editorParent = editor.getRootElement().parentElement;
+                const editorParentTop = editorParent.getBoundingClientRect().top;
+                const tkParentTop = element.parentElement.getBoundingClientRect().top;
 
-            // add to the editor parent (adding to editor triggers an infinite loop)
-            editorParent.appendChild(indicator);
+                // create an element
+                const indicator = document.createElement('div');
+                indicator.style.top = `${tkParentTop - editorParentTop + 4}px`;
+                indicator.textContent = 'TK';
+                indicator.classList.add('absolute', '-right-14', 'p-1', 'text-xs', 'text-grey-600', 'font-medium', 'cursor-pointer');
+                indicator.dataset.hasTk = true;
+                indicator.dataset.keys = JSON.stringify([node.getKey()]);
+                indicator.dataset.count = 1;
+
+                indicator.onclick = indicatorOnClick;
+                indicator.onmouseenter = indicatorOnMouseEnter;
+                indicator.onmouseleave = indicatorOnMouseLeave;
+
+                // add to the editor parent (adding to editor triggers an infinite loop)
+                editorParent.appendChild(indicator);
+
+                tkIndicators[parentKey] = indicator;
+            });
         });
-    }, [editor]);
+    }, [editor, indicatorOnClick, indicatorOnMouseEnter, indicatorOnMouseLeave]);
 
     // run once on mount and then let the editor state listener handle updates
     useLayoutEffect(() => {


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/4190

- switched to storing an array of TK node keys in the indicator dataset
- updated the indicator hover and click event handlers to work with multiple TK nodes within a paragraph
- added a count to the TK indicator to show how many TK nodes exist within a paragraph
