### PR TITLE
Fixed backspacing text in at-linking input

### DIFF
--- a/packages/koenig-lexical/src/plugins/AtLinkPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/AtLinkPlugin.jsx
@@ -237,6 +237,16 @@ export const KoenigAtLinkPlugin = ({searchLinks}) => {
                         // - handles case where text is backspaced to empty
                         if ($isZWNJNode(selection.focus.getNode()) && window.getSelection().anchorOffset === 0) {
                             selectedAtLinkNode.select(1, 1);
+                            const rangeSelection = $getSelection();
+                            if ($isRangeSelection(rangeSelection)) {
+                                rangeSelection.anchor.set(searchNode.getKey(), 0, 'element');
+                                rangeSelection.focus.set(searchNode.getKey(), 0, 'element');
+                            }
+                        }
+
+                        // if the search node is already empty but active, remove the at-link node on backspace
+                        if (searchNodeText === '' && $isZWNJNode(selection.anchor.getNode())) {
+                            $removeAtLink(selectedAtLinkNode, {focus: true});
                         }
                     } else {
                         // search node isn't focused, reset plugin state

--- a/packages/koenig-lexical/test/e2e/internal-linking.test.js
+++ b/packages/koenig-lexical/test/e2e/internal-linking.test.js
@@ -282,5 +282,34 @@ test.describe('Internal linking', async () => {
                 <p><span data-lexical-text="true">@Unknown page</span></p>
             `);
         });
+
+        test.only('removes at-linking when backspacing', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('@');
+            await page.keyboard.type('AB');
+
+            await page.keyboard.press('Backspace');
+            await page.keyboard.press('Backspace');
+            // we should now have an empty input field with placeholder text
+            await assertHTML(page, html`
+                <p>
+                    <span>
+                        <svg></svg>
+                        <span data-lexical-text="true">‌</span>
+                        <span
+                            data-placeholder="Find a post, tag or author"
+                            data-lexical-text="true"
+                        ></span>
+                    </span>
+                </p>
+            `);
+
+            await page.keyboard.press('Backspace');
+
+            // it should now remove the at-linking entirely leaving only an @
+            await assertHTML(page, html`
+                <p><span data-lexical-text="true">@</span></p>
+            `);
+        });
     });
 });


### PR DESCRIPTION
ref MOM-235

- Fixed an issue where the cursor / caret would not behave as expected when deleting text using backspace.
- Added additional tests.