### PR TITLE
Dropped support for Node 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
       matrix:
-        node: ['16.14.0', '18.12.1' ]
+        node: ['18.12.1' ]
     env:
       FORCE_COLOR: 1
       # https://github.com/vitejs/vite/issues/2433

--- a/packages/kg-card-factory/package.json
+++ b/packages/kg-card-factory/package.json
@@ -12,7 +12,7 @@
     "posttest": "yarn lint"
   },
   "engines": {
-    "node": "^14.18.0 || ^16.13.0 || ^18.12.1"
+    "node": "^18.12.1"
   },
   "files": [
     "index.js",

--- a/packages/kg-clean-basic-html/package.json
+++ b/packages/kg-clean-basic-html/package.json
@@ -17,7 +17,7 @@
     "posttest": "yarn lint"
   },
   "engines": {
-    "node": "^14.18.0 || ^16.13.0 || ^18.12.1"
+    "node": "^18.12.1"
   },
   "files": [
     "LICENSE",

--- a/packages/kg-default-atoms/package.json
+++ b/packages/kg-default-atoms/package.json
@@ -12,7 +12,7 @@
     "posttest": "yarn lint"
   },
   "engines": {
-    "node": "^14.18.0 || ^16.13.0 || ^18.12.1"
+    "node": "^18.12.1"
   },
   "files": [
     "index.js",

--- a/packages/kg-default-cards/package.json
+++ b/packages/kg-default-cards/package.json
@@ -12,7 +12,7 @@
     "posttest": "yarn lint"
   },
   "engines": {
-    "node": "^14.18.0 || ^16.13.0 || ^18.12.1"
+    "node": "^18.12.1"
   },
   "files": [
     "LICENSE",

--- a/packages/kg-markdown-html-renderer/package.json
+++ b/packages/kg-markdown-html-renderer/package.json
@@ -12,7 +12,7 @@
     "posttest": "yarn lint"
   },
   "engines": {
-    "node": "^14.18.0 || ^16.13.0 || ^18.12.1"
+    "node": "^18.12.1"
   },
   "files": [
     "index.js",

--- a/packages/kg-mobiledoc-html-renderer/package.json
+++ b/packages/kg-mobiledoc-html-renderer/package.json
@@ -12,7 +12,7 @@
     "posttest": "yarn lint"
   },
   "engines": {
-    "node": "^14.18.0 || ^16.13.0 || ^18.12.1"
+    "node": "^18.12.1"
   },
   "files": [
     "index.js",

--- a/packages/kg-parser-plugins/package.json
+++ b/packages/kg-parser-plugins/package.json
@@ -24,7 +24,7 @@
     "posttest": "yarn lint"
   },
   "engines": {
-    "node": "^14.18.0 || ^16.13.0 || ^18.12.1"
+    "node": "^18.12.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
no issue

- Node 16 is no longer in long-term-support and has been dropped by some of our dependencies
- Node 18 LTS is now the minimum supported version
- Removed Node 16 from our test matrix
