### PR TITLE
Added visibility prop to all Decorative nodes

### DIFF
--- a/packages/kg-default-nodes/lib/generate-decorator-node.js
+++ b/packages/kg-default-nodes/lib/generate-decorator-node.js
@@ -37,7 +37,7 @@ function validateArguments(nodeType, properties) {
  * @param {DecoratorNodeProperty[]} properties - An array of properties for the generated class
  * @returns {Object} - The generated class.
  */
-export function generateDecoratorNode({nodeType, properties = [], version = 1}) {
+export function generateDecoratorNode({nodeType, properties = [], version = 1, visibility}) {
     validateArguments(nodeType, properties);
 
     // Adds a `privateName` field to the properties for convenience (e.g. `__name`):
@@ -134,6 +134,7 @@ export function generateDecoratorNode({nodeType, properties = [], version = 1}) 
             const dataset = {
                 type: nodeType,
                 version: version,
+                visibility: visibility || null,
                 ...properties.reduce((obj, prop) => {
                     obj[prop.name] = this[prop.name];
                     return obj;

--- a/packages/kg-default-nodes/test/nodes/audio.test.js
+++ b/packages/kg-default-nodes/test/nodes/audio.test.js
@@ -136,7 +136,8 @@ describe('AudioNode', function () {
                 title: dataset.title,
                 duration: dataset.duration,
                 mimeType: dataset.mimeType,
-                thumbnailSrc: dataset.thumbnailSrc
+                thumbnailSrc: dataset.thumbnailSrc,
+                visibility: null
             });
         }));
     });

--- a/packages/kg-default-nodes/test/nodes/button.test.js
+++ b/packages/kg-default-nodes/test/nodes/button.test.js
@@ -150,7 +150,8 @@ describe('ButtonNode', function () {
                 version: 1,
                 buttonUrl: dataset.buttonUrl,
                 buttonText: dataset.buttonText,
-                alignment: dataset.alignment
+                alignment: dataset.alignment,
+                visibility: null
             });
         }));
     });

--- a/packages/kg-default-nodes/test/nodes/callout.test.js
+++ b/packages/kg-default-nodes/test/nodes/callout.test.js
@@ -109,6 +109,7 @@ describe('CalloutNode', function () {
             json.should.deepEqual({
                 type: 'callout',
                 version: 1,
+                visibility: null,
                 ...dataset
             });
         }));

--- a/packages/kg-default-nodes/test/nodes/codeblock.test.js
+++ b/packages/kg-default-nodes/test/nodes/codeblock.test.js
@@ -108,7 +108,8 @@ describe('CodeBlockNode', function () {
                     version: 1,
                     code: '<script></script>',
                     language: 'javascript',
-                    caption: 'A code block'
+                    caption: 'A code block',
+                    visibility: null
                 }
             ]);
             done();

--- a/packages/kg-default-nodes/test/nodes/email-cta.test.js
+++ b/packages/kg-default-nodes/test/nodes/email-cta.test.js
@@ -149,7 +149,8 @@ describe('EmailCtaNode', function () {
                 html: dataset.html,
                 segment: dataset.segment,
                 showButton: dataset.showButton,
-                showDividers: dataset.showDividers
+                showDividers: dataset.showDividers,
+                visibility: null
             });
         }));
     });

--- a/packages/kg-default-nodes/test/nodes/email.test.js
+++ b/packages/kg-default-nodes/test/nodes/email.test.js
@@ -106,7 +106,8 @@ describe('EmailNode', function () {
             json.should.deepEqual({
                 type: 'email',
                 version: 1,
-                html: dataset.html
+                html: dataset.html,
+                visibility: null
             });
         }));
     });

--- a/packages/kg-default-nodes/test/nodes/embed.test.js
+++ b/packages/kg-default-nodes/test/nodes/embed.test.js
@@ -361,7 +361,8 @@ describe('EmbedNode', function () {
                 embedType: dataset.embedType,
                 html: dataset.html,
                 metadata: dataset.metadata,
-                caption: dataset.caption
+                caption: dataset.caption,
+                visibility: null
             });
         }));
     });

--- a/packages/kg-default-nodes/test/nodes/gallery.test.js
+++ b/packages/kg-default-nodes/test/nodes/gallery.test.js
@@ -222,7 +222,8 @@ describe('GalleryNode', function () {
                 type: 'gallery',
                 version: 1,
                 images: dataset.images,
-                caption: dataset.caption
+                caption: dataset.caption,
+                visibility: null
             });
         }));
     });

