### PR TITLE
🐛 Fixed duplicate text when pasting URL on selection with multiple formats

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -3,7 +3,7 @@ import {$createAsideNode, $isAsideNode} from '../nodes/AsideNode';
 import {$createCodeBlockNode} from '../nodes/CodeBlockNode';
 import {$createEmbedNode} from '../nodes/EmbedNode';
 import {$createHeadingNode, $createQuoteNode, $isQuoteNode} from '@lexical/rich-text';
-import {$createLinkNode, $isLinkNode} from '@lexical/link';
+import {$createLinkNode, $isLinkNode, TOGGLE_LINK_COMMAND} from '@lexical/link';
 import {
     $createNodeSelection,
     $createParagraphNode,
@@ -1310,14 +1310,9 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                     const nodeContent = node.getTextContent();
 
                     if (selectionContent.length > 0) {
-                        const link = linkMatch[1];
+                        const url = linkMatch[1];
                         if ($isRangeSelection(selection)) {
-                            const textNode = selection.extract()[0];
-                            const linkNode = $createLinkNode(link);
-                            const linkTextNode = $createTextNode(selectionContent);
-                            linkTextNode.setFormat(textNode.getFormat());
-                            linkNode.append(linkTextNode);
-                            textNode.replace(linkNode);
+                            editor.dispatchCommand(TOGGLE_LINK_COMMAND, {url, rel: null});
                         }
                         return true;
                     }

--- a/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
@@ -105,6 +105,44 @@ test.describe('Paste behaviour', async () => {
             `);
         });
 
+        test('pasted on selected text containing formats converts to link', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('Text with ');
+            await page.keyboard.press(`${ctrlOrCmd()}+B`);
+            await page.keyboard.type('bold');
+            await page.keyboard.press(`${ctrlOrCmd()}+B`);
+            await page.keyboard.type(' and ');
+            await page.keyboard.press(`${ctrlOrCmd()}+I`);
+            await page.keyboard.type('italic');
+            await page.keyboard.press(`${ctrlOrCmd()}+I`);
+            await page.keyboard.type(' text.');
+
+            await assertHTML(page, html`
+                <p dir="ltr">
+                    <span data-lexical-text="true">Text with </span>
+                    <strong data-lexical-text="true">bold</strong>
+                    <span data-lexical-text="true"> and </span>
+                    <em data-lexical-text="true">italic</em>
+                    <span data-lexical-text="true"> text.</span>
+                </p>
+            `);
+
+            await page.keyboard.press(`${ctrlOrCmd()}+A`);
+            await pasteText(page, 'https://ghost.org');
+
+            await assertHTML(page, html`
+                <p dir="ltr">
+                    <a href="https://ghost.org" dir="ltr">
+                        <span data-lexical-text="true">Text with </span>
+                        <strong data-lexical-text="true">bold</strong>
+                        <span data-lexical-text="true"> and </span>
+                        <em data-lexical-text="true">italic</em>
+                        <span data-lexical-text="true"> text.</span>
+                    </a>
+                </p>
+            `);
+        });
+
         test('pasted on selected text within a nested editor converts to link', async function () {
             await focusEditor(page);
             await page.keyboard.type('/callout', {delay: 10});


### PR DESCRIPTION
ref ENG-29

- switched to using the `@lexical/link` package's `TOGGLE_LINK_COMMAND` which uses the package's `toggleLink()` function rather than our own crude link-creation as it properly handles child nodes and updating existing link nodes
- used command rather than direct function use so the command override functionality isn't lost
