### PR TITLE
Added custom "no results" state to @-link popup

### DIFF
--- a/packages/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.jsx
+++ b/packages/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.jsx
@@ -74,7 +74,7 @@ export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect
             {groups.map((group, groupIndex) => (
                 <Group key={group.label}>
                     {getGroup(group)}
-                    {group.items.map((item, index) => {
+                    {(group.items || []).map((item, index) => {
                         const itemsBefore = groups.slice(0, groupIndex).reduce((sum, prevGroup) => sum + prevGroup.items.length, 0);
                         const absoluteIndex = itemsBefore + index;
                         const isSelected = absoluteIndex === selectedIndex && !!item.value;

--- a/packages/koenig-lexical/src/components/ui/Portal.jsx
+++ b/packages/koenig-lexical/src/components/ui/Portal.jsx
@@ -2,7 +2,7 @@ import KoenigComposerContext from '../../context/KoenigComposerContext';
 import React from 'react';
 import {createPortal} from 'react-dom';
 
-function Portal({children, to, className}) {
+function Portal({children, to, className, ...props}) {
     const {darkMode} = React.useContext(KoenigComposerContext);
 
     const container = to || document.body;
@@ -16,7 +16,7 @@ function Portal({children, to, className}) {
     }
 
     return createPortal(
-        <div className="koenig-lexical" style={{width: 'fit-content'}} data-kg-portal onMouseDown={cancelEvents}>
+        <div className="koenig-lexical" style={{width: 'fit-content'}} data-kg-portal onMouseDown={cancelEvents} {...props}>
             <div className={`${darkMode ? 'dark' : ''} ${className || ''}`}>
                 {children}
             </div>

--- a/packages/koenig-lexical/src/hooks/useSearchLinks.js
+++ b/packages/koenig-lexical/src/hooks/useSearchLinks.js
@@ -17,7 +17,7 @@ function urlQueryOptions(query) {
     }];
 }
 
-function noResultOptions(query) {
+function defaultNoResultOptions(query) {
     return [{
         label: 'Link to web page',
         items: [{
@@ -29,7 +29,7 @@ function noResultOptions(query) {
     }];
 }
 
-function convertSearchResultsToListOptions(results) {
+function convertSearchResultsToListOptions(results, {noResultOptions} = {noResultOptions: defaultNoResultOptions}) {
     if (!results || !results.length) {
         return noResultOptions();
     }
@@ -50,7 +50,7 @@ function convertSearchResultsToListOptions(results) {
     });
 }
 
-export const useSearchLinks = (query, searchLinks) => {
+export const useSearchLinks = (query, searchLinks, {noResultOptions} = {}) => {
     const [defaultListOptions, setDefaultListOptions] = React.useState([]);
     const [listOptions, setListOptions] = React.useState([]);
     const [isSearching, setIsSearching] = React.useState(false);
@@ -64,7 +64,7 @@ export const useSearchLinks = (query, searchLinks) => {
 
             setIsSearching(true);
             const results = await searchLinks(term);
-            setListOptions(convertSearchResultsToListOptions(results));
+            setListOptions(convertSearchResultsToListOptions(results, {noResultOptions}));
             setIsSearching(false);
         };
     }, [searchLinks]);

--- a/packages/koenig-lexical/src/plugins/AtLinkPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/AtLinkPlugin.jsx
@@ -53,7 +53,13 @@ export const KoenigAtLinkPlugin = ({searchLinks}) => {
 
     const [focusedAtLinkNode, setFocusedAtLinkNode] = React.useState(null);
     const [query, setQuery] = React.useState('');
-    const {isSearching, listOptions} = useSearchLinks(query, searchLinks);
+    const {isSearching, listOptions} = useSearchLinks(query, searchLinks, {
+        noResultOptions() {
+            return [{
+                label: 'No results found'
+            }];
+        }
+    });
 
     // register an event listener to detect '@' character being typed
     // - we only ever want to convert an '@' to an at-link node when it's typed
@@ -356,6 +362,11 @@ export const KoenigAtLinkPlugin = ({searchLinks}) => {
     // when a search result is selected, replace the at-link node with a link node
     const onItemSelect = React.useCallback((item) => {
         editor.update(() => {
+            if (!item?.value) {
+                $removeAtLink(focusedAtLinkNode, {focus: true});
+                return;
+            }
+
             const linkNode = $createLinkNode(item.value);
             const textNode = $createTextNode(item.label);
             linkNode.append(textNode);
@@ -376,7 +387,7 @@ export const KoenigAtLinkPlugin = ({searchLinks}) => {
 
     // otherwise render search results popup
     return (
-        <Portal>
+        <Portal data-testid="at-link-popup">
             <AtLinkResultsPopup
                 atLinkNode={focusedAtLinkNode}
                 isSearching={isSearching}

--- a/packages/koenig-lexical/test/e2e/internal-linking.test.js
+++ b/packages/koenig-lexical/test/e2e/internal-linking.test.js
@@ -106,7 +106,7 @@ test.describe('Internal linking', async () => {
 
             await page.keyboard.type('[');
 
-            await expect(page.locator('[data-testid="bookmark-url-listOption"]')).toBeVisible();
+            await expect(page.locator('[data-testid="bookmark-url-dropdown"]')).toBeVisible();
         });
 
         test('matches URL queries (http)', async function () {
@@ -164,11 +164,99 @@ test.describe('Internal linking', async () => {
         });
     });
 
-    test.describe('Link toolbar', function () {
-
-    });
+    test.describe('Link toolbar', function () {});
 
     test.describe('At-linking', function () {
+        test('displays default links with no query', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('@');
 
+            await assertHTML(page, html`
+                <p>
+                    <span>
+                        <span data-lexical-text="true">‌</span>
+                        <span
+                            data-placeholder="Search for a link"
+                            data-lexical-text="true"
+                        ></span>
+                    </span>
+                </p>
+            `);
+
+            await assertHTML(page, html`
+                <div>
+                    <div>
+                        <div>
+                            <ul>
+                                <li>Latest posts</li>
+                                <li aria-selected="true" role="option">
+                                    <span><span>Remote Work's Impact on Job Markets and Employment</span></span>
+                                    <span>
+                                        <span title="Members only"><svg></svg></span>
+                                        <span>8 May 2024</span>
+                                    </span>
+                                </li>
+                                <li aria-selected="false" role="option">
+                                    <span><span>Robotics Renaissance: How Automation is Transforming Industries</span></span>
+                                </li>
+                                <li aria-selected="false" role="option">
+                                    <span><span>Biodiversity Conservation in Fragile Ecosystems</span></span>
+                                </li>
+                                <li aria-selected="false" role="option">
+                                    <span><span>Unveiling the Crisis of Plastic Pollution: Analyzing Its Profound Impact on the Environment</span></span>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            `, {selector: '[data-testid="at-link-popup"]'});
+        });
+
+        test('can search for links', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('@');
+            await page.keyboard.type('Emo');
+
+            await assertHTML(page, html`
+                <p>
+                    <span dir="ltr">
+                        <span data-lexical-text="true">‌</span>
+                        <span data-placeholder="" data-lexical-text="true">Emo</span>
+                    </span>
+                </p>
+            `);
+
+            // wait for search to complete
+            await expect(page.locator('[data-testid="at-link-results-listOption-label"]')).toContainText(['✨ Emoji autocomplete ✨']);
+
+            await assertHTML(page, html`
+                <div>
+                    <div>
+                        <div>
+                            <ul>
+                                <li>Posts</li>
+                                <li aria-selected="true" role="option">
+                                    <span><span>✨ <span>Emo</span>ji autocomplete ✨</span></span>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            `, {selector: '[data-testid="at-link-popup"]'});
+        });
+
+        test('has custom no result options', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('@');
+            await page.keyboard.type('Unknown page');
+
+            await expect(page.locator('[data-testid="at-link-popup"]')).toContainText('No results found');
+
+            await page.keyboard.press('Enter');
+
+            await assertHTML(page, html`
+                <p><span data-lexical-text="true">@Unknown page</span></p>
+            `);
+        });
     });
 });


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-161

- when using the @-link shortcut our default no-results state doesn't make sense because you wouldn't be entering a url
- added support for passing a custom `noResultOptions` function to the `useSearchResults` hook
- fixed `<KeyboardSelectionWithGroups>` not handling missing item arrays within a group
- fixed `AtLinkPlugin` not handling having no item on "selection", so pressing `Enter` in a no-results state converts back to standard text
