### PR TITLE
Fixed positioning of TK indicators when elements within document change size

### DIFF
--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -1,10 +1,100 @@
 import {$createTKNode, $isTKNode, TKNode} from '@tryghost/kg-default-nodes';
 import {$getNodeByKey, $getSelection, $isRangeSelection, $nodesOfType} from 'lexical';
+import {createPortal} from 'react-dom';
 import {useCallback, useEffect, useLayoutEffect, useState} from 'react';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalTextEntity} from '../hooks/useExtendedTextEntity';
 
 const REGEX = new RegExp(/(^|.)([^a-zA-Z0-9\s]?(TK)+[^a-zA-Z0-9\s]?)($|.)/);
+
+function TKIndicator({editor, rootElement, containingElement, nodeKeys}) {
+    const tkClasses = editor._config.theme.tk?.split(' ') || [];
+    const tkHighlightClasses = editor._config.theme.tkHighlighted?.split(' ') || [];
+
+    // position element relative to the TK Node containing element
+    const calculateTop = useCallback(() => {
+        const rootElementRect = rootElement.getBoundingClientRect();
+        const containerElementRect = containingElement.getBoundingClientRect();
+
+        return containerElementRect.top - rootElementRect.top + 4;
+    }, [rootElement, containingElement]);
+
+    const [top, setTop] = useState(calculateTop());
+
+    // select the TK node when the indicator is clicked,
+    // cycle selection through associated TK nodes when clicked multiple times
+    // TODO: may be some competition with the listener for clicking outside the editor since clicking on the indicator sometimes focuses the document body
+    const onClick = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        editor.update(() => {
+            let nodeKeyToSelect = nodeKeys[0];
+
+            // if there is a selection, and it is a TK node, select the next one
+            const selection = $getSelection();
+            if ($isRangeSelection(selection) && $isTKNode(selection.getNodes()[0])) {
+                const selectedIndex = nodeKeys.indexOf(selection.getNodes()[0].getKey());
+                if (selectedIndex === nodeKeys.length - 1) {
+                    nodeKeyToSelect = nodeKeys[0];
+                } else {
+                    nodeKeyToSelect = nodeKeys[selectedIndex + 1];
+                }
+            }
+
+            const node = $getNodeByKey(nodeKeyToSelect);
+            node.select(0, node.getTextContentSize());
+        });
+    };
+
+    // highlight all associated TK nodes when the indicator is hovered
+    const onMouseEnter = (e) => {
+        nodeKeys.forEach((key) => {
+            editor.getElementByKey(key).classList.remove(...tkClasses);
+            editor.getElementByKey(key).classList.add(...tkHighlightClasses);
+        });
+    };
+
+    const onMouseLeave = (e) => {
+        nodeKeys.forEach((key) => {
+            editor.getElementByKey(key).classList.add(...tkClasses);
+            editor.getElementByKey(key).classList.remove(...tkHighlightClasses);
+        });
+    };
+
+    // set up an observer to reposition the indicator when the TK node containing
+    // element moves relative to the root element
+    useEffect(() => {
+        const recalculateTop = () => {
+            setTop(calculateTop());
+        };
+
+        const rootObserver = new ResizeObserver(recalculateTop);
+        const containerObserver = new ResizeObserver(recalculateTop);
+
+        rootObserver.observe(rootElement);
+        containerObserver.observe(containingElement);
+
+        return () => {
+            rootObserver.disconnect();
+            containerObserver.disconnect();
+        };
+    }, [rootElement, containingElement, calculateTop]);
+
+    const style = {
+        top: `${top}px`
+    };
+
+    return (
+        <div
+            className="absolute -right-14 cursor-pointer p-1 text-xs font-medium text-grey-600"
+            style={style}
+            onClick={onClick}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+        >TK</div>
+    );
+}
 
 export default function TKPlugin({onCountChange = () => {}}) {
     const [editor] = useLexicalComposerContext();
@@ -31,142 +121,25 @@ export default function TKPlugin({onCountChange = () => {}}) {
         return foundNodes;
     }, []);
 
