### PR TITLE
Cleaned up unused arrowstyles code

### DIFF
--- a/packages/koenig-lexical/src/components/ui/FloatingFormatToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/FloatingFormatToolbar.jsx
@@ -33,25 +33,16 @@ export function FloatingFormatToolbar({
     const isInternalLinkingEnabled = cardConfig?.feature?.internalLinking || false;
 
     const toolbarRef = React.useRef(null);
-    const [arrowStyles, setArrowStyles] = React.useState(null);
 
     const internalLinkingToolbarVisible = toolbarItemType === toolbarItemTypes.link && isInternalLinkingEnabled;
-
-    const updateArrowStyles = React.useCallback(() => {
-        const styles = getArrowPositionStyles({ref: toolbarRef, selectionRangeRect});
-        setArrowStyles(styles);
-    }, [selectionRangeRect]);
 
     // toolbar opacity is 0 by default
     // shouldn't display until selection via mouse is complete to avoid toolbar re-positioning while dragging
     const showToolbarIfHidden = React.useCallback((e) => {
         if (toolbarItemType && toolbarRef.current?.style.opacity === '0') {
             toolbarRef.current.style.opacity = '1';
-            updateArrowStyles();
         }
-    }, [toolbarItemType, updateArrowStyles]);
-
-    // TODO: Arrow not updating position on selection change (select all)
+    }, [toolbarItemType]);
 
     React.useEffect(() => {
         const toggle = (e) => {
@@ -158,18 +149,15 @@ export function FloatingFormatToolbar({
                 isVisible={!!toolbarItemType}
                 shouldReposition={toolbarItemType !== toolbarItemTypes.text} // format toolbar shouldn't reposition when applying formats
                 toolbarRef={toolbarRef}
-                onReposition={updateArrowStyles}
             >
                 {isSnippetToolbar && (
                     <SnippetActionToolbar
-                        arrowStyles={arrowStyles}
                         onClose={handleActionToolbarClose}
                     />
                 )}
 
                 {(isLinkToolbar && !isInternalLinkingEnabled) && (
                     <LinkActionToolbar
-                        arrowStyles={arrowStyles}
                         href={href}
                         onClose={handleActionToolbarClose}
                     />
@@ -177,7 +165,6 @@ export function FloatingFormatToolbar({
 
                 {showTextToolbar && (
                     <FormatToolbar
-                        arrowStyles={arrowStyles}
                         editor={editor}
                         hiddenFormats={hiddenFormats}
                         isLinkSelected={!!href || (isInternalLinkingEnabled && isLinkToolbar)}
@@ -198,28 +185,4 @@ export function FloatingFormatToolbar({
             )}
         </>
     );
-}
-
-function getArrowPositionStyles({ref, selectionRangeRect}) {
-    const ARROW_WIDTH = 8;
-
-    if (!ref.current || !selectionRangeRect) {
-        return {};
-    }
-    const selectionLeft = selectionRangeRect.left;
-    const toolbarRect = ref.current.getClientRects()[0];
-    const toolbarLeft = toolbarRect.left;
-    const arrowLeftPosition = (selectionLeft - toolbarLeft) + selectionRangeRect?.width / 2 - ARROW_WIDTH;
-    const max = toolbarRect.width - (ARROW_WIDTH * 3);
-    const min = ARROW_WIDTH / 2;
-
-    if (arrowLeftPosition > max) {
-        return {left: `${max}px`};
-    }
-
-    if (arrowLeftPosition < min) {
-        return {left: `${min}px`};
-    }
-
-    return ({left: `${Math.round(arrowLeftPosition)}px`});
 }

--- a/packages/koenig-lexical/src/components/ui/FormatToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/FormatToolbar.jsx
@@ -56,7 +56,6 @@ export default function FormatToolbar({
     isLinkSelected,
     onLinkClick,
     onSnippetClick,
-    arrowStyles,
     hiddenFormats = []
 }) {
     const [isBold, setIsBold] = React.useState(false);
@@ -174,7 +173,7 @@ export default function FormatToolbar({
     };
 
     return (
-        <ToolbarMenu arrowStyles={arrowStyles}>
+        <ToolbarMenu>
             <ToolbarMenuItem
                 data-kg-toolbar-button="bold"
                 hide={hideBold}

--- a/packages/koenig-lexical/src/components/ui/LinkInput.jsx
+++ b/packages/koenig-lexical/src/components/ui/LinkInput.jsx
@@ -2,7 +2,7 @@ import CloseIcon from '../../assets/icons/kg-close.svg?react';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef} from 'react';
 
-export function LinkInput({href, update, cancel, arrowStyles}) {
+export function LinkInput({href, update, cancel}) {
     const [_href, setHref] = React.useState(href);
 
     // add refs for input and container

--- a/packages/koenig-lexical/src/components/ui/SnippetInput.jsx
+++ b/packages/koenig-lexical/src/components/ui/SnippetInput.jsx
@@ -9,8 +9,7 @@ export function SnippetInput({
     onCreateSnippet,
     onUpdateSnippet,
     onClose,
-    snippets = [],
-    arrowStyles
+    snippets = []
 }) {
     const snippetRef = useRef(null);
     const [isCreateButtonActive, setIsCreateButtonActive] = useState(true);
@@ -121,7 +120,6 @@ export function SnippetInput({
             onClick={e => e.stopPropagation()} // prevents card from losing selected state
         >
             <Input
-                arrowStyles={arrowStyles}
                 value={value}
                 onChange={onChange}
                 onClear={onClose}

--- a/packages/koenig-lexical/src/components/ui/SnippetInput/Input.jsx
+++ b/packages/koenig-lexical/src/components/ui/SnippetInput/Input.jsx
@@ -1,7 +1,7 @@
 import CloseIcon from '../../../assets/icons/kg-close.svg?react';
 import React from 'react';
 
-export const Input = ({value, onChange, onClear, onKeyDown, arrowStyles}) => {
+export const Input = ({value, onChange, onClear, onKeyDown}) => {
     return (
         <div className="relative m-0 flex items-center justify-evenly gap-1 rounded-lg bg-white font-sans text-md font-normal text-black shadow-md dark:bg-grey-950">
             <input

--- a/packages/koenig-lexical/src/components/ui/ToolbarMenu.jsx
+++ b/packages/koenig-lexical/src/components/ui/ToolbarMenu.jsx
@@ -39,7 +39,7 @@ export const TOOLBAR_ICONS = {
     remove: TrashIcon
 };
 
-export function ToolbarMenu({children, hide, arrowStyles, ...props}) {
+export function ToolbarMenu({children, hide, ...props}) {
     if (hide) {
         return null;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7522,10 +7522,10 @@ codemirror-spell-checker@1.1.2:
   dependencies:
     typo-js "*"
 
-codemirror@5.65.16:
-  version "5.65.16"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.65.16.tgz#efc0661be6bf4988a6a1c2fe6893294638cdb334"
-  integrity sha512-br21LjYmSlVL0vFCPWPfhzUCT34FM/pAdK7rRIZwa0rrtrIdotvP4Oh4GUHsu2E3IrQMCfRkL/fN3ytMNxVQvg==
+codemirror@5.65.17:
+  version "5.65.17"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.65.17.tgz#00d71f34c3518471ae4c0de23a2f8bb39a6df6ca"
+  integrity sha512-1zOsUx3lzAOu/gnMAZkQ9kpIHcPYOc9y1Fbm2UVk5UBPkdq380nhkelG0qUwm1f7wPvTbndu9ZYlug35EwAZRQ==
 
 codemirror@^6.0.0, codemirror@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
no issue

- our toolbar design changed a while back so it no longer has an arrow pointing to the selection
- however the related code which calculated the positioning and passed styles through the component tree hadn't been removed when the child components were updated with the new design
