### PR TITLE
Updated LinkToolbar for dark mode

### DIFF
--- a/packages/koenig-lexical/src/components/ui/LinkToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/LinkToolbar.jsx
@@ -2,7 +2,7 @@ import {ToolbarMenuItem} from './ToolbarMenu';
 
 export function LinkToolbar({href, onEdit, onRemove}) {
     return (
-        <div className="relative m-0 flex items-center justify-evenly gap-1 rounded-lg bg-white px-1 font-sans text-md font-normal text-black shadow-md dark:bg-grey-950">
+        <div className="relative m-0 flex items-center justify-evenly gap-1 rounded-lg bg-white px-1 font-sans text-md font-normal text-black shadow-md dark:bg-grey-950 dark:text-white">
             <a className="ml-3 mr-2 max-w-2xl truncate" href={href} rel="noopener noreferrer" target="_blank">{href}</a>
 
             <ToolbarMenuItem


### PR DESCRIPTION
Fixes https://linear.app/tryghost/issue/DES-558/🐛-link-preview-on-hover-within-the-editor-while-in-dark-mode-is

On hover, links were illegible in the toolbar when dark mode is enabled. That is solved now by applying the correct Tailwind markup in `LinkToolbar.jsx`.

