### PR TITLE
🐛 Added readonly overlay to button

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/ButtonCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/ButtonCard.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Button} from '../Button';
 import {ButtonGroupSetting, InputSetting, InputUrlSetting, SettingsPanel} from '../SettingsPanel';
+import {ReadOnlyOverlay} from '../ReadOnlyOverlay';
 
 export function ButtonCard({
     alignment,
@@ -37,6 +38,7 @@ export function ButtonCard({
                     <Button dataTestId="button-card-btn" href={buttonUrl} placeholder={buttonPlaceholder} value={buttonText} />
                 </div>
             </div>
+            <ReadOnlyOverlay />
             {isEditing && (
                 <SettingsPanel>
                     <ButtonGroupSetting


### PR DESCRIPTION
refs TryGhost/Product#4242
- button card was missing readonly overlay
- was possibel to click and leave the editor on accident
- testing the result is still possible via preview rendered html