-    // TODO: may be some competition with the listener for clicking outside the editor since clicking on the indicator sometimes focuses the document body
-    const indicatorOnClick = useCallback((e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        editor.update(() => {
-            const tkNodeKeys = JSON.parse(e.target.dataset.keys);
-            let nodeKeyToSelect = tkNodeKeys[0];
-
-            // if there is a selection, and it is a TK node, select the next one
-            const selection = $getSelection();
-            if ($isRangeSelection(selection) && $isTKNode(selection.getNodes()[0])) {
-                const selectedIndex = tkNodeKeys.indexOf(selection.getNodes()[0].getKey());
-                if (selectedIndex === tkNodeKeys.length - 1) {
-                    nodeKeyToSelect = tkNodeKeys[0];
-                } else {
-                    nodeKeyToSelect = tkNodeKeys[selectedIndex + 1];
-                }
-            }
-
-            const node = $getNodeByKey(nodeKeyToSelect);
-            node.select(0, node.getTextContentSize());
-        });
-    }, [editor]);
-
-    const indicatorOnMouseEnter = useCallback((e) => {
-        const standardClasses = editor._config.theme.tk?.split(' ') || [];
-        const highlightClasses = editor._config.theme.tkHighlighted?.split(' ') || [];
-
-        const keys = JSON.parse(e.target.dataset.keys);
-        keys.forEach((key) => {
-            editor.getElementByKey(key).classList.remove(...standardClasses);
-            editor.getElementByKey(key).classList.add(...highlightClasses);
-        });
-    }, [editor]);
-
-    const indicatorOnMouseLeave = useCallback((e) => {
-        const standardClasses = editor._config.theme.tk?.split(' ') || [];
-        const highlightClasses = editor._config.theme.tkHighlighted?.split(' ') || [];
-
-        const keys = JSON.parse(e.target.dataset.keys);
-        keys.forEach((key) => {
-            editor.getElementByKey(key).classList.add(...standardClasses);
-            editor.getElementByKey(key).classList.remove(...highlightClasses);
-        });
-    }, [editor]);
-
-    const positionIndicators = useCallback(() => {
-        const indicators = document.body.querySelectorAll('[data-has-tk]');
-        const editorParent = editor.getRootElement().parentElement;
-        const editorParentTop = editorParent.getBoundingClientRect().top;
-
-        indicators.forEach((indicator) => {
-            const parentKey = indicator.dataset.parentKey;
-            const element = editor.getElementByKey(parentKey);
-            const elementTop = element.getBoundingClientRect().top;
-            indicator.style.top = `${elementTop - editorParentTop + 4}px`;
-        });
-    }, [editor]);
-
-    const renderIndicators = useCallback((nodes) => {
-        // clean up existing indicators
-        document.body.querySelectorAll('[data-has-tk]').forEach((el) => {
-            el.remove();
-        });
-
-        const tkIndicators = {};
-
-        // add indicators to the dom
-        editor.getEditorState().read(() => {
-            nodes.forEach((node) => {
-                const parentKey = node.getParent().getKey();
-
-                // prevents duplication
-                //  adds count and key to existing indicator
-                if (tkIndicators[parentKey]) {
-                    const keys = JSON.parse(tkIndicators[parentKey].dataset.keys);
-                    keys.push(node.getKey());
-                    tkIndicators[parentKey].dataset.keys = JSON.stringify(keys);
-                    tkIndicators[parentKey].dataset.count = keys.length;
-                    tkIndicators[parentKey].textContent = `TK ● ${keys.length}`;
-                    return;
-                }
-
-                const editorParent = editor.getRootElement().parentElement;
-
-                // create the indicator element
-                const indicator = document.createElement('div');
-                indicator.textContent = 'TK';
-                indicator.classList.add('absolute', '-right-14', 'p-1', 'text-xs', 'text-grey-600', 'font-medium', 'cursor-pointer');
-                indicator.dataset.hasTk = true;
-                indicator.dataset.keys = JSON.stringify([node.getKey()]);
-                indicator.dataset.count = 1;
-                indicator.dataset.parentKey = parentKey;
-
-                indicator.onclick = indicatorOnClick;
-                indicator.onmouseenter = indicatorOnMouseEnter;
-                indicator.onmouseleave = indicatorOnMouseLeave;
-
-                // add to the editor parent (adding to editor triggers an infinite loop)
-                editorParent.appendChild(indicator);
-
-                tkIndicators[parentKey] = indicator;
-
-                positionIndicators();
-            });
-        });
-    }, [editor, indicatorOnClick, indicatorOnMouseEnter, indicatorOnMouseLeave, positionIndicators]);
-
     // run once on mount and then let the editor state listener handle updates
     useLayoutEffect(() => {
         const nodes = getTKNodesForIndicators(editor.getEditorState());
         setTkNodes(nodes);
         onCountChange(nodes.length);
-        renderIndicators(nodes);
-    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+        /* eslint-disable-next-line react-hooks/exhaustive-deps */
     }, []);
 
     // update TKs on editor state updates
     useEffect(() => {
-        const removeListener = editor.registerUpdateListener(({editorState}) => {
+        return editor.registerUpdateListener(({editorState}) => {
             const foundNodes = getTKNodesForIndicators(editorState);
             // this is a simple way to check that the nodes actually changed before we re-render indicators on the dom
             if (JSON.stringify(foundNodes) !== JSON.stringify(tkNodes)) {
                 setTkNodes(foundNodes);
                 onCountChange(foundNodes.length);
-                renderIndicators(foundNodes);
-            } else {
-                // we should always reposition on changes like selection changes
-                positionIndicators();
             }
         });
-
-        return () => {
-            removeListener();
-        };
-    }, [editor, renderIndicators, getTKNodesForIndicators, setTkNodes, tkNodes, onCountChange, positionIndicators]);
+    }, [editor, getTKNodesForIndicators, setTkNodes, tkNodes, onCountChange]);
 
     const createTKNode = useCallback((textNode) => {
         return $createTKNode(textNode.getTextContent());
@@ -207,5 +180,46 @@ export default function TKPlugin({onCountChange = () => {}}) {
         createTKNode,
     );
 
-    return null;
+    const editorRoot = editor.getRootElement();
+    const editorRootParent = editor.getRootElement()?.parentElement;
+
+    if (!editorRootParent) {
+        return null;
+    }
+
+    const tkParentNodesMap = {};
+
+    if (tkNodes.length > 0) {
+        editor.getEditorState().read(() => {
+            tkNodes.forEach((tkNode) => {
+                const parentKey = tkNode.getParent().getKey();
+
+                // prevent duplication, add node keys to existing indicator
+                // for nodes that are contained in the same parent
+                if (tkParentNodesMap[parentKey]) {
+                    tkParentNodesMap[parentKey].push(tkNode.getKey());
+                    return;
+                }
+
+                tkParentNodesMap[parentKey] = [tkNode.getKey()];
+            });
+        });
+    }
+
+    const TKIndicators = Object.entries(tkParentNodesMap).map(([parentKey, nodeKeys]) => {
+        return (
+            <TKIndicator
+                key={parentKey}
+                containingElement={editor.getElementByKey(parentKey)}
+                editor={editor}
+                nodeKeys={nodeKeys}
+                rootElement={editorRoot}
+            />
+        );
+    });
+
+    return createPortal(
+        Object.values(TKIndicators),
+        editorRootParent
+    );
 }

--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -82,6 +82,7 @@ function TKIndicator({editor, rootElement, containingElement, nodeKeys}) {
     return (
         <div
             className="absolute -right-14 cursor-pointer p-1 text-xs font-medium text-grey-600"
+            data-testid="tk-indicator"
             style={style}
             onClick={onClick}
             onMouseEnter={onMouseEnter}

--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -65,19 +65,13 @@ function TKIndicator({editor, rootElement, containingElement, nodeKeys}) {
     // set up an observer to reposition the indicator when the TK node containing
     // element moves relative to the root element
     useEffect(() => {
-        const recalculateTop = () => {
-            setTop(calculateTop());
-        };
+        const observer = new ResizeObserver(() => (setTop(calculateTop())));
 
-        const rootObserver = new ResizeObserver(recalculateTop);
-        const containerObserver = new ResizeObserver(recalculateTop);
-
-        rootObserver.observe(rootElement);
-        containerObserver.observe(containingElement);
+        observer.observe(rootElement);
+        observer.observe(containingElement);
 
         return () => {
-            rootObserver.disconnect();
-            containerObserver.disconnect();
+            observer.disconnect();
         };
     }, [rootElement, containingElement, calculateTop]);
 

--- a/packages/koenig-lexical/test/e2e/plugins/TKPlugin.test.js
+++ b/packages/koenig-lexical/test/e2e/plugins/TKPlugin.test.js
@@ -43,9 +43,9 @@ test.describe('TK Plugin', async function () {
 
         test('changes highlight when TK indicator is hovered', async function () {
             await focusEditor(page);
-            
+
             await page.keyboard.type('TK');
-            await page.locator('[data-has-tk]').hover();
+            await page.getByTestId('tk-indicator').hover();
 
             await expect(await page.getByRole('paragraph').getByText('TK')).toHaveClass('bg-lime-500 dark:bg-lime-800');
         });
@@ -56,7 +56,7 @@ test.describe('TK Plugin', async function () {
             await focusEditor(page);
 
             await page.keyboard.type('TK and TK and TK');
-            await expect(await page.locator('[data-has-tk]')).toBeVisible();
+            await expect(await page.getByTestId('tk-indicator')).toBeVisible();
         });
 
         test('creates a TK indicator for each parent element with a TK', async function () {
@@ -68,14 +68,7 @@ test.describe('TK Plugin', async function () {
             await page.keyboard.press('Enter');
             await page.keyboard.type('TK and some text');
 
-            await expect(await page.locator('[data-has-tk]').all()).toHaveLength(3);
-        });
-
-        test('carries a count for multiple TK nodes in a given parent element', async function () {
-            await focusEditor(page);
-
-            await page.keyboard.type('TK and TK and TK');
-            await expect(await page.locator('[data-has-tk]')).toHaveAttribute('data-count', '3');
+            await expect(await page.getByTestId('tk-indicator').all()).toHaveLength(3);
         });
 
         test('clicking the indicator selects the first TK node in the parent', async function () {
@@ -87,7 +80,7 @@ test.describe('TK Plugin', async function () {
                 expect(selection).toEqual('');
             });
 
-            await page.locator('[data-has-tk]').click();
+            await page.getByTestId('tk-indicator').click();
 
             await page.evaluate(() => window.getSelection().toString()).then((selection) => {
                 expect(selection).toEqual('TK');
@@ -98,7 +91,7 @@ test.describe('TK Plugin', async function () {
             await focusEditor(page);
 
             await page.keyboard.type('TK and TK and TK');
-            await page.locator('[data-has-tk]').click();
+            await page.getByTestId('tk-indicator').click();
 
             // piece 2 in the array is the child node
             await assertSelection(page, {
@@ -108,7 +101,7 @@ test.describe('TK Plugin', async function () {
                 focusOffset: 2
             });
 
-            await page.locator('[data-has-tk]').click();
+            await page.getByTestId('tk-indicator').click();
 
             await assertSelection(page, {
                 anchorPath: [0, 2, 0],
@@ -117,7 +110,7 @@ test.describe('TK Plugin', async function () {
                 focusOffset: 2
             });
 
-            await page.locator('[data-has-tk]').click();
+            await page.getByTestId('tk-indicator').click();
 
             await assertSelection(page, {
                 anchorPath: [0, 4, 0],


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4204

- extracted `TKIndicator` component to handle positioning and mouse behaviour
  - added use of `ResizeObserver` to re-position the component when the document root or TK-containing elements change size, this covers the case where a card changes size when selected and the indicator needs repositioning
- updated rendering to generate a list of `TKIndicator` components derived from the `tkNodes` state, these are then rendered into the editor parent root via a React Portal instead of manually adding/removing using DOM
