### PR TITLE
🐛 Fixed pasting into HTML card editor replacing the card with a paragraph

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -1270,7 +1270,13 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                     // avoid Koenig behaviours when an inner element (e.g. a card input) has focus
                     // and event wasn't triggered from nested editor
                     if (document.activeElement !== editor.getRootElement() && !isNested) {
-                        return false;
+                        // ignore default Lexical behaviour when inside an inner input or contenteditable,
+                        // without this paste events inside CodeMirror for example will replace the card
+                        if (shouldIgnoreEvent(clipboardEvent)) {
+                            return true;
+                        } else {
+                            return false;
+                        }
                     }
 
                     const text = clipboardEvent?.clipboardData?.getData(MIME_TEXT_PLAIN);

--- a/packages/koenig-lexical/src/utils/shouldIgnoreEvent.js
+++ b/packages/koenig-lexical/src/utils/shouldIgnoreEvent.js
@@ -15,7 +15,7 @@ export const shouldIgnoreEvent = (event) => {
         return false;
     }
 
-    const isFromCardEditor = target.matches('input, textarea') || target.cmView || !!target.closest('.cm-editor');
+    const isFromCardEditor = target.matches('input, textarea') || target.cmView || target.cmIgnore || !!target.closest('.cm-editor');
 
     return isFromCardEditor;
 };

--- a/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import {assertHTML, ctrlOrCmd, focusEditor, html, initialize, pasteHtml, pasteText} from '../utils/e2e';
+import {assertHTML, ctrlOrCmd, focusEditor, html, initialize, insertCard, paste, pasteHtml, pasteText} from '../utils/e2e';
 import {expect, test} from '@playwright/test';
 
 test.describe('Paste behaviour', async () => {
@@ -437,6 +437,60 @@ test.describe('Paste behaviour', async () => {
                     <span data-lexical-text="true">Nested Google heading</span>
                 </h1>
             `);
+        });
+    });
+
+    test.describe('Inside cards', function () {
+        test('pasting inside HTML card CodeMirror editor works', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'html'});
+
+            await expect(page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
+
+            await paste(page, {
+                'text/plain': 'ignore default Lexical behaviour',
+                'text/html': '<meta charset=\'utf-8\'><div style="color: #abb2bf;background-color: #282c34;font-family: \'Operator Mono Lig\', Menlo, Monaco, \'Courier New\', monospace;font-weight: normal;font-size: 12px;line-height: 14px;white-space: pre;"><div><span style="color: #7f848e;font-style: italic;">ignore default Lexical behaviour</span></div></div>'
+            });
+
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                  <div><svg></svg></div>
+                  <div
+                    data-kg-card-editing="true"
+                    data-kg-card-selected="true"
+                    data-kg-card="html">
+                    <div>
+                      <div>
+                        <div>
+                          <div aria-live="polite"></div>
+                          <div tabindex="-1">
+                            <div aria-hidden="true">
+                              <div>
+                                <div>9</div>
+                                <div>1</div>
+                              </div>
+                            </div>
+                            <div
+                              spellcheck="false"
+                              autocorrect="off"
+                              autocapitalize="off"
+                              translate="no"
+                              contenteditable="true"
+                              role="textbox"
+                              aria-multiline="true"
+                              data-language="html">
+                              <div>ignore default Lexical behaviour</div>
+                            </div>
+                            <div aria-hidden="true"><div></div></div>
+                            <div aria-hidden="true"></div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <p><br /></p>
+            `, {ignoreCardContents: false});
         });
     });
 });

--- a/packages/koenig-lexical/test/utils/e2e.js
+++ b/packages/koenig-lexical/test/utils/e2e.js
@@ -264,11 +264,17 @@ export async function assertRootChildren(page, expectedState) {
     expect(actual).toEqual(expected);
 }
 
-export async function pasteText(page, text, mimeType = 'text/plain') {
+export async function paste(page, data) {
+    const setDataCommands = Object.keys(data).map((mimeType) => {
+        return `
+            dataTransfer.setData('${mimeType}', ${JSON.stringify(data[mimeType])});
+        `;
+    });
+
     const pasteCommand = `
-        const text = ${JSON.stringify(text)};
         const dataTransfer = new DataTransfer();
-        dataTransfer.setData('${mimeType}', text);
+
+        ${setDataCommands.join('\n')};
 
         document.activeElement.dispatchEvent(new ClipboardEvent('paste', {
             clipboardData: dataTransfer,
@@ -282,12 +288,16 @@ export async function pasteText(page, text, mimeType = 'text/plain') {
     await page.evaluate(pasteCommand);
 }
 
+export async function pasteText(page, content) {
+    await paste(page, {'text/plain': content});
+}
+
 export async function pasteHtml(page, content) {
-    await pasteText(page, content, 'text/html');
+    await paste(page, {'text/html': content});
 }
 
 export async function pasteLexical(page, content) {
-    await pasteText(page, content, 'application/x-lexical-editor');
+    await paste(page, {'application/x-lexical-editor': content});
 }
 
 export async function dragMouse(


### PR DESCRIPTION
part of ENG-657

Something changed in either a Lexical or CodeMirror dependency bump that meant Lexical's default paste handler started to be triggered when pasting inside the HTML card editor, replacing the card with a paragraph instead of pasting content into the card. This was only occurring when the pasted content contained a HTML mimetype such as when copying from a web page or VS Code, if plain text was pasted then it worked as expected.

- added a `shouldIgnoreEvent()` condition to our paste handler so we stop the Lexical command chain rather than allowing it to continue
- updated `shouldIgnoreEvent()` to better detect a paste event inside a CodeMirror editor
- updated test paste utils
  - added core `paste()` function that pastes with multiple mime types on the data transfer object (CodeMirror only accepted the paste when both plaintext and html were present)
  - updated mimetype-specific functions to call out to the new `paste()` function