### PR TITLE
🐛 Fixed signup card text color and styles

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
@@ -18,9 +18,29 @@ export class SignupNode extends generateDecoratorNode({nodeType: 'signup',
         {name: 'labels', default: []},
         {name: 'layout', default: 'wide'},
         {name: 'subheader', default: '', wordCount: true},
-        {name: 'successMessage', default: 'Email sent! Check your inbox to complete your signup.'},
+        {name: 'successMessage', default: 'Email sent! Check your inbox to completes your signup.'},
         {name: 'swapped', default: false}
     ]}) {
+    /* override */
+    constructor({alignment, backgroundColor, backgroundImageSrc, backgroundSize, textColor, buttonColor, buttonTextColor, buttonText, disclaimer, header, labels, layout, subheader, successMessage, swapped} = {}, key) {
+        super(key);
+        this.__alignment = alignment || 'left';
+        this.__backgroundColor = backgroundColor || '#F0F0F0';
+        this.__backgroundImageSrc = backgroundImageSrc || '';
+        this.__backgroundSize = backgroundSize || 'cover';
+        this.__textColor = textColor || (backgroundColor === 'transparent' ? '' : '#000000');
+        this.__buttonColor = buttonColor || 'accent';
+        this.__buttonTextColor = buttonTextColor || '#FFFFFF';
+        this.__buttonText = buttonText || 'Subscribe';
+        this.__disclaimer = disclaimer || '';
+        this.__header = header || '';
+        this.__labels = labels || [];
+        this.__layout = layout || 'wide';
+        this.__subheader = subheader || '';
+        this.__successMessage = successMessage || 'Email sent! Check your inbox to complete your signup.';
+        this.__swapped = swapped || false;
+    }
+
     static importDOM() {
         return signupParser(this);
     }

--- a/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
@@ -9,7 +9,7 @@ export class SignupNode extends generateDecoratorNode({nodeType: 'signup',
         {name: 'backgroundColor', default: '#F0F0F0'},
         {name: 'backgroundImageSrc', default: ''},
         {name: 'backgroundSize', default: 'cover'},
-        {name: 'textColor', default: '#000000'},
+        {name: 'textColor', default: ''},
         {name: 'buttonColor', default: 'accent'},
         {name: 'buttonTextColor', default: '#FFFFFF'},
         {name: 'buttonText', default: 'Subscribe'},
@@ -28,7 +28,7 @@ export class SignupNode extends generateDecoratorNode({nodeType: 'signup',
         this.__backgroundColor = backgroundColor || '#F0F0F0';
         this.__backgroundImageSrc = backgroundImageSrc || '';
         this.__backgroundSize = backgroundSize || 'cover';
-        this.__textColor = textColor || (backgroundColor === 'transparent' ? '' : '#000000');
+        this.__textColor = backgroundColor === 'transparent' ? '' : textColor;
         this.__buttonColor = buttonColor || 'accent';
         this.__buttonTextColor = buttonTextColor || '#FFFFFF';
         this.__buttonText = buttonText || 'Subscribe';

--- a/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
@@ -28,7 +28,7 @@ export class SignupNode extends generateDecoratorNode({nodeType: 'signup',
         this.__backgroundColor = backgroundColor || '#F0F0F0';
         this.__backgroundImageSrc = backgroundImageSrc || '';
         this.__backgroundSize = backgroundSize || 'cover';
-        this.__textColor = backgroundColor === 'transparent' ? '' : textColor;
+        this.__textColor = backgroundColor === 'transparent' ? '' : textColor || '#000000';
         this.__buttonColor = buttonColor || 'accent';
         this.__buttonTextColor = buttonTextColor || '#FFFFFF';
         this.__buttonText = buttonText || 'Subscribe';

--- a/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
@@ -28,7 +28,7 @@ export class SignupNode extends generateDecoratorNode({nodeType: 'signup',
         this.__backgroundColor = backgroundColor || '#F0F0F0';
         this.__backgroundImageSrc = backgroundImageSrc || '';
         this.__backgroundSize = backgroundSize || 'cover';
-        this.__textColor = backgroundColor === 'transparent' ? '' : textColor || '#000000';
+        this.__textColor = (backgroundColor === 'transparent' && (layout === 'split' || !backgroundImageSrc)) ? '' : textColor || '#000000'; // text color should inherit with a transparent bg color unless we're using an image for the background (which supercedes the bg color)
         this.__buttonColor = buttonColor || 'accent';
         this.__buttonTextColor = buttonTextColor || '#FFFFFF';
         this.__buttonText = buttonText || 'Subscribe';

--- a/packages/kg-default-nodes/lib/nodes/signup/signup-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/signup-renderer.js
@@ -25,10 +25,10 @@ function cardTemplate(nodeData) {
                     <span class="kg-signup-card-button-loading">${loadingIcon()}</span>
                 </button>
             </div>
-            <div class="kg-signup-card-success" style="color: ${nodeData.textColor};">
+            <div class="kg-signup-card-success" ${nodeData.textColor ? `style="color: ${nodeData.textColor};"` : ''}>
                 ${nodeData.successMessage || 'Thanks! Now check your email to confirm.'}
             </div>
-            <div class="kg-signup-card-error" style="color: ${nodeData.textColor};" data-members-error></div>
+            <div class="kg-signup-card-error" ${nodeData.textColor ? `style="color: ${nodeData.textColor};"` : ''} data-members-error></div>
         </form>
         `;
 
@@ -38,10 +38,10 @@ function cardTemplate(nodeData) {
             <div class="kg-signup-card-content">
                 ${nodeData.layout === 'split' ? imgTemplate : ''}
                 <div class="kg-signup-card-text ${alignment}">
-                    <h2 class="kg-signup-card-heading" style="color: ${nodeData.textColor};">${nodeData.header}</h2>
-                    <p class="kg-signup-card-subheading" style="color: ${nodeData.textColor};">${nodeData.subheader}</p>
+                    <h2 class="kg-signup-card-heading" ${nodeData.textColor ? `style="color: ${nodeData.textColor};"` : ''}>${nodeData.header}</h2>
+                    <p class="kg-signup-card-subheading" ${nodeData.textColor ? `style="color: ${nodeData.textColor};"` : ''}>${nodeData.subheader}</p>
                     ${formTemplate}
-                    <p class="kg-signup-card-disclaimer" style="color: ${nodeData.textColor};">${nodeData.disclaimer}</p>
+                    <p class="kg-signup-card-disclaimer" ${nodeData.textColor ? `style="color: ${nodeData.textColor};"` : ''}>${nodeData.disclaimer}</p>
                 </div>
             </div>
         </div>

--- a/packages/kg-default-nodes/lib/nodes/signup/signup-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/signup-renderer.js
@@ -5,7 +5,7 @@ import {addCreateDocumentOption} from '../../utils/add-create-document-option';
 function cardTemplate(nodeData) {
     const cardClasses = getCardClasses(nodeData).join(' ');
 
-    const backgroundAccent = nodeData.backgroundColor === 'accent' && !nodeData.backgroundImageSrc ? 'kg-style-accent' : ''; // don't apply accent style if there's a background image
+    const backgroundAccent = getAccentClass(nodeData); // don't apply accent style if there's a background image
     const buttonAccent = nodeData.buttonColor === 'accent' ? 'kg-style-accent' : '';
     const buttonStyle = nodeData.buttonColor !== 'accent' ? `background-color: ${nodeData.buttonColor};` : ``;
     const alignment = nodeData.alignment === 'center' ? 'kg-align-center' : '';
@@ -149,3 +149,15 @@ export function getCardClasses(nodeData) {
 
     return cardClasses;
 }
+
+// In general, we don't want to apply the accent style if there's a background image
+//  but with the split format we display both an image and a background color
+const getAccentClass = (nodeData) => {
+    if (nodeData.layout === 'split' && nodeData.backgroundColor === 'accent') {
+        return 'kg-style-accent';
+    } else if (nodeData.layout !== 'split' && !nodeData.backgroundImageSrc && nodeData.backgroundColor === 'accent') {
+        return 'kg-style-accent';
+    } else {
+        return '';
+    }
+};

--- a/packages/kg-default-nodes/lib/nodes/signup/signup-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/signup-renderer.js
@@ -10,7 +10,6 @@ function cardTemplate(nodeData) {
     const buttonStyle = nodeData.buttonColor !== 'accent' ? `background-color: ${nodeData.buttonColor};` : ``;
     const alignment = nodeData.alignment === 'center' ? 'kg-align-center' : '';
     const backgroundImageStyle = nodeData.backgroundColor !== 'accent' && (!nodeData.backgroundImageSrc || nodeData.layout === 'split') ? `background-color: ${nodeData.backgroundColor}` : '';
-    const useTextColor = !nodeData.backgroundColor === 'transparent';
 
     const imgTemplate = nodeData.backgroundImageSrc ? `
         <picture><img class="kg-signup-card-image" src="${nodeData.backgroundImageSrc}" alt="" /></picture>
@@ -26,10 +25,10 @@ function cardTemplate(nodeData) {
                     <span class="kg-signup-card-button-loading">${loadingIcon()}</span>
                 </button>
             </div>
-            <div class="kg-signup-card-success" ${useTextColor ? `style="color: ${nodeData.textColor};` : ''}>
+            <div class="kg-signup-card-success" style="color: ${nodeData.textColor};">
                 ${nodeData.successMessage || 'Thanks! Now check your email to confirm.'}
             </div>
-            <div class="kg-signup-card-error" ${useTextColor ? `style="color: ${nodeData.textColor};` : ''} data-members-error></div>
+            <div class="kg-signup-card-error" style="color: ${nodeData.textColor};" data-members-error></div>
         </form>
         `;
 
@@ -39,10 +38,10 @@ function cardTemplate(nodeData) {
             <div class="kg-signup-card-content">
                 ${nodeData.layout === 'split' ? imgTemplate : ''}
                 <div class="kg-signup-card-text ${alignment}">
-                    <h2 class="kg-signup-card-heading" ${useTextColor ? `style="color: ${nodeData.textColor};` : ''}>${nodeData.header}</h2>
-                    <p class="kg-signup-card-subheading" ${useTextColor ? `style="color: ${nodeData.textColor};` : ''}>${nodeData.subheader}</p>
+                    <h2 class="kg-signup-card-heading" style="color: ${nodeData.textColor};">${nodeData.header}</h2>
+                    <p class="kg-signup-card-subheading" style="color: ${nodeData.textColor};">${nodeData.subheader}</p>
                     ${formTemplate}
-                    <p class="kg-signup-card-disclaimer" ${useTextColor ? `style="color: ${nodeData.textColor};` : ''}>${nodeData.disclaimer}</p>
+                    <p class="kg-signup-card-disclaimer" style="color: ${nodeData.textColor};">${nodeData.disclaimer}</p>
                 </div>
             </div>
         </div>

--- a/packages/kg-default-nodes/test/nodes/signup.test.js
+++ b/packages/kg-default-nodes/test/nodes/signup.test.js
@@ -416,7 +416,111 @@ describe('SignupNode', function () {
                     </div>
                 </div>
             </div>
-        `);
+            `);
+        }));
+
+        it('applies the accent color class if there is no background image', editorTest(function () {
+            dataset.backgroundColor = 'accent';
+            dataset.backgroundImageSrc = '';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-signup-card kg-width-regular kg-style-accent" data-lexical-signup-form="" style="display:none">
+                    <div class="kg-signup-card-content">
+                        <div class="kg-signup-card-text kg-align-center">
+                            <h2 class="kg-signup-card-heading" style="color: #000000">Header</h2>
+                            <p class="kg-signup-card-subheading" style="color: #000000">Subheader</p>
+                            <form class="kg-signup-card-form" data-members-form="signup">
+                                <input data-members-label="" type="hidden" value="label 1">
+                                <input data-members-label="" type="hidden" value="label 2">
+                                <div class="kg-signup-card-fields">
+                                    <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email">
+                                    <button class="kg-signup-card-button" style="background-color: #000000; color:#ffffff" type="submit">
+                                        <span class="kg-signup-card-button-default">Button</span>
+                                        <span class="kg-signup-card-button-loading">${loadingIcon}</span>
+                                    </button>
+                                </div>
+                                <div class="kg-signup-card-success" style="color: #000000">Success!</div>
+                                <div class="kg-signup-card-error" style="color: #000000" data-members-error=""></div>
+                            </form>
+                            <p class="kg-signup-card-disclaimer" style="color: #000000">Disclaimer</p>
+                        </div>
+                    </div>
+                </div>
+            `);
+        }));
+
+        it('applies the accent color class with a split layout', editorTest(function () {
+            dataset.backgroundColor = 'accent';
+            dataset.layout = 'split';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-signup-card kg-layout-split kg-width-full kg-style-accent" data-lexical-signup-form="" style="display:none">
+                    <div class="kg-signup-card-content">
+                        <picture><img class="kg-signup-card-image" src="https://example.com/image.jpg" alt=""></picture>
+                        <div class="kg-signup-card-text kg-align-center">
+                            <h2 class="kg-signup-card-heading" style="color: #000000">Header</h2>
+                            <p class="kg-signup-card-subheading" style="color: #000000">Subheader</p>
+                            <form class="kg-signup-card-form" data-members-form="signup">
+                                <input data-members-label="" type="hidden" value="label 1">
+                                <input data-members-label="" type="hidden" value="label 2">
+                                <div class="kg-signup-card-fields">
+                                    <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email">
+                                    <button class="kg-signup-card-button" style="background-color:#000000;color:#ffffff" type="submit">
+                                        <span class="kg-signup-card-button-default">Button</span>
+                                        <span class="kg-signup-card-button-loading">${loadingIcon}</span>
+                                    </button>
+                                </div>
+                                <div class="kg-signup-card-success" style="color: #000000">Success!</div>
+                                <div class="kg-signup-card-error" style="color: #000000" data-members-error=""></div>
+                            </form>
+                            <p class="kg-signup-card-disclaimer" style="color: #000000">Disclaimer</p>
+                        </div>
+                    </div>
+                </div>
+            `);
+        }));
+
+        it(`doesn't apply the accent color class if there is a background image`, editorTest(function () {
+            dataset.backgroundColor = 'accent';
+            dataset.backgroundImageSrc = 'https://example.com/image.jpg';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-signup-card kg-width-regular" data-lexical-signup-form="" style="display:none">
+                    <picture>
+                        <img
+                            class="kg-signup-card-image"
+                            src="https://example.com/image.jpg"
+                            alt=""
+                        />
+                    </picture>
+                    <div class="kg-signup-card-content">
+                        <div class="kg-signup-card-text kg-align-center">
+                            <h2 class="kg-signup-card-heading" style="color: #000000">Header</h2>
+                            <p class="kg-signup-card-subheading" style="color: #000000">Subheader</p>
+                            <form class="kg-signup-card-form" data-members-form="signup">
+                                <input data-members-label="" type="hidden" value="label 1">
+                                <input data-members-label="" type="hidden" value="label 2">
+                                <div class="kg-signup-card-fields">
+                                    <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email">
+                                    <button class="kg-signup-card-button" style="background-color: #000000; color:#ffffff" type="submit">
+                                        <span class="kg-signup-card-button-default">Button</span>
+                                        <span class="kg-signup-card-button-loading">${loadingIcon}</span>
+                                    </button>
+                                </div>
+                                <div class="kg-signup-card-success" style="color: #000000">Success!</div>
+                                <div class="kg-signup-card-error" style="color: #000000" data-members-error=""></div>
+                            </form>
+                            <p class="kg-signup-card-disclaimer" style="color: #000000">Disclaimer</p>
+                        </div>
+                    </div>
+                </div>
+            `);
         }));
 
         it('returns empty element if target is email', editorTest(function () {

--- a/packages/kg-default-nodes/test/nodes/signup.test.js
+++ b/packages/kg-default-nodes/test/nodes/signup.test.js
@@ -70,6 +70,7 @@ describe('SignupNode', function () {
 
     describe('data access', function () {
         it('has getters for all properties', editorTest(function () {
+            dataset.backgroundColor = '#000000';
             const signupNode = $createSignupNode(dataset);
             signupNode.alignment.should.equal(dataset.alignment);
             signupNode.backgroundColor.should.equal(dataset.backgroundColor);
@@ -135,6 +136,7 @@ describe('SignupNode', function () {
         });
 
         it('has getDataset() method', editorTest(function () {
+            dataset.backgroundColor = '#000000';
             const signupNode = $createSignupNode(dataset);
             const nodeData = signupNode.getDataset();
             nodeData.should.deepEqual(dataset);
@@ -231,8 +233,8 @@ describe('SignupNode', function () {
                 <div class="kg-card kg-signup-card kg-width-regular kg-style-accent" data-lexical-signup-form="" style="display:none">
                     <div class="kg-signup-card-content">
                         <div class="kg-signup-card-text kg-align-center">
-                            <h2 class="kg-signup-card-heading">Header</h2>
-                            <p class="kg-signup-card-subheading">Subheader</p>
+                            <h2 class="kg-signup-card-heading" style="color: #000000">Header</h2>
+                            <p class="kg-signup-card-subheading" style="color: #000000">Subheader</p>
                             <form class="kg-signup-card-form" data-members-form="signup">
                                 <input data-members-label="" type="hidden" value="label 1">
                                 <input data-members-label="" type="hidden" value="label 2">
@@ -243,10 +245,10 @@ describe('SignupNode', function () {
                                         <span class="kg-signup-card-button-loading">${loadingIcon}</span>
                                     </button>
                                 </div>
-                                <div class="kg-signup-card-success">Success!</div>
-                                <div class="kg-signup-card-error" data-members-error=""></div>
+                                <div class="kg-signup-card-success" style="color: #000000">Success!</div>
+                                <div class="kg-signup-card-error" style="color: #000000" data-members-error=""></div>
                             </form>
-                            <p class="kg-signup-card-disclaimer">Disclaimer</p>
+                            <p class="kg-signup-card-disclaimer" style="color: #000000">Disclaimer</p>
                         </div>
                     </div>
                 </div>
@@ -361,8 +363,8 @@ describe('SignupNode', function () {
                     <picture><img class="kg-signup-card-image" src="https://example.com/image.jpg" alt=""></picture>
                     <div class="kg-signup-card-content">
                         <div class="kg-signup-card-text kg-align-center">
-                            <h2 class="kg-signup-card-heading">Header</h2>
-                            <p class="kg-signup-card-subheading">Subheader</p>
+                            <h2 class="kg-signup-card-heading" style="color: #000000">Header</h2>
+                            <p class="kg-signup-card-subheading" style="color: #000000">Subheader</p>
                             <form class="kg-signup-card-form" data-members-form="signup">
                                 <input data-members-label="" type="hidden" value="label 1">
                                 <input data-members-label="" type="hidden" value="label 2">
@@ -373,14 +375,46 @@ describe('SignupNode', function () {
                                         <span class="kg-signup-card-button-loading">${loadingIcon}</span>
                                     </button>
                                 </div>
-                                <div class="kg-signup-card-success">Success!</div>
-                                <div class="kg-signup-card-error" data-members-error=""></div>
+                                <div class="kg-signup-card-success" style="color: #000000">Success!</div>
+                                <div class="kg-signup-card-error" style="color: #000000" data-members-error=""></div>
                             </form>
-                            <p class="kg-signup-card-disclaimer">Disclaimer</p>
+                            <p class="kg-signup-card-disclaimer" style="color: #000000">Disclaimer</p>
                         </div>
                     </div>
                 </div>
             `);
+        }));
+
+        it('does not render text colors with a transparent background', editorTest(function () {
+            dataset.backgroundColor = 'transparent';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-signup-card kg-width-regular" data-lexical-signup-form="" style="display:none">
+                <picture><img class="kg-signup-card-image" src="https://example.com/image.jpg" alt=""></picture>
+                <div class="kg-signup-card-content">
+                    <div class="kg-signup-card-text kg-align-center">
+                        <h2 class="kg-signup-card-heading">Header</h2>
+                        <p class="kg-signup-card-subheading">Subheader</p>
+                        <form class="kg-signup-card-form" data-members-form="signup">
+                            <input data-members-label="" type="hidden" value="label 1">
+                            <input data-members-label="" type="hidden" value="label 2">
+                            <div class="kg-signup-card-fields">
+                                <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email">
+                                <button class="kg-signup-card-button" style="background-color:#000000;color:#ffffff" type="submit">
+                                    <span class="kg-signup-card-button-default">Button</span>
+                                    <span class="kg-signup-card-button-loading">${loadingIcon}</span>
+                                </button>
+                            </div>
+                            <div class="kg-signup-card-success">Success!</div>
+                            <div class="kg-signup-card-error" data-members-error=""></div>
+                        </form>
+                        <p class="kg-signup-card-disclaimer">Disclaimer</p>
+                    </div>
+                </div>
+            </div>
+        `);
         }));
 
         it('returns empty element if target is email', editorTest(function () {
@@ -496,7 +530,7 @@ describe('SignupNode', function () {
                 backgroundColor: dataset.backgroundColor,
                 backgroundImageSrc: dataset.backgroundImageSrc,
                 backgroundSize: dataset.backgroundSize,
-                textColor: dataset.textColor,
+                textColor: '', // transparent results in no text color
                 buttonColor: dataset.buttonColor,
                 buttonText: dataset.buttonText,
                 buttonTextColor: dataset.buttonTextColor,

--- a/packages/kg-default-nodes/test/nodes/signup.test.js
+++ b/packages/kg-default-nodes/test/nodes/signup.test.js
@@ -55,9 +55,11 @@ describe('SignupNode', function () {
 
     describe('clone', function () {
         it('clones the node', editorTest(function () {
+            dataset.backgroundColor = '#000000';
             const signupNode = $createSignupNode(dataset);
             const clonedSignupNode = SignupNode.clone(signupNode);
-            clonedSignupNode.should.deepEqual(signupNode);
+            const cloneDataset = clonedSignupNode.getDataset();
+            cloneDataset.should.deepEqual(dataset);
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/signup.test.js
+++ b/packages/kg-default-nodes/test/nodes/signup.test.js
@@ -172,8 +172,8 @@ describe('SignupNode', function () {
                     <picture><img class="kg-signup-card-image" src="https://example.com/image.jpg" alt=""/></picture>
                     <div class="kg-signup-card-content">
                         <div class="kg-signup-card-text kg-align-center">
-                            <h2 class="kg-signup-card-heading">Header</h2>
-                            <p class="kg-signup-card-subheading">Subheader</p>
+                            <h2 class="kg-signup-card-heading" style="color: #000000">Header</h2>
+                            <p class="kg-signup-card-subheading" style="color: #000000">Subheader</p>
                             <form class="kg-signup-card-form" data-members-form="signup">
                                 <input data-members-label="" type="hidden" value="label 1">
                                 <input data-members-label="" type="hidden" value="label 2">
@@ -184,10 +184,10 @@ describe('SignupNode', function () {
                                         <span class="kg-signup-card-button-loading">${loadingIcon}</span>
                                     </button>
                                 </div>
-                                <div class="kg-signup-card-success">Success!</div>
-                                <div class="kg-signup-card-error" data-members-error=""></div>
+                                <div class="kg-signup-card-success" style="color: #000000">Success!</div>
+                                <div class="kg-signup-card-error" style="color: #000000" data-members-error=""></div>
                             </form>
-                            <p class="kg-signup-card-disclaimer">Disclaimer</p>
+                            <p class="kg-signup-card-disclaimer" style="color: #000000">Disclaimer</p>
                         </div>
                     </div>
                 </div>
@@ -215,8 +215,8 @@ describe('SignupNode', function () {
                                         <span class="kg-signup-card-button-loading">${loadingIcon}</span>
                                     </button>
                                 </div>
-                                <div class="kg-signup-card-success">Success!</div>
-                                <div class="kg-signup-card-error" data-members-error=""></div>
+                                <div class="kg-signup-card-success" style="color: #000000">Success!</div>
+                                <div class="kg-signup-card-error" style="color: #000000" data-members-error=""></div>
                             </form>
                         </div>
                     </div>
@@ -362,7 +362,7 @@ describe('SignupNode', function () {
             const {element} = signupNode.exportDOM(exportOptions);
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-signup-card kg-width-regular" data-lexical-signup-form="" style="display:none">
-                    <picture><img class="kg-signup-card-image" src="https://example.com/image.jpg" alt=""></picture>
+                <picture><img class="kg-signup-card-image" src="https://example.com/image.jpg" alt=""></picture>
                     <div class="kg-signup-card-content">
                         <div class="kg-signup-card-text kg-align-center">
                             <h2 class="kg-signup-card-heading" style="color: #000000">Header</h2>
@@ -389,12 +389,12 @@ describe('SignupNode', function () {
 
         it('does not render text colors with a transparent background', editorTest(function () {
             dataset.backgroundColor = 'transparent';
+            dataset.backgroundImageSrc = '';
 
             const signupNode = $createSignupNode(dataset);
             const {element} = signupNode.exportDOM(exportOptions);
             element.outerHTML.should.prettifyTo(html`
-                <div class="kg-card kg-signup-card kg-width-regular" data-lexical-signup-form="" style="display:none">
-                <picture><img class="kg-signup-card-image" src="https://example.com/image.jpg" alt=""></picture>
+                <div class="kg-card kg-signup-card kg-width-regular" data-lexical-signup-form="" style="background-color: transparent; display:none">
                 <div class="kg-signup-card-content">
                     <div class="kg-signup-card-text kg-align-center">
                         <h2 class="kg-signup-card-heading">Header</h2>
@@ -636,7 +636,7 @@ describe('SignupNode', function () {
                 backgroundColor: dataset.backgroundColor,
                 backgroundImageSrc: dataset.backgroundImageSrc,
                 backgroundSize: dataset.backgroundSize,
-                textColor: '', // transparent results in no text color
+                textColor: dataset.textColor,
                 buttonColor: dataset.buttonColor,
                 buttonText: dataset.buttonText,
                 buttonTextColor: dataset.buttonTextColor,


### PR DESCRIPTION
closes TryGhost/Product#4168, closes TryGhost/Product#4232, closes TryGhost/Ghost#19282
- reverted handling to use overridden constructor when mounting node
- grid background now correctly shows when loading content with transparent bg color
- signup card split view was not correctly applying the accent class when set as the bg color
- added tests to cover various cases