### PR TITLE
Revert "Update dependency @prettier/sync to ^0.5.0"

### DIFF
--- a/packages/kg-default-nodes/package.json
+++ b/packages/kg-default-nodes/package.json
@@ -33,7 +33,7 @@
     "@babel/plugin-syntax-import-assertions": "^7.20.0",
     "@lexical/headless": "0.13.1",
     "@lexical/html": "0.13.1",
-    "@prettier/sync": "^0.5.0",
+    "@prettier/sync": "^0.3.0",
     "@rollup/plugin-babel": "6.0.4",
     "c8": "9.1.0",
     "html-minifier": "^4.0.0",

--- a/packages/koenig-lexical/package.json
+++ b/packages/koenig-lexical/package.json
@@ -61,7 +61,7 @@
     "@lexical/utils": "0.13.1",
     "@lezer/highlight": "^1.1.3",
     "@playwright/test": "^1.33.0",
-    "@prettier/sync": "^0.5.0",
+    "@prettier/sync": "^0.3.0",
     "@sentry/vite-plugin": "^2.2.2",
     "@storybook/addon-actions": "7.6.19",
     "@storybook/addon-essentials": "7.6.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2860,12 +2860,10 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.24.tgz#58601079e11784d20f82d0585865bb42305c4df3"
   integrity sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==
 
-"@prettier/sync@^0.5.0":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@prettier/sync/-/sync-0.5.2.tgz#f8401e45b667e8d6207015fd03619ea2c2e3e680"
-  integrity sha512-Yb569su456XNx5BsH/Vyem7xD6g/y9iLmLUzRKM1a/dhU/D7HqqvkAG72znulXlMXztbV0iiu9O5AL8K98TzZQ==
-  dependencies:
-    make-synchronized "^0.2.8"
+"@prettier/sync@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@prettier/sync/-/sync-0.3.0.tgz#91f2cfc23490a21586d1cf89c6f72157c000ca1e"
+  integrity sha512-3dcmCyAxIcxy036h1I7MQU/uEEBq8oLwf1CE3xeze+MPlgkdlb/+w6rGR/1dhp6Hqi17fRS6nvwnOzkESxEkOw==
 
 "@radix-ui/number@1.0.1":
   version "1.0.1"
@@ -14335,11 +14333,6 @@ make-iterator@^1.0.0:
   integrity sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==
   dependencies:
     kind-of "^6.0.2"
-
-make-synchronized@^0.2.8:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/make-synchronized/-/make-synchronized-0.2.9.tgz#edcbe2d8e7aeac8e0f41a0bb25b05cc7a7e2e8e4"
-  integrity sha512-4wczOs8SLuEdpEvp3vGo83wh8rjJ78UsIk7DIX5fxdfmfMJGog4bQzxfvOwq7Q3yCHLC4jp1urPHIxRS/A93gA==
 
 makeerror@1.0.12:
   version "1.0.12"


### PR DESCRIPTION
Reverts TryGhost/Koenig#1232

- we started seeing frequent random errors in CI coming from `make-synchronized` that's used by `@prettier/sync`

Example failure:
```
  1) GalleryNode
       exportDOM
         renders:
     AtomicsWaitError: Unexpected error
      at _Lock.lock (/home/runner/work/Koenig/Koenig/node_modules/make-synchronized/index.cjs:132:11)
      at request (/home/runner/work/Koenig/Koenig/node_modules/make-synchronized/index.cjs:165:8)
      at #sendActionToWorker (/home/runner/work/Koenig/Koenig/node_modules/make-synchronized/index.cjs:221:61)
      at ThreadsWorker.sendAction (/home/runner/work/Koenig/Koenig/node_modules/make-synchronized/index.cjs:181:36)
      at _Synchronizer.apply (/home/runner/work/Koenig/Koenig/node_modules/make-synchronized/index.cjs:300:25)
      at Module.<anonymous> (/home/runner/work/Koenig/Koenig/node_modules/make-synchronized/index.cjs:306:40)
      at html (test/utils/index.js:26:21)
      at /home/runner/work/Koenig/Koenig/packages/kg-default-nodes/test/nodes/gallery.test.js:650:53
```