### PR TITLE
Added support for matching emdash TKs

### DIFF
--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -180,14 +180,14 @@ export default function TKPlugin() {
         function isValidMatch(match) {
             // negative lookbehind isn't supported before Safari 16.4
             // so we capture the preceding char and test it here
-            if (match[1] && match[1].trim() && WORD_CHAR_REGEX.test(match[1])) {
+            if (match[1] && match[1].trim() && WORD_CHAR_REGEX.test(match[1]) && match[2].slice(0, 1) !== '—') {
                 return false;
             }
 
             // we also check any following char in code to avoid an overly
             // complex regex when looking for word-chars following the optional
             // trailing symbol char
-            if (match[4] && match[4].trim() && WORD_CHAR_REGEX.test(match[4])) {
+            if (match[4] && match[4].trim() && WORD_CHAR_REGEX.test(match[4]) && match[2].slice(-1) !== '—') {
                 return false;
             }
 

--- a/packages/koenig-lexical/test/e2e/plugins/TKPlugin.test.js
+++ b/packages/koenig-lexical/test/e2e/plugins/TKPlugin.test.js
@@ -1,4 +1,4 @@
-import {assertSelection, focusEditor, initialize} from '../../utils/e2e';
+import {assertHTML, assertSelection, focusEditor, html, initialize} from '../../utils/e2e';
 import {expect, test} from '@playwright/test';
 
 test.describe('TK Plugin', async function () {
@@ -74,6 +74,24 @@ test.describe('TK Plugin', async function () {
             await page.keyboard.type('TKs and TK and [TK]');
 
             await expect(page.locator('[data-kg-tk="true"]')).toHaveCount(2);
+        });
+
+        test('highlights TK when preceded or follow by emdash', async function () {
+            await focusEditor(page);
+
+            await page.keyboard.type('First---TK Second---TK---Third TK---Last');
+
+            await assertHTML(page, html`
+                <p dir="ltr">
+                    <span data-lexical-text="true">First</span>
+                    <span data-kg-tk="true" data-lexical-text="true">—TK</span>
+                    <span data-lexical-text="true">Second</span>
+                    <span data-kg-tk="true" data-lexical-text="true">—TK—</span>
+                    <span data-lexical-text="true">Third</span>
+                    <span data-kg-tk="true" data-lexical-text="true">TK—</span>
+                    <span data-lexical-text="true">Last</span>
+                </p>
+            `);
         });
     });
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/4229

- emdash characters are typically used with no spaces surrounding them so when a TK is preceded/trailed by an emdash we should allow matches when there's a word character touching the emdash
