### PR TITLE
Fixed image editing not saving changes

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/ImageCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/ImageCard.jsx
@@ -115,6 +115,7 @@ const ImageHolder = ({
                 openImageEditor={openImageEditor}
                 previewSrc={previewSrc}
                 src={src}
+                onFileChange={onFileChange}
             />
         );
     } else {
@@ -209,11 +210,11 @@ PopulatedImageCard.propTypes = {
     alt: PropTypes.string,
     previewSrc: PropTypes.string,
     imageUploader: PropTypes.object,
-    onFileChange: PropTypes.func,
     imageCardDragHandler: PropTypes.object,
     imageFileDragHandler: PropTypes.object,
     isPinturaEnabled: PropTypes.bool,
-    openImageEditor: PropTypes.func
+    openImageEditor: PropTypes.func,
+    onFileChange: PropTypes.func
 };
 
 EmptyImageCard.propTypes = {


### PR DESCRIPTION
refs [ENG-1363](https://linear.app/tryghost/issue/ENG-1363/bug-with-image-editing-not-saving-changes)

Fixed image editing not saving changes due to `onFileChange` handler erroneously not being passed to the `PopulatedImageCard` component. This is regression was introduced in: https://github.com/TryGhost/Koenig/pull/1277