### PR TITLE
🐛 Fixed style regressions

### DIFF
--- a/packages/koenig-lexical/demo/components/InitialContentToggle.jsx
+++ b/packages/koenig-lexical/demo/components/InitialContentToggle.jsx
@@ -36,7 +36,7 @@ const InitialContentToggle = ({defaultContent, setTitle, searchParams, setSearch
             <button className="absolute right-6 top-4 z-20 block h-[22px] w-[42px] cursor-pointer rounded-full bg-black transition-all ease-in-out" type="button" onClick={toggle}>
                 <EyeOpenIcon className="absolute left-[6px] top-[5px] size-3 text-white" />
                 <EyeClosedIcon className="absolute right-[6px] top-[5px] size-3 text-white" />
-                <div className={`absolute top-[2px] size-[18px] rounded-full bg-white transition-all ease-in-out${isOn ? 'left-[22px]' : 'left-[2px]'}`}></div>
+                <div className={`absolute top-[2px] size-[18px] rounded-full bg-white transition-all ease-in-out ${isOn ? 'left-[22px]' : 'left-[2px]'}`}></div>
             </button>
         </>
     );

--- a/packages/koenig-lexical/src/components/ui/ColorOptionButtons.jsx
+++ b/packages/koenig-lexical/src/components/ui/ColorOptionButtons.jsx
@@ -17,7 +17,7 @@ export function ColorOptionButtons({buttons = [], selectedName, onClick}) {
                             onClick={onClick}
                         />
                         :
-                        <li key='background-image' className={`flex size-[3rem] cursor-pointer items-center justify-center rounded-full border-2${selectedName === name ? 'border-green' : 'border-transparent'}`} data-testid="background-image-color-button" type="button" onClick={() => onClick(name)}>
+                        <li key='background-image' className={`flex size-[3rem] cursor-pointer items-center justify-center rounded-full border-2 ${selectedName === name ? 'border-green' : 'border-transparent'}`} data-testid="background-image-color-button" type="button" onClick={() => onClick(name)}>
                             <span className="border-1 flex size-6 items-center justify-center rounded-full border border-black/5">
                                 <PlusIcon className="size-3 stroke-grey-700 stroke-2 dark:stroke-grey-500 dark:group-hover:stroke-grey-100" />
                             </span>
@@ -37,7 +37,7 @@ export function ColorButton({onClick, label, name, color, selectedName}) {
         <li>
             <button
                 aria-label={label}
-                className={`flex size-[2.6rem] cursor-pointer items-center justify-center rounded-full border-2${isActive ? 'border-green' : 'border-transparent'}`}
+                className={`flex size-[2.6rem] cursor-pointer items-center justify-center rounded-full border-2 ${isActive ? 'border-green' : 'border-transparent'}`}
                 data-test-id={`color-picker-${name}`}
                 type="button"
                 onClick={handleClick}

--- a/packages/koenig-lexical/src/components/ui/Dropdown.jsx
+++ b/packages/koenig-lexical/src/components/ui/Dropdown.jsx
@@ -73,7 +73,7 @@ export function Dropdown({value, menu, onChange, dataTestId}) {
                 onMouseDownCapture={preventLoseFocus}
             >
                 {trigger}
-                <ArrowIcon className={`absolute right-2 top-4 size-2 text-grey-600${open && 'rotate-180'}`} />
+                <ArrowIcon className={`absolute right-2 top-4 size-2 text-grey-600 ${open && 'rotate-180'}`} />
             </button>
             {open && (
                 <DropdownContainer>

--- a/packages/koenig-lexical/src/components/ui/MediaPlayer.jsx
+++ b/packages/koenig-lexical/src/components/ui/MediaPlayer.jsx
@@ -6,7 +6,7 @@ import UnmuteIcon from '../../assets/icons/kg-unmute.svg?react';
 export function MediaPlayer({type, duration, theme, ...args}) {
     return (
         <div className="mt-auto flex w-full items-center py-2" {...args}>
-            <PlayIcon className={`mr-2 size-[1.4rem]${theme === 'light' ? 'fill-white' : 'fill-black dark:fill-white'}`} />
+            <PlayIcon className={`mr-2 size-[1.4rem] ${theme === 'light' ? 'fill-white' : 'fill-black dark:fill-white'}`} />
             <div className={`mb-[1px] font-sans text-sm font-medium ${theme === 'light' ? 'text-white/60' : 'text-black/50 dark:text-white/50'} `}>
                 <span className={`${theme === 'light' ? 'text-white' : 'text-black dark:text-white'}`}>0:00 </span>
                 / <span data-testid="media-duration">{duration}</span>

--- a/packages/koenig-lexical/src/components/ui/MultiSelectDropdown.jsx
+++ b/packages/koenig-lexical/src/components/ui/MultiSelectDropdown.jsx
@@ -133,7 +133,7 @@ export function MultiSelectDropdown({placeholder = '', items = [], availableItem
                     />
                 </div>
 
-                <ArrowIcon className={`absolute right-2 top-4 size-2 text-grey-600${open && 'rotate-180'}`} />
+                <ArrowIcon className={`absolute right-2 top-4 size-2 text-grey-600 ${open && 'rotate-180'}`} />
             </div>
             {open && !!filteredItems.length && (
                 <DropdownContainer>

--- a/packages/koenig-lexical/src/components/ui/file-selectors/Unsplash/UnsplashButton.jsx
+++ b/packages/koenig-lexical/src/components/ui/file-selectors/Unsplash/UnsplashButton.jsx
@@ -15,7 +15,7 @@ function UnsplashButton({icon, label, ...props}) {
             onClick={e => e.stopPropagation()}
             {...props}
         >
-            {icon && <Icon className={`size-4 fill-red stroke-[3px]${label && 'mr-1'}`} />}
+            {icon && <Icon className={`size-4 fill-red stroke-[3px] ${label && 'mr-1'}`} />}
             {label && <span>{label}</span>}
         </a>
     );


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/19557

- the linting auto-fix applied in a recent Tailwind update broke some styles because it removed a space between a class name and a following template literal expression resulting in an unknown class name that effectively removed the two now-concatenated classes
