### PR TITLE
Fixed error when parsing callout card HTML with missing text node element

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/callout/callout-parser.js
+++ b/packages/kg-default-nodes/lib/nodes/callout/callout-parser.js
@@ -15,7 +15,7 @@ export function parseCalloutNode(CalloutNode) {
                         const color = getColorTag(domNode);
 
                         const payload = {
-                            calloutText: textNode && textNode.innerHTML.trim(),
+                            calloutText: textNode && textNode.innerHTML.trim() || '',
                             calloutEmoji: emojiNode && emojiNode.innerHTML.trim() || '',
                             backgroundColor: color
                         };

--- a/packages/kg-parser-plugins/lib/parser-plugins.js
+++ b/packages/kg-parser-plugins/lib/parser-plugins.js
@@ -71,13 +71,13 @@ export function createParserPlugins(_options = {}) {
 
         let calloutEmoji = '';
         if (emojiNode) {
-            calloutEmoji = emojiNode.textContent;
+            calloutEmoji = emojiNode?.textContent;
             if (calloutEmoji) {
                 calloutEmoji = calloutEmoji.trim();
             }
         }
 
-        let calloutText = htmlNode.innerHTML;
+        let calloutText = htmlNode?.innerHTML || '';
 
         const payload = {
             calloutEmoji,

--- a/packages/kg-parser-plugins/test/parser-plugins.test.js
+++ b/packages/kg-parser-plugins/test/parser-plugins.test.js
@@ -82,6 +82,19 @@ describe('parser-plugins', function () {
                 backgroundColor: 'red'
             });
         });
+
+        it('parses a card without text', function () {
+            const dom = buildDOM('<div class="kg-callout-card" style="background-color: red;"><div class="kg-callout-emoji">⚠️</div><div>Text with missing class</div>');
+            const [section] = parser.parse(dom).sections.toArray();
+
+            section.type.should.equal('card-section');
+            section.name.should.equal('callout');
+            section.payload.should.deepEqual({
+                calloutEmoji: '⚠️',
+                calloutText: '',
+                backgroundColor: 'red'
+            });
+        });
     });
 
     describe('brToSoftBreakAtom', function () {


### PR DESCRIPTION
closes https://github.com/TryGhost/Koenig/issues/723

- adds checks to ensure we aren't trying to read DOM properties from non-existent nodes
