### PR TITLE
Switched to using mutationListener in TKPlugin

### DIFF
--- a/packages/koenig-lexical/src/context/TKContext.jsx
+++ b/packages/koenig-lexical/src/context/TKContext.jsx
@@ -1,56 +1,99 @@
 import React from 'react';
+import {throttle} from 'lodash';
 
 const Context = React.createContext({});
 
 export const TKContext = ({children}) => {
-    // {
-    //   editorKey: {
-    //     topLevelNodeKey: tkNodeKey, // key for containing node in primary editor
-    //     tkNodes: [tkNodeKey, tkNodeKey, ...]
-    //   },
-    // }
+    // Map(
+    //   editorKey: Map(
+    //     tkNodeKey: {topLevelNodeKey}
+    //   )
+    // )
     //
     // We store under the editor key because a top level node (i.e. a decorator)
     // may contain multiple nested editors and it's easier for the plugin in each
     // editor to only know about it's own nodes
-    const [editorTkNodeMap, setEditorTkNodeMap] = React.useState({});
+    const editorTkNodeMapRef = React.useRef(new Map());
 
-    const setEditorTkNodes = React.useCallback((editorKey, nodeMap) => {
-        if (nodeMap === undefined) {
-            const newEditorTkNodeMap = {...editorTkNodeMap};
-            delete newEditorTkNodeMap[editorKey];
-            setEditorTkNodeMap(newEditorTkNodeMap);
-        } else {
-            setEditorTkNodeMap({...editorTkNodeMap, [editorKey]: nodeMap});
+    // node map used in top-level editor to display indicators
+    const [tkNodeMap, setTkNodeMap] = React.useState({});
+    const [tkCount, setTkCount] = React.useState(0);
+
+    // throttled update function to update the top-level node map
+    //
+    // this is throttled because the add/remove functions are called many times
+    // in succession when the editor is opened or large blocks of TK-containing
+    // content is added/removed (e.g. delete and undo)
+    const updateTkNodeMap = React.useMemo(() => {
+        const updateFn = () => {
+            // derive a top-level tk node map to use for rendering indicators
+            const editorTkNodeMap = editorTkNodeMapRef.current;
+
+            const newTkNodeMap = {};
+            let newTkCount = 0;
+
+            editorTkNodeMap.forEach((nodeMap) => {
+                nodeMap.forEach(({topLevelNodeKey}, tkNodeKey) => {
+                    newTkCount = newTkCount + 1;
+
+                    if (newTkNodeMap[topLevelNodeKey] === undefined) {
+                        newTkNodeMap[topLevelNodeKey] = [tkNodeKey];
+                    } else {
+                        newTkNodeMap[topLevelNodeKey].push(tkNodeKey);
+                    }
+                });
+            });
+
+            setTkNodeMap(newTkNodeMap);
+            setTkCount(newTkCount);
+        };
+
+        return throttle(updateFn, 5, {trailing: true});
+    }, []);
+
+    const addEditorTkNode = React.useCallback((editorKey, topLevelNodeKey, tkNodeKey) => {
+        const editorTkNodeMap = editorTkNodeMapRef.current;
+
+        if (!editorTkNodeMap.has(editorKey)) {
+            editorTkNodeMap.set(editorKey, new Map());
         }
-    }, [editorTkNodeMap]);
+
+        editorTkNodeMap.get(editorKey).set(tkNodeKey, {topLevelNodeKey});
+
+        updateTkNodeMap();
+    }, [updateTkNodeMap]);
+
+    const removeEditorTkNode = React.useCallback((editorKey, tkNodeKey) => {
+        const editorTkNodeMap = editorTkNodeMapRef.current;
+
+        editorTkNodeMap.get(editorKey)?.delete(tkNodeKey);
+
+        if (editorTkNodeMap.get(editorKey)?.size === 0) {
+            editorTkNodeMap.delete(editorKey);
+        }
+
+        updateTkNodeMap();
+    }, [updateTkNodeMap]);
+
+    const removeEditor = React.useCallback((editorKey) => {
+        editorTkNodeMapRef.current.delete(editorKey);
+        updateTkNodeMap();
+    }, [updateTkNodeMap]);
 
     const contextValue = React.useMemo(() => {
-        // derive a top-level tk node map to use for rendering indicators
-        const tkNodeMap = {};
-        let tkCount = 0;
-
-        Object.entries(editorTkNodeMap).forEach(([editorKey, nodeMap]) => {
-            nodeMap.forEach(({topLevelNodeKey, tkNodeKeys}) => {
-                tkCount = tkCount + tkNodeKeys.length;
-
-                if (tkNodeMap[topLevelNodeKey] === undefined) {
-                    tkNodeMap[topLevelNodeKey] = [...tkNodeKeys];
-                } else {
-                    tkNodeMap[topLevelNodeKey].push(...tkNodeKeys);
-                }
-            });
-        });
-
         return {
             tkNodeMap,
             tkCount,
-            editorTkNodeMap,
-            setEditorTkNodes
+            addEditorTkNode,
+            removeEditorTkNode,
+            removeEditor
         };
     }, [
-        editorTkNodeMap,
-        setEditorTkNodes
+        tkNodeMap,
+        tkCount,
+        addEditorTkNode,
+        removeEditorTkNode,
+        removeEditor
     ]);
 
     return <Context.Provider value={contextValue}>{children}</Context.Provider>;


### PR DESCRIPTION
no issue

Using a Lexical `mutationListener` is more performant because we only run code when a TKNode is added/modified/removed rather than on every keystroke. It also lets us simplify the code a bit because we can deal with nodes one-by-one in the context object instead of fetching all of them in TKPlugin and manipulating into a map to then store in the context.

- updated `TKContext` to expose methods for managing TK nodes
  - `addEditorTkNode()` / `removeEditorTkNode()` to be called from within the mutation listener
  - `removeEditor()` to be called from an effect run when an editor is removed to perform cleanup (mutation listener doesn't fire in this case)
  - these methods modify a map that is stored in a ref rather than updating state directly because the methods will be called many times when initiating an editor containing TK nodes and React doesn't handle that well if state is updated each time. After modifying the ref'd map they call a debounced update method that generates the tkNode state used for rendering TK indicators
- updated `TKContext` to use a simpler map model
  - by keying by editor and tkNode keys it makes adding/removing nodes one-by-one a lot easier
- updated `TKPlugin` to use the new context methods
