### PR TITLE
Updated @tryghost/kg-lexical-html-renderer to accept onError option

### DIFF
--- a/packages/kg-lexical-html-renderer/lib/LexicalHTMLRenderer.ts
+++ b/packages/kg-lexical-html-renderer/lib/LexicalHTMLRenderer.ts
@@ -15,11 +15,16 @@ interface RenderOptions {
     renderData?: Map<number, any>;
 }
 
+function defaultOnError() {
+    // do nothing
+}
+
 export default class LexicalHTMLRenderer {
     dom: import('jsdom').JSDOM;
     nodes: Klass<LexicalNode>[];
+    onError: (error: Error) => void;
 
-    constructor({dom, nodes}: {dom?: import('jsdom').JSDOM, nodes?: Klass<LexicalNode>[]} = {}) {
+    constructor({dom, nodes, onError}: {dom?: import('jsdom').JSDOM, nodes?: Klass<LexicalNode>[], onError?: () => void} = {}) {
         if (!dom) {
             // eslint-disable-next-line @typescript-eslint/no-var-requires
             const jsdom = require('jsdom');
@@ -31,6 +36,7 @@ export default class LexicalHTMLRenderer {
         }
 
         this.nodes = nodes || [];
+        this.onError = onError || defaultOnError;
     }
 
     async render(lexicalState: SerializedEditorState | string, userOptions: RenderOptions = {}) {
@@ -50,7 +56,8 @@ export default class LexicalHTMLRenderer {
         ];
 
         const editor: LexicalEditor = createHeadlessEditor({
-            nodes: DEFAULT_NODES
+            nodes: DEFAULT_NODES,
+            onError: this.onError
         });
 
         const editorState = editor.parseEditorState(lexicalState);

--- a/packages/kg-lexical-html-renderer/test/utils/should-render.js
+++ b/packages/kg-lexical-html-renderer/test/utils/should-render.js
@@ -6,8 +6,12 @@ const dom = new JSDOM();
 
 function shouldRender({input, output, options = {}}) {
     return async function () {
-        const {nodes, ...renderOptions} = options;
-        const renderer = new Renderer({dom, nodes});
+        const defaultOnError = (err) => {
+            throw err;
+        };
+
+        const {nodes, onError, ...renderOptions} = options;
+        const renderer = new Renderer({dom, nodes, onError: onError || defaultOnError});
         const renderedInput = await renderer.render(input, renderOptions);
         renderedInput.should.equal(output);
     };


### PR DESCRIPTION
no issue

- the renderer would silently fail and output a blank string if anything caused the internal headless editor instance to error
- aside from not giving consumers a way to handle errors, this made testing more difficult because you often wouldn't get any error back from a failing test
- added `onError` option to the `LexicalHTMLRenderer` constructor, defaulting to a function that does nothing in order to preserve current behaviour
- updated our `shouldRender` test helper to throw an error when one is encountered so failing tests can have meaningful output
