### PR TITLE
🐛 Fixed inability to drag-select text in caption alt inputs

### DIFF
--- a/packages/koenig-lexical/src/components/ui/CardCaptionEditor.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardCaptionEditor.jsx
@@ -32,6 +32,7 @@ function AltTextInput({value, placeholder, onChange, readOnly, dataTestId, autoF
             placeholder={placeholder}
             readOnly={readOnly}
             value={value}
+            data-koenig-dnd-disabled
             onChange={handleChange}
         />
     );


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/19244

- the alt input didn't have the drag-and-drop disable data attribute so trying to drag to select text triggered the card drag-to-reorder behaviour instead
