### PR TITLE
🐛 Fixed BookmarkNode not auto selecting in Editor

### DIFF
--- a/packages/koenig-lexical/src/nodes/BookmarkNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/BookmarkNodeComponent.jsx
@@ -1,6 +1,6 @@
-import CardContext from '../context/CardContext';
+// import CardContext from '../context/CardContext';
 import KoenigComposerContext from '../context/KoenigComposerContext.jsx';
-import React, {useCallback} from 'react';
+import React, {useCallback, useEffect} from 'react';
 import {$createLinkNode} from '@lexical/link';
 import {$createParagraphNode, $createTextNode, $getNodeByKey, $isParagraphNode} from 'lexical';
 import {ActionToolbar} from '../components/ui/ActionToolbar.jsx';
@@ -8,17 +8,25 @@ import {BookmarkCard} from '../components/ui/cards/BookmarkCard';
 import {BookmarkCardWithSearch} from '../components/ui/cards/BookmarkCardWithSearch.jsx';
 import {SnippetActionToolbar} from '../components/ui/SnippetActionToolbar.jsx';
 import {ToolbarMenu, ToolbarMenuItem} from '../components/ui/ToolbarMenu.jsx';
+import {useKoenigSelectedCardContext} from '../context/KoenigSelectedCardContext';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
 export function BookmarkNodeComponent({author, nodeKey, url, icon, title, description, publisher, thumbnail, captionEditor, captionEditorInitialState, createdWithUrl}) {
     const [editor] = useLexicalComposerContext();
 
     const {cardConfig} = React.useContext(KoenigComposerContext);
-    const {isSelected} = React.useContext(CardContext);
     const [urlInputValue, setUrlInputValue] = React.useState(url);
     const [loading, setLoading] = React.useState(false);
     const [urlError, setUrlError] = React.useState(false);
     const [showSnippetToolbar, setShowSnippetToolbar] = React.useState(false);
+
+    // Since the node isn't triggered by the input field, we need to set the selected card key manually
+    const {selectedCardKey, setSelectedCardKey} = useKoenigSelectedCardContext();
+    useEffect(() => {
+        setSelectedCardKey(nodeKey);
+    }, [nodeKey, setSelectedCardKey]);
+
+    const isSelected = selectedCardKey === nodeKey;
 
     const handleUrlChange = (eventOrUrl) => {
         // TODO: change this so we only get given URL strings - child components should handle their own events

--- a/packages/koenig-lexical/src/nodes/BookmarkNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/BookmarkNodeComponent.jsx
@@ -1,6 +1,6 @@
-// import CardContext from '../context/CardContext';
+import CardContext from '../context/CardContext';
 import KoenigComposerContext from '../context/KoenigComposerContext.jsx';
-import React, {useCallback, useEffect} from 'react';
+import React, {useCallback} from 'react';
 import {$createLinkNode} from '@lexical/link';
 import {$createParagraphNode, $createTextNode, $getNodeByKey, $isParagraphNode} from 'lexical';
 import {ActionToolbar} from '../components/ui/ActionToolbar.jsx';
@@ -8,25 +8,17 @@ import {BookmarkCard} from '../components/ui/cards/BookmarkCard';
 import {BookmarkCardWithSearch} from '../components/ui/cards/BookmarkCardWithSearch.jsx';
 import {SnippetActionToolbar} from '../components/ui/SnippetActionToolbar.jsx';
 import {ToolbarMenu, ToolbarMenuItem} from '../components/ui/ToolbarMenu.jsx';
-import {useKoenigSelectedCardContext} from '../context/KoenigSelectedCardContext';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
 export function BookmarkNodeComponent({author, nodeKey, url, icon, title, description, publisher, thumbnail, captionEditor, captionEditorInitialState, createdWithUrl}) {
     const [editor] = useLexicalComposerContext();
 
     const {cardConfig} = React.useContext(KoenigComposerContext);
+    const {isSelected} = React.useContext(CardContext);
     const [urlInputValue, setUrlInputValue] = React.useState(url);
     const [loading, setLoading] = React.useState(false);
     const [urlError, setUrlError] = React.useState(false);
     const [showSnippetToolbar, setShowSnippetToolbar] = React.useState(false);
-
-    // Since the node isn't triggered by the input field, we need to set the selected card key manually
-    const {selectedCardKey, setSelectedCardKey} = useKoenigSelectedCardContext();
-    useEffect(() => {
-        setSelectedCardKey(nodeKey);
-    }, [nodeKey, setSelectedCardKey]);
-
-    const isSelected = selectedCardKey === nodeKey;
 
     const handleUrlChange = (eventOrUrl) => {
         // TODO: change this so we only get given URL strings - child components should handle their own events

--- a/packages/koenig-lexical/src/plugins/BookmarkPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/BookmarkPlugin.jsx
@@ -5,7 +5,7 @@ import {
     $isRangeSelection,
     COMMAND_PRIORITY_HIGH
 } from 'lexical';
-import {$insertAndSelectNode} from '../utils/$insertAndSelectNode';
+import {INSERT_CARD_COMMAND} from './KoenigBehaviourPlugin';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
@@ -29,8 +29,8 @@ export const BookmarkPlugin = () => {
 
                     const focusNode = selection.focus.getNode();
                     if (focusNode !== null) {
-                        const bookmarkNode = $createBookmarkNode(dataset);
-                        $insertAndSelectNode({selectedNode: focusNode, newNode: bookmarkNode});
+                        const cardNode = $createBookmarkNode(dataset);
+                        editor.dispatchCommand(INSERT_CARD_COMMAND, {cardNode});
                     }
 
                     return true;

--- a/packages/koenig-lexical/test/e2e/cards/bookmark-card-labs.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/bookmark-card-labs.test.js
@@ -89,7 +89,7 @@ test.describe('Bookmark card (labs: internalLinking)', async () => {
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="bookmark"></div>
+                <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="bookmark"></div>
             </div>
             <p><br /></p>
         `, {ignoreCardContents: true});

--- a/packages/koenig-lexical/test/e2e/cards/bookmark-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/bookmark-card.test.js
@@ -89,7 +89,7 @@ test.describe('Bookmark card', async () => {
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="bookmark"></div>
+                <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="bookmark"></div>
             </div>
             <p><br /></p>
         `, {ignoreCardContents: true});


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C02G9E68C/p1713864338521819

- Fixes an issue where the BookmarkNode didn't initialise selected upon creating a new Bookmark card.
- This fix makes use of the "INSERT_CARD_COMMAND" that takes the selections into account at plugin level and removes the `$insertAndSelectNode` initialising function.