### PR TITLE
Fixed Embed card tests

### DIFF
--- a/packages/koenig-lexical/src/nodes/EmbedNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/EmbedNodeComponent.jsx
@@ -73,7 +73,7 @@ export function EmbedNodeComponent({nodeKey, url, html, createdWithUrl, embedTyp
         let response;
         try {
             // set the test data return values in fetchEmbed.js
-            response = await cardConfig.fetchEmbed(href);
+            response = await cardConfig.fetchEmbed(href, {});
             // we may end up with a bookmark return if the url is valid but doesn't return an embed
             if (response.type === 'bookmark') {
                 editor.update(() => {


### PR DESCRIPTION
no issue

- `fetchEmbed` uses an object as second parameter