### PR TITLE
Changed <KeyboardSelectionWithGroups> to also select on mouse hover

### DIFF
--- a/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
@@ -14,7 +14,7 @@ export function InputListLoadingItem({dataTestId}) {
     );
 }
 
-export function InputListItem({dataTestId, item, selected, onClick}) {
+export function InputListItem({dataTestId, item, selected, onClick, onMouseOver}) {
     let selectionClass = '';
 
     if (selected) {
@@ -36,7 +36,7 @@ export function InputListItem({dataTestId, item, selected, onClick}) {
     const Icon = item.Icon;
 
     return (
-        <li className={`${selectionClass} my-[.2rem] flex cursor-pointer items-center gap-[.6rem] rounded-md px-4 py-2 text-left text-black hover:bg-grey-100 dark:text-white dark:hover:bg-grey-900`} data-testid={`${dataTestId}-listOption`} onMouseDownCapture={handleMouseDown}>
+        <li className={`${selectionClass} my-[.2rem] flex cursor-pointer items-center gap-[.6rem] rounded-md px-4 py-2 text-left text-black dark:text-white`} data-testid={`${dataTestId}-listOption`} onMouseDownCapture={handleMouseDown} onMouseOver={onMouseOver}>
             {Icon && <Icon className="size-[1.4rem] stroke-[1.5px]" />}
             <span className="block text-sm font-medium leading-snug" data-testid={`${dataTestId}-listOption-${item.label}`}>{item.label}</span>
         </li>
@@ -68,9 +68,16 @@ export function InputListCopy({autoFocus, className, inputClassName, dataTestId,
         setInputFocused(false);
     };
 
-    const getItem = (item, selected) => {
+    const getItem = (item, selected, onMouseOver) => {
         return (
-            <InputListItem key={item.value} dataTestId={dataTestId} item={item} selected={selected} onClick={onSelectEvent}/>
+            <InputListItem
+                key={item.value}
+                dataTestId={dataTestId}
+                item={item}
+                selected={selected}
+                onClick={onSelectEvent}
+                onMouseOver={onMouseOver}
+            />
         );
     };
 

--- a/packages/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.jsx
+++ b/packages/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.jsx
@@ -74,7 +74,9 @@ export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect
                     {group.items.map((item, index) => {
                         const itemsBefore = groups.slice(0, groupIndex).reduce((sum, prevGroup) => sum + prevGroup.items.length, 0);
                         const absoluteIndex = itemsBefore + index;
-                        return getItem(item, absoluteIndex === selectedIndex && !!item.value);
+                        const isSelected = absoluteIndex === selectedIndex && !!item.value;
+                        const onMouseOver = () => !!item.value && setSelectedIndex(absoluteIndex);
+                        return getItem(item, isSelected, onMouseOver);
                     })}
                 </Group>
             ))}

--- a/packages/koenig-lexical/src/components/ui/LinkInputCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/LinkInputCopy.jsx
@@ -50,9 +50,16 @@ export function LinkInputCopy({href, update, cancel}) {
         update(item.value);
     };
 
-    const getItem = (item, selected) => {
+    const getItem = (item, selected, onMouseOver) => {
         return (
-            <InputListItem key={item.value} dataTestId={testId} item={item} selected={selected} onClick={onItemSelected}/>
+            <InputListItem
+                key={item.value}
+                dataTestId={testId}
+                item={item}
+                selected={selected}
+                onClick={onItemSelected}
+                onMouseOver={onMouseOver}
+            />
         );
     };
 


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-59

- previously hovering over an item in the internal link list would make it appear the same as the item that had been selected via the keyboard making it look like both were selected and creating a mental disconnect over which one would be used when performing actions
- replaced the hover styling with an actual change in selected index so we only ever have one truly selected item whether using mouse or keyboard
