### PR TITLE
🐛 Fixed quote and aside formatting being lost in single-block snippets

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/ExtendedQuoteNode.js
+++ b/packages/kg-default-nodes/lib/nodes/ExtendedQuoteNode.js
@@ -42,6 +42,12 @@ export class ExtendedQuoteNode extends QuoteNode {
         json.type = 'extended-quote';
         return json;
     }
+
+    /* c8 ignore start */
+    extractWithChild() {
+        return true;
+    }
+    /* c8 ignore end */
 }
 
 function convertBlockquoteElement() {

--- a/packages/kg-default-nodes/lib/nodes/aside/AsideNode.js
+++ b/packages/kg-default-nodes/lib/nodes/aside/AsideNode.js
@@ -55,6 +55,10 @@ export class AsideNode extends ElementNode {
     isInline() {
         return false;
     }
+
+    extractWithChild() {
+        return true;
+    }
     /* c8 ignore stop */
 }
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/4197

- adds `extractWithChild() { return true; }` to our Quote and Aside nodes so they have the same behaviour as other nodes like headings and list items
