### PR TITLE
🐛 Fixed breakout adjustment not working for panel positioning

### DIFF
--- a/packages/koenig-lexical/src/styles/index.css
+++ b/packages/koenig-lexical/src/styles/index.css
@@ -30,6 +30,4 @@
     --black: #15171A;
 
     --green: #30CF43;
-
-    --kg-breakout-adjustment: 0px;
 }


### PR DESCRIPTION
ref DES-112

- within our card settings panel positioning we use the `--kg-breakout-adjustment` CSS variable to adjust the apparent screen width so panels don't open underneath/hidden by any sidebars in the parent app
- this was broken because our styles specified a `0px` value for the variable on our top-level editor element overriding any value that was set on the variable by the parent app
