### PR TITLE
Added initial version of internal linking for standard link input

### DIFF
--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -204,8 +204,9 @@ function DemoComposer({editorType, isMultiplayer, setWordCount, setTKCount}) {
     function maybeSkipFocusEditor(event) {
         const clickedOnDecorator = (event.target.closest('[data-lexical-decorator]') !== null) || event.target.hasAttribute('data-lexical-decorator');
         const clickedOnSlashMenu = (event.target.closest('[data-kg-slash-menu]') !== null) || event.target.hasAttribute('data-kg-slash-menu');
+        const clickedOnPortal = (event.target.closest('[data-kg-portal]') !== null) || event.target.hasAttribute('data-kg-portal');
 
-        if (clickedOnDecorator || clickedOnSlashMenu) {
+        if (clickedOnDecorator || clickedOnSlashMenu || clickedOnPortal) {
             skipFocusEditor.current = true;
         }
     }
@@ -213,8 +214,9 @@ function DemoComposer({editorType, isMultiplayer, setWordCount, setTKCount}) {
     function focusEditor(event) {
         const clickedOnDecorator = (event.target.closest('[data-lexical-decorator]') !== null) || event.target.hasAttribute('data-lexical-decorator');
         const clickedOnSlashMenu = (event.target.closest('[data-kg-slash-menu]') !== null) || event.target.hasAttribute('data-kg-slash-menu');
+        const clickedOnPortal = (event.target.closest('[data-kg-portal]') !== null) || event.target.hasAttribute('data-kg-portal');
 
-        if (!skipFocusEditor.current && editorAPI && !clickedOnDecorator && !clickedOnSlashMenu) {
+        if (!skipFocusEditor.current && editorAPI && !clickedOnDecorator && !clickedOnSlashMenu && !clickedOnPortal) {
             let editor = editorAPI.editorInstance;
 
             // if a mousedown and subsequent mouseup occurs below the editor

--- a/packages/koenig-lexical/src/components/ui/FloatingFormatToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/FloatingFormatToolbar.jsx
@@ -1,10 +1,15 @@
 import FloatingToolbar from '../../components/ui/FloatingToolbar';
 import FormatToolbar from './FormatToolbar';
+import KoenigComposerContext from '../../context/KoenigComposerContext.jsx';
+import Portal from './Portal.jsx';
 import React from 'react';
 import debounce from 'lodash/debounce';
 import {$getSelection, $isRangeSelection, COMMAND_PRIORITY_LOW, DELETE_CHARACTER_COMMAND} from 'lexical';
+import {$getSelectionRangeRect} from '../../utils/$getSelectionRangeRect.js';
 import {LinkActionToolbar} from './LinkActionToolbar.jsx';
+import {LinkActionToolbarCopy} from './LinkActionToolbarCopy.jsx';
 import {SnippetActionToolbar} from './SnippetActionToolbar';
+import {getScrollParent} from '../../utils/getScrollParent.js';
 import {mergeRegister} from '@lexical/utils';
 
 // don't show the toolbar until the mouse has moved a certain distance,
@@ -27,8 +32,14 @@ export function FloatingFormatToolbar({
     selectionRangeRect,
     hiddenFormats = []
 }) {
+    const {cardConfig} = React.useContext(KoenigComposerContext);
+    const isInternalLinkingEnabled = cardConfig?.feature?.internalLinking || false;
+
     const toolbarRef = React.useRef(null);
+    const linkToolbarRef = React.useRef(null);
     const [arrowStyles, setArrowStyles] = React.useState(null);
+
+    const internalLinkingToolbarVisible = toolbarItemType === toolbarItemTypes.link && isInternalLinkingEnabled;
 
     const updateArrowStyles = React.useCallback(() => {
         const styles = getArrowPositionStyles({ref: toolbarRef, selectionRangeRect});
@@ -130,6 +141,62 @@ export function FloatingFormatToolbar({
         };
     }, [editor, showToolbarIfHidden]);
 
+    // position the link input and search results when they open
+    // appears below the selected text, the full-width of the editor canvas
+    const updateLinkToolbarPosition = React.useCallback(() => {
+        if (internalLinkingToolbarVisible) {
+            editor.update(() => {
+                const toolbarElement = linkToolbarRef.current;
+                if (!toolbarElement) {
+                    return;
+                }
+
+                const selection = $getSelection();
+                const rangeRect = $getSelectionRangeRect({editor, selection});
+
+                // setFloatingElemPosition(rangeRect, toolbarElement, anchorElem, {controlOpacity});
+
+                const scrollerElem = anchorElem.parentElement;
+
+                if (!rangeRect || !scrollerElem || !toolbarElement) {
+                    return;
+                }
+
+                const editorScrollerRect = scrollerElem.getBoundingClientRect();
+
+                const top = rangeRect.bottom + 10;
+                const left = editorScrollerRect.left;
+                const right = editorScrollerRect.right;
+
+                toolbarElement.style.top = `${top}px`;
+                toolbarElement.style.left = `${left}px`;
+                toolbarElement.style.width = `${right - left}px`;
+            });
+        }
+    }, [anchorElem, editor, internalLinkingToolbarVisible]);
+
+    React.useEffect(() => {
+        if (internalLinkingToolbarVisible) {
+            updateLinkToolbarPosition();
+        }
+    }, [internalLinkingToolbarVisible, updateLinkToolbarPosition]);
+
+    React.useEffect(() => {
+        const scrollElement = getScrollParent(anchorElem);
+
+        window.addEventListener('resize', updateLinkToolbarPosition);
+        if (scrollElement) {
+            scrollElement.addEventListener('scroll', updateLinkToolbarPosition);
+        }
+
+        return () => {
+            window.removeEventListener('resize', updateLinkToolbarPosition);
+            if (scrollElement) {
+                scrollElement.removeEventListener('scroll', updateLinkToolbarPosition);
+            }
+        };
+    }, [anchorElem, updateLinkToolbarPosition]);
+
     const handleActionToolbarClose = () => {
         setToolbarItemType(null);
     };
@@ -138,44 +205,61 @@ export function FloatingFormatToolbar({
     const isLinkToolbar = toolbarItemTypes.link === toolbarItemType;
     const isTextToolbar = toolbarItemTypes.text === toolbarItemType;
 
-    return (
-        <FloatingToolbar
-            anchorElem={anchorElem}
-            // toolbar opacity is 0 by default
-            // shouldn't display until selection via mouse is complete to avoid toolbar re-positioning while dragging
-            controlOpacity={!isTextToolbar}
-            editor={editor}
-            isVisible={!!toolbarItemType}
-            shouldReposition={toolbarItemType !== toolbarItemTypes.text} // format toolbar shouldn't reposition when applying formats
-            toolbarRef={toolbarRef}
-            onReposition={updateArrowStyles}
-        >
-            {isSnippetToolbar && (
-                <SnippetActionToolbar
-                    arrowStyles={arrowStyles}
-                    onClose={handleActionToolbarClose}
-                />
-            )}
+    const showTextToolbar = isTextToolbar || (isInternalLinkingEnabled && isLinkToolbar);
 
-            {isLinkToolbar && (
-                <LinkActionToolbar
-                    arrowStyles={arrowStyles}
-                    href={href}
-                    onClose={handleActionToolbarClose}
-                />
+    return (
+        <>
+            <FloatingToolbar
+                anchorElem={anchorElem}
+                // toolbar opacity is 0 by default
+                // shouldn't display until selection via mouse is complete to avoid toolbar re-positioning while dragging
+                controlOpacity={!isTextToolbar}
+                editor={editor}
+                isVisible={!!toolbarItemType}
+                shouldReposition={toolbarItemType !== toolbarItemTypes.text} // format toolbar shouldn't reposition when applying formats
+                toolbarRef={toolbarRef}
+                onReposition={updateArrowStyles}
+            >
+                {isSnippetToolbar && (
+                    <SnippetActionToolbar
+                        arrowStyles={arrowStyles}
+                        onClose={handleActionToolbarClose}
+                    />
+                )}
+
+                {(isLinkToolbar && !isInternalLinkingEnabled) && (
+                    <LinkActionToolbar
+                        arrowStyles={arrowStyles}
+                        href={href}
+                        onClose={handleActionToolbarClose}
+                    />
+                )}
+
+                {showTextToolbar && (
+                    <FormatToolbar
+                        arrowStyles={arrowStyles}
+                        editor={editor}
+                        hiddenFormats={hiddenFormats}
+                        isLinkSelected={!!href || (isInternalLinkingEnabled && isLinkToolbar)}
+                        isSnippetsEnabled={isSnippetsEnabled}
+                        onLinkClick={() => setToolbarItemType(toolbarItemTypes.link)}
+                        onSnippetClick={() => setToolbarItemType(toolbarItemTypes.snippet)}
+                    />
+                )}
+
+            </FloatingToolbar>
+
+            {internalLinkingToolbarVisible && (
+                <Portal>
+                    <div ref={linkToolbarRef} className="not-kg-prose fixed z-[10000]">
+                        <LinkActionToolbarCopy
+                            href={href}
+                            onClose={handleActionToolbarClose}
+                        />
+                    </div>
+                </Portal>
             )}
-            {isTextToolbar && (
-                <FormatToolbar
-                    arrowStyles={arrowStyles}
-                    editor={editor}
-                    hiddenFormats={hiddenFormats}
-                    isLinkSelected={!!href}
-                    isSnippetsEnabled={isSnippetsEnabled}
-                    onLinkClick={() => setToolbarItemType(toolbarItemTypes.link)}
-                    onSnippetClick={() => setToolbarItemType(toolbarItemTypes.snippet)}
-                />
-            )}
-        </FloatingToolbar>
+        </>
     );
 }
 

--- a/packages/koenig-lexical/src/components/ui/Input.jsx
+++ b/packages/koenig-lexical/src/components/ui/Input.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export const INPUT_CLASSES = 'rounded border border-grey-300 py-2 px-3 font-sans text-sm font-normal text-grey-900 focus:border-green focus:shadow-insetgreen focus-visible:outline-none dark:border-grey-900 dark:bg-grey-900 dark:text-white dark:placeholder:text-grey-700 dark:selection:bg-grey-800';
 
-export function Input({autoFocus, className, dataTestId, value, placeholder, onChange, onFocus, onBlur}) {
+export function Input({className, dataTestId, value, onChange, ...props}) {
     const [localValue, setLocalValue] = React.useState(value);
 
     const onChangeWrapper = React.useCallback((e) => {
@@ -21,14 +21,11 @@ export function Input({autoFocus, className, dataTestId, value, placeholder, onC
         <>
             <div className="relative">
                 <input
-                    autoFocus={autoFocus}
                     className={`relative w-full ${className || INPUT_CLASSES}`}
                     data-testid={dataTestId}
-                    placeholder={placeholder}
                     value={localValue}
-                    onBlur={onBlur}
                     onChange={onChangeWrapper}
-                    onFocus={onFocus}
+                    {...props}
                 />
             </div>
         </>

--- a/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
@@ -3,7 +3,7 @@ import {DropdownContainerCopy} from './DropdownContainerCopy';
 import {Input} from './Input';
 import {KeyboardSelectionWithGroups} from './KeyboardSelectionWithGroups';
 
-function LoadingItem({dataTestId}) {
+export function InputListLoadingItem({dataTestId}) {
     return (
         <li className={`mb-0 px-4 py-2 text-left`} data-testid={`${dataTestId}-loading`}>
             <span className="block text-sm font-medium leading-tight text-grey-900 dark:text-white">Searching...</span>
@@ -11,7 +11,7 @@ function LoadingItem({dataTestId}) {
     );
 }
 
-function Item({dataTestId, item, selected, onClick}) {
+export function InputListItem({dataTestId, item, selected, onClick}) {
     let selectionClass = '';
 
     if (selected) {
@@ -33,9 +33,9 @@ function Item({dataTestId, item, selected, onClick}) {
     );
 }
 
-function Group({group}) {
+export function InputListGroup({dataTestId, group}) {
     return (
-        <span className="flex items-center justify-between px-4 py-2 text-[1.1rem] font-semibold uppercase tracking-wide text-grey-600">{group.label}</span>
+        <li className="flex items-center justify-between px-4 py-2 text-[1.1rem] font-semibold uppercase tracking-wide text-grey-600" data-test-id={`${dataTestId}-listGroup-${group.label}`}>{group.label}</li>
     );
 }
 
@@ -47,7 +47,7 @@ function Group({group}) {
  * @param {string} [options.list]
  * @returns
  */
-export function InputListCopy({autoFocus, className, dataTestId, listOptions, isLoading, value, placeholder, onChange, onSelect}) {
+export function InputListCopy({autoFocus, className, inputClassName, dataTestId, listOptions, isLoading, value, placeholder, onChange, onSelect}) {
     const [inputFocused, setInputFocused] = React.useState(false);
 
     const onFocus = () => {
@@ -60,13 +60,13 @@ export function InputListCopy({autoFocus, className, dataTestId, listOptions, is
 
     const getItem = (item, selected) => {
         return (
-            <Item key={item.value} dataTestId={dataTestId} item={item} selected={selected} onClick={onSelectEvent}/>
+            <InputListItem key={item.value} dataTestId={dataTestId} item={item} selected={selected} onClick={onSelectEvent}/>
         );
     };
 
     const getGroup = (group) => {
         return (
-            <Group group={group} />
+            <InputListGroup key={group.label} dataTestId={dataTestId} group={group} />
         );
     };
 
@@ -82,10 +82,10 @@ export function InputListCopy({autoFocus, className, dataTestId, listOptions, is
 
     return (
         <>
-            <div className="relative z-0">
+            <div className={`relative z-0 ${className || ''}`}>
                 <Input
                     autoFocus={autoFocus}
-                    className={className}
+                    className={inputClassName}
                     dataTestId={dataTestId}
                     placeholder={placeholder}
                     value={value}
@@ -95,7 +95,7 @@ export function InputListCopy({autoFocus, className, dataTestId, listOptions, is
                 />
                 {showSuggestions &&
                     <DropdownContainerCopy>
-                        {isLoading && <LoadingItem dataTestId={dataTestId}/>}
+                        {isLoading && <InputListLoadingItem dataTestId={dataTestId}/>}
                         <KeyboardSelectionWithGroups
                             getGroup={getGroup}
                             getItem={getItem}

--- a/packages/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.jsx
+++ b/packages/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.jsx
@@ -1,5 +1,13 @@
 import React from 'react';
 
+const Group = ({children}) => {
+    return (
+        <>
+            {children}
+        </>
+    );
+};
+
 /**
  * Renders a list of options, which are selectable by using the up and down arrow keys.
  * You pass in the template for each option via the getItem function, which is called for each option and also passes in whether the item is selected or not.
@@ -61,14 +69,14 @@ export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect
     return (
         <>
             {groups.map((group, groupIndex) => (
-                <div key={group.key}>
+                <Group key={group.label}>
                     {getGroup(group)}
                     {group.items.map((item, index) => {
                         const itemsBefore = groups.slice(0, groupIndex).reduce((sum, prevGroup) => sum + prevGroup.items.length, 0);
                         const absoluteIndex = itemsBefore + index;
                         return getItem(item, absoluteIndex === selectedIndex);
                     })}
-                </div>
+                </Group>
             ))}
         </>
     );

--- a/packages/koenig-lexical/src/components/ui/LinkActionToolbarCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/LinkActionToolbarCopy.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {$createRangeSelection, $getSelection, $setSelection} from 'lexical';
+import {LinkInputCopy} from './LinkInputCopy.jsx';
+import {TOGGLE_LINK_COMMAND} from '@lexical/link';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+
+export function LinkActionToolbarCopy({href, onClose, ...props}) {
+    const [editor] = useLexicalComposerContext();
+
+    const onLinkUpdate = (updatedHref) => {
+        editor.update(() => {
+            editor.dispatchCommand(TOGGLE_LINK_COMMAND, updatedHref || null);
+            // remove selection to avoid format menu popup
+            const selection = $getSelection();
+            const focusNode = selection.focus.getNode();
+            const rangeSelection = $createRangeSelection();
+            rangeSelection.setTextNodeRange(focusNode, focusNode.getTextContentSize(), focusNode, focusNode.getTextContentSize());
+            $setSelection(rangeSelection);
+            onClose();
+        });
+    };
+    return (
+        <LinkInputCopy
+            cancel={onClose}
+            href={href}
+            update={onLinkUpdate}
+            {...props}
+        />
+    );
+}

--- a/packages/koenig-lexical/src/components/ui/LinkInputCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/LinkInputCopy.jsx
@@ -1,0 +1,108 @@
+import KoenigComposerContext from '../../context/KoenigComposerContext';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Input} from './Input';
+import {InputListGroup, InputListItem, InputListLoadingItem} from './InputListCopy';
+import {KeyboardSelectionWithGroups} from './KeyboardSelectionWithGroups';
+import {useSearchLinks} from '../../hooks/useSearchLinks';
+
+export function LinkInputCopy({href, update, cancel}) {
+    const {cardConfig: {searchLinks}} = React.useContext(KoenigComposerContext);
+
+    // store the href/query in state so we can update it without affecting the saved editor value
+    const [_href, setHref] = React.useState(href);
+    const {isSearching, listOptions} = useSearchLinks(_href, searchLinks);
+
+    // add refs for input and container
+    const containerRef = React.useRef(null);
+
+    const testId = 'link-input';
+
+    // update the internal href when the prop changes
+    React.useEffect(() => {
+        setHref(href);
+    }, [href]);
+
+    // close link input when clicking outside or pressing escape
+    React.useEffect(() => {
+        const closeOnClickOutside = (event) => {
+            if (containerRef.current && !containerRef.current.contains(event.target)) {
+                cancel();
+            }
+        };
+
+        const onEscape = (event) => {
+            if (event.key === 'Escape') {
+                cancel();
+            }
+        };
+
+        window.addEventListener('mousedown', closeOnClickOutside);
+        window.addEventListener('keydown', onEscape);
+
+        return () => {
+            window.removeEventListener('mousedown', closeOnClickOutside);
+            window.removeEventListener('keydown', onEscape);
+        };
+    }, [cancel]);
+
+    const onItemSelected = (item) => {
+        update(item.value);
+    };
+
+    const getItem = (item, selected) => {
+        return (
+            <InputListItem key={item.value} dataTestId={testId} item={item} selected={selected} onClick={onItemSelected}/>
+        );
+    };
+
+    const getGroup = (group) => {
+        return (
+            <InputListGroup group={group} />
+        );
+    };
+
+    const showSuggestions = (isSearching || (listOptions && !!listOptions.length));
+
+    return (
+        <div ref={containerRef} className="relative m-0 flex w-full flex-col rounded bg-white p-1 font-sans text-sm font-medium shadow-md dark:bg-grey-950">
+            <Input
+                autoFocus={true}
+                className="mb-[1px] h-auto w-full rounded pl-3 leading-loose"
+                dataTestId={testId}
+                placeholder="Paste URL or search posts and pages..."
+                value={_href}
+                onChange={(e) => {
+                    // update local value to allow searching
+                    setHref(e.target.value);
+                }}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                        // prevent Enter from triggering in the editor and removing text
+                        // update the link value in the editor
+                        e.preventDefault();
+                        update(_href);
+                        return;
+                    }
+                }}
+            />
+            {showSuggestions && (
+                <>
+                    <ul className="max-h-[30vh] w-full overflow-y-auto bg-white px-2 py-1 dark:bg-grey-950">
+                        {isSearching && <InputListLoadingItem dataTestId={testId}/>}
+                        <KeyboardSelectionWithGroups
+                            getGroup={getGroup}
+                            getItem={getItem}
+                            groups={listOptions}
+                            onSelect={onItemSelected}
+                        />
+                    </ul>
+                </>
+            )}
+        </div>
+    );
+}
+
+LinkInputCopy.propTypes = {
+    href: PropTypes.string
+};

--- a/packages/koenig-lexical/src/components/ui/LinkInputCopy.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/LinkInputCopy.stories.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import {LinkInputCopy} from './LinkInputCopy';
+
+const story = {
+    title: 'Toolbar/LinkInputCopy',
+    component: LinkInputCopy,
+    parameters: {
+        status: {
+            type: 'functional'
+        }
+    }
+};
+export default story;
+
+const Template = (args) => {
+    return (
+        <div className="flex">
+            <LinkInputCopy {...args} />
+        </div>
+    );
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+    href: ''
+};
+
+export const Populated = Template.bind({});
+Populated.args = {
+    href: 'https://ghost.org'
+};

--- a/packages/koenig-lexical/src/components/ui/Portal.jsx
+++ b/packages/koenig-lexical/src/components/ui/Portal.jsx
@@ -16,8 +16,8 @@ function Portal({children, to, className}) {
     }
 
     return createPortal(
-        <div className="koenig-lexical" style={{width: 'fit-content'}} onMouseDown={cancelEvents}>
-            <div className={`${darkMode ? 'dark' : ''} ${className}`}>
+        <div className="koenig-lexical" style={{width: 'fit-content'}} data-kg-portal onMouseDown={cancelEvents}>
+            <div className={`${darkMode ? 'dark' : ''} ${className || ''}`}>
                 {children}
             </div>
         </div>,

--- a/packages/koenig-lexical/src/hooks/useSearchLinks.js
+++ b/packages/koenig-lexical/src/hooks/useSearchLinks.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import debounce from 'lodash/debounce';
+
+const DEBOUNCE_MS = 200;
+const IGNORE_QUERY_REGEX = /^http/;
+
+function convertSearchResultsToListOptions(results) {
+    return results.map((result) => {
+        const items = result.items.map((item) => {
+            return {
+                label: item.title,
+                value: item.url
+            };
+        });
+
+        return {...result, items};
+    });
+}
+
+export const useSearchLinks = (query, searchLinks) => {
+    const [defaultListOptions, setDefaultListOptions] = React.useState([]);
+    const [listOptions, setListOptions] = React.useState([]);
+    const [isSearching, setIsSearching] = React.useState(false);
+
+    const debouncedSearch = React.useMemo(() => {
+        return debounce(async (term) => {
+            setIsSearching(true);
+            const results = await searchLinks(term);
+            setListOptions(convertSearchResultsToListOptions(results));
+            setIsSearching(false);
+        }, DEBOUNCE_MS);
+    }, [searchLinks]);
+
+    // Fetch default search results when first rendering
+    React.useEffect(() => {
+        if (IGNORE_QUERY_REGEX.test(query)) {
+            return;
+        }
+
+        const fetchDefaultOptions = async () => {
+            setIsSearching(true);
+            const results = await searchLinks();
+            setDefaultListOptions(convertSearchResultsToListOptions(results));
+            setIsSearching(false);
+        };
+
+        fetchDefaultOptions().catch(console.error); // eslint-disable-line no-console
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    React.useEffect(() => {
+        if (IGNORE_QUERY_REGEX.test(query)) {
+            setListOptions([]);
+        } else {
+            debouncedSearch(query);
+        }
+    }, [query, debouncedSearch]);
+
+    const displayedListOptions = query ? listOptions : defaultListOptions;
+
+    return {
+        isSearching,
+        listOptions: displayedListOptions
+    };
+};

--- a/packages/koenig-lexical/src/nodes/BookmarkNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/BookmarkNodeComponent.jsx
@@ -194,7 +194,7 @@ export function BookmarkNodeComponent({author, nodeKey, url, icon, title, descri
 
     return (
         <>
-            {cardConfig.feature.internalLinking ? LabsBookmarkCard : DefaultBookmarkCard}
+            {cardConfig.feature?.internalLinking ? LabsBookmarkCard : DefaultBookmarkCard}
             <ActionToolbar
                 data-kg-card-toolbar="bookmark"
                 isVisible={showSnippetToolbar}


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-81

- extracted link search behaviour into `useSearchLinks` hook so we can add behaviour to components other than `<UrlSearchInput>`
- added copies of `<LinkInput>` and `<LinkActionToolbar>` so we can modify design and behaviour behind the feature flag
  - `<LinkInputCopy>` has been updated to use the the `useSearchLinks` hook and render an input+search results together rather than having the results appear in a popup as in `<InputListCopy>`
  - `<LinkActionToolbarCopy>` has no changes other than a switch to using `<LinkInputCopy>`
- renamed and exported the `InputList*` components in `<InputListCopy>` used in the results list
  - TODO: extract those to a different file so it's clear they are re-usable
- updated `<FloatingFormatToolbar>` to switch link toolbar components when the `internalLinking` feature is enabled
  - updated to show both the text toolbar and link input+results when in link mode
  - adds positioning behaviour for the new link toolbar as it needs to be rendered in a portal outside of the main editor (TODO: extract to separate component)
- fixed `<KeyboardSelectionWithGroups>` rendering a `<div>` around groups which isn't valid inside of `<ul>` elements
- updated DemoApp to skip "focus editor" clicks below the editor canvas for any clicks that occur inside a `<Portal>` component
  - fixes focus issues when interacting with the link input field that's rendered in a portal
