### PR TITLE
Removed case-sensitivity for TK reminders

### DIFF
--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -8,7 +8,7 @@ import {useKoenigTextEntity} from '../hooks/useKoenigTextEntity';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useTKContext} from '../context/TKContext';
 
-const REGEX = new RegExp(/(^|.)([^\p{L}\p{N}\s]*(TK)+[^\p{L}\p{N}\s]*)(.)?/u);
+const REGEX = new RegExp(/(^|.)([^\p{L}\p{N}\s]*(TK|Tk|tk)+[^\p{L}\p{N}\s]*)(.)?/u);
 const WORD_CHAR_REGEX = new RegExp(/\p{L}|\p{N}/u);
 
 function TKIndicator({editor, rootElement, parentKey, nodeKeys}) {

--- a/packages/koenig-lexical/test/e2e/plugins/TKPlugin.test.js
+++ b/packages/koenig-lexical/test/e2e/plugins/TKPlugin.test.js
@@ -19,10 +19,14 @@ test.describe('TK Plugin', async function () {
     test.describe('highlights TK nodes', async function () {
         test('highlights a TK node when TK is typed in text', async function () {
             await focusEditor(page);
-
             await page.keyboard.type('TK');
-
             await expect(page.getByRole('paragraph').getByText('TK')).toHaveAttribute('data-kg-tk', 'true');
+        });
+
+        test('highlights a TK node when TK is typed in text (case insensitive)', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('tk');
+            await expect(page.getByRole('paragraph').getByText('tk')).toHaveAttribute('data-kg-tk', 'true');
         });
 
         test('highlights a TK when surrounded by symbols', async function () {
@@ -37,6 +41,12 @@ test.describe('TK Plugin', async function () {
             await expect(page.getByRole('paragraph').getByText('TKTK')).toHaveAttribute('data-kg-tk', 'true');
         });
 
+        test('highlights a TK when TK is repeated (case insensitive)', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('TkTk');
+            await expect(page.getByRole('paragraph').getByText('TkTk')).toHaveAttribute('data-kg-tk', 'true');
+        });
+
         test('does not highlight TK when surrounded by letters', async function () {
             await focusEditor(page);
             await page.keyboard.type('TKtest');
@@ -45,40 +55,31 @@ test.describe('TK Plugin', async function () {
 
         test('highlights a TK node when TK is typed in a heading', async function () {
             await focusEditor(page);
-
             await page.keyboard.type('# TK');
-
             await expect(page.getByRole('heading').getByText('TK')).toHaveAttribute('data-kg-tk', 'true');
         });
 
         test('highlights a TK node when TK is typed in a list item', async function () {
             await focusEditor(page);
-
             await page.keyboard.type('- TK');
-
             await expect(page.getByRole('listitem').getByText('TK')).toHaveAttribute('data-kg-tk', 'true');
         });
 
         test('changes highlight when TK indicator is hovered', async function () {
             await focusEditor(page);
-
             await page.keyboard.type('TK');
             await page.getByTestId('tk-indicator').hover();
-
             await expect(page.getByRole('paragraph').getByText('TK')).toHaveClass('bg-lime-500 dark:bg-lime-800 py-1');
         });
 
         test('highlights TK nodes following invalid TK text', async function () {
             await focusEditor(page);
-
             await page.keyboard.type('TKs and TK and [TK]');
-
             await expect(page.locator('[data-kg-tk="true"]')).toHaveCount(2);
         });
 
         test('highlights TK when preceded or follow by emdash', async function () {
             await focusEditor(page);
-
             await page.keyboard.type('First---TK Second---TK---Third TK---Last');
 
             await assertHTML(page, html`
@@ -98,7 +99,6 @@ test.describe('TK Plugin', async function () {
     test.describe('indicators', async function () {
         test('creates a TK indicator for each TK node', async function () {
             await focusEditor(page);
-
             await page.keyboard.type('TK and TK and TK');
             await expect(page.getByTestId('tk-indicator')).toBeVisible();
         });
@@ -117,7 +117,6 @@ test.describe('TK Plugin', async function () {
 
         test('clicking the indicator selects the first TK node in the parent', async function () {
             await focusEditor(page);
-
             await page.keyboard.type('TK and TK and TK');
 
             await page.evaluate(() => window.getSelection().toString()).then((selection) => {
@@ -133,7 +132,6 @@ test.describe('TK Plugin', async function () {
 
         test('continuing to click the indicator cycles through the TK nodes in the parent', async function () {
             await focusEditor(page);
-
             await page.keyboard.type('TK and TK and TK');
             await page.getByTestId('tk-indicator').click();
 

--- a/packages/koenig-lexical/test/utils/e2e.js
+++ b/packages/koenig-lexical/test/utils/e2e.js
@@ -24,7 +24,7 @@ export async function initialize({page, uri = '/#/?content=false'}) {
 
         await exposeLexicalEditor(page);
     } else {
-        // Subsequent pages nagivated to using react router
+        // Subsequent pages navigated to using react router
         await page.evaluate(async ([navigateTo, force]) => {
             window.lexicalEditor.blur();
             window.lexicalEditor.setEditorState(window.originalEditorState);


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/MOM-11

- allowed `Tk`/`tk`/`tK` instead of only `TK`
- avoids need to know about the previous case-sensitive behaviour and subsequent confusion around feature "not working"
