### PR TITLE
Fix: video upload hangs on iOS Safari

### DIFF
--- a/packages/koenig-lexical/src/utils/extractVideoMetadata.js
+++ b/packages/koenig-lexical/src/utils/extractVideoMetadata.js
@@ -14,10 +14,11 @@ export default function extractVideoMetadata(file) {
             duration = video.duration;
             width = video.videoWidth;
             height = video.videoHeight;
+        };
 
-            setTimeout(() => {
-                video.currentTime = 0.5;
-            }, 200);
+        video.oncanplay = function () {
+            video.currentTime = 0.5;
+            video.oncanplay = null;
         };
 
         video.onseeked = function () {
@@ -42,5 +43,7 @@ export default function extractVideoMetadata(file) {
         };
 
         video.src = URL.createObjectURL(file);
+        // required for iPhone Safari to load the video contents for the thumbnail
+        video.load();
     });
 }


### PR DESCRIPTION
This PR addresses issue #1121.

The problem is that Safari on iOS does not seem to load the video content until `.load()` is called on the video object, so the Promise never resolves with the video metadata and thumbnail.

I haven't found where exactly this behavior is documented, but a search online reveals others have run into it before too. Anyway, the fix is simple: call `.load` after setting the video source. 

This commit also adds `oncanplay` to set the currentTime, rather than waiting on a timeout. This could save a few milliseconds per load, but I can remove those lines if preferred; the only one needed is the `.load` call.

**Steps to test:**
1. `yarn link` from `packages/koenig-lexical`
2. `yarn link` again from Ghost
3. `yarn build` in both places, then launch Ghost `yarn dev`
4. Visit admin page, create a post, and upload MP4 video from iOS Safari (note that .mov files are blocked via server-side config, so this has to be an mp4 video)

Working example:

https://github.com/TryGhost/Koenig/assets/2406051/ede0da5e-7096-4ba1-a40e-e6ad9e8985a8

