### PR TITLE
Fixed button card displaying in full width

### DIFF
--- a/packages/koenig-lexical/src/components/ui/Button.jsx
+++ b/packages/koenig-lexical/src/components/ui/Button.jsx
@@ -15,7 +15,7 @@ export function Button({color, dataTestId, href, size, width, rounded, shrink, v
     return (
         <Tag
             className={clsx(
-                'not-kg-prose inline-block grow cursor-pointer text-center font-sans font-medium',
+                'not-kg-prose inline-block cursor-pointer text-center font-sans font-medium',
                 (!shrink && 'shrink-0'), // This is for dynamic buttons that need to wrap onto a new line if width exceeds editor width, such as the ButtonCard
                 width === 'regular' || 'w-full',
                 rounded && 'rounded-md',


### PR DESCRIPTION
REF DES-350

- This turned out to be a regression introduced by the following commit: https://github.com/TryGhost/Koenig/commit/985ab8d8ff3fa1292528eef990fb29bb8cc5b872