### PR TITLE
🐛 Fixed crash when converting or pasting lists containing headings+text

### DIFF
--- a/packages/html-to-mobiledoc/test/converter.test.js
+++ b/packages/html-to-mobiledoc/test/converter.test.js
@@ -1,7 +1,7 @@
 // Switch these lines once there are useful utils
 // const testUtils = require('./utils');
 require('./utils');
-const converter = require('../lib/converter');
+const converter = require('../');
 
 describe('Converter test', function () {
     describe('Minimal examples', function () {
@@ -149,6 +149,30 @@ describe('Converter test', function () {
             mobiledoc.sections[1].should.eql([3, 'ul', [[[0, [], 0, 'Big']]]]);
             mobiledoc.sections[2].should.be.an.Array().with.lengthOf(3);
             mobiledoc.sections[2].should.eql([1, 'p', [[0, [], 0, 'World']]]);
+        });
+
+        it('Can convert headings and paragraphs inside list items', function () {
+            const mobiledoc = converter
+                .toMobiledoc(`
+                    <ul>
+                        <li>
+                            <h2>Heading</h2>
+                            <p>Paragraph</p>
+                        </li>
+                    </ul>
+                `, {plugins: []});
+
+            mobiledoc.should.deepEqual({
+                atoms: [],
+                cards: [],
+                markups: [],
+                sections: [
+                    [3, 'ul', [[[0, [], 0, '']]]],
+                    [1, 'h2', [[0, [], 0, 'Heading']]],
+                    [1, 'p', [[0, [], 0, 'Paragraph']]]
+                ],
+                version: '0.3.1'
+            });
         });
     });
 

--- a/packages/kg-default-transforms/test/transforms/denest.test.ts
+++ b/packages/kg-default-transforms/test/transforms/denest.test.ts
@@ -1,6 +1,6 @@
 import {assertTransform, createEditor} from '../utils';
 import {$createParagraphNode, LexicalEditor, ParagraphNode, TextNode} from 'lexical';
-import {ExtendedHeadingNode, ImageNode} from '@tryghost/kg-default-nodes';
+import {ImageNode, ExtendedHeadingNode} from '@tryghost/kg-default-nodes';
 import {registerDenestTransform} from '../../';
 import {$createListItemNode, $createListNode, ListItemNode, ListNode} from '@lexical/list';
 import {$createHeadingNode, HeadingNode} from '@lexical/rich-text';
@@ -437,6 +437,127 @@ describe('Denest transform', function () {
                         caption: '',
                         cardWidth: 'regular',
                         href: ''
+                    }
+                ],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        };
+
+        const editor = createEditor();
+
+        assertTransform(editor, registerTransforms, before, after);
+    });
+
+    it('handles headings+text inside list items', function () {
+        const registerTransforms = (editor: LexicalEditor) => {
+            registerDenestTransform(editor, ParagraphNode, () => ($createParagraphNode()));
+            registerDenestTransform(editor, HeadingNode, node => ($createHeadingNode(node.getTag())));
+            registerDenestTransform(editor, ExtendedHeadingNode, node => ($createHeadingNode(node.getTag())));
+            registerDenestTransform(editor, ListNode, node => ($createListNode(node.getListType(), node.getStart())));
+            registerDenestTransform(editor, ListItemNode, () => ($createListItemNode()));
+        };
+
+        const before = {
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                children: [
+                                    {
+                                        children: [
+                                            {
+                                                type: 'extended-text',
+                                                text: 'Heading',
+                                                format: 0,
+                                                style: '',
+                                                mode: 0,
+                                                detail: 0
+                                            }
+                                        ],
+                                        type: 'extended-heading',
+                                        format: 0,
+                                        indent: 0,
+                                        dir: null,
+                                        tag: 'h4'
+                                    },
+                                    {
+                                        type: 'extended-text',
+                                        text: 'Paragraph',
+                                        format: 0,
+                                        style: '',
+                                        mode: 0,
+                                        detail: 0
+                                    }
+                                ],
+                                type: 'listitem',
+                                format: 0,
+                                indent: 0,
+                                dir: null,
+                                value: 1,
+                                checked: false
+                            }
+                        ],
+                        type: 'list',
+                        format: 0,
+                        indent: 0,
+                        dir: null,
+                        listType: 'bullet',
+                        tag: 'ul',
+                        start: 1
+                    }
+                ],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        };
+
+        const after = {
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                type: 'extended-text',
+                                text: 'Heading',
+                                format: 0,
+                                style: '',
+                                mode: undefined,
+                                detail: 0,
+                                version: 1
+                            }
+                        ],
+                        direction: undefined,
+                        format: '',
+                        indent: 0,
+                        tag: 'h4',
+                        type: 'extended-heading',
+                        version: 1
+                    },
+                    {
+                        children: [
+                            {
+                                type: 'extended-text',
+                                text: 'Paragraph',
+                                format: 0,
+                                style: '',
+                                mode: undefined,
+                                detail: 0,
+                                version: 1
+                            }
+                        ],
+                        direction: null,
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
                     }
                 ],
                 direction: null,

--- a/packages/koenig-lexical/package.json
+++ b/packages/koenig-lexical/package.json
@@ -105,6 +105,7 @@
     "fast-average-color": "^9.3.0",
     "jsdom": "23.2.0",
     "lexical": "0.12.2",
+    "lodash": "^4.17.21",
     "luxon": "^3.3.0",
     "pluralize": "^8.0.0",
     "postcss": "8.4.33",
@@ -125,8 +126,5 @@
     "vitest": "1.2.1",
     "y-websocket": "^1.5.0",
     "yjs": "^13.5.50"
-  },
-  "dependencies": {
-    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4234

- updates denest transform to properly handle extracting nested heading and paragraph nodes from inside a list as a listitem node in Lexical can only contain text nodes or other inline nodes
- matches behaviour to previous Mobiledoc editor where the invalid nodes are moved outside of the list
