### PR TITLE
Added mailto: and tel: to internal linking URL detection

### DIFF
--- a/packages/koenig-lexical/src/hooks/useSearchLinks.js
+++ b/packages/koenig-lexical/src/hooks/useSearchLinks.js
@@ -3,7 +3,7 @@ import React from 'react';
 import debounce from 'lodash/debounce';
 
 const DEBOUNCE_MS = 100;
-const URL_QUERY_REGEX = /^http|^#|^\//;
+const URL_QUERY_REGEX = /^http|^#|^\/|^mailto:|^tel:/;
 
 function urlQueryOptions(query) {
     return [{
@@ -29,9 +29,9 @@ function defaultNoResultOptions(query) {
     }];
 }
 
-function convertSearchResultsToListOptions(results, {noResultOptions} = {noResultOptions: defaultNoResultOptions}) {
+function convertSearchResultsToListOptions(results, {noResultOptions} = {}) {
     if (!results || !results.length) {
-        return noResultOptions();
+        return (noResultOptions || defaultNoResultOptions)();
     }
 
     return results.map((result) => {

--- a/packages/koenig-lexical/test/e2e/internal-linking.test.js
+++ b/packages/koenig-lexical/test/e2e/internal-linking.test.js
@@ -162,6 +162,24 @@ test.describe('Internal linking', async () => {
                 </li>
             `, {selector: '[data-testid="bookmark-url-dropdown"]'});
         });
+
+        test('matches URL queries (mailto)', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+            await expect(page.getByTestId('bookmark-url-dropdown')).toBeVisible();
+
+            await page.keyboard.type('mailto:test@example.com');
+
+            await assertHTML(page, html`
+                <li>Link to web page</li>
+                <li aria-selected="true" role="option">
+                  <span>
+                    <svg></svg>
+                    <span>mailto:test@example.com</span>
+                  </span>
+                </li>
+            `, {selector: '[data-testid="bookmark-url-dropdown"]'});
+        });
     });
 
     test.describe('Link toolbar', function () {});


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-195

- supports immediate switch to the "link to URL" state in the internal link dropdowns
