### PR TITLE
Enforced `<p>` inside `<blockquote>` when rendering for email

### DIFF
--- a/packages/kg-lexical-html-renderer/lib/LexicalHTMLRenderer.ts
+++ b/packages/kg-lexical-html-renderer/lib/LexicalHTMLRenderer.ts
@@ -11,7 +11,7 @@ import getDynamicDataNodes from './get-dynamic-data-nodes';
 const {registerRemoveAtLinkNodesTransform} = require('@tryghost/kg-default-transforms');
 
 interface RenderOptions {
-    target?: 'html' | 'plaintext';
+    target?: 'html' | 'email' | 'plaintext';
     dom?: import('jsdom').JSDOM;
     // TODO: we should define some standard here once we move to more cards with dynamic data
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/kg-lexical-html-renderer/lib/kg-default-nodes.d.ts
+++ b/packages/kg-lexical-html-renderer/lib/kg-default-nodes.d.ts
@@ -4,8 +4,9 @@ declare module '@tryghost/kg-default-nodes' {
 
     export interface RendererOptions {
         usedIdAttributes?: Record<string, number>;
-        dom?: import('jsdom').JSDOM,
-        type?: 'inner' | 'outer' | 'value'
+        dom?: import('jsdom').JSDOM;
+        type?: 'inner' | 'outer' | 'value';
+        target?: 'html' | 'email' | 'plaintext';
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -15,7 +16,7 @@ declare module '@tryghost/kg-default-nodes' {
         // TODO: exportDOM override isn't directly compatible with base class, should fix when converting kg-default-nodes
         exportDOM(options: LexicalEditor | RendererOptions): {
             element: HTMLElement | HTMLInputElement | HTMLTextAreaElement;
-            type: 'inner' | 'outer' | 'value'
+            type: 'inner' | 'outer' | 'value';
         };
         hasDynamicData?(): boolean;
         getDynamicData?(options: RendererOptions): Promise<{key: number; data: unknown}>;

--- a/packages/kg-lexical-html-renderer/lib/transformers/element/blockquote.ts
+++ b/packages/kg-lexical-html-renderer/lib/transformers/element/blockquote.ts
@@ -9,6 +9,16 @@ module.exports = {
             return null;
         }
 
+        if (options.target === 'email') {
+            let children = exportChildren(node);
+
+            if (!children.startsWith('<p>')) {
+                children = `<p>${children}</p>`;
+            }
+
+            return `<blockquote>${children}</blockquote>`;
+        }
+
         return `<blockquote>${exportChildren(node)}</blockquote>`;
     }
 };

--- a/packages/kg-lexical-html-renderer/test/quotes.test.js
+++ b/packages/kg-lexical-html-renderer/test/quotes.test.js
@@ -18,4 +18,21 @@ describe('Quotes', function () {
         input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Aside with ","type":"text","version":1},{"detail":0,"format":1,"mode":"normal","style":"","text":"formatting","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"aside","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
         output: `<blockquote class="kg-blockquote-alt">Aside with <strong>formatting</strong></blockquote>`
     }));
+
+    describe('email target', function () {
+        it('forces inner p', shouldRender({
+            input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Blockquote with ","type":"text","version":1},{"detail":0,"format":1,"mode":"normal","style":"","text":"formatting","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"quote","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+            output: `<blockquote><p>Blockquote with <strong>formatting</strong></p></blockquote>`,
+            options: {target: 'email'}
+        }));
+
+        // at time of writing our denest transform pulls the p content to top-level in blockquote
+        // so this test is a bit redundant _but_ we expect to allow paragraphs in blockquotes in
+        // the future so this is here to ensure we don't have a regression
+        it('does not create double p', shouldRender({
+            input: `{"root":{"children":[{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Blockquote with ","type":"text","version":1},{"detail":0,"format":1,"mode":"normal","style":"","text":"formatting","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"quote","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+            output: `<blockquote><p>Blockquote with <strong>formatting</strong></p></blockquote>`,
+            options: {target: 'email'}
+        }));
+    });
 });


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-1432

- iOS Mail ignores spacing on `<blockquote>` so we need an inner `<p>` to style instead
- enforcing inner `<p>` ensures consistency with our markdown card output
- email-only to avoid wider changes for themes, this will likely change in future but for now we just want to fix the email rendering with minimal impact
