### PR TITLE
Improved loading and no results for internal link inputs

### DIFF
--- a/packages/koenig-lexical/src/components/ui/Delayed.jsx
+++ b/packages/koenig-lexical/src/components/ui/Delayed.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export function Delayed({children, waitBeforeShow = 500}) {
+    const [show, setShow] = React.useState(false);
+
+    React.useEffect(() => {
+        const timeout = setTimeout(() => {
+            setShow(true);
+        }, waitBeforeShow);
+
+        return () => {
+            clearTimeout(timeout);
+        };
+    }, [waitBeforeShow]);
+
+    return show ? children : null;
+}

--- a/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
+import {Delayed} from './Delayed';
 import {DropdownContainerCopy} from './DropdownContainerCopy';
 import {Input} from './Input';
 import {KeyboardSelectionWithGroups} from './KeyboardSelectionWithGroups';
 
 export function InputListLoadingItem({dataTestId}) {
     return (
-        <li className={`mb-0 px-4 py-2 text-left`} data-testid={`${dataTestId}-loading`}>
-            <span className="block text-sm font-medium leading-tight text-grey-900 dark:text-white">Searching...</span>
-        </li>
+        <Delayed>
+            <li className={`mb-0 px-4 py-2 text-left`} data-testid={`${dataTestId}-loading`}>
+                <span className="block text-sm font-medium leading-tight text-grey-900 dark:text-white">Searching...</span>
+            </li>
+        </Delayed>
     );
 }
 

--- a/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
@@ -18,6 +18,10 @@ export function InputListItem({dataTestId, item, selected, onClick}) {
         selectionClass = 'bg-grey-100 dark:bg-grey-900';
     }
 
+    if (!item.value) {
+        selectionClass = 'pointer-events-none';
+    }
+
     // We use the capture phase of the mouse down event, otherwise the list option will be removed when blurring the input
     // before calling the click event
     const handleMouseDown = (event) => {

--- a/packages/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.jsx
+++ b/packages/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.jsx
@@ -74,7 +74,7 @@ export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect
                     {group.items.map((item, index) => {
                         const itemsBefore = groups.slice(0, groupIndex).reduce((sum, prevGroup) => sum + prevGroup.items.length, 0);
                         const absoluteIndex = itemsBefore + index;
-                        return getItem(item, absoluteIndex === selectedIndex);
+                        return getItem(item, absoluteIndex === selectedIndex && !!item.value);
                     })}
                 </Group>
             ))}

--- a/packages/koenig-lexical/src/hooks/useSearchLinks.js
+++ b/packages/koenig-lexical/src/hooks/useSearchLinks.js
@@ -2,21 +2,8 @@ import EarthIcon from '../assets/icons/kg-earth.svg?react';
 import React from 'react';
 import debounce from 'lodash/debounce';
 
-const DEBOUNCE_MS = 200;
+const DEBOUNCE_MS = 100;
 const URL_QUERY_REGEX = /^http/;
-
-function convertSearchResultsToListOptions(results) {
-    return results.map((result) => {
-        const items = result.items.map((item) => {
-            return {
-                label: item.title,
-                value: item.url
-            };
-        });
-
-        return {...result, items};
-    });
-}
 
 function urlQueryOptions(query) {
     return [{
@@ -27,6 +14,33 @@ function urlQueryOptions(query) {
             Icon: EarthIcon
         }]
     }];
+}
+
+function noResultOptions(query) {
+    return [{
+        label: 'Link to web page',
+        items: [{
+            label: `Enter URL to create link`,
+            value: null
+        }]
+    }];
+}
+
+function convertSearchResultsToListOptions(results) {
+    if (!results || !results.length) {
+        return noResultOptions();
+    }
+
+    return results.map((result) => {
+        const items = result.items.map((item) => {
+            return {
+                label: item.title,
+                value: item.url
+            };
+        });
+
+        return {...result, items};
+    });
 }
 
 export const useSearchLinks = (query, searchLinks) => {


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/MOM-96
ref https://linear.app/tryghost/issue/MOM-93

- Added "no results" state to internal link inputs
  - when search doesn't return any results display an option that hints at usage
  - updated `<KeyboardSelectionWithGroups>` and `<InputListCopy>` to make any options with no value unselectable
- Added delay before showing "Searching..." in internal link inputs
  - the constant flashing of "Searching..." whilst typing was off-putting and made the component feel glitchy
  - added a `<Delayed>` component that wraps the loading component so it's not shown unless the search takes more than 500ms