### PR TITLE
Slash menu padding

### DIFF
--- a/packages/koenig-lexical/src/components/ui/CardMenu.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardMenu.jsx
@@ -172,7 +172,7 @@ export const CardMenu = ({menu = new Map(), insert = () => {}, selectedItemIndex
     }
 
     return (
-        <ul className="not-kg-prose z-[9999999] m-0 mb-3 max-h-[420px] w-[312px] flex-col overflow-y-auto rounded-lg bg-white bg-clip-padding p-0 font-sans text-sm shadow-md after:block after:pb-1 dark:bg-grey-950 md:w-[348px]" role="menu">
+        <ul className="not-kg-prose z-[9999999] m-0 mb-3 max-h-[420px] w-[312px] scroll-p-2 flex-col overflow-y-auto rounded-lg bg-white bg-clip-padding p-0 font-sans text-sm shadow-md after:block after:pb-1 dark:bg-grey-950 md:w-[348px]" role="menu">
             {CardMenuSections}
         </ul>
     );

--- a/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/EmojiPickerPlugin.jsx
@@ -177,7 +177,7 @@ export function EmojiPickerPlugin() {
                 }
                 return (
                     <Portal className="w-[240px]" to={anchorElementRef.current}>
-                        <ul className="relative z-10 max-h-[214px] select-none list-none overflow-y-auto rounded-md bg-white p-1 shadow dark:bg-grey-950" data-testid="emoji-menu" style={getPositionStyles()}>
+                        <ul className="relative z-10 max-h-[214px] select-none scroll-p-2 list-none overflow-y-auto rounded-md bg-white p-1  shadow dark:bg-grey-950" data-testid="emoji-menu" style={getPositionStyles()}>
                             {searchResults.map((emoji, index) => (
                                 <div key={emoji.id}>
                                     <EmojiMenuItem


### PR DESCRIPTION
Fixes https://linear.app/tryghost/issue/DES-361/nicer-keyboard-navigation-on-dropdowns

Added scroll-padding to the `slash menu` and `emoji menu` in the Editor. This makes navigation through those menus by keyboard just a tad nicer.