### PR TITLE
Fixed TypeError when `contentBoxSize` array is empty

### DIFF
--- a/packages/koenig-lexical/src/hooks/useSettingsPanelReposition.js
+++ b/packages/koenig-lexical/src/hooks/useSettingsPanelReposition.js
@@ -215,7 +215,7 @@ export default function useSettingsPanelReposition({positionToRef} = {}, cardWid
 
         const resizeObserver = new ResizeObserver((entries) => {
             for (const entry of entries) {
-                if (entry.contentBoxSize) {
+                if (entry.contentBoxSize?.[0]) {
                     const width = entry.contentBoxSize[0].inlineSize;
                     if (typeof width === 'number' && width !== prevWidth) {
                         panelRepositionDebounced(width);


### PR DESCRIPTION
fix https://linear.app/tryghost/issue/SLO-176/typeerror-ycontentboxsize[0]-is-undefined

- in the case `contentBoxSize` array is empty, the code will still try and look up the first index and extract `inlineSize`
- this will result in a TypError: `y.contentBoxSize[0] is undefined`
- this is because an empty array is still truthy, so the if-statement doesn't do exactly what we need
- fixed this by adding optional chaining and a lookup for the first index