### PR TITLE
Added matching for relative and anchor links to link search

### DIFF
--- a/packages/koenig-lexical/src/components/ui/DropdownContainerCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/DropdownContainerCopy.jsx
@@ -8,7 +8,7 @@ import debounce from 'lodash/debounce';
  * Displays the dropdown above or below the parent element, depending on the space available in the viewport.
  * The parent should be positioned relative.
  */
-export function DropdownContainerCopy({children, ...props}) {
+export function DropdownContainerCopy({dataTestId, children, ...props}) {
     const divRef = React.useRef(null);
 
     const [placement, setPlacement] = React.useState('bottom');
@@ -56,7 +56,7 @@ export function DropdownContainerCopy({children, ...props}) {
     }, []);
 
     return (
-        <ul ref={divRef} className={`absolute ${placementClasses} z-[-1] max-h-[30vh] w-full overflow-y-auto bg-white px-2 py-1 shadow-md dark:bg-grey-950`} {...props}>
+        <ul ref={divRef} className={`absolute ${placementClasses} z-[-1] max-h-[30vh] w-full overflow-y-auto bg-white px-2 py-1 shadow-md dark:bg-grey-950`} data-testid={`${dataTestId}-dropdown`} {...props}>
             {children}
         </ul>
     );

--- a/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
@@ -142,7 +142,7 @@ export function InputListCopy({autoFocus, className, inputClassName, dataTestId,
                     onFocus={onFocus}
                 />
                 {showSuggestions &&
-                    <DropdownContainerCopy data-testid={`${dataTestId}-dropdown`}>
+                    <DropdownContainerCopy dataTestId={dataTestId}>
                         {isLoading && <InputListLoadingItem dataTestId={dataTestId}/>}
                         <KeyboardSelectionWithGroups
                             getGroup={getGroup}

--- a/packages/koenig-lexical/src/hooks/useSearchLinks.js
+++ b/packages/koenig-lexical/src/hooks/useSearchLinks.js
@@ -3,7 +3,7 @@ import React from 'react';
 import debounce from 'lodash/debounce';
 
 const DEBOUNCE_MS = 100;
-const URL_QUERY_REGEX = /^http/;
+const URL_QUERY_REGEX = /^http|^#|^\//;
 
 function urlQueryOptions(query) {
     return [{

--- a/packages/koenig-lexical/test/e2e/internal-linking.test.js
+++ b/packages/koenig-lexical/test/e2e/internal-linking.test.js
@@ -108,6 +108,60 @@ test.describe('Internal linking', async () => {
 
             await expect(page.locator('[data-testid="bookmark-url-listOption"]')).toBeVisible();
         });
+
+        test('matches URL queries (http)', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+            await expect(page.getByTestId('bookmark-url-dropdown')).toBeVisible();
+
+            await page.keyboard.type('http');
+
+            await assertHTML(page, html`
+                <li>Link to web page</li>
+                <li aria-selected="true" role="option">
+                  <span>
+                    <svg></svg>
+                    <span>http</span>
+                  </span>
+                </li>
+            `, {selector: '[data-testid="bookmark-url-dropdown"]'});
+        });
+
+        test('matches URL queries (anchor)', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+            await expect(page.getByTestId('bookmark-url-dropdown')).toBeVisible();
+
+            await page.keyboard.type('#test');
+
+            await assertHTML(page, html`
+                <li>Link to web page</li>
+                <li aria-selected="true" role="option">
+                  <span>
+                    <svg></svg>
+                    <span>#test</span>
+                  </span>
+                </li>
+            `, {selector: '[data-testid="bookmark-url-dropdown"]'});
+        });
+
+        test('matches URL queries (relative)', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+            await expect(page.getByTestId('bookmark-url-dropdown')).toBeVisible();
+
+            await page.keyboard.type('/test');
+
+            await assertHTML(page, html`
+                <li>Link to web page</li>
+                <li aria-selected="true" role="option">
+                  <span>
+                    <svg></svg>
+                    <span>/test</span>
+                  </span>
+                </li>
+            `, {selector: '[data-testid="bookmark-url-dropdown"]'});
+        });
     });
 
     test.describe('Link toolbar', function () {


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-129
closes https://linear.app/tryghost/issue/MOM-142

- added matching of `#` and `/` text as "urls" to the `useSearchLinks` hook
- allows creation of anchor links
- fixes issues with pressing enter quickly after pasting relative link resulting in incorrect link
