### PR TITLE
Fixed active state for toolbar in dark mode

### DIFF
--- a/packages/koenig-lexical/src/components/ui/ToolbarMenu.jsx
+++ b/packages/koenig-lexical/src/components/ui/ToolbarMenu.jsx
@@ -68,7 +68,7 @@ export function ToolbarMenuItem({label, isActive, onClick, icon, shortcutKeys, s
                 type="button"
                 onClick={onClick}
             >
-                <Icon className={`size-4 overflow-visible transition dark:text-white ${secondary ? 'stroke-2' : 'stroke-[2.5]'} ${isActive ? 'text-green-600 dark:text-green-600' : 'text-black dark:text-white'}`} />
+                <Icon className={`size-4 overflow-visible transition dark:text-white ${secondary ? 'stroke-2' : 'stroke-[2.5]'} ${isActive ? 'text-green-600 dark:text-green-500' : 'text-black dark:text-white'}`} />
             </button>
             <Tooltip label={label} shortcutKeys={shortcutKeys} />
         </li>

--- a/packages/koenig-lexical/src/components/ui/ToolbarMenu.jsx
+++ b/packages/koenig-lexical/src/components/ui/ToolbarMenu.jsx
@@ -68,7 +68,7 @@ export function ToolbarMenuItem({label, isActive, onClick, icon, shortcutKeys, s
                 type="button"
                 onClick={onClick}
             >
-                <Icon className={`size-4 overflow-visible transition dark:text-white ${secondary ? 'stroke-2' : 'stroke-[2.5]'} ${isActive ? 'text-green-600 dark:text-green-500' : 'text-black dark:text-white'}`} />
+                <Icon className={`size-4 overflow-visible transition ${secondary ? 'stroke-2' : 'stroke-[2.5]'} ${isActive ? 'text-green-600 dark:text-green-600' : 'text-black dark:text-white'}`} />
             </button>
             <Tooltip label={label} shortcutKeys={shortcutKeys} />
         </li>


### PR DESCRIPTION
A slight issue with the markup surrounding `isActive` was preventing the active state from being applied correctly in dark mode.