### PR TITLE
Fixed typo in default text for signup node

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
@@ -18,7 +18,7 @@ export class SignupNode extends generateDecoratorNode({nodeType: 'signup',
         {name: 'labels', default: []},
         {name: 'layout', default: 'wide'},
         {name: 'subheader', default: '', wordCount: true},
-        {name: 'successMessage', default: 'Email sent! Check your inbox to completes your signup.'},
+        {name: 'successMessage', default: 'Email sent! Check your inbox to complete your signup.'},
         {name: 'swapped', default: false}
     ]}) {
     /* override */


### PR DESCRIPTION
refs 36cfdbb
- successMessage was pluralized when it shouldn't have been
- because this is overridden at the moment, it shouldn't have an impact but is good to clean up