### PR TITLE
Enforced `<p>` inside `<blockquote>` when rendering aside nodes for email

### DIFF
--- a/packages/kg-lexical-html-renderer/lib/transformers/element/aside.ts
+++ b/packages/kg-lexical-html-renderer/lib/transformers/element/aside.ts
@@ -8,6 +8,16 @@ module.exports = {
             return null;
         }
 
+        if (options.target === 'email') {
+            let children = exportChildren(node);
+
+            if (!children.startsWith('<p>')) {
+                children = `<p>${children}</p>`;
+            }
+
+            return `<blockquote class="kg-blockquote-alt">${children}</blockquote>`;
+        }
+
         return `<blockquote class="kg-blockquote-alt">${exportChildren(node)}</blockquote>`;
     }
 };

--- a/packages/kg-lexical-html-renderer/test/quotes.test.js
+++ b/packages/kg-lexical-html-renderer/test/quotes.test.js
@@ -21,18 +21,35 @@ describe('Quotes', function () {
 
     describe('email target', function () {
         it('forces inner p', shouldRender({
+            options: {target: 'email'},
             input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Blockquote with ","type":"text","version":1},{"detail":0,"format":1,"mode":"normal","style":"","text":"formatting","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"quote","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
-            output: `<blockquote><p>Blockquote with <strong>formatting</strong></p></blockquote>`,
-            options: {target: 'email'}
+            output: `<blockquote><p>Blockquote with <strong>formatting</strong></p></blockquote>`
         }));
 
         // at time of writing our denest transform pulls the p content to top-level in blockquote
         // so this test is a bit redundant _but_ we expect to allow paragraphs in blockquotes in
         // the future so this is here to ensure we don't have a regression
         it('does not create double p', shouldRender({
+            options: {target: 'email'},
             input: `{"root":{"children":[{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Blockquote with ","type":"text","version":1},{"detail":0,"format":1,"mode":"normal","style":"","text":"formatting","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"quote","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
-            output: `<blockquote><p>Blockquote with <strong>formatting</strong></p></blockquote>`,
-            options: {target: 'email'}
+            output: `<blockquote><p>Blockquote with <strong>formatting</strong></p></blockquote>`
         }));
+
+        describe('aside', function () {
+            it('forces inner p', shouldRender({
+                options: {target: 'email', nodes: [AsideNode]},
+                input: `{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Blockquote with ","type":"text","version":1},{"detail":0,"format":1,"mode":"normal","style":"","text":"formatting","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"aside","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+                output: `<blockquote class="kg-blockquote-alt"><p>Blockquote with <strong>formatting</strong></p></blockquote>`
+            }));
+
+            // at time of writing our denest transform pulls the p content to top-level in blockquote
+            // so this test is a bit redundant _but_ we expect to allow paragraphs in blockquotes in
+            // the future so this is here to ensure we don't have a regression
+            it('does not create double p', shouldRender({
+                options: {target: 'email', nodes: [AsideNode]},
+                input: `{"root":{"children":[{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Blockquote with ","type":"text","version":1},{"detail":0,"format":1,"mode":"normal","style":"","text":"formatting","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"aside","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`,
+                output: `<blockquote class="kg-blockquote-alt"><p>Blockquote with <strong>formatting</strong></p></blockquote>`
+            }));
+        });
     });
 });


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-1432
ref https://github.com/TryGhost/Koenig/commit/eb5730bf252b19674606ee4aa46376fb9e1c75ec

- see previous commit ref above for more details
- our Aside nodes also render to `<blockquote>` so need to same enforced `<p>` fix
