### PR TITLE
Fixed Signup card showing empty label list to contributors

### DIFF
--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -40,6 +40,7 @@ const defaultCardConfig = {
         {label: 'Homepage', value: window.location.origin + '/'},
         {label: 'Free signup', value: window.location.origin + '/#/portal/signup/free'}
     ]),
+    renderLabels: true,
     fetchLabels: () => Promise.resolve(['Label 1', 'Label 2']),
     siteTitle: 'Koenig Lexical',
     siteDescription: `There's a whole lot to discover in this editor. Let us help you settle in.`,

--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
@@ -52,6 +52,7 @@ export function SignupCard({alignment,
     imageDragHandler,
     headerTextEditor,
     headerTextEditorInitialState,
+    renderLabels,
     subheaderTextEditor,
     subheaderTextEditorInitialState,
     disclaimerTextEditor,
@@ -503,15 +504,17 @@ export function SignupCard({alignment,
                         onBlur={handleButtonTextBlur}
                         onChange={handleButtonText}
                     />
-                    <MultiSelectDropdownSetting
-                        availableItems={availableLabels}
-                        dataTestId='labels-dropdown'
-                        description='Added to members created using this form'
-                        items={labels}
-                        label='Labels'
-                        placeholder='Select'
-                        onChange={handleLabels}
-                    />
+                    { renderLabels && (
+                        <MultiSelectDropdownSetting
+                            availableItems={availableLabels}
+                            dataTestId='labels-dropdown'
+                            description='Added to members created using this form'
+                            items={labels}
+                            label='Labels'
+                            placeholder='Select'
+                            onChange={handleLabels}
+                        />
+                    )}
                 </SettingsPanel>
             )}
         </>
@@ -552,6 +555,7 @@ SignupCard.propTypes = {
     imageDragHandler: PropTypes.object,
     headerTextEditor: PropTypes.object,
     headerTextEditorInitialState: PropTypes.object,
+    renderLabels: PropTypes.bool,
     subheaderTextEditor: PropTypes.object,
     subheaderTextEditorInitialState: PropTypes.object,
     disclaimerTextEditor: PropTypes.object,

--- a/packages/koenig-lexical/src/nodes/SignupNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/SignupNodeComponent.jsx
@@ -52,7 +52,7 @@ function SignupNodeComponent({
     const fileInputRef = useRef(null);
 
     useEffect(() => {
-        if (cardConfig?.fetchLabels) {
+        if (cardConfig.renderLabels && cardConfig.fetchLabels) {
             cardConfig.fetchLabels().then((options) => {
                 setAvailableLabels(options);
             });
@@ -254,6 +254,7 @@ function SignupNodeComponent({
                 labels={labels}
                 layout={layout}
                 openImageEditor={openImageEditor}
+                renderLabels={cardConfig.renderLabels}
                 setFileInputRef={ref => fileInputRef.current = ref}
                 showBackgroundImage={showBackgroundImage}
                 subheader={subheader}


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/SLO-127

- problem: contributors see an empty list of labels in the Signup card, even if some exist
- cause: contributors do not have permission to browse labels
- solution: hide the label input entirely for contributors in the Signup card

