### PR TITLE
Fixed pasting URL into at-link

### DIFF
--- a/packages/koenig-lexical/src/components/ui/AtLinkResultsPopup.jsx
+++ b/packages/koenig-lexical/src/components/ui/AtLinkResultsPopup.jsx
@@ -118,7 +118,7 @@ export function AtLinkResultsPopup({atLinkNode, isSearching, listOptions, query,
     };
 
     return (
-        <div ref={popupRef} className="not-kg-prose fixed z-[10000]">
+        <div ref={popupRef} className="not-kg-prose fixed z-[10000]" data-testid="at-link-results">
             <div className="relative m-0 flex w-full flex-col rounded-lg bg-white p-1 px-2 font-sans text-sm font-medium shadow-md dark:bg-grey-950">
                 <ul className="max-h-[30vh] w-full overflow-y-auto bg-white py-1 dark:bg-grey-950">
                     <KeyboardSelectionWithGroups

--- a/packages/koenig-lexical/test/e2e/internal-linking.test.js
+++ b/packages/koenig-lexical/test/e2e/internal-linking.test.js
@@ -1,4 +1,4 @@
-import {assertHTML, focusEditor, html, initialize, insertCard} from '../utils/e2e';
+import {assertHTML, focusEditor, html, initialize, insertCard, pasteText} from '../utils/e2e';
 import {expect, test} from '@playwright/test';
 
 test.describe('Internal linking', async () => {
@@ -347,6 +347,23 @@ test.describe('Internal linking', async () => {
                 </div>
                 <div contenteditable="false" data-lexical-cursor="true"></div>
             `, {ignoreCardToolbarContents: true, ignoreInnerSVG: true});
+        });
+
+        test('can paste into at-link node', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('@');
+            await pasteText(page, 'https://ghost.org');
+            await expect(page.getByTestId('at-link-results')).toBeVisible();
+
+            await assertHTML(page, html`
+                <p>
+                    <span dir="ltr">
+                        <svg></svg>
+                        <span data-lexical-text="true">‌</span>
+                        <span data-placeholder="" data-lexical-text="true">https://ghost.org</span>
+                    </span>
+                </p>
+            `);
         });
     });
 });


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/MOM-250

- added paste command handler to at-link plugin to intercept pastes onto at-link nodes to avoid the default behaviour of instantly creating a bookmark node
