### PR TITLE
🐛 Fixed external images not populating dimensions

### DIFF
--- a/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
@@ -108,7 +108,7 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, captionE
         };
 
         // If we're just given a URL, try to populate the width/height
-        // This occurs if the user runs /image [URL] or pastes a URL into the editor
+        // This occurs if the user runs /image [URL] or pastes a HTML image
         if (src && !initialFile && !triggerFileDialog) {
             populateImageDimensions(src).then(({width, height}) => {
                 editor.update(() => {

--- a/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
@@ -90,6 +90,7 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, captionE
     }, [editor, imageUploader.isLoading, imageUploader.upload, nodeKey, src]);
 
     React.useEffect(() => {
+        // If an initial file is provided, upload it
         const uploadInitialFile = async (file) => {
             if (file && !src) {
                 await imageUploadHandler([file], nodeKey, editor, imageUploader.upload);
@@ -98,26 +99,20 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, captionE
 
         uploadInitialFile(initialFile);
 
-        // We only do this for init
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
-    React.useEffect(() => {
-        const populateImageDimensions = async (imageSrc) => {
-            return await getImageDimensions(imageSrc);
-        };
-
-        // If we're just given a URL, try to populate the width/height
-        // This occurs if the user runs /image [URL] or pastes a HTML image
-        if (src && !initialFile && !triggerFileDialog) {
-            populateImageDimensions(src).then(({width, height}) => {
+        // If we're given a URL instead of a file, populate the image dimensions
+        const populateImageDimensions = async () => {
+            if (src && !initialFile && !triggerFileDialog) {
+                const {width, height} = await getImageDimensions(src);
                 editor.update(() => {
                     const node = $getNodeByKey(nodeKey);
                     node.width = width;
                     node.height = height;
                 });
-            });
-        }
+            }
+        };
+
+        populateImageDimensions();
+
         // We only do this for init
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
@@ -13,6 +13,7 @@ import {LinkInput} from '../components/ui/LinkInput';
 import {SnippetActionToolbar} from '../components/ui/SnippetActionToolbar';
 import {ToolbarMenu, ToolbarMenuItem, ToolbarMenuSeparator} from '../components/ui/ToolbarMenu';
 import {dataSrcToFile} from '../utils/dataSrcToFile.js';
+import {getImageDimensions} from '../utils/getImageDimensions.js';
 import {getImageFilenameFromSrc} from '../utils/getImageFilenameFromSrc';
 import {imageUploadHandler} from '../utils/imageUploadHandler';
 import {isGif} from '../utils/isGif';
@@ -97,6 +98,26 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, captionE
 
         uploadInitialFile(initialFile);
 
+        // We only do this for init
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    React.useEffect(() => {
+        const populateImageDimensions = async (imageSrc) => {
+            return await getImageDimensions(imageSrc);
+        };
+
+        // If we're just given a URL, try to populate the width/height
+        // This occurs if the user runs /image [URL] or pastes a URL into the editor
+        if (src && !initialFile && !triggerFileDialog) {
+            populateImageDimensions(src).then(({width, height}) => {
+                editor.update(() => {
+                    const node = $getNodeByKey(nodeKey);
+                    node.width = width;
+                    node.height = height;
+                });
+            });
+        }
         // We only do this for init
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/packages/koenig-lexical/src/utils/getImageDimensions.js
+++ b/packages/koenig-lexical/src/utils/getImageDimensions.js
@@ -2,11 +2,12 @@
 
 export async function getImageDimensions(url) {
     const img = new Image();
-    img.src = url;
     return new Promise((resolve, reject) => {
         img.onload = () => {
             resolve({width: img.naturalWidth, height: img.naturalHeight});
         };
         img.onerror = reject;
+        // Set image src after listeners to avoid the image loading before the listener is set
+        img.src = url;
     });
 }


### PR DESCRIPTION
refs TryGhost/Product#4243

- When image cards are created without height and width set, the post can render improperly in certain email clients, particularly Outlook
- This PR uses the existing `getImageDimensions` utility function to populate the height and width of external images when they are added to the editor
- External images can be added by either typing `/image [URL]` or by pasting HTML content that includes an image tag — this fix covers both cases