### PR TITLE
Added flag to image file to indicate that it has been edited

### DIFF
--- a/packages/koenig-lexical/src/hooks/usePinturaEditor.js
+++ b/packages/koenig-lexical/src/hooks/usePinturaEditor.js
@@ -139,6 +139,7 @@ export default function usePinturaEditor({
 
             editor.on('process', (result) => {
                 // save edited image
+                result.dest.edited = true;
                 handleSave(result.dest);
                 trackEvent('Image Edit Saved', {location: 'editor'});
             });


### PR DESCRIPTION
refs [ENG-1260](https://linear.app/tryghost/issue/ENG-1260/🔒-redacting-pictures-in-pintura-leaves-easily-findable-original-image)

Added flag to image file to indicate that it has been edited. This can be used by the uploader to determine to execute different logic based on whether the image has been edited or not