--- a/packages/kg-default-nodes/test/nodes/horizontalrule.test.js
+++ b/packages/kg-default-nodes/test/nodes/horizontalrule.test.js
@@ -72,7 +72,8 @@ describe('HorizontalNode', function () {
 
             json.should.deepEqual({
                 type: 'horizontalrule',
-                version: 1
+                version: 1,
+                visibility: null
             });
         }));
     });

--- a/packages/kg-default-nodes/test/nodes/html.test.js
+++ b/packages/kg-default-nodes/test/nodes/html.test.js
@@ -204,7 +204,8 @@ describe('HtmlNode', function () {
             json.should.deepEqual({
                 type: 'html',
                 version: 1,
-                html: '<p>Paragraph with:</p><ul><li>list</li><li>items</li></ul>'
+                html: '<p>Paragraph with:</p><ul><li>list</li><li>items</li></ul>',
+                visibility: null
             });
         }));
     });

--- a/packages/kg-default-nodes/test/nodes/markdown.test.js
+++ b/packages/kg-default-nodes/test/nodes/markdown.test.js
@@ -138,7 +138,8 @@ describe('MarkdownNode', function () {
             json.should.deepEqual({
                 type: 'markdown',
                 version: 1,
-                markdown: '#HEADING\r\n- list\r\n- items'
+                markdown: '#HEADING\r\n- list\r\n- items',
+                visibility: null
             });
         }));
     });

--- a/packages/kg-default-nodes/test/nodes/paywall.test.js
+++ b/packages/kg-default-nodes/test/nodes/paywall.test.js
@@ -50,7 +50,8 @@ describe('PaywallNode', function () {
 
             json.should.deepEqual({
                 type: 'paywall',
-                version: 1
+                version: 1,
+                visibility: null
             });
         }));
     });

--- a/packages/kg-default-nodes/test/nodes/signup.test.js
+++ b/packages/kg-default-nodes/test/nodes/signup.test.js
@@ -646,7 +646,8 @@ describe('SignupNode', function () {
                 layout: dataset.layout,
                 subheader: dataset.subheader,
                 successMessage: dataset.successMessage,
-                swapped: dataset.swapped
+                swapped: dataset.swapped,
+                visibility: null
             });
         }));
     });

--- a/packages/kg-default-nodes/test/nodes/toggle.test.js
+++ b/packages/kg-default-nodes/test/nodes/toggle.test.js
@@ -118,7 +118,8 @@ describe('ToggleNode', function () {
                 type: 'toggle',
                 version: 1,
                 heading: dataset.heading,
-                content: dataset.content
+                content: dataset.content,
+                visibility: null
             });
         }));
     });

--- a/packages/koenig-lexical/test/e2e/cards/markdown-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/markdown-card.test.js
@@ -38,6 +38,7 @@ test.describe('Markdown card', async () => {
                     children: [{
                         type: 'markdown',
                         version: 1,
+                        visibility: null,
                         markdown: '# This is a heading'
                     }],
                     direction: null,
@@ -214,6 +215,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '![large-image.png](blob:...)'
             },
             {
@@ -240,6 +242,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '**bold text**'
             },
             {
@@ -274,6 +277,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '**bold**'
             },
             {
@@ -300,6 +304,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '*italic text*'
             },
             {
@@ -336,6 +341,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '*italic*'
             },
             {
@@ -362,6 +368,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '~~text~~'
             },
             {
@@ -396,6 +403,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '~~text~~'
             },
             {
@@ -422,6 +430,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '# Heading text'
             },
             {
@@ -448,6 +457,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '# Heading'
             },
             {
@@ -474,6 +484,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '> quote'
             },
             {
@@ -500,6 +511,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '> quote'
             },
             {
@@ -526,6 +538,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '* First list item'
             },
             {
@@ -552,6 +565,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '* A list item'
             },
             {
@@ -578,6 +592,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '1. First list item'
             },
             {
@@ -604,6 +619,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '1. A list item'
             },
             {
@@ -629,6 +645,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '[](http://)'
             },
             {
@@ -663,6 +680,7 @@ test.describe('Markdown card', async () => {
             {
                 type: 'markdown',
                 version: 1,
+                visibility: null,
                 markdown: '[link](http://)'
             },
             {


### PR DESCRIPTION
ref MOM-223

- Added visibility props to decorative nodes.
- defaults to null, which means the output is unchanged.
- idea is to be able to set the value to something like `emailHidden` or `webHidden` (TBC) in future to specific where you want the card visible.