### PR TITLE
🐛 Fixed HTML entities being converted when rendering HTML card content

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/html/html-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/html/html-renderer.js
@@ -12,7 +12,7 @@ export function renderHtmlNode(node, options = {}) {
     }
 
     const textarea = document.createElement('textarea');
-    textarea.innerHTML = `\n<!--kg-card-begin: html-->\n${html}\n<!--kg-card-end: html-->\n`;
+    textarea.value = `\n<!--kg-card-begin: html-->\n${html}\n<!--kg-card-end: html-->\n`;
 
     // `type: 'value'` will render the value of the textarea element
     // @see @tryghost/kg-lexical-html-renderer package

--- a/packages/kg-default-nodes/test/nodes/html.test.js
+++ b/packages/kg-default-nodes/test/nodes/html.test.js
@@ -149,6 +149,22 @@ describe('HtmlNode', function () {
             // do not prettify, it will add a closing tag to the compared string causing a false pass
             element.value.should.equal('\n<!--kg-card-begin: html-->\n<div style="color:red">\n<!--kg-card-end: html-->\n');
         }));
+
+        it('renders html entities', editorTest(function () {
+            const htmlNode = $createHtmlNode({html: '<p>&lt;pre&gt;Test&lt;/pre&gt;</p>'});
+            const {element, type} = htmlNode.exportDOM(exportOptions);
+            type.should.equal('value');
+
+            element.value.should.equal('\n<!--kg-card-begin: html-->\n<p>&lt;pre&gt;Test&lt;/pre&gt;</p>\n<!--kg-card-end: html-->\n');
+        }));
+
+        it('handles single-quote attributes', editorTest(function () {
+            const htmlNode = $createHtmlNode({html: '<div data-graph-name=\'The "all-in" cost of a grant\'>Test</div>'});
+            const {element, type} = htmlNode.exportDOM(exportOptions);
+            type.should.equal('value');
+
+            element.value.should.equal('\n<!--kg-card-begin: html-->\n<div data-graph-name=\'The "all-in" cost of a grant\'>Test</div>\n<!--kg-card-end: html-->\n');
+        }));
     });
 
     describe('importDOM', function () {

--- a/packages/kg-lexical-html-renderer/test/cards.test.js
+++ b/packages/kg-lexical-html-renderer/test/cards.test.js
@@ -120,4 +120,22 @@ describe('Cards', function () {
 `;
         renderedInput.should.equal(expected);
     });
+
+    it('renders HTML card with html entities and single-quote attributes', async function () {
+        lexicalState.root.children.push({
+            type: 'html',
+            html: '<p>&lt;pre&gt;Test&lt;/pre&gt;</p>\n<div data-graph-name=\'The "all-in" cost of a grant\'>Test</div>'
+        });
+
+        const renderer = new Renderer({nodes});
+        const renderedInput = await renderer.render(JSON.stringify(lexicalState), options);
+
+        const expected = `
+<!--kg-card-begin: html-->
+<p>&lt;pre&gt;Test&lt;/pre&gt;</p>
+<div data-graph-name='The "all-in" cost of a grant'>Test</div>
+<!--kg-card-end: html-->
+`;
+        renderedInput.should.equal(expected);
+    });
 });


### PR DESCRIPTION
part of ENG-608

HTML entities that were intentionally entered into HTML card content to be preserved in the rendered output were being converted when rendering resulting in potentially malformed rendering.

- switched `textarea.innerHTML =` to `textarea.value =` as the former parses the assigned value and decodes HTML entities unintentionally