### PR TITLE
🐛 Fixed editor crash when typing `:,`,`:|`, or similar

### DIFF
--- a/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
@@ -172,7 +172,7 @@ export function EmojiPickerPlugin() {
                 anchorElementRef,
                 {selectedIndex, selectOptionAndCleanUp, setHighlightedIndex}
             ) => {
-                if (anchorElementRef.current === null || searchResults === null || searchResults.length === 0) {
+                if (anchorElementRef.current === null || !searchResults || searchResults.length === 0) {
                     return null;
                 }
                 return (

--- a/packages/koenig-lexical/test/e2e/plugins/EmojiPickerPlugin.test.js
+++ b/packages/koenig-lexical/test/e2e/plugins/EmojiPickerPlugin.test.js
@@ -1,4 +1,4 @@
-import {assertHTML, ctrlOrCmd, focusEditor, initialize, insertCard} from '../../utils/e2e';
+import {assertHTML, ctrlOrCmd, focusEditor, html, initialize, insertCard} from '../../utils/e2e';
 import {expect, test} from '@playwright/test';
 
 test.describe('Emoji Picker Plugin', async function () {
@@ -142,6 +142,18 @@ test.describe('Emoji Picker Plugin', async function () {
         await page.keyboard.type(':', {delay: 10});
 
         await assertHTML(page, '<p dir="ltr"><mark data-lexical-text="true"><span>Test ❤️</span></mark></p>');
+    });
+
+    test('can handle :, with no search matches', async function () {
+        await focusEditor(page);
+        await page.keyboard.type(':,', {delay: 10});
+        await expect(page.getByTestId('emoji-menu')).not.toBeVisible();
+        // can continue typing (previous bug crashed editor)
+        await page.keyboard.type(' testing');
+
+        await assertHTML(page, html`
+            <p dir="ltr"><span data-lexical-text="true">:, testing</span></p>
+        `);
     });
 
     test(`can use emojis in nested editors`, async function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/19375

- problem was a type error in the emoji picker plugin where `searchResults` is `undefined` rather than the expected `null` which meant we then tried to access `undefined.length` and crashed the editor
