### PR TITLE
🐛 Fixed callout card not rendering all inline formats

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/callout/callout-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/callout/callout-renderer.js
@@ -28,7 +28,7 @@ export function renderCalloutNode(node, options = {}) {
     const temporaryContainer = document.createElement('div');
     temporaryContainer.innerHTML = node.calloutText;
 
-    const allowedTags = ['A', 'STRONG', 'EM', 'B', 'I', 'BR'];
+    const allowedTags = ['A', 'STRONG', 'EM', 'B', 'I', 'BR', 'CODE', 'MARK', 'S', 'DEL', 'U', 'SUP', 'SUB'];
     cleanDOM(temporaryContainer, allowedTags);
 
     textElement.innerHTML = temporaryContainer.innerHTML;

--- a/packages/kg-default-nodes/test/nodes/callout.test.js
+++ b/packages/kg-default-nodes/test/nodes/callout.test.js
@@ -166,6 +166,22 @@ describe('CalloutNode', function () {
                 </div>
             `);
         }));
+
+        it('can render with inline code', editorTest(function () {
+            dataset.calloutText = '<p><span style=\"white-space: pre-wrap;\">Does </span><code spellcheck=\"false\" style=\"white-space: pre-wrap;\"><span>inline code</span></code><span style=\"white-space: pre-wrap;\"> render properly?</span></p>';
+
+            const node = $createCalloutNode(dataset);
+            const {element} = node.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-callout-card kg-callout-card-blue">
+                    <div class="kg-callout-emoji">💡</div>
+                    <div class="kg-callout-text">
+                        Does <code spellcheck="false" style="white-space: pre-wrap">inline code</code> render properly?
+                    </div>
+                </div>
+            `);
+        }));
     });
 
     describe('importDOM', function () {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/19129

- callout card renderer has a whitelist of allowed tags in it's inner HTML content, this was missing some of our supported inline formats such as inline code
