### PR TITLE
Fixed internal link results being cut off at bottom of document

### DIFF
--- a/packages/koenig-lexical/src/components/ui/LinkActionToolbarCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/LinkActionToolbarCopy.jsx
@@ -10,14 +10,14 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 export function LinkActionToolbarCopy({anchorElem, href, onClose, ...props}) {
     const [editor] = useLexicalComposerContext();
 
-    const [portalContainer] = React.useState(() => {
+    const scrollContainer = React.useMemo(() => {
         return getScrollParent(editor.getRootElement());
-    });
+    }, [editor]);
 
     const linkToolbarRef = React.useRef(null);
 
     // Position the link input and search results when they open.
-    // By default appears below the selected text.
+    // Appears below the selected text unless at bottom of the document where it appears above toolbar.
     const updateLinkToolbarPosition = React.useCallback(() => {
         editor.update(() => {
             const toolbarElement = linkToolbarRef.current;
@@ -26,53 +26,46 @@ export function LinkActionToolbarCopy({anchorElem, href, onClose, ...props}) {
             }
 
             const selection = $getSelection();
-            const rangeRect = $getSelectionRangeRect({editor, selection});
-
-            const scrollerElem = anchorElem.parentElement;
-
-            if (!rangeRect || !scrollerElem || !toolbarElement) {
+            if (!selection) {
                 return;
             }
 
-            const editorScrollerRect = scrollerElem.getBoundingClientRect();
+            const rangeRect = $getSelectionRangeRect({editor, selection});
+
+            const editorElem = anchorElem.parentElement;
+
+            if (!rangeRect || !editorElem || !toolbarElement) {
+                return;
+            }
+
+            const editorRect = editorElem.getBoundingClientRect();
 
             const top = rangeRect.bottom + 10;
-            const left = editorScrollerRect.left;
-            const right = editorScrollerRect.right;
+            const left = editorRect.left;
+            const right = editorRect.right;
 
             toolbarElement.style.top = `${top}px`;
             toolbarElement.style.left = `${left}px`;
             toolbarElement.style.width = `${right - left}px`;
+
+            // TODO: Max height is hardcoded to 30% of window height for results list + 54px (toolbar height),
+            //  this is based on current styling and will need adjusting if styles change. We make this calculation
+            //  to avoid the toolbar jumping between above/below positioning when the results list changes size.
+            const toolbarMaxHeight = (window.innerHeight / 100 * 30) + 54;
+            const toolbarRect = toolbarElement.getBoundingClientRect();
+
+            if (scrollContainer.scrollTop + toolbarRect.top + toolbarMaxHeight > scrollContainer.scrollHeight) {
+                toolbarElement.style.top = `${rangeRect.top - toolbarRect.height - 55}px`;
+            }
         });
-    }, [anchorElem, editor]);
+    }, [anchorElem, editor, scrollContainer]);
 
     React.useEffect(() => {
         updateLinkToolbarPosition();
     }, [updateLinkToolbarPosition]);
 
-    // update padding on the portal container so the portal can always be scrolled
-    // into view when it would otherwise be cut off at the bottom of the screen
-    React.useEffect(() => {
-        const toolbarElement = linkToolbarRef.current;
-
-        if (toolbarElement) {
-            const resizeObserver = new ResizeObserver((entries) => {
-                for (const entry of entries) {
-                    if (entry.target === toolbarElement) {
-                        portalContainer.style.paddingBottom = `${entry.contentRect.height}px`;
-                    }
-                }
-            });
-
-            resizeObserver.observe(toolbarElement);
-
-            return () => {
-                resizeObserver.unobserve(toolbarElement);
-                portalContainer.style.paddingBottom = null;
-            };
-        }
-    }, [portalContainer]);
-
+    // re-position on document scroll, window resize,
+    // plus search results change to avoid gap appearing when positioned above the toolbar
     React.useEffect(() => {
         const scrollElement = getScrollParent(anchorElem);
 
@@ -81,10 +74,17 @@ export function LinkActionToolbarCopy({anchorElem, href, onClose, ...props}) {
             scrollElement.addEventListener('scroll', updateLinkToolbarPosition);
         }
 
+        const toolbarElement = linkToolbarRef.current;
+        const toolbarMutationObserver = new MutationObserver(updateLinkToolbarPosition);
+        toolbarMutationObserver.observe(toolbarElement, {childList: true, subtree: true});
+
         return () => {
             window.removeEventListener('resize', updateLinkToolbarPosition);
             if (scrollElement) {
                 scrollElement.removeEventListener('scroll', updateLinkToolbarPosition);
+            }
+            if (toolbarElement) {
+                toolbarMutationObserver.disconnect();
             }
         };
     }, [anchorElem, updateLinkToolbarPosition]);
@@ -103,7 +103,7 @@ export function LinkActionToolbarCopy({anchorElem, href, onClose, ...props}) {
     };
 
     return (
-        <Portal to={portalContainer}>
+        <Portal>
             <div ref={linkToolbarRef} className="not-kg-prose fixed z-[10000]">
                 <LinkInputCopy
                     cancel={onClose}


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-92

- updated positioning of link input+results to show above the floating toolbar when it would be cut off at bottom of screen
  -  uses a fixed calculation for the max height the input+results toolbar can be to avoid position jumping between above/below when the search results height changes
- adds mutation observer to trigger re-positioning when elements are added/removed in search results
  - uses mutation rather than resize observer because the latter caused problems with Lexical losing it's selection meaning none of the positioning calculations worked