### PR TITLE
Updated searchable url dropdown to show group headings

### DIFF
--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -55,23 +55,43 @@ const defaultCardConfig = {
         // no delay to simulate posts being pre-loaded in editor
         if (!term) {
             return [
-                {id: '1', groupName: 'Latest posts', title: 'Remote Work\'s Impact on Job Markets and Employment', url: 'https://source.ghost.io/remote-works-impact-on-job-markets/'},
-                {id: '2', groupName: 'Latest posts', title: 'Robotics Renaissance: How Automation is Transforming Industries', url: 'https://source-newsletter.ghost.io/mental-health-awareness-in-the-workplace/'},
-                {id: '3', groupName: 'Latest posts', title: 'Biodiversity Conservation in Fragile Ecosystems', url: 'https://source.ghost.io/biodiversity-conservation-in-fragile-ecosystems/'}
+                {label: 'Latest posts', key: 'latest-posts', items: [
+                    {id: '1', groupName: 'Latest posts', title: 'Remote Work\'s Impact on Job Markets and Employment', url: 'https://source.ghost.io/remote-works-impact-on-job-markets/'},
+                    {id: '2', groupName: 'Latest posts', title: 'Robotics Renaissance: How Automation is Transforming Industries', url: 'https://source-newsletter.ghost.io/mental-health-awareness-in-the-workplace/'},
+                    {id: '3', groupName: 'Latest posts', title: 'Biodiversity Conservation in Fragile Ecosystems', url: 'https://source.ghost.io/biodiversity-conservation-in-fragile-ecosystems/'}
+                ]}
             ];
         }
 
         // actual search, simulate a network request delay
         return new Promise((resolve) => {
             setTimeout(() => {
-                const items = [
+                const posts = [
                     {id: '1', groupName: 'Posts', title: 'TK Reminders', url: 'https://ghost.org/changelog/tk-reminders/'},
-                    {id: '2', groupName: 'Posts', title: '✨ Emoji autocomplete ✨', url: 'https://ghost.org/changelog/emoji-picker/'},
-                    {id: '3', groupName: 'Pages', title: 'How to update Ghost', url: 'https://ghost.org/docs/update/'},
+                    {id: '2', groupName: 'Posts', title: '✨ Emoji autocomplete ✨', url: 'https://ghost.org/changelog/emoji-picker/'}
+                ].filter(item => item.title.toLowerCase().includes(term.toLowerCase()));
+
+                const pages = [
+                    {id: '3', groupName: 'Pages', title: 'How to update Ghost', url: 'https://ghost.org/docs/update/'}
+                ].filter(item => item.title.toLowerCase().includes(term.toLowerCase()));
+
+                const tags = [
                     {id: '4', groupName: 'Tags', title: 'Improved', url: 'https://ghost.org/changelog/tag/improved/'}
                 ].filter(item => item.title.toLowerCase().includes(term.toLowerCase()));
 
-                resolve(items);
+                const groups = [];
+
+                if (posts.length) {
+                    groups.push({label: 'Posts', key: 'posts', items: posts});
+                }
+                if (pages.length) {
+                    groups.push({label: 'Pages', key: 'pages', items: pages});
+                }
+                if (tags.length) {
+                    groups.push({label: 'Tags', key: 'tags', items: tags});
+                }
+
+                resolve(groups);
             }, 250);
         });
     }

--- a/packages/koenig-lexical/src/components/ui/DropdownContainerCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/DropdownContainerCopy.jsx
@@ -57,7 +57,6 @@ export function DropdownContainerCopy({children}) {
 
     return (
         <ul ref={divRef} className={`absolute ${placementClasses} z-[-1] max-h-[30vh] w-full overflow-y-auto bg-white py-1 shadow-md dark:bg-grey-950`}>
-            <span className="flex items-center justify-between px-4 py-2 text-[1.1rem] font-semibold uppercase tracking-wide text-grey-600">Recent</span>
             {children}
         </ul>
     );

--- a/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {DropdownContainerCopy} from './DropdownContainerCopy';
 import {Input} from './Input';
-import {KeyboardSelection} from './KeyboardSelection';
+import {KeyboardSelectionWithGroups} from './KeyboardSelectionWithGroups';
 
 function LoadingItem({dataTestId}) {
     return (
@@ -33,6 +33,12 @@ function Item({dataTestId, item, selected, onClick}) {
     );
 }
 
+function Group({group}) {
+    return (
+        <span className="flex items-center justify-between px-4 py-2 text-[1.1rem] font-semibold uppercase tracking-wide text-grey-600">{group.label}</span>
+    );
+}
+
 /**
  * Little warning here: this has an onChange handler that doesn't have an event as parameter, but just the value.
  *
@@ -55,6 +61,12 @@ export function InputListCopy({autoFocus, className, dataTestId, listOptions, is
     const getItem = (item, selected) => {
         return (
             <Item key={item.value} dataTestId={dataTestId} item={item} selected={selected} onClick={onSelectEvent}/>
+        );
+    };
+
+    const getGroup = (group) => {
+        return (
+            <Group group={group} />
         );
     };
 
@@ -84,9 +96,10 @@ export function InputListCopy({autoFocus, className, dataTestId, listOptions, is
                 {showSuggestions &&
                     <DropdownContainerCopy>
                         {isLoading && <LoadingItem dataTestId={dataTestId}/>}
-                        <KeyboardSelection
+                        <KeyboardSelectionWithGroups
+                            getGroup={getGroup}
                             getItem={getItem}
-                            items={listOptions}
+                            groups={listOptions}
                             onSelect={onSelectEvent}
                         />
                     </DropdownContainerCopy>

--- a/packages/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.jsx
+++ b/packages/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+/**
+ * Renders a list of options, which are selectable by using the up and down arrow keys.
+ * You pass in the template for each option via the getItem function, which is called for each option and also passes in whether the item is selected or not.
+ *
+ * @param {object} options
+ * @param {T[]} [options.items]
+ * @param {(T, selected) => import('react').ReactElement} [options.getItem]
+ */
+export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect, defaultSelected}) {
+    const items = groups.flatMap(group => group.items);
+    const defaultIndex = Math.max(0, items.findIndex(item => item === defaultSelected));
+    const [selectedIndex, setSelectedIndex] = React.useState(defaultIndex);
+
+    // If items change, check if the selectedIndex is still valid, and if not, reset it to 0
+    React.useEffect(() => {
+        if (selectedIndex >= items.length) {
+            setSelectedIndex(defaultIndex);
+        }
+    }, [items, selectedIndex, defaultIndex]);
+
+    // If the default index changes, select it again
+    React.useEffect(() => {
+        setSelectedIndex(defaultIndex);
+    }, [defaultIndex]);
+
+    const handleKeydown = React.useCallback((event) => {
+        if (event.key === 'ArrowDown') {
+            // The stop propagation is required for Safari
+            event.preventDefault();
+            event.stopPropagation();
+            setSelectedIndex((i) => {
+                return Math.min(i + 1, items.length - 1);
+            });
+        }
+        if (event.key === 'ArrowUp') {
+            // The stop propagation is required for Safari
+            event.preventDefault();
+            event.stopPropagation();
+            setSelectedIndex((i) => {
+                return Math.max(i - 1, 0);
+            });
+        }
+        if (event.key === 'Enter') {
+            // The stop propagation is required for Safari
+            event.preventDefault();
+            event.stopPropagation();
+            onSelect(items[selectedIndex]);
+        }
+    }, [items, selectedIndex, onSelect]);
+
+    React.useEffect(() => {
+        // The capture phase is required for Safari
+        window.addEventListener('keydown', handleKeydown, {capture: true});
+        return () => {
+            window.removeEventListener('keydown', handleKeydown, {capture: true});
+        };
+    }, [handleKeydown]);
+
+    return (
+        <>
+            {groups.map((group, groupIndex) => (
+                <div key={group.key}>
+                    {getGroup(group)}
+                    {group.items.map((item, index) => {
+                        const itemsBefore = groups.slice(0, groupIndex).reduce((sum, prevGroup) => sum + prevGroup.items.length, 0);
+                        const absoluteIndex = itemsBefore + index;
+                        return getItem(item, absoluteIndex === selectedIndex);
+                    })}
+                </div>
+            ))}
+        </>
+    );
+}

--- a/packages/koenig-lexical/src/components/ui/UrlSearchInput.jsx
+++ b/packages/koenig-lexical/src/components/ui/UrlSearchInput.jsx
@@ -7,10 +7,14 @@ const DEBOUNCE_MS = 200;
 
 function convertSearchResultsToListOptions(results) {
     return results.map((result) => {
-        return {
-            label: result.title,
-            value: result.url
-        };
+        const items = result.items.map((item) => {
+            return {
+                label: item.title,
+                value: item.url
+            };
+        });
+
+        return {...result, items};
     });
 }
 


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/MOM-49

- duplicated `KeyboardSelection` to add groups support
- updated demo app to provide search results in groups
- updated search result normalization in `UrlSearchInput` to account for groups
- updated `InputListCopy` to use `KeyboardSelectionWithGroups`
