### PR TITLE
Added scroll-into-view when using keyboard to navigate internal link results

### DIFF
--- a/packages/koenig-lexical/src/components/ui/AtLinkResultsPopup.jsx
+++ b/packages/koenig-lexical/src/components/ui/AtLinkResultsPopup.jsx
@@ -88,13 +88,14 @@ export function AtLinkResultsPopup({atLinkNode, isSearching, listOptions, query,
         };
     }, [editor, scrollContainer, updatePopupPosition]);
 
-    const getItem = (item, selected, onMouseOver) => {
+    const getItem = (item, selected, onMouseOver, scrollIntoView) => {
         return (
             <InputListItem
                 key={item.value}
                 dataTestId={testId}
                 highlightString={query}
                 item={item}
+                scrollIntoView={scrollIntoView}
                 selected={selected}
                 onClick={onSelect}
                 onMouseOver={onMouseOver}

--- a/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
@@ -15,7 +15,15 @@ export function InputListLoadingItem({dataTestId}) {
     );
 }
 
-export function InputListItem({dataTestId, item, selected, onClick, onMouseOver, highlightString}) {
+export function InputListItem({dataTestId, item, selected, onClick, onMouseOver, highlightString, scrollIntoView}) {
+    const itemRef = React.useRef(null);
+
+    React.useEffect(() => {
+        if (selected && scrollIntoView) {
+            itemRef.current.scrollIntoView({behavior: 'smooth', block: 'nearest', inline: 'nearest'});
+        }
+    }, [selected, scrollIntoView]);
+
     let selectionClass = '';
 
     if (selected) {
@@ -58,7 +66,7 @@ export function InputListItem({dataTestId, item, selected, onClick, onMouseOver,
     const Icon = item.Icon;
 
     return (
-        <li aria-selected={selected} className={`${selectionClass} my-[.2rem] flex cursor-pointer items-center justify-between gap-3 rounded-md px-4 py-2 text-left text-black dark:text-white`} data-testid={`${dataTestId}-listOption`} role="option" onMouseDownCapture={handleMouseDown} onMouseOver={onMouseOver}>
+        <li ref={itemRef} aria-selected={selected} className={`${selectionClass} my-[.2rem] flex cursor-pointer items-center justify-between gap-3 rounded-md px-4 py-2 text-left text-black dark:text-white`} data-testid={`${dataTestId}-listOption`} role="option" onMouseDownCapture={handleMouseDown} onMouseOver={onMouseOver}>
             <span className="line-clamp-1 flex items-center gap-[.6rem]">
                 {Icon && <Icon className="size-[1.4rem] stroke-[1.5px]" />}
                 <span className="block truncate text-sm font-medium leading-snug" data-testid={`${dataTestId}-listOption-label`}><HighlightedLabel /></span>
@@ -98,13 +106,14 @@ export function InputListCopy({autoFocus, className, inputClassName, dataTestId,
         setInputFocused(false);
     };
 
-    const getItem = (item, selected, onMouseOver) => {
+    const getItem = (item, selected, onMouseOver, scrollIntoView) => {
         return (
             <InputListItem
                 key={item.value}
                 dataTestId={dataTestId}
                 highlightString={value}
                 item={item}
+                scrollIntoView={scrollIntoView}
                 selected={selected}
                 onClick={onSelectEvent}
                 onMouseOver={onMouseOver}

--- a/packages/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.jsx
+++ b/packages/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.jsx
@@ -20,6 +20,7 @@ export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect
     const items = groups.flatMap(group => group.items);
     const defaultIndex = Math.max(0, items.findIndex(item => item === defaultSelected));
     const [selectedIndex, setSelectedIndex] = React.useState(defaultIndex);
+    const [scrollSelectedIntoView, setScrollSelectedIntoView] = React.useState(false);
 
     // If items change, check if the selectedIndex is still valid, and if not, reset it to 0
     React.useEffect(() => {
@@ -41,6 +42,7 @@ export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect
             setSelectedIndex((i) => {
                 return Math.min(i + 1, items.length - 1);
             });
+            setScrollSelectedIntoView(true);
         }
         if (event.key === 'ArrowUp') {
             // The stop propagation is required for Safari
@@ -49,6 +51,7 @@ export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect
             setSelectedIndex((i) => {
                 return Math.max(i - 1, 0);
             });
+            setScrollSelectedIntoView(true);
         }
         if (event.key === 'Enter') {
             // The stop propagation is required for Safari
@@ -75,8 +78,11 @@ export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect
                         const itemsBefore = groups.slice(0, groupIndex).reduce((sum, prevGroup) => sum + prevGroup.items.length, 0);
                         const absoluteIndex = itemsBefore + index;
                         const isSelected = absoluteIndex === selectedIndex && !!item.value;
-                        const onMouseOver = () => !!item.value && setSelectedIndex(absoluteIndex);
-                        return getItem(item, isSelected, onMouseOver);
+                        const onMouseOver = () => {
+                            !!item.value && setSelectedIndex(absoluteIndex);
+                            setScrollSelectedIntoView(false);
+                        };
+                        return getItem(item, isSelected, onMouseOver, scrollSelectedIntoView);
                     })}
                 </Group>
             ))}

--- a/packages/koenig-lexical/src/components/ui/LinkInputCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/LinkInputCopy.jsx
@@ -50,13 +50,14 @@ export function LinkInputCopy({href, update, cancel}) {
         update(item.value);
     };
 
-    const getItem = (item, selected, onMouseOver) => {
+    const getItem = (item, selected, onMouseOver, scrollIntoView) => {
         return (
             <InputListItem
                 key={item.value}
                 dataTestId={testId}
                 highlightString={_href}
                 item={item}
+                scrollIntoView={scrollIntoView}
                 selected={selected}
                 onClick={onItemSelected}
                 onMouseOver={onMouseOver}


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-163

- uses additional state in `<KeyboardSelectionWithGroups>` to track when selection changes via keyboard in `scrollSelectedIntoView`
- passes `scrollSelectedIntoView` to `getItem()` that's used across the various results lists
- added effect to `<InputListItem>` to scroll item's element into view when both `selected` and `scrollIntoView` are `true`
