### PR TITLE
Fixed duplicate bundling of lodash in koenig-lexical

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/embed/types/twitter.js
+++ b/packages/kg-default-nodes/lib/nodes/embed/types/twitter.js
@@ -1,5 +1,5 @@
 import {DateTime} from 'luxon';
-import {toArray} from 'lodash';
+import toArray from 'lodash/toArray';
 
 export default function render(node, document, options) {
     const metadata = node.metadata;

--- a/packages/koenig-lexical/package.json
+++ b/packages/koenig-lexical/package.json
@@ -105,7 +105,6 @@
     "fast-average-color": "^9.3.0",
     "jsdom": "23.2.0",
     "lexical": "0.12.2",
-    "lodash-es": "^4.17.21",
     "luxon": "^3.3.0",
     "pluralize": "^8.0.0",
     "postcss": "8.4.33",
@@ -126,5 +125,8 @@
     "vitest": "1.2.1",
     "y-websocket": "^1.5.0",
     "yjs": "^13.5.50"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
   }
 }

--- a/packages/koenig-lexical/src/components/ui/DropdownContainer.jsx
+++ b/packages/koenig-lexical/src/components/ui/DropdownContainer.jsx
@@ -1,5 +1,5 @@
 import React, {useLayoutEffect} from 'react';
