### PR TITLE
🐛 Patched snippets capturing only leaf nodes

### DIFF
--- a/packages/koenig-lexical/src/components/ui/SnippetActionToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/SnippetActionToolbar.jsx
@@ -34,7 +34,7 @@ export function SnippetActionToolbar({onClose, ...props}) {
 
                 const selectedNodes = selection.getNodes();
                 if (selectedNodes.length === 1 && $isTextNode(selectedNodes[0])) {
-                    const node = selection.getNodes()[0];
+                    const node = selectedNodes[0];
                     const parentNode = node.getParent(); // textNodes must have a parent
                     if ($isQuoteNode(parentNode)) {
                         const quoteNode = $createQuoteNode();

--- a/packages/koenig-lexical/src/components/ui/SnippetActionToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/SnippetActionToolbar.jsx
@@ -32,7 +32,8 @@ export function SnippetActionToolbar({onClose, ...props}) {
                 const selection = $getSelection();
                 let nodeJson;
 
-                if (selection.getNodes().length === 1 && $isTextNode(selection.getNodes()[0])) {
+                const selectedNodes = selection.getNodes();
+                if (selectedNodes.length === 1 && $isTextNode(selectedNodes[0])) {
                     const node = selection.getNodes()[0];
                     const parentNode = node.getParent(); // textNodes must have a parent
                     if ($isQuoteNode(parentNode)) {


### PR DESCRIPTION
closes TryGhost/Product#4197
- lexical selection only grabs the leaf nodes if there's not multiple parent nodes
- without parent nodes being in the selection, we don't know if quotes are quotes or asides as asides