### PR TITLE
Fixed errors when cursor placed at beginning of at-link node

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/at-link/AtLinkSearchNode.js
+++ b/packages/kg-default-nodes/lib/nodes/at-link/AtLinkSearchNode.js
@@ -86,6 +86,18 @@ export class AtLinkSearchNode extends TextNode {
         const self = this.getLatest();
         return self.__placeholder;
     }
+
+    // Lexical will incorrectly pick up this node as an element node when the
+    // cursor is placed by the SVG icon element in the parent AtLinkNode. We
+    // need these methods to avoid throwing errors in that case but otherwise
+    // behaviour is unaffected.
+    getChildrenSize() {
+        return 0;
+    }
+
+    getChildAtIndex() {
+        return null;
+    }
 }
 
 export function $createAtLinkSearchNode(text = '', placeholder = null) {

--- a/packages/kg-default-nodes/test/nodes/at-link-search.test.js
+++ b/packages/kg-default-nodes/test/nodes/at-link-search.test.js
@@ -150,4 +150,10 @@ describe('AtLinkSearchNode', function () {
         atLinkNode.setTextContent('test');
         atLinkNode.getTextContent().should.equal('test');
     }));
+
+    it('has "element"-like methods', editorTest(function () {
+        const atLinkNode = $createAtLinkSearchNode();
+        atLinkNode.getChildrenSize().should.equal(0);
+        should.equal(atLinkNode.getChildAtIndex(0), null);
+    }));
 });


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/MOM-247

- lexical gets confused by the at-link node element containing an SVG element and incorrectly picks up the at-link-search node expecting it to be an instance of ElementNode, which then causes errors because it calls ElementNode methods on it
- added stubs for the methods that get called to avoid throwing errors
