### PR TITLE
Adjusted panel drag to disallow positioning off-screen

### DIFF
--- a/packages/koenig-lexical/src/hooks/useSettingsPanelReposition.js
+++ b/packages/koenig-lexical/src/hooks/useSettingsPanelReposition.js
@@ -86,15 +86,12 @@ function keepWithinSpacing(panelElem, {x, y, origin = {x: 0, y: 0}, topSpacing, 
 }
 
 function keepWithinSpacingOnDrag(panelElem, {x, y, origin}) {
-    const width = panelElem.offsetWidth;
-    const height = panelElem.offsetHeight;
+    const DISTANCE_FROM_BOUNDARY = 10;
 
-    // Make sure at least 40px is still visible
-    const MINIMUM_VISIBLE = isMobile() ? 100 : 40;
-    const topSpacing = MINIMUM_VISIBLE - height;
-    const bottomSpacing = MINIMUM_VISIBLE - height;
-    const rightSpacing = MINIMUM_VISIBLE - width;
-    const leftSpacing = MINIMUM_VISIBLE - width;
+    const topSpacing = DISTANCE_FROM_BOUNDARY;
+    const bottomSpacing = DISTANCE_FROM_BOUNDARY;
+    const rightSpacing = DISTANCE_FROM_BOUNDARY;
+    const leftSpacing = DISTANCE_FROM_BOUNDARY;
 
     // Last spacing is ignored
     return keepWithinSpacing(panelElem, {x, y, origin, topSpacing, bottomSpacing, rightSpacing, leftSpacing, lastSpacing: undefined});


### PR DESCRIPTION
ref DES-112
closes ENG-629

- changed the "keep withing spacing" algorithm to keep full panels on-screen 10px from the boundary
- adjusted settings panel reposition on resize to take sidebar into account
  - swapped window resize event for a ResizeObserver that watches the scroll container of the settings panel which will typically be the outer container for the editor itself which in this case works well for panel positioning
  - adjusted resize re-position event handler to take the adjusted window width into account so it matches drag behaviour
  - extracted functions for getting window width adjustment and viewport dimensions as they were re-used throughout