### PR TITLE
Moved providers down the tree

### DIFF
--- a/packages/kg-unsplash-selector/demo/App.tsx
+++ b/packages/kg-unsplash-selector/demo/App.tsx
@@ -1,29 +1,24 @@
-import React, {useMemo} from 'react';
-import {InMemoryUnsplashProvider} from '../src/api/InMemoryUnsplashProvider';
-import {UnsplashProvider} from '../src/api/UnsplashProvider';
-import {UnsplashSearchModal} from '../src/index';
+import React from 'react';
+import {DefaultHeaderTypes, UnsplashSearchModal} from '../src/index';
 
 const App = () => {
-    const unsplashRepo = useMemo(() => {
-        if (import.meta.env.VITE_APP_TESTING === 'true') {
-            return new InMemoryUnsplashProvider();
-        } else {
-            const unsplashConfig = {
-                defaultHeaders: {
-                    Authorization: `Client-ID 8672af113b0a8573edae3aa3713886265d9bb741d707f6c01a486cde8c278980`,
-                    'Accept-Version': 'v1',
-                    'Content-Type': 'application/json',
-                    'App-Pragma': 'no-cache',
-                    'X-Unsplash-Cache': true
-                }
-            };
-            return new UnsplashProvider(unsplashConfig.defaultHeaders);
-        }
-    }, []);
+    let unsplashConfig:DefaultHeaderTypes | null
+     = {
+         Authorization: `Client-ID 8672af113b0a8573edae3aa3713886265d9bb741d707f6c01a486cde8c278980`,
+         'Accept-Version': 'v1',
+         'Content-Type': 'application/json',
+         'App-Pragma': 'no-cache',
+         'X-Unsplash-Cache': true
+     };
+
+    // disable API access for testing
+    if (import.meta.env.VITE_APP_TESTING === 'true') {
+        unsplashConfig = null;
+    }
 
     return (
         <UnsplashSearchModal
-            unsplashProvider={unsplashRepo}
+            unsplashProviderConfig={unsplashConfig}
             onClose={() => {
                 alert('not implemented');
             }}

--- a/packages/kg-unsplash-selector/src/UnsplashSearchModal.tsx
+++ b/packages/kg-unsplash-selector/src/UnsplashSearchModal.tsx
@@ -2,18 +2,27 @@ import MasonryService from './api/MasonryService';
 import React, {useMemo, useRef, useState} from 'react';
 import UnsplashGallery from './ui/UnsplashGallery';
 import UnsplashSelector from './ui/UnsplashSelector';
-import {IUnsplashProvider} from './api/IUnsplashProvider';
+import {DefaultHeaderTypes} from './UnsplashTypes';
+import {InMemoryUnsplashProvider} from './api/InMemoryUnsplashProvider';
 import {Photo} from './UnsplashTypes';
 import {PhotoUseCases} from './api/PhotoUseCase';
+import {UnsplashProvider} from './api/UnsplashProvider';
 import {UnsplashService} from './api/UnsplashService';
 
 interface UnsplashModalProps {
     onClose: () => void;
     onImageInsert: (image: Photo) => void;
-    unsplashProvider: IUnsplashProvider;
+    unsplashProviderConfig: DefaultHeaderTypes | null;
   }
 
-const UnsplashSearchModal : React.FC<UnsplashModalProps> = ({onClose, onImageInsert, unsplashProvider}) => {
+const UnsplashSearchModal : React.FC<UnsplashModalProps> = ({onClose, onImageInsert, unsplashProviderConfig}) => {
+    const unsplashProvider = useMemo(() => {
+        if (!unsplashProviderConfig) {
+            return new InMemoryUnsplashProvider();
+        }
+        return new UnsplashProvider(unsplashProviderConfig);
+    },[unsplashProviderConfig]);
+
     const photoUseCase = useMemo(() => new PhotoUseCases(unsplashProvider), [unsplashProvider]);
     const masonryService = useMemo(() => new MasonryService(3), []);
     const UnsplashLib = useMemo(() => new UnsplashService(photoUseCase, masonryService), [photoUseCase, masonryService]);

--- a/packages/kg-unsplash-selector/types/UnsplashSearchModal.d.ts
+++ b/packages/kg-unsplash-selector/types/UnsplashSearchModal.d.ts
@@ -1,10 +1,10 @@
 import React from 'react';
-import { IUnsplashProvider } from './api/IUnsplashProvider';
+import { DefaultHeaderTypes } from './UnsplashTypes';
 import { Photo } from './UnsplashTypes';
 interface UnsplashModalProps {
     onClose: () => void;
     onImageInsert: (image: Photo) => void;
-    unsplashProvider: IUnsplashProvider;
+    unsplashProviderConfig: DefaultHeaderTypes | null;
 }
 declare const UnsplashSearchModal: React.FC<UnsplashModalProps>;
 export default UnsplashSearchModal;


### PR DESCRIPTION
no issue

- Moved Unsplash Providers down the tree and make the API only available if config was provided, else reverts to in memory mock data, which is ideal for testing.