### PR TITLE
Allowed multiple symbol characters to surround a TK

### DIFF
--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -5,7 +5,7 @@ import {useCallback, useEffect, useLayoutEffect, useState} from 'react';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useLexicalTextEntity} from '../hooks/useExtendedTextEntity';
 
-const REGEX = new RegExp(/(^|.)([^a-zA-Z0-9\s]?(TK)+[^a-zA-Z0-9\s]?)($|.)/);
+const REGEX = new RegExp(/(^|.)([^a-zA-Z0-9\s]*(TK)+[^a-zA-Z0-9\s]*)($|.)/);
 
 function TKIndicator({editor, rootElement, containingElement, nodeKeys}) {
     const tkClasses = editor._config.theme.tk?.split(' ') || [];
@@ -156,7 +156,7 @@ export default function TKPlugin({onCountChange = () => {}}) {
         // we also check any following char in code to avoid an overly
         // complex regex when looking for word-chars following the optional
         // trailing symbol char
-        if (matchArr[4] && !/\s/.test(matchArr[4])) {
+        if (matchArr[4] && /\w/.test(matchArr[4])) {
             return null;
         }
 

--- a/packages/koenig-lexical/test/e2e/plugins/TKPlugin.test.js
+++ b/packages/koenig-lexical/test/e2e/plugins/TKPlugin.test.js
@@ -25,6 +25,24 @@ test.describe('TK Plugin', async function () {
             await expect(await page.getByRole('paragraph').getByText('TK')).toHaveClass('bg-lime-300 dark:bg-lime-900');
         });
 
+        test('highlights a TK when surrounded by symbols', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('[TK],');
+            await expect(await page.getByRole('paragraph').getByText('[TK],')).toHaveClass('bg-lime-300 dark:bg-lime-900');
+        });
+
+        test('highlights a TK when TK is repeated', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('TKTK');
+            await expect(await page.getByRole('paragraph').getByText('TKTK')).toHaveClass('bg-lime-300 dark:bg-lime-900');
+        });
+
+        test('does not highlight TK when surrounded by letters', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('TKtest');
+            await expect(await page.getByRole('paragraph').getByText('TKtest')).not.toHaveClass('bg-lime-300 dark:bg-lime-900');
+        });
+
         test('highlights a TK node when TK is typed in a heading', async function () {
             await focusEditor(page);
 


### PR DESCRIPTION
no issue

- updated regex and trailing char test to allow multiple characters around a TK, e.g. `[[TK]],`
