### PR TITLE
Added searching indicator to internal link popups

### DIFF
--- a/packages/koenig-lexical/src/components/ui/AtLinkResultsPopup.jsx
+++ b/packages/koenig-lexical/src/components/ui/AtLinkResultsPopup.jsx
@@ -103,9 +103,9 @@ export function AtLinkResultsPopup({atLinkNode, isSearching, listOptions, query,
         );
     };
 
-    const getGroup = (group) => {
+    const getGroup = (group, {showSpinner} = {}) => {
         return (
-            <InputListGroup dataTestId={testId} group={group} />
+            <InputListGroup dataTestId={testId} group={group} showSpinner={showSpinner} />
         );
     };
 
@@ -117,6 +117,7 @@ export function AtLinkResultsPopup({atLinkNode, isSearching, listOptions, query,
                         getGroup={getGroup}
                         getItem={getItem}
                         groups={listOptions}
+                        isLoading={isSearching}
                         onSelect={onSelect}
                     />
                 </ul>

--- a/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
@@ -4,6 +4,7 @@ import {Delayed} from './Delayed';
 import {DropdownContainerCopy} from './DropdownContainerCopy';
 import {Input} from './Input';
 import {KeyboardSelectionWithGroups} from './KeyboardSelectionWithGroups';
+import {Spinner} from './Spinner';
 
 export function InputListLoadingItem({dataTestId}) {
     return (
@@ -81,9 +82,14 @@ export function InputListItem({dataTestId, item, selected, onClick, onMouseOver,
     );
 }
 
-export function InputListGroup({dataTestId, group}) {
+export function InputListGroup({dataTestId, group, showSpinner}) {
     return (
-        <li className="mb-0 mt-2 flex items-center justify-between border-t border-grey-200 px-4 pb-2 pt-3 text-[1.1rem] font-semibold uppercase tracking-wide text-grey-600 first-of-type:mt-0 first-of-type:border-t-0 dark:border-grey-900" data-testid={`${dataTestId}-listGroup`}>{group.label}</li>
+        <li className="mb-0 mt-2 flex items-center justify-between border-t border-grey-200 px-4 pb-2 pt-3 text-[1.1rem] font-semibold uppercase tracking-wide text-grey-600 first-of-type:mt-0 first-of-type:border-t-0 dark:border-grey-900" data-testid={`${dataTestId}-listGroup`}>
+            <div className="flex items-center gap-1.5">
+                {group.label}
+                {showSpinner && <span className="ml-px"><Spinner size="mini" /></span>}
+            </div>
+        </li>
     );
 }
 
@@ -95,7 +101,7 @@ export function InputListGroup({dataTestId, group}) {
  * @param {string} [options.list]
  * @returns
  */
-export function InputListCopy({autoFocus, className, inputClassName, dataTestId, listOptions, isLoading, value, placeholder, onChange, onSelect}) {
+export function InputListCopy({autoFocus, className, inputClassName, dataTestId, listOptions, isLoading, isSearching, value, placeholder, onChange, onSelect}) {
     const [inputFocused, setInputFocused] = React.useState(false);
 
     const onFocus = () => {
@@ -121,9 +127,9 @@ export function InputListCopy({autoFocus, className, inputClassName, dataTestId,
         );
     };
 
-    const getGroup = (group) => {
+    const getGroup = (group, {showSpinner} = {}) => {
         return (
-            <InputListGroup key={group.label} dataTestId={dataTestId} group={group} />
+            <InputListGroup key={group.label} dataTestId={dataTestId} group={group} showSpinner={showSpinner} />
         );
     };
 
@@ -152,11 +158,12 @@ export function InputListCopy({autoFocus, className, inputClassName, dataTestId,
                 />
                 {showSuggestions &&
                     <DropdownContainerCopy dataTestId={dataTestId}>
-                        {isLoading && <InputListLoadingItem dataTestId={dataTestId}/>}
+                        {isLoading && !listOptions?.length && <InputListLoadingItem dataTestId={dataTestId}/>}
                         <KeyboardSelectionWithGroups
                             getGroup={getGroup}
                             getItem={getItem}
                             groups={listOptions}
+                            isLoading={isLoading}
                             onSelect={onSelectEvent}
                         />
                     </DropdownContainerCopy>

--- a/packages/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.jsx
+++ b/packages/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.jsx
@@ -16,7 +16,7 @@ const Group = ({children}) => {
  * @param {T[]} [options.items]
  * @param {(T, selected) => import('react').ReactElement} [options.getItem]
  */
-export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect, defaultSelected}) {
+export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect, defaultSelected, isLoading}) {
     const items = groups.flatMap(group => group.items);
     const defaultIndex = Math.max(0, items.findIndex(item => item === defaultSelected));
     const [selectedIndex, setSelectedIndex] = React.useState(defaultIndex);
@@ -73,7 +73,7 @@ export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect
         <>
             {groups.map((group, groupIndex) => (
                 <Group key={group.label}>
-                    {getGroup(group)}
+                    {getGroup(group, {showSpinner: groupIndex === 0 && isLoading})}
                     {(group.items || []).map((item, index) => {
                         const itemsBefore = groups.slice(0, groupIndex).reduce((sum, prevGroup) => sum + prevGroup.items.length, 0);
                         const absoluteIndex = itemsBefore + index;

--- a/packages/koenig-lexical/src/components/ui/LinkInputCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/LinkInputCopy.jsx
@@ -65,9 +65,9 @@ export function LinkInputCopy({href, update, cancel}) {
         );
     };
 
-    const getGroup = (group) => {
+    const getGroup = (group, {showSpinner} = {}) => {
         return (
-            <InputListGroup dataTestId={testId} group={group} />
+            <InputListGroup dataTestId={testId} group={group} showSpinner={showSpinner} />
         );
     };
 
@@ -98,11 +98,12 @@ export function LinkInputCopy({href, update, cancel}) {
             {showSuggestions && (
                 <>
                     <ul className="max-h-[30vh] w-full overflow-y-auto bg-white py-1 dark:bg-grey-950">
-                        {isSearching && <InputListLoadingItem dataTestId={testId}/>}
+                        {isSearching && !listOptions.length && <InputListLoadingItem dataTestId={testId}/>}
                         <KeyboardSelectionWithGroups
                             getGroup={getGroup}
                             getItem={getItem}
                             groups={listOptions}
+                            isLoading={isSearching}
                             onSelect={onItemSelected}
                         />
                     </ul>

--- a/packages/koenig-lexical/src/components/ui/Spinner.jsx
+++ b/packages/koenig-lexical/src/components/ui/Spinner.jsx
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export function Spinner({size}) {
+    let sizeClasses = '';
+    switch (size) {
+    case 'mini':
+        sizeClasses = 'h-3 w-3';
+        break;
+    default:
+        sizeClasses = 'h-5 w-5';
+        break;
+    }
+
+    return (
+        <div className='' data-testid="spinner">
+            <svg className={`${sizeClasses} animate-spin text-grey-500 dark:text-grey-200`} fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" style={{
+                    opacity: '0.3'
+                }}></circle>
+                <path d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" fill="currentColor"></path>
+            </svg>
+        </div>
+    );
+}
+
+Spinner.propTypes = {
+    colorClass: PropTypes.string,
+    size: PropTypes.string
+};

--- a/packages/koenig-lexical/test/e2e/internal-linking.test.js
+++ b/packages/koenig-lexical/test/e2e/internal-linking.test.js
@@ -31,7 +31,7 @@ test.describe('Internal linking', async () => {
                       <div>
                         <div><input placeholder="Paste URL or search posts and pages..." value="" /></div>
                         <ul>
-                          <li>Latest posts</li>
+                          <li><div>Latest posts</div></li>
                           <li aria-selected="true" role="option">
                             <span><span>Remote Work's Impact on Job Markets and Employment</span></span>
                             <span>
@@ -117,7 +117,7 @@ test.describe('Internal linking', async () => {
             await page.keyboard.type('http');
 
             await assertHTML(page, html`
-                <li>Link to web page</li>
+                <li><div>Link to web page</div></li>
                 <li aria-selected="true" role="option">
                   <span>
                     <svg></svg>
@@ -135,7 +135,7 @@ test.describe('Internal linking', async () => {
             await page.keyboard.type('#test');
 
             await assertHTML(page, html`
-                <li>Link to web page</li>
+                <li><div>Link to web page</div></li>
                 <li aria-selected="true" role="option">
                   <span>
                     <svg></svg>
@@ -153,7 +153,7 @@ test.describe('Internal linking', async () => {
             await page.keyboard.type('/test');
 
             await assertHTML(page, html`
-                <li>Link to web page</li>
+                <li><div>Link to web page</div></li>
                 <li aria-selected="true" role="option">
                   <span>
                     <svg></svg>
@@ -171,7 +171,7 @@ test.describe('Internal linking', async () => {
             await page.keyboard.type('mailto:test@example.com');
 
             await assertHTML(page, html`
-                <li>Link to web page</li>
+                <li><div>Link to web page</div></li>
                 <li aria-selected="true" role="option">
                   <span>
                     <svg></svg>
@@ -206,7 +206,7 @@ test.describe('Internal linking', async () => {
                     <div>
                         <div>
                             <ul>
-                                <li>Latest posts</li>
+                                <li><div>Latest posts</div></li>
                                 <li aria-selected="true" role="option">
                                     <span><span>Remote Work's Impact on Job Markets and Employment</span></span>
                                     <span>
@@ -252,7 +252,7 @@ test.describe('Internal linking', async () => {
                     <div>
                         <div>
                             <ul>
-                                <li>Posts</li>
+                                <li><div>Posts</div></li>
                                 <li aria-selected="true" role="option">
                                     <span><span>✨ <span>Emo</span>ji autocomplete ✨</span></span>
                                 </li>


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-174

- added `showSpinner` prop to `<InputListGroup>`
  - when `true` displays a spinner icon next to the group label
- added `isLoading` prop to `<KeyboardSelectionWithGroups>`
  - passes `showSpinner` option to `getGroup()` for the first displayed group if `isLoading` is `true`
- updated all `getGroup()` implementations to accept the `showSpinner` option and pass it through to the `<InputListGroup>` components
