### PR TITLE
Fixed regexp special chars in input list searches crashing editor

### DIFF
--- a/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import escapeRegExp from 'lodash/escapeRegExp';
 import {Delayed} from './Delayed';
 import {DropdownContainerCopy} from './DropdownContainerCopy';
 import {Input} from './Input';
@@ -38,7 +39,7 @@ export function InputListItem({dataTestId, item, selected, onClick, onMouseOver,
             return item.label;
         }
 
-        const parts = item.label.split(new RegExp(`(${highlightString})`, 'gi'));
+        const parts = item.label.split(new RegExp(`(${escapeRegExp(highlightString)})`, 'gi'));
 
         return (
             <>

--- a/packages/koenig-lexical/test/e2e/internal-linking.test.js
+++ b/packages/koenig-lexical/test/e2e/internal-linking.test.js
@@ -87,5 +87,34 @@ test.describe('Internal linking', async () => {
                 </span>
             `, {selector: '[data-testid="bookmark-url-listOption"][aria-selected="true"]'});
         });
+
+        test('highlights matches in results', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+            await expect(page.getByTestId('bookmark-url-dropdown')).toBeVisible();
+
+            await page.keyboard.type('Emoji');
+
+            await expect(page.locator('[data-testid="bookmark-url-listOption"]')).toBeVisible();
+            await expect(page.locator('span.font-bold').first()).toHaveText('Emoji');
+        });
+
+        test('does not crash with regexp chars in search', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+            await expect(page.getByTestId('bookmark-url-dropdown')).toBeVisible();
+
+            await page.keyboard.type('[');
+
+            await expect(page.locator('[data-testid="bookmark-url-listOption"]')).toBeVisible();
+        });
+    });
+
+    test.describe('Link toolbar', function () {
+
+    });
+
+    test.describe('At-linking', function () {
+
     });
 });


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-159

- added escaping to the string used inside a regexp for highlighting matching strings in search results
