### PR TITLE
Fixed TypeError when pasting into input fields

### DIFF
--- a/packages/koenig-lexical/src/plugins/AtLinkPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/AtLinkPlugin.jsx
@@ -337,6 +337,11 @@ export const KoenigAtLinkPlugin = ({searchLinks, siteUrl}) => {
                 PASTE_COMMAND,
                 (clipboardEvent) => {
                     const selection = $getSelection();
+
+                    if (!selection || document.activeElement !== editor.getRootElement()) {
+                        return false;
+                    }
+
                     const anchorNode = selection.anchor.getNode();
                     if ($isRangeSelection(selection) && ($isAtLinkNode(anchorNode) || $isAtLinkSearchNode(anchorNode))) {
                         clipboardEvent.preventDefault();

--- a/packages/koenig-lexical/test/e2e/cards/bookmark-card-labs.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/bookmark-card-labs.test.js
@@ -1,4 +1,4 @@
-import {assertHTML, createSnippet, focusEditor, html, initialize, insertCard, isMac} from '../../utils/e2e';
+import {assertHTML, createSnippet, focusEditor, html, initialize, insertCard, isMac, pasteText} from '../../utils/e2e';
 import {expect, test} from '@playwright/test';
 
 test.describe('Bookmark card (labs: internalLinking)', async () => {
@@ -333,6 +333,20 @@ test.describe('Bookmark card (labs: internalLinking)', async () => {
         await assertHTML(page, html`
             <p><br /></p>
         `, {ignoreCardContents: true});
+    });
+
+    // AtLinkPlugin added a PASTE_COMMAND handler which didn't account for
+    // pastes occurring in input fields inside the main editor resulting in a TypeError
+    test('can paste into URL input', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'bookmark'});
+
+        const urlInput = await page.getByTestId('bookmark-url');
+        await expect(urlInput).toBeFocused();
+
+        await pasteText(page, 'https://ghost.org/');
+
+        expect(errors).toEqual([]);
     });
 
     // Searchable URL input ----------------------------------------------------


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/SLO-183

- `AtLinkPlugin` added a `PASTE_COMMAND` handler but it wasn't accounting for paste events firing for non-editor inputs resulting in attempts to use `null` as a selection object
