### PR TITLE
Fixed autofocus not working in `<Input>` when initialized with a value

### DIFF
--- a/packages/koenig-lexical/src/components/ui/Input.jsx
+++ b/packages/koenig-lexical/src/components/ui/Input.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 
 export const INPUT_CLASSES = 'rounded-md border border-grey-300 py-2 px-3 font-sans text-sm font-normal text-grey-900 focus:border-green focus:shadow-insetgreen focus-visible:outline-none dark:border-grey-900 dark:bg-grey-900 dark:text-white dark:placeholder:text-grey-700 dark:selection:bg-grey-800';
 
-export function Input({className, dataTestId, value, onChange, ...props}) {
+export function Input({autoFocus, className, dataTestId, value, onChange, ...props}) {
+    const inputRef = React.useRef(null);
+    const shouldFocusOnUpdate = React.useRef(autoFocus);
     const [localValue, setLocalValue] = React.useState(value);
 
     const onChangeWrapper = React.useCallback((e) => {
@@ -15,12 +17,21 @@ export function Input({className, dataTestId, value, onChange, ...props}) {
 
     React.useEffect(() => {
         setLocalValue(value);
+
+        // setting a value via state immediately after mounting results in React's
+        // autoFocus not working, so we need to manually focus the input
+        if (shouldFocusOnUpdate.current) {
+            shouldFocusOnUpdate.current = false;
+            setTimeout(() => inputRef.current.focus(), 0);
+        }
     }, [value]);
 
     return (
         <>
             <div className="relative">
                 <input
+                    ref={inputRef}
+                    autoFocus={autoFocus}
                     className={`relative w-full ${className || INPUT_CLASSES}`}
                     data-testid={dataTestId}
                     value={localValue}


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-82
closes https://linear.app/tryghost/issue/MOM-91

- due to the way the component uses internal state updated in an effect we were clobbering React's own `autoFocus` implementation
- by manually focusing within a setTimeout we ensure the focus happens after the mount+update+rerender flow
  - uses a ref to make sure we only trigger the focus once during the first update