-import {debounce} from 'lodash';
+import debounce from 'lodash/debounce';
 
 /**
  * Note: when using the DropdownContainer, make sure the input and the dropdown both are in a relative container with a defined z-index (or new stacking context)

--- a/packages/koenig-lexical/src/components/ui/FloatingFormatToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/FloatingFormatToolbar.jsx
@@ -1,10 +1,10 @@
 import FloatingToolbar from '../../components/ui/FloatingToolbar';
 import FormatToolbar from './FormatToolbar';
 import React from 'react';
+import debounce from 'lodash/debounce';
 import {$getSelection, $isRangeSelection, COMMAND_PRIORITY_LOW, DELETE_CHARACTER_COMMAND} from 'lexical';
 import {LinkActionToolbar} from './LinkActionToolbar.jsx';
 import {SnippetActionToolbar} from './SnippetActionToolbar';
-import {debounce} from 'lodash-es';
 import {mergeRegister} from '@lexical/utils';
 
 // don't show the toolbar until the mouse has moved a certain distance,

--- a/packages/koenig-lexical/src/components/ui/FloatingLinkToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/FloatingLinkToolbar.jsx
@@ -1,10 +1,10 @@
 import FloatingToolbar from './FloatingToolbar';
 import React from 'react';
+import debounce from 'lodash/debounce';
 import {$createRangeSelection, $getNearestNodeFromDOMNode, $setSelection} from 'lexical';
 import {$isLinkNode} from '@lexical/link';
 import {LinkToolbar} from './LinkToolbar';
 import {TOGGLE_LINK_COMMAND} from '@lexical/link';
-import {debounce} from 'lodash';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
 export function FloatingLinkToolbar({anchorElem, onEditLink, disabled}) {

--- a/packages/koenig-lexical/src/context/TKContext.jsx
+++ b/packages/koenig-lexical/src/context/TKContext.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {throttle} from 'lodash';
+import throttle from 'lodash/throttle';
 
 const Context = React.createContext({});
 

--- a/packages/koenig-lexical/src/hooks/useGalleryReorder.js
+++ b/packages/koenig-lexical/src/hooks/useGalleryReorder.js
@@ -1,7 +1,7 @@
 import KoenigComposerContext from '../context/KoenigComposerContext';
 import React from 'react';
+import pick from 'lodash/pick';
 import {getImageFilenameFromSrc} from '../utils/getImageFilenameFromSrc';
-import {pick} from 'lodash-es';
 
 export default function useGalleryReorder({images, updateImages, isSelected = false, maxImages = 9, disabled = false}) {
     const koenig = React.useContext(KoenigComposerContext);

--- a/packages/koenig-lexical/src/hooks/useSettingsPanelReposition.js
+++ b/packages/koenig-lexical/src/hooks/useSettingsPanelReposition.js
@@ -1,5 +1,5 @@
+import debounce from 'lodash/debounce';
 import useMovable from './useMovable.js';
-import {debounce} from 'lodash';
 import {useCallback, useLayoutEffect, useRef} from 'react';
 
 const CARD_SPACING = 20; // default distance between card and settings panel

--- a/packages/koenig-lexical/src/nodes/GalleryNode.jsx
+++ b/packages/koenig-lexical/src/nodes/GalleryNode.jsx
@@ -1,11 +1,11 @@
 import GalleryCardIcon from '../assets/icons/kg-card-type-gallery.svg?react';
 import cleanBasicHtml from '@tryghost/kg-clean-basic-html';
+import pick from 'lodash/pick';
 import {$generateHtmlFromNodes} from '@lexical/html';
 import {GalleryNode as BaseGalleryNode} from '@tryghost/kg-default-nodes';
 import {GalleryNodeComponent} from './GalleryNodeComponent';
 import {KoenigCardWrapper, MINIMAL_NODES} from '../index.js';
 import {createCommand} from 'lexical';
-import {pick} from 'lodash-es';
 import {populateNestedEditor, setupNestedEditor} from '../utils/nested-editors';
 
 export const INSERT_GALLERY_COMMAND = createCommand();

--- a/packages/koenig-lexical/src/plugins/WordCountPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/WordCountPlugin.jsx
@@ -1,8 +1,8 @@
 import KoenigComposerContext from '../context/KoenigComposerContext';
 import React from 'react';
+import throttle from 'lodash/throttle';
 import {$getRoot, $isElementNode} from 'lexical';
 import {mergeRegister} from '@lexical/utils';
-import {throttle} from 'lodash';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {utils} from '@tryghost/helpers';
 

--- a/packages/koenig-lexical/src/utils/draggable/draggable-constants.js
+++ b/packages/koenig-lexical/src/utils/draggable/draggable-constants.js
@@ -1,4 +1,4 @@
-import {kebabCase} from 'lodash-es';
+import kebabCase from 'lodash/kebabCase';
 
 // we use data attributes rather than classes even though they can be slower
 // because in many instances our draggable/droppable element's classes attribute

--- a/packages/koenig-lexical/src/utils/services/tenor.js
+++ b/packages/koenig-lexical/src/utils/services/tenor.js
@@ -1,4 +1,4 @@
-import {debounce} from 'lodash';
+import debounce from 'lodash/debounce';
 import {useRef, useState} from 'react';
 
 const API_URL = 'https://tenor.googleapis.com';

--- a/yarn.lock
+++ b/yarn.lock
@@ -9113,7 +9113,6 @@ eslint-plugin-es-x@^7.1.0:
 
 eslint-plugin-filenames@allouis/eslint-plugin-filenames#15dc354f4e3d155fc2d6ae082dbfc26377539a18:
   version "1.3.2"
-  uid "15dc354f4e3d155fc2d6ae082dbfc26377539a18"
   resolved "https://codeload.github.com/allouis/eslint-plugin-filenames/tar.gz/15dc354f4e3d155fc2d6ae082dbfc26377539a18"
   dependencies:
     lodash.camelcase "4.3.0"
@@ -13329,7 +13328,7 @@ locate-path@^7.1.0:
   dependencies:
     p-locate "^6.0.0"
 
-lodash-es@^4.17.11, lodash-es@^4.17.21:
+lodash-es@^4.17.11:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==


### PR DESCRIPTION
no issue

- we were importing from both `lodash-es` and `lodash` which resulted in the former importing only what was needed from the library and the latter importing the entire library a second time
- moving all imports over to `lodash` with explicit `lodash/module` imports cut 72KB (27KB gzipped) from our bundle size
- used `lodash` as the common module so that the `kg-default-nodes` CJS build doesn't run into issues importing es modules
