### PR TITLE
Second iteration of @ shortcut for internal links

### DIFF
--- a/packages/kg-default-nodes/lib/kg-default-nodes.js
+++ b/packages/kg-default-nodes/lib/kg-default-nodes.js
@@ -24,6 +24,8 @@ import * as textnode from './nodes/ExtendedTextNode';
 import * as headingnode from './nodes/ExtendedHeadingNode';
 import * as quotenode from './nodes/ExtendedQuoteNode';
 import * as tk from './nodes/TKNode';
+import * as atLink from './nodes/at-link/index.js';
+import * as zwnj from './nodes/zwnj/ZWNJNode.js';
 
 // re-export everything for easier importing
 export * from './KoenigDecoratorNode';
@@ -53,6 +55,8 @@ export * from './nodes/ExtendedTextNode';
 export * from './nodes/ExtendedHeadingNode';
 export * from './nodes/ExtendedQuoteNode';
 export * from './nodes/TKNode';
+export * from './nodes/at-link/index.js';
+export * from './nodes/zwnj/ZWNJNode';
 
 // export convenience objects for use elsewhere
 export const DEFAULT_NODES = [
@@ -84,5 +88,8 @@ export const DEFAULT_NODES = [
     emailCta.EmailCtaNode,
     signup.SignupNode,
     collection.CollectionNode,
-    tk.TKNode
+    tk.TKNode,
+    atLink.AtLinkNode,
+    atLink.AtLinkSearchNode,
+    zwnj.ZWNJNode
 ];

--- a/packages/kg-default-nodes/lib/nodes/at-link/AtLinkNode.js
+++ b/packages/kg-default-nodes/lib/nodes/at-link/AtLinkNode.js
@@ -1,0 +1,91 @@
+/* eslint-disable ghost/filenames/match-exported-class */
+import {$applyNodeReplacement, ElementNode} from 'lexical';
+
+// Container element for a link search query. Temporary node used only inside
+// the editor that will be replaced with a LinkNode when the search is complete.
+export class AtLinkNode extends ElementNode {
+    // We keep track of the format that was applied to the original '@' character
+    // so we can re-apply that when converting to a LinkNode
+    __linkFormat = null;
+
+    static getType() {
+        return 'at-link';
+    }
+
+    constructor(linkFormat, key) {
+        super(key);
+        this.__linkFormat = linkFormat;
+    }
+
+    static clone(node) {
+        return new AtLinkNode(node.__linkFormat, node.__key);
+    }
+
+    // This is a temporary node, it should never be serialized but we need
+    // to implement just in case and to match expected types. The AtLinkPlugin
+    // should take care of replacing this node with it's children when needed.
+    static importJSON({linkFormat}) {
+        return $createAtLinkNode(linkFormat);
+    }
+
+    exportJSON() {
+        return {
+            ...super.exportJSON(),
+            type: 'at-link',
+            version: 1,
+            linkFormat: this.__linkFormat
+        };
+    }
+
+    createDOM(config) {
+        const span = document.createElement('span');
+
+        span.classList.add(...config.theme.atLink.split(' '));
+
+        return span;
+    }
+
+    updateDOM() {
+        return false;
+    }
+
+    // should not render anything - this is a placeholder node
+    exportDOM() {
+        return null;
+    }
+
+    /* c8 ignore next 3 */
+    static importDOM() {
+        return null;
+    }
+
+    getTextContent() {
+        return '';
+    }
+
+    isInline() {
+        return true;
+    }
+
+    canBeEmpty() {
+        return false;
+    }
+
+    setLinkFormat(linkFormat) {
+        const self = this.getWritable();
+        self.__linkFormat = linkFormat;
+    }
+
+    getLinkFormat() {
+        const self = this.getLatest();
+        return self.__linkFormat;
+    }
+}
+
+export function $createAtLinkNode(linkFormat) {
+    return $applyNodeReplacement(new AtLinkNode(linkFormat));
+}
+
+export function $isAtLinkNode(node) {
+    return node instanceof AtLinkNode;
+}

--- a/packages/kg-default-nodes/lib/nodes/at-link/AtLinkSearchNode.js
+++ b/packages/kg-default-nodes/lib/nodes/at-link/AtLinkSearchNode.js
@@ -1,0 +1,97 @@
+/* eslint-disable ghost/filenames/match-exported-class */
+import {$applyNodeReplacement, TextNode} from 'lexical';
+
+// Represents the search query string inside an AtLinkNode. Used in place of a
+// regular TextNode to allow for :after styling to be applied to work as a placeholder
+export class AtLinkSearchNode extends TextNode {
+    __placeholder = null;
+
+    defaultPlaceholder = 'Search for a link';
+
+    static getType() {
+        return 'at-link-search';
+    }
+
+    constructor(text, placeholder, key) {
+        super(text, key);
+        this.__placeholder = placeholder;
+    }
+
+    static clone(node) {
+        return new AtLinkSearchNode(
+            node.__text,
+            node.__placeholder,
+            node.__key
+        );
+    }
+
+    // This is a temporary node, it should never be serialized but we need
+    // to implement just in case and to match expected types. The AtLinkPlugin
+    // should take care of replacing this node when needed.
+    static importJSON({text, placeholder}) {
+        return $createAtLinkSearchNode(text, placeholder);
+    }
+
+    exportJSON() {
+        return {
+            ...super.exportJSON(),
+            type: 'at-link-search',
+            version: 1,
+            placeholder: this.__placeholder
+        };
+    }
+
+    createDOM(config) {
+        const span = super.createDOM(config);
+        span.dataset.placeholder = '';
+        if (!this.__text) {
+            span.dataset.placeholder =
+                this.__placeholder ?? this.defaultPlaceholder;
+        } else {
+            span.dataset.placeholder = this.__placeholder || '';
+        }
+        span.classList.add(...config.theme.atLinkSearch.split(' '));
+
+        return span;
+    }
+
+    updateDOM(prevNode, dom) {
+        if (this.__text) {
+            dom.dataset.placeholder = this.__placeholder ?? '';
+        }
+
+        return super.updateDOM(...arguments);
+    }
+
+    // should not render anything - this is a placeholder node
+    exportDOM() {
+        return null;
+    }
+
+    /* c8 ignore next 3 */
+    static importDOM() {
+        return null;
+    }
+
+    canHaveFormat() {
+        return false;
+    }
+
+    setPlaceholder(text) {
+        const self = this.getWritable();
+        self.__placeholder = text;
+    }
+
+    getPlaceholder() {
+        const self = this.getLatest();
+        return self.__placeholder;
+    }
+}
+
+export function $createAtLinkSearchNode(text = '', placeholder = null) {
+    return $applyNodeReplacement(new AtLinkSearchNode(text, placeholder));
+}
+
+export function $isAtLinkSearchNode(node) {
+    return node instanceof AtLinkSearchNode;
+}

--- a/packages/kg-default-nodes/lib/nodes/at-link/index.js
+++ b/packages/kg-default-nodes/lib/nodes/at-link/index.js
@@ -1,0 +1,4 @@
+/* c8 ignore start */
+export * from './AtLinkNode';
+export * from './AtLinkSearchNode';
+/* c8 ignore end */

--- a/packages/kg-default-nodes/lib/nodes/zwnj/ZWNJNode.js
+++ b/packages/kg-default-nodes/lib/nodes/zwnj/ZWNJNode.js
@@ -1,0 +1,49 @@
+/* eslint-disable ghost/filenames/match-exported-class */
+import {TextNode} from 'lexical';
+
+// This is used in places where we need an extra cursor position at the
+// beginning of an element node as it prevents Lexical normalizing the
+// cursor position to the end of the previous node.
+export class ZWNJNode extends TextNode {
+    static getType() {
+        return 'zwnj';
+    }
+
+    static clone(node) {
+        return new ZWNJNode('', node.__key);
+    }
+
+    createDOM(config) {
+        const span = super.createDOM(config);
+        span.innerHTML = '&zwnj;';
+        return span;
+    }
+
+    updateDOM() {
+        return false;
+    }
+
+    exportJSON() {
+        return {
+            ...super.exportJSON(),
+            type: 'zwnj',
+            version: 1
+        };
+    }
+
+    getTextContent() {
+        return '';
+    }
+
+    isToken() {
+        return true;
+    }
+}
+
+export function $createZWNJNode() {
+    return new ZWNJNode('');
+}
+
+export function $isZWNJNode(node) {
+    return node instanceof ZWNJNode;
+}

--- a/packages/kg-default-nodes/test/nodes/at-link-search.test.js
+++ b/packages/kg-default-nodes/test/nodes/at-link-search.test.js
@@ -1,0 +1,153 @@
+require('../utils');
+const {JSDOM} = require('jsdom');
+const {createHeadlessEditor} = require('@lexical/headless');
+const {AtLinkSearchNode, $createAtLinkSearchNode, $isAtLinkNode, $isAtLinkSearchNode} = require('../../');
+
+const editorNodes = [AtLinkSearchNode];
+
+describe('AtLinkSearchNode', function () {
+    let editor;
+
+    const config = {theme: {atLinkSearch: 'multiple classes'}};
+
+    // NOTE: all tests should use this function, without it you need manual
+    // try/catch and done handling to avoid assertion failures not triggering
+    // failed tests
+    const editorTest = testFn => function (done) {
+        editor.update(() => {
+            try {
+                testFn();
+                done();
+            } catch (e) {
+                done(e);
+            }
+        });
+    };
+
+    beforeEach(function () {
+        editor = createHeadlessEditor({nodes: editorNodes});
+
+        const {window} = new JSDOM('<!doctype html><html><body></body></html>');
+        global.document = window.document;
+        global.window = window;
+    });
+
+    afterEach(function () {
+        delete global.document;
+        delete global.window;
+    });
+
+    it('matches node with $isAtLinkSearchNode', editorTest(function () {
+        const atLinkSearchNode = $createAtLinkSearchNode();
+        $isAtLinkSearchNode(atLinkSearchNode).should.be.true;
+    }));
+
+    it('can be constructed with text and placeholder', editorTest(function () {
+        const atLinkNode = $createAtLinkSearchNode('test', 'placeholder');
+        atLinkNode.getTextContent().should.equal('test');
+        atLinkNode.getPlaceholder().should.equal('placeholder');
+    }));
+
+    it('can be closed with all data', editorTest(function () {
+        const atLinkSearch = $createAtLinkSearchNode('test', 'placeholder');
+        const atLinkSearchClone = AtLinkSearchNode.clone(atLinkSearch);
+
+        atLinkSearch.__key.should.equal(atLinkSearchClone.__key);
+        atLinkSearchClone.getTextContent().should.equal('test');
+        atLinkSearchClone.getPlaceholder().should.equal('placeholder');
+    }));
+
+    it('exports all data via exportJSON()', editorTest(function () {
+        const atLinkSearch = $createAtLinkSearchNode('test', 'placeholder');
+        atLinkSearch.exportJSON().should.deepEqual({
+            detail: 0,
+            format: 0,
+            mode: 'normal',
+            placeholder: 'placeholder',
+            style: '',
+            text: 'test',
+            type: 'at-link-search',
+            version: 1
+        });
+    }));
+
+    it('imports all data via importJSON()', editorTest(function () {
+        const atLinkSearch = AtLinkSearchNode.importJSON({text: 'test', placeholder: 'placeholder'});
+        atLinkSearch.getTextContent().should.equal('test');
+        atLinkSearch.getPlaceholder().should.equal('placeholder');
+    }));
+
+    it('renders using theme classes and default placeholder', editorTest(function () {
+        const atLinkNode = $createAtLinkSearchNode();
+        const dom = atLinkNode.createDOM(config);
+        dom.classList.contains('multiple').should.be.true;
+        dom.classList.contains('classes').should.be.true;
+        dom.dataset.placeholder.should.equal('Search for a link');
+    }));
+
+    it('renders without default placeholder if text is present', editorTest(function () {
+        const atLinkNode = $createAtLinkSearchNode('test');
+        const dom = atLinkNode.createDOM(config);
+        dom.dataset.placeholder.should.equal('');
+    }));
+
+    it('renders with custom placeholder (no text)', editorTest(function () {
+        const atLinkNode = $createAtLinkSearchNode('', 'custom');
+        const dom = atLinkNode.createDOM(config);
+        dom.dataset.placeholder.should.equal('custom');
+    }));
+
+    it('renders with custom placeholder (with text)', editorTest(function () {
+        const atLinkNode = $createAtLinkSearchNode('test', 'custom');
+        const dom = atLinkNode.createDOM(config);
+        dom.dataset.placeholder.should.equal('custom');
+    }));
+
+    it('updates to remove default placeholder when text is added', editorTest(function () {
+        const atLinkNode = $createAtLinkSearchNode();
+        const dom = atLinkNode.createDOM(config);
+        dom.dataset.placeholder.should.equal('Search for a link');
+
+        const prevNode = AtLinkSearchNode.clone(atLinkNode);
+
+        atLinkNode.setTextContent('test');
+        atLinkNode.updateDOM(prevNode, dom, config);
+        dom.dataset.placeholder.should.equal('');
+    }));
+
+    it('keeps custom placeholder when text changes', editorTest(function () {
+        const atLinkNode = $createAtLinkSearchNode('test', 'custom');
+        const dom = atLinkNode.createDOM(config);
+        dom.dataset.placeholder.should.equal('custom');
+
+        const prevNode = AtLinkSearchNode.clone(atLinkNode);
+
+        atLinkNode.setTextContent('test2');
+        atLinkNode.updateDOM(prevNode, dom, config);
+        dom.dataset.placeholder.should.equal('custom');
+    }));
+
+    it('returns null for exportDOM()', editorTest(function () {
+        const atLinkSearchNode = $createAtLinkSearchNode('test');
+        should.equal(atLinkSearchNode.exportDOM(), null);
+    }));
+
+    it('cannot have format', editorTest(function () {
+        const atLinkSearchNode = $createAtLinkSearchNode();
+        atLinkSearchNode.canHaveFormat().should.be.false;
+    }));
+
+    it('can set custom placeholder', editorTest(function () {
+        const atLinkNode = $createAtLinkSearchNode();
+        atLinkNode.setPlaceholder('test');
+        atLinkNode.getPlaceholder().should.equal('test');
+    }));
+
+    it('returns contents from .getTextContent()', editorTest(function () {
+        const atLinkNode = $createAtLinkSearchNode();
+        atLinkNode.getTextContent().should.equal('');
+
+        atLinkNode.setTextContent('test');
+        atLinkNode.getTextContent().should.equal('test');
+    }));
+});

--- a/packages/kg-default-nodes/test/nodes/at-link.test.js
+++ b/packages/kg-default-nodes/test/nodes/at-link.test.js
@@ -1,0 +1,118 @@
+require('../utils');
+const {JSDOM} = require('jsdom');
+const {createHeadlessEditor} = require('@lexical/headless');
+const {AtLinkNode, $createAtLinkNode, $isAtLinkNode, $createAtLinkSearchNode, AtLinkSearchNode} = require('../../');
+
+const editorNodes = [AtLinkNode, AtLinkSearchNode];
+
+describe('AtLinkNode', function () {
+    let editor;
+
+    // NOTE: all tests should use this function, without it you need manual
+    // try/catch and done handling to avoid assertion failures not triggering
+    // failed tests
+    const editorTest = testFn => function (done) {
+        editor.update(() => {
+            try {
+                testFn();
+                done();
+            } catch (e) {
+                done(e);
+            }
+        });
+    };
+
+    beforeEach(function () {
+        editor = createHeadlessEditor({nodes: editorNodes});
+
+        const {window} = new JSDOM('<!doctype html><html><body></body></html>');
+        global.document = window.document;
+        global.window = window;
+    });
+
+    afterEach(function () {
+        delete global.document;
+        delete global.window;
+    });
+
+    it('matches node with $isAtLinkNode', editorTest(function () {
+        const atLinkNode = $createAtLinkNode();
+        $isAtLinkNode(atLinkNode).should.be.true;
+    }));
+
+    it('can be constructed with link format', editorTest(function () {
+        const atLinkNode = $createAtLinkNode('bold');
+        atLinkNode.getLinkFormat().should.equal('bold');
+    }));
+
+    it('can be cloned with all data', editorTest(function () {
+        const atLinkNode = $createAtLinkNode('bold');
+        const atLinkNodeClone = AtLinkNode.clone(atLinkNode);
+
+        atLinkNode.__key.should.equal(atLinkNodeClone.__key);
+        atLinkNodeClone.getLinkFormat().should.equal('bold');
+    }));
+
+    it('exports all data via exportJSON()', editorTest(function () {
+        const atLinkNode = $createAtLinkNode('bold');
+        atLinkNode.exportJSON().should.deepEqual({
+            children: [],
+            direction: null,
+            format: '',
+            indent: 0,
+            linkFormat: 'bold',
+            type: 'at-link',
+            version: 1
+        });
+    }));
+
+    it('imports all data via importJSON()', editorTest(function () {
+        const atLinkNode = AtLinkNode.importJSON({linkFormat: 'bold'});
+        atLinkNode.getLinkFormat().should.equal('bold');
+    }));
+
+    it('uses theme class when creating DOM', editorTest(function () {
+        const atLinkNode = $createAtLinkNode();
+        const dom = atLinkNode.createDOM(
+            {theme: {atLink: 'multiple classes'}},
+            editor
+        );
+        dom.classList.contains('multiple').should.be.true;
+        dom.classList.contains('classes').should.be.true;
+    }));
+
+    it('never updates dom after creation', editorTest(function () {
+        const atLinkNode = $createAtLinkNode();
+        atLinkNode.updateDOM().should.be.false;
+    }));
+
+    it('can get and set link format', editorTest(function () {
+        const atLinkNode = $createAtLinkNode();
+        atLinkNode.setLinkFormat('bold');
+        atLinkNode.getLinkFormat().should.equal('bold');
+    }));
+
+    it('returns null for exportDOM()', editorTest(function () {
+        const atLinkNode = $createAtLinkNode();
+        const atLinkSearchNode = $createAtLinkSearchNode('test');
+        atLinkNode.append(atLinkSearchNode);
+        should.equal(atLinkNode.exportDOM(), null);
+    }));
+
+    it('returns blank string for .getTextContent()', editorTest(function () {
+        const atLinkNode = $createAtLinkNode();
+        const atLinkSearchNode = $createAtLinkSearchNode('test');
+        atLinkNode.append(atLinkSearchNode);
+        atLinkNode.getTextContent().should.equal('');
+    }));
+
+    it('is inline', editorTest(function () {
+        const atLinkNode = $createAtLinkNode();
+        atLinkNode.isInline().should.be.true;
+    }));
+
+    it('cannot be empty', editorTest(function () {
+        const atLinkNode = $createAtLinkNode();
+        atLinkNode.canBeEmpty().should.be.false;
+    }));
+});

--- a/packages/kg-default-nodes/test/nodes/zwnj.test.js
+++ b/packages/kg-default-nodes/test/nodes/zwnj.test.js
@@ -1,0 +1,32 @@
+require('../utils');
+const {createHeadlessEditor} = require('@lexical/headless');
+const {ZWNJNode, $createZWNJNode, $isZWNJNode} = require('../../');
+
+const editorNodes = [ZWNJNode];
+
+describe('ZWNJNode', function () {
+    let editor;
+
+    // NOTE: all tests should use this function, without it you need manual
+    // try/catch and done handling to avoid assertion failures not triggering
+    // failed tests
+    const editorTest = testFn => function (done) {
+        editor.update(() => {
+            try {
+                testFn();
+                done();
+            } catch (e) {
+                done(e);
+            }
+        });
+    };
+
+    beforeEach(function () {
+        editor = createHeadlessEditor({nodes: editorNodes});
+    });
+
+    it('matches node with $isZWNJNode', editorTest(function () {
+        const zwnjNode = $createZWNJNode();
+        $isZWNJNode(zwnjNode).should.be.true;
+    }));
+});

--- a/packages/kg-default-transforms/src/default-transforms.ts
+++ b/packages/kg-default-transforms/src/default-transforms.ts
@@ -12,6 +12,9 @@ export * from './transforms/denest.js';
 export * from './transforms/merge-list-nodes.js';
 export * from './transforms/remove-alignment.js';
 
+// only used when rendering so not registered by default
+export * from './transforms/remove-at-link-nodes.js';
+
 export function registerDefaultTransforms(editor: LexicalEditor) {
     return mergeRegister(
         // strip unwanted alignment formats

--- a/packages/kg-default-transforms/src/kg-default-nodes.d.ts
+++ b/packages/kg-default-transforms/src/kg-default-nodes.d.ts
@@ -1,0 +1,7 @@
+declare module '@tryghost/kg-default-nodes' {
+    import {ElementNode, TextNode} from 'lexical';
+
+    export class AtLinkNode extends ElementNode {}
+    export class AtLinkSearchNode extends TextNode {}
+    export class ZWNJNode extends TextNode {}
+}

--- a/packages/kg-default-transforms/src/transforms/remove-at-link-nodes.ts
+++ b/packages/kg-default-transforms/src/transforms/remove-at-link-nodes.ts
@@ -1,0 +1,32 @@
+import {$isTextNode, LexicalEditor} from 'lexical';
+import {AtLinkNode} from '@tryghost/kg-default-nodes';
+
+// used when rendering to make sure we're not rendering the temporary
+// nodes used for searching internal links
+export function removeAtLinkNodesTransform(node: AtLinkNode) {
+    const prevSibling = node.getPreviousSibling();
+    const nextSibling = node.getNextSibling();
+
+    // Remove a surrounding space if it exists to avoid double-spacing after removal
+    // AtLink nodes should always exist surrounded by spaces unless at beginning or end of text
+    if (prevSibling) {
+        if ($isTextNode(prevSibling) && prevSibling.getTextContent().endsWith(' ')) {
+            prevSibling.setTextContent(prevSibling.getTextContent().slice(0, -1));
+        }
+    } else if (nextSibling) {
+        if ($isTextNode(nextSibling) && nextSibling.getTextContent().startsWith(' ')) {
+            nextSibling.setTextContent(nextSibling.getTextContent().slice(1));
+        }
+    }
+
+    node.remove();
+}
+
+export function registerRemoveAtLinkNodesTransform(editor: LexicalEditor) {
+    if (editor.hasNodes([AtLinkNode])) {
+        return editor.registerNodeTransform(AtLinkNode, removeAtLinkNodesTransform);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return () => {};
+}

--- a/packages/kg-default-transforms/test/transforms/remove-at-link-nodes.test.ts
+++ b/packages/kg-default-transforms/test/transforms/remove-at-link-nodes.test.ts
@@ -1,0 +1,405 @@
+import {LexicalEditor, ParagraphNode, TextNode} from 'lexical';
+import {registerRemoveAtLinkNodesTransform} from '../../build';
+import {assertTransform, createEditor} from '../utils';
+import {AtLinkNode, AtLinkSearchNode, ZWNJNode} from '@tryghost/kg-default-nodes';
+
+const nodes = [AtLinkNode, AtLinkSearchNode, ZWNJNode, TextNode, ParagraphNode];
+
+describe('Remove AtLink nodes transform', function () {
+    it('removes when only node in paragraph', function () {
+        const before = {
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                children: [
+                                    {
+                                        detail: 0,
+                                        format: 0,
+                                        mode: 'normal',
+                                        style: '',
+                                        text: '',
+                                        type: 'zwnj',
+                                        version: 1
+                                    },
+                                    {
+                                        detail: 0,
+                                        format: 0,
+                                        mode: 'normal',
+                                        style: '',
+                                        text: 'test',
+                                        type: 'at-link-search',
+                                        version: 1,
+                                        placeholder: null
+                                    }
+                                ],
+                                direction: 'ltr',
+                                format: '',
+                                indent: 0,
+                                type: 'at-link',
+                                version: 1,
+                                linkFormat: 0
+                            }
+                        ],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        };
+
+        const after = {
+            root: {
+                children: [
+                    {
+                        children: [],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        };
+
+        const registerTransforms = (editor: LexicalEditor) => {
+            registerRemoveAtLinkNodesTransform(editor);
+        };
+
+        const editor = createEditor({nodes});
+
+        assertTransform(editor, registerTransforms, before, after);
+    });
+
+    it('removes when at start of paragraph', function () {
+        const before = {
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                children: [
+                                    {
+                                        detail: 0,
+                                        format: 0,
+                                        mode: 'normal',
+                                        style: '',
+                                        text: '',
+                                        type: 'zwnj',
+                                        version: 1
+                                    },
+                                    {
+                                        detail: 0,
+                                        format: 0,
+                                        mode: 'normal',
+                                        style: '',
+                                        text: 'test',
+                                        type: 'at-link-search',
+                                        version: 1,
+                                        placeholder: null
+                                    }
+                                ],
+                                direction: 'ltr',
+                                format: '',
+                                indent: 0,
+                                type: 'at-link',
+                                version: 1,
+                                linkFormat: 0
+                            },
+                            {
+                                detail: 0,
+                                format: 0,
+                                mode: 'normal',
+                                style: '',
+                                text: ' After',
+                                type: 'text',
+                                version: 1
+                            }
+                        ],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        };
+
+        const after = {
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                detail: 0,
+                                format: 0,
+                                mode: 'normal',
+                                style: '',
+                                text: 'After',
+                                type: 'text',
+                                version: 1
+                            }
+                        ],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        };
+
+        const registerTransforms = (editor: LexicalEditor) => {
+            registerRemoveAtLinkNodesTransform(editor);
+        };
+
+        const editor = createEditor({nodes});
+
+        assertTransform(editor, registerTransforms, before, after);
+    });
+
+    it('removes when at end of paragraph', function () {
+        const before = {
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                detail: 0,
+                                format: 0,
+                                mode: 'normal',
+                                style: '',
+                                text: 'Before ',
+                                type: 'text',
+                                version: 1
+                            },
+                            {
+                                children: [
+                                    {
+                                        detail: 0,
+                                        format: 0,
+                                        mode: 'normal',
+                                        style: '',
+                                        text: '',
+                                        type: 'zwnj',
+                                        version: 1
+                                    },
+                                    {
+                                        detail: 0,
+                                        format: 0,
+                                        mode: 'normal',
+                                        style: '',
+                                        text: 'test',
+                                        type: 'at-link-search',
+                                        version: 1,
+                                        placeholder: null
+                                    }
+                                ],
+                                direction: 'ltr',
+                                format: '',
+                                indent: 0,
+                                type: 'at-link',
+                                version: 1,
+                                linkFormat: 0
+                            }
+                        ],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        };
+
+        const after = {
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                detail: 0,
+                                format: 0,
+                                mode: 'normal',
+                                style: '',
+                                text: 'Before',
+                                type: 'text',
+                                version: 1
+                            }
+                        ],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        };
+
+        const registerTransforms = (editor: LexicalEditor) => {
+            registerRemoveAtLinkNodesTransform(editor);
+        };
+
+        const editor = createEditor({nodes});
+
+        assertTransform(editor, registerTransforms, before, after);
+    });
+
+    it('removes when surrounded by text', function () {
+        const before = {
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                detail: 0,
+                                format: 0,
+                                mode: 'normal',
+                                style: '',
+                                text: 'Testing Before ',
+                                type: 'text',
+                                version: 1
+                            },
+                            {
+                                children: [
+                                    {
+                                        detail: 0,
+                                        format: 0,
+                                        mode: 'normal',
+                                        style: '',
+                                        text: '',
+                                        type: 'zwnj',
+                                        version: 1
+                                    },
+                                    {
+                                        detail: 0,
+                                        format: 0,
+                                        mode: 'normal',
+                                        style: '',
+                                        text: 'search',
+                                        type: 'at-link-search',
+                                        version: 1,
+                                        placeholder: null
+                                    }
+                                ],
+                                direction: 'ltr',
+                                format: '',
+                                indent: 0,
+                                type: 'at-link',
+                                version: 1,
+                                linkFormat: 0
+                            },
+                            {
+                                detail: 0,
+                                format: 0,
+                                mode: 'normal',
+                                style: '',
+                                text: ' After',
+                                type: 'text',
+                                version: 1
+                            }
+                        ],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        };
+
+        const after = {
+            root: {
+                children: [
+                    {
+                        children: [
+                            {
+                                detail: 0,
+                                format: 0,
+                                mode: 'normal',
+                                style: '',
+                                text: 'Testing Before After',
+                                type: 'text',
+                                version: 1
+                            }
+                        ],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }
+                ],
+                direction: 'ltr',
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        };
+
+        const registerTransforms = (editor: LexicalEditor) => {
+            registerRemoveAtLinkNodesTransform(editor);
+        };
+
+        const editor = createEditor({nodes});
+
+        assertTransform(editor, registerTransforms, before, after);
+    });
+
+    it('can register without node loaded in editor', function () {
+        const registerTransforms = (editor: LexicalEditor) => {
+            registerRemoveAtLinkNodesTransform(editor);
+        };
+
+        const editor = createEditor({nodes: []});
+
+        registerTransforms(editor);
+        editor.update(() => {}, {discrete: true});
+    });
+});

