### PR TITLE
Added internal linking PoC to bookmark card

### DIFF
--- a/packages/koenig-lexical/src/components/ui/Input.jsx
+++ b/packages/koenig-lexical/src/components/ui/Input.jsx
@@ -2,21 +2,30 @@ import React from 'react';
 
 export const INPUT_CLASSES = 'rounded border border-grey-300 py-2 px-3 font-sans text-sm font-normal text-grey-900 focus:border-green focus:shadow-insetgreen focus-visible:outline-none dark:border-grey-900 dark:bg-grey-900 dark:text-white dark:placeholder:text-grey-700 dark:selection:bg-grey-800';
 
-export function Input({dataTestId, value, placeholder, onChange, onFocus, onBlur}) {
-    const onChangeWrapper = (e) => {
+export function Input({autoFocus, className, dataTestId, value, placeholder, onChange, onFocus, onBlur}) {
+    const [localValue, setLocalValue] = React.useState(value);
+
+    const onChangeWrapper = React.useCallback((e) => {
+        setLocalValue(e.target.value);
+
         if (onChange) {
             onChange(e);
         }
-    };
+    }, [onChange]);
+
+    React.useEffect(() => {
+        setLocalValue(value);
+    }, [value]);
 
     return (
         <>
             <div className="relative">
                 <input
-                    className={`relative w-full ${INPUT_CLASSES}`}
+                    autoFocus={autoFocus}
+                    className={`relative w-full ${className || INPUT_CLASSES}`}
                     data-testid={dataTestId}
-                    defaultValue={value}
                     placeholder={placeholder}
+                    value={localValue}
                     onBlur={onBlur}
                     onChange={onChangeWrapper}
                     onFocus={onFocus}

--- a/packages/koenig-lexical/src/components/ui/InputList.jsx
+++ b/packages/koenig-lexical/src/components/ui/InputList.jsx
@@ -3,6 +3,14 @@ import {DropdownContainer} from './DropdownContainer';
 import {Input} from './Input';
 import {KeyboardSelection} from './KeyboardSelection';
 
+function LoadingItem({dataTestId}) {
+    return (
+        <li className={`px-4 py-2 text-left`} data-testid={`${dataTestId}-loading`}>
+            <span className="block text-sm font-semibold leading-tight text-black dark:text-white">Loading...</span>
+        </li>
+    );
+}
+
 function Item({dataTestId, item, selected, onChange}) {
     let selectionClass = '';
 
@@ -36,7 +44,7 @@ function Item({dataTestId, item, selected, onChange}) {
  * @param {string} [options.list]
  * @returns
  */
-export function InputList({dataTestId, listOptions, value, placeholder, onChange}) {
+export function InputList({autoFocus, className, dataTestId, listOptions, isLoading, value, placeholder, onChange, onSelect}) {
     const [inputFocused, setInputFocused] = React.useState(false);
 
     const onFocus = () => {
@@ -57,12 +65,18 @@ export function InputList({dataTestId, listOptions, value, placeholder, onChange
         onChange(event.target.value);
     };
 
-    const showSuggestions = listOptions && !!listOptions.length && inputFocused;
+    const onSelectEvent = (item) => {
+        (onSelect || onChange)(item.value);
+    };
+
+    const showSuggestions = (isLoading || (listOptions && !!listOptions.length)) && inputFocused;
 
     return (
         <>
             <div className="relative z-0">
                 <Input
+                    autoFocus={autoFocus}
+                    className={className}
                     dataTestId={dataTestId}
                     placeholder={placeholder}
                     value={value}
@@ -72,10 +86,11 @@ export function InputList({dataTestId, listOptions, value, placeholder, onChange
                 />
                 {showSuggestions &&
                     <DropdownContainer>
+                        {isLoading && <LoadingItem dataTestId={dataTestId}/>}
                         <KeyboardSelection
                             getItem={getItem}
                             items={listOptions}
-                            onSelect={item => onChange(item.value)}
+                            onSelect={onSelectEvent}
                         />
                     </DropdownContainer>
                 }

--- a/packages/koenig-lexical/src/components/ui/SnippetInput.jsx
+++ b/packages/koenig-lexical/src/components/ui/SnippetInput.jsx
@@ -57,7 +57,7 @@ export function SnippetInput({
             if (suggestedList.length === 0) {
                 return;
             }
-            
+
             // handle first arrow down from input
             if (activeMenuItem === -1 && !isCreateButtonActive) {
                 setIsCreateButtonActive(true);
@@ -120,7 +120,13 @@ export function SnippetInput({
             ref={snippetRef}
             onClick={e => e.stopPropagation()} // prevents card from losing selected state
         >
-            <Input arrowStyles={arrowStyles} value={value} onChange={onChange} onClear={onClose} onKeyDown={handleInputKeyDown} />
+            <Input
+                arrowStyles={arrowStyles}
+                value={value}
+                onChange={onChange}
+                onClear={onClose}
+                onKeyDown={handleInputKeyDown}
+            />
             {
                 !!value && (
                     <Dropdown

--- a/packages/koenig-lexical/src/components/ui/UrlSearchInput.jsx
+++ b/packages/koenig-lexical/src/components/ui/UrlSearchInput.jsx
@@ -1,0 +1,125 @@
+import CloseIcon from '../../assets/icons/kg-close.svg?react';
+import React from 'react';
+import debounce from 'lodash/debounce';
+import {InputList} from './InputList';
+
+const DEBOUNCE_MS = 200;
+
+function convertSearchResultsToListOptions(results) {
+    return results.map((result) => {
+        return {
+            label: result.title,
+            value: result.url
+        };
+    });
+}
+
+export function UrlSearchInput({dataTestId, value, placeholder, handleUrlChange, handleUrlSubmit, hasError, handlePasteAsLink, handleRetry, handleClose, isLoading, searchLinks}) {
+    const [defaultListOptions, setDefaultListOptions] = React.useState([]);
+    const [listOptions, setListOptions] = React.useState([]);
+    const [isSearching, setIsSearching] = React.useState(false);
+
+    const debouncedSearch = React.useMemo(() => {
+        return debounce(async (term) => {
+            setIsSearching(true);
+            const results = await searchLinks(term);
+            setListOptions(convertSearchResultsToListOptions(results));
+            setIsSearching(false);
+        }, DEBOUNCE_MS);
+    }, [searchLinks]);
+
+    // Fetch default search results when first rendering
+    // TODO: feels kinda hacky, check React best practices
+    React.useEffect(() => {
+        const urlMatch = value?.match(/^http.*$/);
+
+        if (!urlMatch) {
+            const fetchDefaultOptions = async () => {
+                setIsSearching(true);
+                const results = await searchLinks();
+                setDefaultListOptions(convertSearchResultsToListOptions(results));
+                setIsSearching(false);
+            };
+
+            fetchDefaultOptions()
+                .catch(console.error); // eslint-disable-line no-console
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    React.useEffect(() => {
+        const handleKeyDown = (e) => {
+            if (e.key === 'Escape') {
+                handleClose();
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [handleClose]);
+
+    if (isLoading) {
+        return (
+            <div className="flex w-full items-center justify-center rounded border border-grey-300 p-2 font-sans text-sm font-normal leading-snug text-grey-900 focus-visible:outline-none dark:border-grey-800 dark:bg-grey-900 dark:placeholder:text-grey-800" data-testid={`${dataTestId}-loading-container`}>
+                <div className="-ml-1 mr-3 inline-block size-5 animate-spin rounded-full border-4 border-green/20 text-white after:mt-[11px] after:block after:size-1 after:rounded-full after:bg-green/70 after:content-['']" data-testid={`${dataTestId}-loading-spinner`}></div>
+            </div>
+        );
+    }
+    if (hasError) {
+        return (
+            <div className="min-width-[500px] flex flex-row items-center justify-between rounded-sm border border-red bg-red/5 px-3 py-2 text-sm leading-snug text-red" data-testid={`${dataTestId}-error-container`}>
+                <div>
+                    <span className="mr-3" data-testid={`${dataTestId}-error-message`}>There was an error when parsing the URL.</span>
+                    <button className="mr-3 cursor-pointer" data-testid={`${dataTestId}-error-retry`} type="button"><span className="underline" onClick={handleRetry}><strong>Retry</strong></span></button>
+                    <button className="mr-3 cursor-pointer" data-testid={`${dataTestId}-error-pasteAsLink`} type="button"><span className="underline" onClick={() => handlePasteAsLink(value)}><strong>Paste URL as link</strong></span></button>
+                </div>
+                <button className="cursor-pointer p-1" data-testid={`${dataTestId}-error-close`} type="button" onClick={handleClose}>
+                    <CloseIcon className="red size-3"/>
+                </button>
+            </div>
+        );
+    }
+
+    const onChangeEvent = async (inputValue) => {
+        handleUrlChange(inputValue);
+
+        // disable searching when a URL is entered to avoid unnecessary flashing
+        const urlMatch = value?.match(/^http.*$/);
+
+        if (urlMatch) {
+            setListOptions([]);
+        } else {
+            debouncedSearch(inputValue);
+        }
+    };
+
+    const onSelectEvent = (selectedValue) => {
+        handleUrlSubmit(selectedValue);
+    };
+
+    const handleKeyDown = (event) => {
+        if (!event.isComposing && event.key === 'Enter') {
+            event.preventDefault();
+            handleUrlSubmit(event.target.value);
+        }
+    };
+
+    const displayedListOptions = value ? listOptions : defaultListOptions;
+
+    return (
+        <div className="not-kg-prose" onKeyDown={handleKeyDown}>
+            <InputList
+                autoFocus={true}
+                className={`w-full rounded border ${isSearching || displayedListOptions.length ? 'rounded-b-none border-b-0' : ''} border-grey-300 p-2 font-sans text-sm font-normal leading-snug text-grey-900 focus-visible:outline-none dark:border-grey-800 dark:bg-grey-950 dark:text-grey-100 dark:placeholder:text-grey-800`}
+                dataTestId={dataTestId}
+                isLoading={isSearching}
+                listOptions={displayedListOptions}
+                placeholder={placeholder}
+                value={value}
+                onChange={onChangeEvent}
+                onSelect={onSelectEvent}
+            />
+        </div>
+    );
+}

--- a/packages/koenig-lexical/src/components/ui/UrlSearchInput.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/UrlSearchInput.stories.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import {UrlSearchInput} from './UrlSearchInput';
+
+const story = {
+    title: 'Generic/Searchable URL Input',
+    component: UrlSearchInput,
+    parameters: {
+        status: {
+            type: 'uiReady'
+        }
+    }
+};
+export default story;
+
+const Template = args => (
+    <div className="w-[740px]">
+        <div className="p-4">
+            <UrlSearchInput {...args} />
+        </div>
+        <div className="dark bg-black p-4">
+            <UrlSearchInput {...args} />
+        </div>
+    </div>
+);
+
+export const Empty = Template.bind({});
+Empty.args = {
+    value: '',
+    onChange: () => {}
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+    value: 'https://ghost.org/',
+    onChange: () => {},
+    isLoading: true
+};
+
+export const Placeholder = Template.bind({});
+Placeholder.args = {
+    value: '',
+    onChange: () => {},
+    placeholder: 'Enter a URL to add content...'
+};
+
+export const Populated = Template.bind({});
+Populated.args = {
+    value: 'https://sampleurl.com',
+    onChange: () => {}
+};
+
+export const Error = Template.bind({});
+Error.args = {
+    value: 'thisisntaurl',
+    hasError: true,
+    onChange: () => {},
+    handleRetry: () => {},
+    handlePasteAsLink: () => {}
+};

--- a/packages/koenig-lexical/src/components/ui/cards/BookmarkCardWithSearch.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/BookmarkCardWithSearch.jsx
@@ -1,0 +1,107 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {CardCaptionEditor} from '../CardCaptionEditor';
+import {UrlSearchInput} from '../UrlSearchInput';
+
+export function BookmarkCardWithSearch({
+    author,
+    handleClose,
+    handlePasteAsLink,
+    handleRetry,
+    handleUrlChange,
+    handleUrlSubmit,
+    url,
+    urlInputValue,
+    urlPlaceholder,
+    thumbnail,
+    title,
+    description,
+    icon,
+    publisher,
+    captionEditor,
+    captionEditorInitialState,
+    isSelected,
+    isLoading,
+    urlError,
+    searchLinks
+}) {
+    if (url && !urlError && title) {
+        return (
+            <div>
+                <div className="not-kg-prose relative flex min-h-[120px] w-full rounded border border-grey/40 bg-transparent font-sans dark:border-grey/20" data-testid="bookmark-container">
+                    <div className="flex grow basis-full flex-col items-start justify-start p-5" data-testid="bookmark-text-container">
+                        <div className="text-[1.5rem] font-semibold leading-normal tracking-normal text-grey-900 dark:text-grey-100" data-testid="bookmark-title">{title}</div>
+                        <div className="mt-1 line-clamp-2 max-h-[44px] overflow-y-hidden text-sm font-normal leading-normal text-grey-800 dark:text-grey-600" data-testid="bookmark-description">{description}</div>
+                        <div className="mt-[20px] flex items-center text-sm font-medium leading-9 text-grey-900">
+                            {icon && <BookmarkIcon src={icon} />}
+                            <span className=" db max-w-[240px] truncate leading-6 text-grey-900 dark:text-grey-100" data-testid="bookmark-publisher">{publisher}</span>
+                            {author && <span className="font-normal text-grey-800 before:mx-1.5 before:text-grey-900 before:content-['•'] dark:text-grey-600 dark:before:text-grey-100" data-testid="bookmark-author">{author}</span>}
+                        </div>
+                    </div>
+                    {thumbnail &&
+                        (<div className={'grow-1 relative m-0 min-w-[33%]'} data-testid="bookmark-thumbnail-container">
+                            <img alt="" className="absolute inset-0 size-full rounded-r-[.3rem] object-cover" data-testid="bookmark-thumbnail" src={thumbnail}/>
+                        </div>)
+                    }
+                    <div className="absolute inset-0 z-50 mt-0"></div>
+                </div>
+                <CardCaptionEditor
+                    captionEditor={captionEditor}
+                    captionEditorInitialState={captionEditorInitialState}
+                    captionPlaceholder="Type caption for bookmark (optional)"
+                    dataTestId="bookmark-caption"
+                    isSelected={isSelected}
+                />
+            </div>
+        );
+    }
+
+    return (
+        <UrlSearchInput
+            dataTestId="bookmark-url"
+            handleClose={handleClose}
+            handlePasteAsLink={handlePasteAsLink}
+            handleRetry={handleRetry}
+            handleUrlChange={handleUrlChange}
+            handleUrlSubmit={handleUrlSubmit}
+            hasError={urlError}
+            isLoading={isLoading}
+            placeholder={urlPlaceholder}
+            searchLinks={searchLinks}
+            value={urlInputValue}
+        />
+    );
+}
+
+export function BookmarkIcon({src}) {
+    return (
+        <img alt="" className="mr-2 size-5 shrink-0" data-testid="bookmark-icon" src={src}/>
+    );
+}
+
+BookmarkCardWithSearch.propTypes = {
+    author: PropTypes.string,
+    handleClose: PropTypes.func,
+    handlePasteAsLink: PropTypes.func,
+    handleRetry: PropTypes.func,
+    handleUrlChange: PropTypes.func,
+    handleUrlSubmit: PropTypes.func,
+    url: PropTypes.string,
+    urlInputValue: PropTypes.string,
+    urlPlaceholder: PropTypes.string,
+    thumbnail: PropTypes.string,
+    title: PropTypes.string,
+    description: PropTypes.string,
+    icon: PropTypes.string,
+    publisher: PropTypes.string,
+    captionEditor: PropTypes.object,
+    captionEditorInitialState: PropTypes.object,
+    isSelected: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    urlError: PropTypes.bool,
+    searchLinks: PropTypes.func
+};
+
+BookmarkIcon.propTypes = {
+    src: PropTypes.string
+};

--- a/packages/koenig-lexical/src/components/ui/cards/BookmarkCardWithSearch.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/BookmarkCardWithSearch.stories.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import populateEditor from '../../../utils/storybook/populate-storybook-editor.js';
+import {BookmarkCardWithSearch} from './BookmarkCardWithSearch.jsx';
+import {CardWrapper} from '../CardWrapper.jsx';
+import {MINIMAL_NODES} from '../../../index.js';
+import {createEditor} from 'lexical';
+
+const displayOptions = {
+    Default: {isSelected: false, isEditing: false},
+    Selected: {isSelected: true, isEditing: false}
+};
+
+const story = {
+    title: 'Primary cards/Bookmark card with search',
+    component: BookmarkCardWithSearch,
+    subcomponent: {CardWrapper},
+    argTypes: {
+        display: {
+            options: Object.keys(displayOptions),
+            mapping: displayOptions,
+            control: {
+                type: 'radio',
+                labels: {
+                    Default: 'Default',
+                    Selected: 'Selected'
+                },
+                defaultValue: displayOptions.Default
+            }
+        }
+    },
+    parameters: {
+        status: {
+            type: 'uiReady'
+        }
+    }
+};
+export default story;
+
+const Template = ({display, caption, ...args}) => {
+    const captionEditor = createEditor({nodes: MINIMAL_NODES});
+    populateEditor({editor: captionEditor, initialHtml: `${caption}`});
+
+    return (
+        <div className="kg-prose">
+            <div className="not-kg-prose mx-auto my-8 min-w-[initial] max-w-[740px] p-4">
+                <CardWrapper {...display} {...args}>
+                    <BookmarkCardWithSearch {...display} {...args} captionEditor={captionEditor} />
+                </CardWrapper>
+            </div>
+            <div className="not-kg-prose dark mx-auto my-8 min-w-[initial] max-w-[740px] bg-black p-4">
+                <CardWrapper {...display} {...args}>
+                    <BookmarkCardWithSearch {...display} {...args} captionEditor={captionEditor} />
+                </CardWrapper>
+            </div>
+        </div>
+    );
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+    display: 'Selected',
+    url: '',
+    urlPlaceholder: 'Paste URL to add bookmark content...',
+    title: 'Ghost: The Creator Economy Platform',
+    description: 'The world’s most popular modern publishing platform for creating a new media platform. Used by Apple, SkyNews, Buffer, OpenAI, and thousands more.',
+    icon: 'https://www.ghost.org/favicon.ico',
+    publisher: 'Ghost - The Professional Publishing Platform',
+    author: 'Author McAuthory',
+    thumbnail: 'https://ghost.org/images/meta/ghost.png'
+};
+
+export const Populated = Template.bind({});
+Populated.args = {
+    display: 'Selected',
+    url: 'https://ghost.org/',
+    urlPlaceholder: 'Paste URL to add bookmark content...',
+    title: 'Ghost: The Creator Economy Platform',
+    description: 'The world’s most popular modern publishing platform for creating a new media platform. Used by Apple, SkyNews, Buffer, OpenAI, and thousands more.',
+    icon: 'https://www.ghost.org/favicon.ico',
+    publisher: 'Ghost - The Professional Publishing Platform',
+    author: 'Author McAuthory',
+    thumbnail: 'https://ghost.org/images/meta/ghost.png',
+    caption: ''
+};
+
+export const WithCaption = Template.bind({});
+WithCaption.args = {
+    display: 'Selected',
+    url: 'https://ghost.org/',
+    urlPlaceholder: 'Paste URL to add bookmark content...',
+    title: 'Ghost: The Creator Economy Platform',
+    description: 'The world’s most popular modern publishing platform for creating a new media platform. Used by Apple, SkyNews, Buffer, OpenAI, and thousands more.',
+    icon: 'https://www.ghost.org/favicon.ico',
+    publisher: 'Ghost - The Professional Publishing Platform',
+    author: 'Author McAuthory',
+    thumbnail: 'https://ghost.org/images/meta/ghost.png',
+    caption: 'This is a caption'
+};

--- a/packages/koenig-lexical/src/nodes/BookmarkNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/BookmarkNodeComponent.jsx
@@ -5,6 +5,7 @@ import {$createLinkNode} from '@lexical/link';
 import {$createParagraphNode, $createTextNode, $getNodeByKey, $isParagraphNode} from 'lexical';
 import {ActionToolbar} from '../components/ui/ActionToolbar.jsx';
 import {BookmarkCard} from '../components/ui/cards/BookmarkCard';
+import {BookmarkCardWithSearch} from '../components/ui/cards/BookmarkCardWithSearch.jsx';
 import {SnippetActionToolbar} from '../components/ui/SnippetActionToolbar.jsx';
 import {ToolbarMenu, ToolbarMenuItem} from '../components/ui/ToolbarMenu.jsx';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
@@ -19,13 +20,23 @@ export function BookmarkNodeComponent({author, nodeKey, url, icon, title, descri
     const [urlError, setUrlError] = React.useState(false);
     const [showSnippetToolbar, setShowSnippetToolbar] = React.useState(false);
 
-    const handleUrlChange = (event) => {
-        setUrlInputValue(event.target.value);
+    const handleUrlChange = (eventOrUrl) => {
+        // TODO: change this so we only get given URL strings - child components should handle their own events
+        if (typeof eventOrUrl === 'string') {
+            setUrlInputValue(eventOrUrl);
+            return;
+        }
+        setUrlInputValue(eventOrUrl.target.value);
     };
 
-    const handleUrlSubmit = async (event) => {
-        if (event.key === 'Enter') {
-            fetchMetadata(event.target.value);
+    const handleUrlSubmit = async (eventOrUrl) => {
+        // TODO: change this so we only get given URL strings - child components should handle their own events
+        if (typeof eventOrUrl === 'string') {
+            fetchMetadata(eventOrUrl);
+        }
+
+        if (eventOrUrl.key === 'Enter') {
+            fetchMetadata(eventOrUrl.target.value);
         }
     };
 
@@ -132,29 +143,58 @@ export function BookmarkNodeComponent({author, nodeKey, url, icon, title, descri
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    const DefaultBookmarkCard = (
+        <BookmarkCard
+            author={author}
+            captionEditor={captionEditor}
+            captionEditorInitialState={captionEditorInitialState}
+            description={description}
+            handleClose={handleClose}
+            handlePasteAsLink={handlePasteAsLink}
+            handleRetry={handleRetry}
+            handleUrlChange={handleUrlChange}
+            handleUrlSubmit={handleUrlSubmit}
+            icon={icon}
+            isLoading={loading}
+            isSelected={isSelected}
+            publisher={publisher}
+            thumbnail={thumbnail}
+            title={title}
+            url={url}
+            urlError={urlError}
+            urlInputValue={urlInputValue}
+            urlPlaceholder={`Paste URL to add bookmark content...`}
+        />
+    );
+
+    const LabsBookmarkCard = (
+        <BookmarkCardWithSearch
+            author={author}
+            captionEditor={captionEditor}
+            captionEditorInitialState={captionEditorInitialState}
+            description={description}
+            handleClose={handleClose}
+            handlePasteAsLink={handlePasteAsLink}
+            handleRetry={handleRetry}
+            handleUrlChange={handleUrlChange}
+            handleUrlSubmit={handleUrlSubmit}
+            icon={icon}
+            isLoading={loading}
+            isSelected={isSelected}
+            publisher={publisher}
+            searchLinks={cardConfig.searchLinks}
+            thumbnail={thumbnail}
+            title={title}
+            url={url}
+            urlError={urlError}
+            urlInputValue={urlInputValue}
+            urlPlaceholder={`Paste URL or search posts and pages...`}
+        />
+    );
+
     return (
         <>
-            <BookmarkCard
-                author={author}
-                captionEditor={captionEditor}
-                captionEditorInitialState={captionEditorInitialState}
-                description={description}
-                handleClose={handleClose}
-                handlePasteAsLink={handlePasteAsLink}
-                handleRetry={handleRetry}
-                handleUrlChange={handleUrlChange}
-                handleUrlSubmit={handleUrlSubmit}
-                icon={icon}
-                isLoading={loading}
-                isSelected={isSelected}
-                publisher={publisher}
-                thumbnail={thumbnail}
-                title={title}
-                url={url}
-                urlError={urlError}
-                urlInputValue={urlInputValue}
-                urlPlaceholder={`Paste URL to add bookmark content...`}
-            />
+            {cardConfig.feature.internalLinking ? LabsBookmarkCard : DefaultBookmarkCard}
             <ActionToolbar
                 data-kg-card-toolbar="bookmark"
                 isVisible={showSnippetToolbar}

--- a/packages/koenig-lexical/test/e2e/cards/bookmark-card-labs.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/bookmark-card-labs.test.js
@@ -1,0 +1,331 @@
+import {assertHTML, createSnippet, focusEditor, html, initialize, insertCard, isMac} from '../../utils/e2e';
+import {expect, test} from '@playwright/test';
+
+test.describe('Bookmark card (labs: internalLinking)', async () => {
+    const ctrlOrCmd = isMac() ? 'Meta' : 'Control';
+    let page;
+
+    test.beforeAll(async ({browser}) => {
+        page = await browser.newPage();
+    });
+
+    test.beforeEach(async () => {
+        await initialize({page, uri: '/#/?content=false&labs=internalLinking'});
+    });
+
+    test.afterAll(async () => {
+        await page.close();
+    });
+
+    test('can import serialized bookmark card nodes', async function () {
+        const contentParam = encodeURIComponent(JSON.stringify({
+            root: {
+                children: [{
+                    type: 'bookmark',
+                    url: 'https://www.ghost.org/',
+                    caption: 'caption here',
+                    metadata: {
+                        icon: 'https://www.ghost.org/favicon.ico',
+                        title: 'Ghost: The Creator Economy Platform',
+                        description: 'lorem ipsum dolor amet lorem ipsum dolor amet',
+                        author: 'ghost',
+                        publisher: 'Ghost - The Professional Publishing Platform',
+                        thumbnail: 'https://ghost.org/images/meta/ghost.png'
+                    }
+                }],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        }));
+
+        await initialize({page, uri: `/#/?content=${contentParam}`});
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="bookmark">
+                    <div>
+                        <div>
+                            <div>
+                                <div>Ghost: The Creator Economy Platform</div>
+                                <div>lorem ipsum dolor amet lorem ipsum dolor amet</div>
+                                <div>
+                                    <img alt="" src="https://www.ghost.org/favicon.ico" />
+                                    <span>Ghost - The Professional Publishing Platform</span>
+                                    <span>ghost</span>
+                                </div>
+                            </div>
+                            <div><img alt="" src="https://ghost.org/images/meta/ghost.png" /></div>
+                            <div></div>
+                        </div>
+                        <figcaption>
+                            <div data-kg-allow-clickthrough="true">
+                                <div>
+                                    <div data-kg="editor">
+                                        <div
+                                            contenteditable="true"
+                                            role="textbox"
+                                            spellcheck="true"
+                                            data-lexical-editor="true">
+                                            <p dir="ltr">
+                                                <span data-lexical-text="true">caption here</span>
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </figcaption>
+                    </div>
+                </div>
+            </div>
+        `, {ignoreCardToolbarContents: true, ignoreInnerSVG: true});
+    });
+
+    test('renders bookmark card node', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'bookmark'});
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="bookmark"></div>
+            </div>
+            <p><br /></p>
+        `, {ignoreCardContents: true});
+    });
+
+    test('can interact with url input after inserting', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'bookmark'});
+
+        const urlInput = await page.getByTestId('bookmark-url');
+        await expect(urlInput).toHaveAttribute('placeholder','Paste URL or search posts and pages...');
+
+        await urlInput.fill('test');
+        await expect(urlInput).toHaveValue('test');
+    });
+
+    test.describe('Valid URL handling', async () => {
+        test('shows loading wheel', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+
+            const urlInput = await page.getByTestId('bookmark-url');
+            await urlInput.fill('https://ghost.org/');
+            await urlInput.press('Enter');
+
+            await expect(await page.getByTestId('bookmark-url-loading-container')).toBeVisible();
+            await expect(await page.getByTestId('bookmark-url-loading-spinner')).toBeVisible();
+        });
+
+        test('displays expected metadata', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+
+            const urlInput = await page.getByTestId('bookmark-url');
+            await urlInput.fill('https://ghost.org/');
+            await urlInput.press('Enter');
+
+            await expect(await page.getByTestId('bookmark-title')).toHaveText('Ghost: The Creator Economy Platform');
+            await expect(await page.getByTestId('bookmark-description')).toContainText('The former of the two songs addresses the issue of negative rumors in a relationship, while the latter, with a more upbeat pulse, is a classic club track; the single is highlighted by a hyped bridge.');
+            await expect(await page.getByTestId('bookmark-publisher')).toContainText('Ghost - The Professional Publishing Platform');
+        });
+
+        // TODO: the caption editor is very nested, and we don't have an actual input field here, so we aren't testing for filling it
+        test('caption displays on insert', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+
+            const urlInput = await page.getByTestId('bookmark-url');
+            await urlInput.fill('https://ghost.org/');
+            await urlInput.press('Enter');
+
+            const captionInput = await page.getByTestId('bookmark-caption');
+            await expect(captionInput).toContainText('Type caption for bookmark (optional)');
+        });
+    });
+
+    test.describe('Error Handling', async () => {
+        test('bad url entry shows error message', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+
+            const urlInput = await page.getByTestId('bookmark-url');
+            await urlInput.fill('badurl');
+            await expect(urlInput).toHaveValue('badurl');
+            await urlInput.press('Enter');
+
+            await expect(await page.getByTestId('bookmark-url-error-message')).toContainText('There was an error when parsing the URL.');
+        });
+
+        test('retry button bring back url input', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+
+            const urlInput = await page.getByTestId('bookmark-url');
+            await expect(urlInput).toHaveAttribute('placeholder','Paste URL or search posts and pages...');
+
+            await urlInput.fill('badurl');
+            await expect(urlInput).toHaveValue('badurl');
+            await urlInput.press('Enter');
+
+            const retryButton = await page.getByTestId('bookmark-url-error-retry');
+            await retryButton.click();
+
+            const urlInputRetry = await page.getByTestId('bookmark-url');
+            await expect(urlInputRetry).toHaveValue('badurl');
+            await expect(retryButton).not.toBeVisible();
+        });
+
+        // todo: test is failing, need to figure if the error in test logic or on code
+        test.skip('paste as link button removes card and inserts text node link', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+
+            const urlInput = await page.getByTestId('bookmark-url');
+            await expect(urlInput).toHaveAttribute('placeholder','Paste URL or search posts and pages...');
+
+            await urlInput.fill('badurl');
+            await expect(urlInput).toHaveValue('badurl');
+            await urlInput.press('Enter');
+
+            const retryButton = await page.getByTestId('bookmark-url-error-pasteAsLink');
+            await retryButton.click();
+
+            await assertHTML(page, html`
+                <p>
+                    <a href="badurl" dir="ltr"><span data-lexical-text="true">badurl</span></a>
+                </p>
+                <p><br /></p>
+            `);
+        });
+
+        test('close button removes card', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+
+            const urlInput = await page.getByTestId('bookmark-url');
+            await expect(urlInput).toHaveAttribute('placeholder','Paste URL or search posts and pages...');
+
+            await urlInput.fill('badurl');
+            await expect(urlInput).toHaveValue('badurl');
+            await urlInput.press('Enter');
+
+            const retryButton = await page.getByTestId('bookmark-url-error-close');
+            await retryButton.click();
+
+            await assertHTML(page, html`<p><br /></p>`);
+        });
+    });
+
+    test('can add snippet', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'bookmark'});
+
+        const urlInput = await page.getByTestId('bookmark-url');
+        await urlInput.fill('https://ghost.org/');
+        await urlInput.press('Enter');
+        await expect(await page.getByTestId('bookmark-description')).toBeVisible();
+
+        // create snippet
+        await page.keyboard.press('Escape');
+        await createSnippet(page);
+
+        // can insert card from snippet
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('/snippet');
+        await page.waitForSelector('[data-kg-cardmenu-selected="true"]');
+        await page.keyboard.press('Enter');
+        await expect(await page.locator('[data-kg-card="bookmark"]')).toHaveCount(2);
+    });
+
+    test('can undo/redo without losing caption', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'bookmark'});
+
+        const urlInput = await page.getByTestId('bookmark-url');
+        await urlInput.fill('https://ghost.org/');
+        await urlInput.press('Enter');
+        await expect(await page.getByTestId('bookmark-description')).toBeVisible();
+
+        await page.click('[data-testid="bookmark-caption"]');
+        await page.keyboard.type('My test caption');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Backspace');
+        await page.keyboard.press('Backspace');
+        await page.keyboard.press(`${ctrlOrCmd}+z`);
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="bookmark">
+                    <div>
+                        <div>
+                            <div>
+                                <div>Ghost: The Creator Economy Platform</div>
+                                <div>
+                                    The former of the two songs addresses the issue of negative rumors
+                                    in a relationship, while the latter, with a more upbeat pulse, is a
+                                    classic club track; the single is highlighted by a hyped bridge.
+                                </div>
+                                <div>
+                                    <img alt="" src="https://www.ghost.org/favicon.ico" />
+                                    <span>Ghost - The Professional Publishing Platform</span>
+                                    <span>Author McAuthory</span>
+                                </div>
+                            </div>
+                            <div><img alt="" src="https://ghost.org/images/meta/ghost.png" /></div>
+                            <div></div>
+                        </div>
+                        <figcaption>
+                            <div data-kg-allow-clickthrough="true">
+                                <div>
+                                    <div data-kg="editor">
+                                        <div
+                                            contenteditable="true"
+                                            role="textbox"
+                                            spellcheck="true"
+                                            data-lexical-editor="true">
+                                            <p dir="ltr">
+                                                <span data-lexical-text="true">My test caption</span>
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </figcaption>
+                    </div>
+                    <div data-kg-card-toolbar="bookmark"></div>
+                </div>
+            </div>
+            <p><br /></p>
+        `, {ignoreCardToolbarContents: true, ignoreInnerSVG: true});
+    });
+
+    test('escape removes url input component', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'bookmark'});
+
+        await page.keyboard.press('Escape');
+
+        await assertHTML(page, html`
+            <p><br /></p>
+        `, {ignoreCardContents: true});
+    });
+
+    test('escape removes url error component', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'bookmark'});
+
+        await page.keyboard.type('badurl');
+        await page.keyboard.press('Enter');
+
+        await expect(await page.getByTestId('bookmark-url-error-message')).toContainText('There was an error when parsing the URL.');
+
+        await page.keyboard.press('Escape');
+
+        await assertHTML(page, html`
+            <p><br /></p>
+        `, {ignoreCardContents: true});
+    });
+});


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/MOM-1

- updated demo app
  - added `cardConfig.searchLinks()` method to simulate default list loading and searching behaviour
  - added handling of searchParams so it's possible to test the labs-flag bookmark card using `?labs=internalLinking`
- updated `<Input>` component
  - added `autoFocus` prop/attribute support
  - added ability to override default class list by passing `className` prop
  - re-enabled 2-way binding; by switching to using local value state the input's `value` is always updated synchronously before the `onChange()` method is called which can trigger an asynchronous update which otherwise results in React losing track of the cursor position
- updated `<InputList>` component
  - added `autoFocus` and `className` prop passthrough
  - added `isLoading` prop and associated loading item display
  - added `onSelect` prop so a differentiation can be made by the consumer between the input changing and an item being selected, default behaviour when not passed is to call `onChange` to maintain backwards compatibility
- added `<UrlSearchInput>`
  - duplicate of `<UrlInput>` that is used in the bookmark and embed cards
  - adds `searchLinks` prop used for fetching default list or searching
  - adds loading of "default" list of links when first rendered by calling `searchLinks()` with no term
  - adds debounced call of `searchLinks(term)` when the input value changes
  - adds `onSelect` handling so `handleUrlSubmit()` is called immediately when an item from the list is selected
  - replaces the Lexical plugin handling of the `Enter` key with a JS key event to capture events from the input field
- duplicated `<BookmarkCard>` to `<BookmarkCardWithSearch>` which uses `<UrlSearchInput>` in place of `<UrlInput>`
- updated `<BookmarkNodeComponent>` to switch between the original `<BookmarkCard>` and the new `<BookmarkCardWithSearch>` components based on the `cardConfig.feature.internalLinking` value
