### PR TITLE
🐛 Fixed regression with wide/full card styling in the editor

### DIFF
--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -256,7 +256,7 @@ function DemoComposer({editorType, isMultiplayer, setWordCount, setTKCount}) {
             multiplayerEndpoint={WEBSOCKET_ENDPOINT}
             nodes={getAllowedNodes({editorType})}
         >
-            <div className={`koenig-demo relative h-full grow ${darkMode ? 'dark' : ''}`} style={{'--kg-breakout-adjustment': isSidebarOpen ? '440px' : '0px'}}>
+            <div className={`koenig-demo relative h-full grow ${darkMode ? 'dark' : ''}`} style={isSidebarOpen ? {'--kg-breakout-adjustment': '440px'} : {}}>
                 {
                     !isMultiplayer && searchParams !== 'false'
                         ? <InitialContentToggle defaultContent={defaultContent} searchParams={searchParams} setSearchParams={setSearchParams} setTitle={setTitle} />

--- a/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
@@ -3,11 +3,11 @@ import React from 'react';
 
 const CARD_WIDTH_CLASSES = {
     wide: [
-        'w-[calc(75vw-var(--kg-breakout-adjustment)+2px)] mx-[calc(50%-(50vw-var(--kg-breakout-adjustment))-.8rem)] min-w-[calc(100%+3.6rem)] translate-x-[calc(50vw-50%+.8rem-var(--kg-breakout-adjustment))]',
+        'w-[calc(75vw-var(--kg-breakout-adjustment-with-fallback)+2px)] mx-[calc(50%-(50vw-var(--kg-breakout-adjustment-with-fallback))-.8rem)] min-w-[calc(100%+3.6rem)] translate-x-[calc(50vw-50%+.8rem-var(--kg-breakout-adjustment-with-fallback))]',
         'sm:min-w-[calc(100%+10rem)]',
         'lg:min-w-[calc(100%+18rem)]'
     ].join(' '),
-    full: 'inset-x-[-1px] mx-[calc(50%-50vw)] w-[calc(100vw+2px)] lg:mx-[calc(50%-50vw+(var(--kg-breakout-adjustment)/2))] lg:w-[calc(100vw-var(--kg-breakout-adjustment)+2px)]'
+    full: 'inset-x-[-1px] mx-[calc(50%-50vw)] w-[calc(100vw+2px)] lg:mx-[calc(50%-50vw+(var(--kg-breakout-adjustment-with-fallback)/2))] lg:w-[calc(100vw-var(--kg-breakout-adjustment-with-fallback)+2px)]'
 };
 
 export const CardWrapper = React.forwardRef(({

--- a/packages/koenig-lexical/src/styles/index.css
+++ b/packages/koenig-lexical/src/styles/index.css
@@ -30,4 +30,6 @@
     --black: #15171A;
 
     --green: #30CF43;
+
+    --kg-breakout-adjustment-with-fallback: var(--kg-breakout-adjustment, 0px);
 }


### PR DESCRIPTION
part of ENG-651

When we "fixed" settings panel positioning not respecting the sidebar width by removing the unintentionally fixed `0px` value for `--kg-breakout-width` CSS variable we introduced a regression when the value was not set at all because it broke our usage of the variable inside `calc()` styles.

- added a new `--kg-breakout-width-with-fallback` CSS variable so that when the parent app doesn't set a value at all we still have our `0px` value for use in our styling calculations
  - using inline fallbacks like `var(--kg-breakout-width, 0px)` doesn't appear to work inside Tailwind classes so the global variable was needed
  - updated demo app to replicate the behaviour we see with consumer apps so it's more realistic when testing