--- a/packages/kg-lexical-html-renderer/lib/LexicalHTMLRenderer.ts
+++ b/packages/kg-lexical-html-renderer/lib/LexicalHTMLRenderer.ts
@@ -1,11 +1,14 @@
 import {SerializedEditorState, LexicalEditor, LexicalNode, Klass} from 'lexical';
-
 import {createHeadlessEditor} from '@lexical/headless';
 import {ListItemNode, ListNode} from '@lexical/list';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {LinkNode} from '@lexical/link';
 import $convertToHtmlString from './convert-to-html-string';
 import getDynamicDataNodes from './get-dynamic-data-nodes';
+
+// TODO: Using import causes circular definitions for kg-default-nodes
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {registerRemoveAtLinkNodesTransform} = require('@tryghost/kg-default-transforms');
 
 interface RenderOptions {
     target?: 'html' | 'plaintext';
@@ -78,10 +81,14 @@ export default class LexicalHTMLRenderer {
 
         options.renderData = renderData;
 
-        // render nodes
+        // set up editor with our state
         editor.setEditorState(editorState);
-        let html = '';
 
+        // register transforms that clean up state for rendering
+        registerRemoveAtLinkNodesTransform(editor);
+
+        // render
+        let html = '';
         editor.update(async () => {
             html = $convertToHtmlString(options);
         });

--- a/packages/kg-lexical-html-renderer/package.json
+++ b/packages/kg-lexical-html-renderer/package.json
@@ -42,6 +42,7 @@
     "@lexical/list": "0.13.1",
     "@lexical/rich-text": "0.13.1",
     "@tryghost/kg-default-nodes": "1.0.16",
+    "@tryghost/kg-default-transforms": "1.0.17",
     "jsdom": "^24.0.0",
     "lexical": "0.13.1",
     "prettier": "3.2.5"

--- a/packages/kg-lexical-html-renderer/test/render.test.js
+++ b/packages/kg-lexical-html-renderer/test/render.test.js
@@ -1,4 +1,5 @@
 const {shouldRender} = require('./utils');
+const {AtLinkNode, AtLinkSearchNode, ZWNJNode} = require('@tryghost/kg-default-nodes');
 
 const Renderer = require('../build/LexicalHTMLRenderer').default;
 
@@ -69,5 +70,13 @@ describe('Unexpected input', function () {
     it('paragraphs with no children', shouldRender({
         input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Testing Before","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Testing After","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
         output: `<p>Testing Before</p><p></p><p>Testing After</p>`
+    }));
+});
+
+describe('Transforms',function () {
+    it('removes AtLink nodes when rendering', shouldRender({
+        options: {nodes: [AtLinkNode, AtLinkSearchNode, ZWNJNode]},
+        input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Testing Before ","type":"text","version":1},{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"","type":"zwnj","version":1},{"detail":0,"format":0,"mode":"normal","style":"","text":"search","type":"at-link-search","version":1,"placeholder":null}],"direction":"ltr","format":"","indent":0,"type":"at-link","version":1,"linkFormat":0},{"detail":0,"format":0,"mode":"normal","style":"","text":" After","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+        output: '<p>Testing Before After</p>'
     }));
 });

--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -304,7 +304,8 @@ function DemoComposer({editorType, isMultiplayer, setWordCount, setTKCount}) {
         fetchCollectionPosts,
         feature: {
             ...defaultCardConfig.feature,
-            internalLinking: searchParams.get('labs')?.includes('internalLinking')
+            internalLinking: searchParams.get('labs')?.includes('internalLinking'),
+            internalLinkingAtLinks: searchParams.get('labs')?.includes('internalLinking')
         }
     };
 

--- a/packages/koenig-lexical/src/components/ui/AtLinkResultsPopup.jsx
+++ b/packages/koenig-lexical/src/components/ui/AtLinkResultsPopup.jsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import {$getSelection} from 'lexical';
+import {InputListGroup, InputListItem} from './InputListCopy';
+import {KeyboardSelectionWithGroups} from './KeyboardSelectionWithGroups';
+import {getScrollParent} from '../../utils/getScrollParent';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+
+export function AtLinkResultsPopup({atLinkNode, isSearching, listOptions, query, onSelect}) {
+    const [editor] = useLexicalComposerContext();
+
+    const scrollContainer = React.useMemo(() => {
+        return getScrollParent(editor.getRootElement());
+    }, [editor]);
+
+    const popupRef = React.useRef(null);
+
+    const testId = 'at-link-results';
+
+    // Position the results popup when they open.
+    // Appears below the at-link node unless at bottom of the document where it appears above.
+    const updatePopupPosition = React.useCallback(() => {
+        editor.update(() => {
+            const popupElement = popupRef.current;
+            if (!popupElement) {
+                return;
+            }
+
+            const selection = $getSelection();
+            if (!selection) {
+                return;
+            }
+
+            const atLinkElement = editor.getElementByKey(atLinkNode.getKey());
+            const atLinkRect = atLinkElement.getBoundingClientRect();
+
+            const editorElem = editor.getRootElement();
+
+            if (!atLinkRect || !editorElem || !popupElement) {
+                return;
+            }
+
+            const editorRect = editorElem.getBoundingClientRect();
+
+            const top = atLinkRect.bottom + 10;
+            const left = editorRect.left;
+            const right = editorRect.right;
+
+            popupElement.style.top = `${top}px`;
+            popupElement.style.left = `${left}px`;
+            popupElement.style.width = `${right - left}px`;
+
+            // TODO: Max height is hardcoded to 30% of window height for results list + 54px (toolbar height),
+            //  this is based on current styling and will need adjusting if styles change. We make this calculation
+            //  to avoid the toolbar jumping between above/below positioning when the results list changes size.
+            const popupMaxHeight = (window.innerHeight / 100 * 30) + 54;
+            const popupRect = popupElement.getBoundingClientRect();
+
+            if (scrollContainer.scrollTop + popupRect.top + popupMaxHeight > scrollContainer.scrollHeight) {
+                popupElement.style.top = `${atLinkRect.top - popupRect.height - 10}px`;
+            }
+        });
+    }, [editor, atLinkNode, scrollContainer]);
+
+    React.useEffect(() => {
+        updatePopupPosition();
+    }, [updatePopupPosition]);
+
+    // re-position on document scroll, window resize,
+    // plus search results change to avoid gap appearing when positioned above the toolbar
+    React.useEffect(() => {
+        window.addEventListener('resize', updatePopupPosition);
+        if (scrollContainer) {
+            scrollContainer.addEventListener('scroll', updatePopupPosition);
+        }
+
+        const popupElement = popupRef.current;
+        const popupMutationObserver = new MutationObserver(updatePopupPosition);
+        popupMutationObserver.observe(popupElement, {childList: true, subtree: true});
+
+        return () => {
+            window.removeEventListener('resize', updatePopupPosition);
+            if (scrollContainer) {
+                scrollContainer.removeEventListener('scroll', updatePopupPosition);
+            }
+            if (popupElement) {
+                popupMutationObserver.disconnect();
+            }
+        };
+    }, [editor, scrollContainer, updatePopupPosition]);
+
+    const getItem = (item, selected, onMouseOver) => {
+        return (
+            <InputListItem
+                key={item.value}
+                dataTestId={testId}
+                highlightString={query}
+                item={item}
+                selected={selected}
+                onClick={onSelect}
+                onMouseOver={onMouseOver}
+            />
+        );
+    };
+
+    const getGroup = (group) => {
+        return (
+            <InputListGroup dataTestId={testId} group={group} />
+        );
+    };
+
+    return (
+        <div ref={popupRef} className="not-kg-prose fixed z-[10000]">
+            <div className="relative m-0 flex w-full flex-col rounded-lg bg-white p-1 px-2 font-sans text-sm font-medium shadow-md dark:bg-grey-950">
+                <ul className="max-h-[30vh] w-full overflow-y-auto bg-white py-1 dark:bg-grey-950">
+                    <KeyboardSelectionWithGroups
+                        getGroup={getGroup}
+                        getItem={getItem}
+                        groups={listOptions}
+                        onSelect={onSelect}
+                    />
+                </ul>
+            </div>
+        </div>
+    );
+}
+
+export default AtLinkResultsPopup;

--- a/packages/koenig-lexical/src/hooks/useKoenigTextEntity.js
+++ b/packages/koenig-lexical/src/hooks/useKoenigTextEntity.js
@@ -1,4 +1,5 @@
 // see lexical useLexicalTextEntity hook
+// duplicated here because the upstream version is dependent on TextNode but we use ExtendedTextNode
 
 import {$createTextNode, $isTextNode, TextNode} from 'lexical';
 import {mergeRegister} from '@lexical/utils';

--- a/packages/koenig-lexical/src/nodes/DefaultNodes.js
+++ b/packages/koenig-lexical/src/nodes/DefaultNodes.js
@@ -1,8 +1,11 @@
 import {
+    AtLinkNode,
+    AtLinkSearchNode,
     ExtendedHeadingNode,
     ExtendedQuoteNode,
     ExtendedTextNode,
     TKNode,
+    ZWNJNode,
     extendedHeadingNodeReplacement,
     extendedQuoteNodeReplacement,
     extendedTextNodeReplacement
@@ -68,7 +71,10 @@ const DEFAULT_NODES = [
     GalleryNode,
     SignupNode,
     CollectionNode,
-    TKNode
+    TKNode,
+    AtLinkNode,
+    AtLinkSearchNode,
+    ZWNJNode
 ];
 
 export default DEFAULT_NODES;

--- a/packages/koenig-lexical/src/plugins/AllDefaultPlugins.jsx
+++ b/packages/koenig-lexical/src/plugins/AllDefaultPlugins.jsx
@@ -1,3 +1,4 @@
+import AtLinkPlugin from './AtLinkPlugin.jsx';
 import CollectionPlugin from '../plugins/CollectionPlugin';
 import EmEnDashPlugin from '../plugins/EmEnDashPlugin';
 import HorizontalRulePlugin from '../plugins/HorizontalRulePlugin';
@@ -35,7 +36,10 @@ export const AllDefaultPlugins = () => {
 
             {/* Koenig Plugins */}
             <CardMenuPlugin />
+            <KoenigSnippetPlugin />
+            <KoenigSelectorPlugin /> {/* Tenor/Unsplash selectors */}
             <EmojiPickerPlugin />
+            <AtLinkPlugin />
 
             {/* Card Plugins */}
             <AudioPlugin />
@@ -53,16 +57,12 @@ export const AllDefaultPlugins = () => {
             <HeaderPlugin />
             <BookmarkPlugin />
             <PaywallPlugin />
-            <KoenigSelectorPlugin />
             <ProductPlugin />
             <EmailCtaPlugin />
             <EmailPlugin />
             <EmbedPlugin />
             <SignupPlugin />
             <CollectionPlugin />
-
-            {/* Snippet Plugins */}
-            <KoenigSnippetPlugin />
         </>
     );
 };

--- a/packages/koenig-lexical/src/plugins/AtLinkPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/AtLinkPlugin.jsx
@@ -1,0 +1,411 @@
+import KoenigComposerContext from '../context/KoenigComposerContext';
+import Portal from '../components/ui/Portal';
+import React from 'react';
+import {
+    $createAtLinkNode,
+    $createAtLinkSearchNode,
+    $createZWNJNode,
+    $isAtLinkNode,
+    $isAtLinkSearchNode,
+    $isZWNJNode,
+    AtLinkNode,
+    AtLinkSearchNode
+} from '@tryghost/kg-default-nodes';
+import {$createLinkNode} from '@lexical/link';
+import {
+    $createTextNode,
+    $getSelection,
+    $isRangeSelection,
+    $isTextNode,
+    $nodesOfType,
+    COMMAND_PRIORITY_HIGH,
+    DELETE_CHARACTER_COMMAND,
+    FORMAT_ELEMENT_COMMAND,
+    FORMAT_TEXT_COMMAND,
+    KEY_ESCAPE_COMMAND
+} from 'lexical';
+import {$insertFirst, mergeRegister} from '@lexical/utils';
+import {AtLinkResultsPopup} from '../components/ui/AtLinkResultsPopup';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useSearchLinks} from '../hooks/useSearchLinks';
+
+function $removeAtLink(node, {focus = false} = {}) {
+    if (!$isAtLinkNode(node)) {
+        // eslint-disable-next-line no-console
+        console.warn('$removeAtLink called on a non-at-link node', node);
+        return;
+    }
+
+    const searchNode = node.getChildAtIndex(1);
+
+    const textNode = $createTextNode('@' + searchNode.getTextContent());
+    textNode.setFormat(node.getLinkFormat());
+    node.replace(textNode);
+
+    if (focus) {
+        textNode.selectEnd();
+    }
+}
+
+// Manages at-link search nodes and display of the search results panel when appropriate
+export const KoenigAtLinkPlugin = ({searchLinks}) => {
+    const [editor] = useLexicalComposerContext();
+
+    const [focusedAtLinkNode, setFocusedAtLinkNode] = React.useState(null);
+    const [query, setQuery] = React.useState('');
+    const {isSearching, listOptions} = useSearchLinks(query, searchLinks);
+
+    // register an event listener to detect '@' character being typed
+    // - we only ever want to convert an '@' to an at-link node when it's typed
+    //   so a native event listener makes more sense than a lexical update listener
+    //   that would need to constantly compare against current and previous states
+    // - '@' must be preceded by beginning of line, whitespace, or br
+    // - '@' must be followed by whitespace, end of line, or br
+    React.useEffect(() => {
+        const rootElement = editor.getRootElement();
+
+        const handleAtInsert = (event) => {
+            if (event.isComposing) {
+                return;
+            }
+
+            if (event.inputType === 'insertText' && event.data === '@') {
+                let replaceAt = false;
+
+                editor.getEditorState().read(() => {
+                    // get the current selection
+                    const selection = $getSelection();
+                    if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+                        return;
+                    }
+
+                    const anchor = selection.anchor;
+                    if (anchor.type !== 'text') {
+                        return;
+                    }
+
+                    const anchorNode = anchor.getNode();
+                    if (!anchorNode.isSimpleText()) {
+                        return;
+                    }
+
+                    let anchorOffset = anchor.offset;
+                    let textBeforeAnchor = anchorNode.getTextContent().slice(0, anchorOffset);
+                    let textAfterAnchor = anchorNode.getTextContent().slice(anchorOffset);
+
+                    // adjust before/after text if we're immediately preceded/followed by a text node
+                    // because that content needs to be accounted for in our regex match
+                    const prevSibling = anchorNode.getPreviousSibling();
+                    const nextSibling = anchorNode.getNextSibling();
+
+                    if (anchorOffset === 0 && $isTextNode(prevSibling)) {
+                        textBeforeAnchor = prevSibling.getTextContent();
+                    }
+
+                    if (anchorOffset === anchorNode.getTextContent().length && $isTextNode(nextSibling)) {
+                        textAfterAnchor = nextSibling.getTextContent();
+                    }
+
+                    const textBeforeRegExp = /(^|\s)@$/;
+                    const textAfterRegExp = /^($|\s)/;
+
+                    if (
+                        textBeforeRegExp.test(textBeforeAnchor)
+                        && textAfterRegExp.test(textAfterAnchor)
+                    ) {
+                        replaceAt = true;
+                    }
+                });
+
+                if (replaceAt) {
+                    editor.update(() => {
+                        // selection should now be where the '@' character was
+                        const selection = $getSelection();
+
+                        // store current node's format so it can be re-applied to the eventual link node
+                        const linkFormat = selection.anchor.getNode().getFormat();
+
+                        // delete the '@' character
+                        selection.deleteCharacter(true);
+
+                        // prep the at-link node
+                        const atLinkNode = $createAtLinkNode();
+                        atLinkNode.setLinkFormat(linkFormat);
+                        const zwnjNode = $createZWNJNode();
+                        atLinkNode.append(zwnjNode);
+                        const atLinkSearchNode = $createAtLinkSearchNode('');
+                        atLinkNode.append(atLinkSearchNode);
+
+                        // insert it
+                        selection.insertNodes([atLinkNode]);
+
+                        // ensure we still have a cursor and it's inside the search node
+                        atLinkNode.select(1, 1);
+                    });
+                }
+            }
+        };
+
+        // weirdly the 'input' event doesn't fire for the first character typed in a paragraph
+        const handleAtBeforeInput = (event) => {
+            if (event.inputType === 'insertText' && event.data === '@') {
+                editor.update(() => {
+                    const selection = $getSelection();
+                    if ($isRangeSelection(selection) && selection.isCollapsed() && !selection.anchor.getNode().getPreviousSibling()) {
+                        handleAtInsert(event);
+                    }
+                });
+            }
+        };
+
+        rootElement.addEventListener('input', handleAtInsert);
+        rootElement.addEventListener('beforeinput', handleAtBeforeInput);
+
+        return () => {
+            rootElement.removeEventListener('input', handleAtInsert);
+            rootElement.removeEventListener('beforeinput', handleAtBeforeInput);
+        };
+    }, [editor]);
+
+    // register an update listener
+    // - update plugin state with a focused at-link node
+    // - update plugin state with search query based on at-link-search node text content
+    // - remove at-link nodes when they don't have focus (i.e. using arrow keys to move out of them)
+    React.useEffect(() => {
+        return editor.registerUpdateListener(() => {
+            // do nothing if we're in the middle of composing text
+            if (editor.isComposing()) {
+                return;
+            }
+
+            editor.update(() => {
+                const atLinkNodes = $nodesOfType(AtLinkNode);
+                const selection = $getSelection();
+
+                // we don't have a normal selection so we don't have a cursor inside
+                // an at-link node, remove all of them
+                if (!$isRangeSelection(selection)) {
+                    atLinkNodes.forEach($removeAtLink);
+                    setFocusedAtLinkNode(null);
+                    setQuery('');
+                    return;
+                }
+
+                // we have a collapsed selection, remove any at-link nodes that don't have focus
+                // handles cursor movement out of at-link nodes
+                if (selection.isCollapsed()) {
+                    const anchorNode = selection.anchor.getNode();
+                    let selectedAtLinkNode;
+
+                    if ($isAtLinkNode(anchorNode)) {
+                        selectedAtLinkNode = anchorNode;
+                    }
+                    if ($isAtLinkNode(anchorNode.getParent())) {
+                        selectedAtLinkNode = anchorNode.getParent();
+                    }
+
+                    atLinkNodes.forEach((atLinkNode) => {
+                        if (atLinkNode !== selectedAtLinkNode) {
+                            $removeAtLink(atLinkNode);
+                        }
+                    });
+
+                    if (selectedAtLinkNode) {
+                        // search node is focused, update our search query
+                        setFocusedAtLinkNode(selectedAtLinkNode);
+
+                        // at-link nodes always have a ZWNJ node followed by an at-link-search node
+                        const searchNode = selectedAtLinkNode.getChildAtIndex(1);
+                        const searchNodeText = searchNode?.getTextContent?.();
+
+                        setQuery(searchNodeText);
+
+                        // normalize selection to be inside the search node when on zwnj
+                        // - handles case where text is backspaced to empty
+                        if ($isZWNJNode(selection.focus.getNode()) && window.getSelection().anchorOffset === 0) {
+                            selectedAtLinkNode.select(1, 1);
+                        }
+                    } else {
+                        // search node isn't focused, reset plugin state
+                        setFocusedAtLinkNode(null);
+                        setQuery('');
+                    }
+
+                    return;
+                }
+
+                // TODO: prevent range selection spanning outside of at-link node
+            });
+        });
+    }, [editor]);
+
+    // register some command handlers to avoid certain actions happening whilst
+    // an at-link-search node is focused
+    React.useEffect(() => {
+        function $skipFormatCommandIfNeeded() {
+            const selection = $getSelection();
+            if ($isRangeSelection(selection) && $isAtLinkSearchNode(selection.anchor.getNode())) {
+                return true;
+            }
+            return false;
+        }
+
+        return mergeRegister(
+            // revert to '@' when pressing escape with a focused at-link node
+            editor.registerCommand(
+                KEY_ESCAPE_COMMAND,
+                () => {
+                    const selection = $getSelection();
+                    if ($isRangeSelection(selection)) {
+                        const anchorNode = selection.anchor.getNode();
+                        if ($isAtLinkNode(anchorNode)) {
+                            $removeAtLink(anchorNode, {focus: true});
+                            return true;
+                        }
+                        if ($isAtLinkSearchNode(anchorNode) || ($isZWNJNode(anchorNode) && $isAtLinkNode(anchorNode.getParent()))) {
+                            $removeAtLink(anchorNode.getParent(), {focus: true});
+                            return true;
+                        }
+                    }
+                    return false;
+                },
+                COMMAND_PRIORITY_HIGH
+            ),
+            // revert to '@' when backspacing or deleting chars at the beginning/end of an at-link node
+            editor.registerCommand(
+                DELETE_CHARACTER_COMMAND,
+                (isBackward) => {
+                    const selection = $getSelection();
+                    if ($isRangeSelection(selection)) {
+                        const anchorNode = selection.anchor.getNode();
+                        if ($isAtLinkSearchNode(anchorNode) || ($isZWNJNode(anchorNode) && $isAtLinkNode(anchorNode.getParent()))) {
+                            const anchorOffset = selection.anchor.offset;
+                            if (isBackward && anchorOffset === 0) {
+                                $removeAtLink(anchorNode.getParent(), {focus: true});
+                                return true;
+                            }
+                            if (!isBackward && anchorOffset === anchorNode.getTextContentSize()) {
+                                $removeAtLink(anchorNode.getParent(), {focus: true});
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                },
+                COMMAND_PRIORITY_HIGH
+            ),
+            // prevent formatting commands when an at-link-search node is focused
+            editor.registerCommand(
+                FORMAT_TEXT_COMMAND,
+                $skipFormatCommandIfNeeded,
+                COMMAND_PRIORITY_HIGH
+            ),
+            editor.registerCommand(
+                FORMAT_ELEMENT_COMMAND,
+                $skipFormatCommandIfNeeded,
+                COMMAND_PRIORITY_HIGH
+            )
+        );
+    });
+
+    // register transforms to ensure at-link node trees are valid
+    React.useEffect(() => {
+        return editor.registerNodeTransform(AtLinkNode, (atLinkNode) => {
+            // first child should always be a ZWNJ
+            if (!$isZWNJNode(atLinkNode.getFirstChild())) {
+                const zwnjNode = $createZWNJNode();
+                $insertFirst(atLinkNode, zwnjNode);
+            }
+
+            // second child should be a search node
+            if (!$isAtLinkSearchNode(atLinkNode.getChildAtIndex(1))) {
+                const atLinkSearchNode = $createAtLinkSearchNode('');
+                atLinkNode.append(atLinkSearchNode);
+            }
+
+            // we only want one search node, remove or replace any non-search nodes
+            atLinkNode.getChildren().forEach((child, index) => {
+                if (index > 0 && !$isAtLinkSearchNode(child)) {
+                    const text = child.getTextContent?.();
+
+                    if (!text) {
+                        child.remove();
+                    } else {
+                        const atLinkSearchNode = $createAtLinkSearchNode(text);
+                        child.replace(atLinkSearchNode);
+                    }
+                }
+            });
+
+            // consolidate multiple search nodes from previous step into single node
+            const searchNode = atLinkNode.getChildAtIndex(1);
+            const currentText = searchNode.getTextContent();
+            let consolidatedText = currentText;
+            atLinkNode.getChildren().forEach((child, index) => {
+                if (index > 1) {
+                    consolidatedText += child.getTextContent();
+                    child.remove();
+                }
+            });
+            if (consolidatedText !== currentText) {
+                searchNode.setTextContent(consolidatedText);
+            }
+        });
+    }, [editor]);
+
+    // when a search result is selected, replace the at-link node with a link node
+    const onItemSelect = React.useCallback((item) => {
+        editor.update(() => {
+            const linkNode = $createLinkNode(item.value);
+            const textNode = $createTextNode(item.label);
+            linkNode.append(textNode);
+            linkNode.setFormat(focusedAtLinkNode.getLinkFormat());
+
+            focusedAtLinkNode.replace(linkNode);
+            linkNode.selectEnd();
+
+            setQuery('');
+            setFocusedAtLinkNode(null);
+        });
+    }, [editor, focusedAtLinkNode]);
+
+    // render nothing when we don't have a focused at-link node
+    if (!focusedAtLinkNode) {
+        return null;
+    }
+
+    // otherwise render search results popup
+    return (
+        <Portal>
+            <AtLinkResultsPopup
+                atLinkNode={focusedAtLinkNode}
+                isSearching={isSearching}
+                listOptions={listOptions}
+                query={query}
+                onSelect={onItemSelect}
+            />
+        </Portal>
+    );
+};
+
+// wrapping KoenigAtLinkPlugin means we can ensure all dependencies are available
+// before rendering the plugin, avoiding complex conditionals in the plugin itself
+export const AtLinkPlugin = () => {
+    const {cardConfig} = React.useContext(KoenigComposerContext);
+    const [editor] = useLexicalComposerContext();
+
+    // do nothing if we haven't been passed a way to search internal links
+    const betaEnabled = cardConfig?.feature?.internalLinking && cardConfig?.feature?.internalLinkingAtLinks;
+    if (!cardConfig?.searchLinks || !betaEnabled) {
+        return null;
+    }
+
+    // do nothing if the required nodes aren't loaded
+    if (!editor.hasNodes([AtLinkNode, AtLinkSearchNode])) {
+        return null;
+    }
+
+    return <KoenigAtLinkPlugin searchLinks={cardConfig.searchLinks} />;
+};
+
+export default AtLinkPlugin;

--- a/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/FloatingToolbarPlugin.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {$getSelection, $isParagraphNode, $isRangeSelection, $isTextNode, COMMAND_PRIORITY_LOW, KEY_MODIFIER_COMMAND} from 'lexical';
 import {$getSelectionRangeRect} from '../utils/$getSelectionRangeRect';
+import {$isAtLinkSearchNode} from '@tryghost/kg-default-nodes';
 import {$isLinkNode} from '@lexical/link';
 import {FloatingFormatToolbar, toolbarItemTypes} from '../components/ui/FloatingFormatToolbar';
 import {FloatingLinkToolbar} from '../components/ui/FloatingLinkToolbar';
@@ -41,7 +42,7 @@ function useFloatingFormatToolbar(editor, anchorElem, isSnippetsEnabled, hiddenF
                 return;
             }
 
-            if (!$isRangeSelection(selection)) {
+            if (!$isRangeSelection(selection) || $isAtLinkSearchNode(selection.anchor.getNode())) {
                 if (toolbarItemType) {
                     setToolbarItemType(null);
                 }

--- a/packages/koenig-lexical/src/plugins/SlashCardMenuPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/SlashCardMenuPlugin.jsx
@@ -157,7 +157,7 @@ function useSlashCardMenu(editor) {
                 setCommandParams(cps);
             });
         });
-    }, [editor, closeMenu, setQuery, setCommandParams]);
+    }, [editor, isShowingMenu, closeMenu, setQuery, setCommandParams]);
 
     // open the menu when / is pressed on a blank paragraph
     React.useEffect(() => {

--- a/packages/koenig-lexical/src/themes/default.js
+++ b/packages/koenig-lexical/src/themes/default.js
@@ -30,7 +30,9 @@ const defaultTheme = {
         code: undefined
     },
     code: undefined,
-    tkHighlighted: 'bg-lime-500 dark:bg-lime-800 py-1'
+    tkHighlighted: 'bg-lime-500 dark:bg-lime-800 py-1',
+    atLink: 'inline-block bg-grey-200 dark:bg-grey-800 px-1',
+    atLinkSearch: 'after:content-[attr(data-placeholder)] after:text-grey-500 min-w-[5px]'
 };
 
 export default defaultTheme;

--- a/yarn.lock
+++ b/yarn.lock
@@ -16426,7 +16426,7 @@ possible-typed-array-names@^1.0.0:
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
   integrity sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==
 
-postcss-import@16.1.0, postcss-import@^16.0.1:
+postcss-import@16.1.0:
   version "16.1.0"
   resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-16.1.0.tgz#258732175518129667fe1e2e2a05b19b5654b96a"
   integrity sha512-7hsAZ4xGXl4MW+OKEWCnF6T5jqBw80/EE9aXg1r2yyn1RsVEU8EtKXbijEODa+rg7iih4bKf7vlvTGYR4CnPNg==
@@ -16508,12 +16508,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
-"prettier-fallback@npm:prettier@^3":
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz#e52bc3090586e824964a8813b09aba6233b28368"
-  integrity sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==
-
-prettier@3.2.5:
+"prettier-fallback@npm:prettier@^3", prettier@3.2.5:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz#e52bc3090586e824964a8813b09aba6233b28368"
   integrity sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==
@@ -18452,7 +18447,7 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18469,15 +18464,6 @@ string-width@^1.0.1, string-width@^1.0.2:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^3.0.0:
   version "3.1.0"
@@ -18586,7 +18572,7 @@ stringify-object@^5.0.0:
     is-obj "^3.0.0"
     is-regexp "^3.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18606,13 +18592,6 @@ strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -20475,7 +20454,7 @@ workerpool@^6.4.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -20496,15 +20475,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/MOM-83

- uses two element nodes and an associated plugin to handle searching after typing '@' when not connected to a non-space character
