### PR TITLE
Added error message when uploading images to the gallery card fails

### DIFF
--- a/packages/koenig-lexical/src/nodes/GalleryNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/GalleryNodeComponent.jsx
@@ -88,7 +88,11 @@ export function GalleryNodeComponent({nodeKey, captionEditor, captionEditorIniti
         const uploadResult = await imageUploader.upload(strippedFiles);
         const uploadedImages = [...newImages];
 
-        // TODO: handle upload failures
+        if (!uploadResult) {
+            setErrorMessage('Something went wrong while uploading images. Please refresh the page and try again');
+            return;
+        }
+
         uploadResult.forEach((result) => {
             const image = uploadedImages.find(i => i.fileName === result.fileName);
 


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/SLO-174/typeerror-null-is-not-an-object-evaluating-zforeach

- if the image upload fails for some reason (e.g. network issue), we now show an error message inviting to try again