### PR TITLE
Added event tracking for internal link feature

### DIFF
--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -44,6 +44,7 @@ const defaultCardConfig = {
     fetchLabels: () => Promise.resolve(['Label 1', 'Label 2']),
     siteTitle: 'Koenig Lexical',
     siteDescription: `There's a whole lot to discover in this editor. Let us help you settle in.`,
+    siteUrl: window.location.origin,
     membersEnabled: true,
     feature: {
         collections: true,

--- a/packages/koenig-lexical/src/components/ui/AtLinkResultsPopup.jsx
+++ b/packages/koenig-lexical/src/components/ui/AtLinkResultsPopup.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import trackEvent from '../../utils/analytics';
 import {$getSelection} from 'lexical';
 import {InputListGroup, InputListItem} from './InputListCopy';
 import {KeyboardSelectionWithGroups} from './KeyboardSelectionWithGroups';
@@ -7,6 +8,13 @@ import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
 export function AtLinkResultsPopup({atLinkNode, isSearching, listOptions, query, onSelect}) {
     const [editor] = useLexicalComposerContext();
+
+    React.useEffect(() => {
+        if (!query) {
+            trackEvent('Link dropdown: Opened', {context: 'at-link'});
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const scrollContainer = React.useMemo(() => {
         return getScrollParent(editor.getRootElement());

--- a/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/InputListCopy.jsx
@@ -138,7 +138,7 @@ export function InputListCopy({autoFocus, className, inputClassName, dataTestId,
     };
 
     const onSelectEvent = (item) => {
-        (onSelect || onChange)(item.value);
+        (onSelect || onChange)(item.value, item.type);
     };
 
     const showSuggestions = (isLoading || (listOptions && !!listOptions.length)) && inputFocused;

--- a/packages/koenig-lexical/src/components/ui/LinkInputCopy.jsx
+++ b/packages/koenig-lexical/src/components/ui/LinkInputCopy.jsx
@@ -1,6 +1,7 @@
 import KoenigComposerContext from '../../context/KoenigComposerContext';
 import PropTypes from 'prop-types';
 import React from 'react';
+import trackEvent from '../../utils/analytics';
 import {Input} from './Input';
 import {InputListGroup, InputListItem, InputListLoadingItem} from './InputListCopy';
 import {KeyboardSelectionWithGroups} from './KeyboardSelectionWithGroups';
@@ -17,6 +18,11 @@ export function LinkInputCopy({href, update, cancel}) {
     const containerRef = React.useRef(null);
 
     const testId = 'link-input';
+
+    React.useEffect(() => {
+        trackEvent('Link dropdown: Opened', {context: 'text'});
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     // update the internal href when the prop changes
     React.useEffect(() => {
@@ -47,7 +53,7 @@ export function LinkInputCopy({href, update, cancel}) {
     }, [cancel]);
 
     const onItemSelected = (item) => {
-        update(item.value);
+        update(item.value, item.type);
     };
 
     const getItem = (item, selected, onMouseOver, scrollIntoView) => {

--- a/packages/koenig-lexical/src/components/ui/UrlSearchInput.jsx
+++ b/packages/koenig-lexical/src/components/ui/UrlSearchInput.jsx
@@ -1,10 +1,18 @@
 import CloseIcon from '../../assets/icons/kg-close.svg?react';
 import React from 'react';
+import trackEvent from '../../utils/analytics';
 import {InputListCopy} from './InputListCopy';
 import {useSearchLinks} from '../../hooks/useSearchLinks';
 
 export function UrlSearchInput({dataTestId, value, placeholder, handleUrlChange, handleUrlSubmit, hasError, handlePasteAsLink, handleRetry, handleClose, isLoading, searchLinks}) {
     const {isSearching, listOptions} = useSearchLinks(value, searchLinks);
+
+    React.useEffect(() => {
+        if (!value) {
+            trackEvent('Link dropdown: Opened', {context: 'bookmark'});
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     React.useEffect(() => {
         const handleKeyDown = (e) => {
@@ -44,8 +52,8 @@ export function UrlSearchInput({dataTestId, value, placeholder, handleUrlChange,
         handleUrlChange(inputValue);
     };
 
-    const onSelectEvent = (selectedValue) => {
-        handleUrlSubmit(selectedValue);
+    const onSelectEvent = (selectedValue, type) => {
+        handleUrlSubmit(selectedValue, type);
     };
 
     const handleKeyDown = (event) => {

--- a/packages/koenig-lexical/src/hooks/useSearchLinks.js
+++ b/packages/koenig-lexical/src/hooks/useSearchLinks.js
@@ -12,7 +12,8 @@ function urlQueryOptions(query) {
             label: query,
             value: query,
             Icon: EarthIcon,
-            highlight: false
+            highlight: false,
+            type: 'url'
         }]
     }];
 }
@@ -24,12 +25,13 @@ function defaultNoResultOptions(query) {
             label: `Enter URL to create link`,
             value: null,
             Icon: EarthIcon,
-            highlight: false
+            highlight: false,
+            type: 'no-results'
         }]
     }];
 }
 
-function convertSearchResultsToListOptions(results, {noResultOptions} = {}) {
+function convertSearchResultsToListOptions(results, {noResultOptions, type} = {}) {
     if (!results || !results.length) {
         return (noResultOptions || defaultNoResultOptions)();
     }
@@ -42,7 +44,8 @@ function convertSearchResultsToListOptions(results, {noResultOptions} = {}) {
                 Icon: item.Icon,
                 metaText: item.metaText,
                 MetaIcon: item.MetaIcon,
-                metaIconTitle: item.metaIconTitle
+                metaIconTitle: item.metaIconTitle,
+                type: type || 'internal'
             };
         });
 
@@ -90,7 +93,7 @@ export const useSearchLinks = (query, searchLinks, {noResultOptions} = {}) => {
             // they're available when the query is cleared
             !query && setIsSearching(true);
             const results = await searchLinks();
-            setDefaultListOptions(convertSearchResultsToListOptions(results));
+            setDefaultListOptions(convertSearchResultsToListOptions(results, {type: 'default'}));
             !query && setIsSearching(false);
         };
 

--- a/packages/koenig-lexical/src/utils/analytics.js
+++ b/packages/koenig-lexical/src/utils/analytics.js
@@ -8,4 +8,5 @@ export default function trackEvent(eventName, props = {}) {
     if (window.posthog) {
         window.posthog.capture(eventName, props);
     }
+    console.log('trackEvent', eventName, props); // eslint-disable-line no-console
 }

--- a/packages/koenig-lexical/src/utils/isInternalUrl.js
+++ b/packages/koenig-lexical/src/utils/isInternalUrl.js
@@ -1,0 +1,14 @@
+export function isInternalUrl(url, siteUrl) {
+    if (!url || !siteUrl) {
+        return false;
+    }
+
+    try {
+        const urlObj = new URL(url);
+        const subdir = `/${new URL(siteUrl).pathname.split('/')[1]}`;
+        return urlObj.hostname === new URL(siteUrl).hostname
+            && urlObj.pathname.startsWith(subdir);
+    } catch (e) {
+        return false;
+    }
+}


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-78

- adds `isInternalUrl` util that checks if a URL matches the domain+subdir of a supplied site URL
- adds `siteUrl` to `cardConfig` object
- updates `trackEvent` to log to the console for easier testing during development
- updates at-link plugin, link toolbar, and bookmark card to track opens and selections with context
