### PR TITLE
Fixed default options not appearing when existing url in link input cleared

### DIFF
--- a/packages/koenig-lexical/src/hooks/useSearchLinks.js
+++ b/packages/koenig-lexical/src/hooks/useSearchLinks.js
@@ -68,15 +68,14 @@ export const useSearchLinks = (query, searchLinks) => {
 
     // Fetch default search results when first rendering
     React.useEffect(() => {
-        if (URL_QUERY_REGEX.test(query)) {
-            return;
-        }
-
         const fetchDefaultOptions = async () => {
-            setIsSearching(true);
+            // if we have a query we don't want to show the searching state but
+            // we still want to load the default options in the background so
+            // they're available when the query is cleared
+            !query && setIsSearching(true);
             const results = await searchLinks();
             setDefaultListOptions(convertSearchResultsToListOptions(results));
-            setIsSearching(false);
+            !query && setIsSearching(false);
         };
 
         fetchDefaultOptions().catch(console.error); // eslint-disable-line no-console


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-107

- we were skipping the load of default options during initialisation when we already had a URL set but this meant they weren't available when the URL was cleared
- updated to always fetch the default options but not to show loading state when we already have a query so we don't cause any unexpected "Searching..." text to show
