### PR TITLE
Added PostHog to trackEvent function

### DIFF
--- a/packages/koenig-lexical/src/utils/analytics.js
+++ b/packages/koenig-lexical/src/utils/analytics.js
@@ -5,4 +5,7 @@ export default function trackEvent(eventName, props = {}) {
         (window.plausible.q = window.plausible.q || []).push(arguments);
     };
     window.plausible(eventName, {props: props});
+    if (window.posthog) {
+        window.posthog.capture(eventName, props);
+    }
 }


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PA-53/add-posthog-tracking-to-trackevent-in-admin-x-settings-and-lexical

- Added `posthog.capture()` to the existing `trackEvent` function to send events to PostHog from the editor