### PR TITLE
Updated editor indicator icons

### DIFF
--- a/packages/koenig-lexical/src/assets/icons/kg-indicator-email.svg
+++ b/packages/koenig-lexical/src/assets/icons/kg-indicator-email.svg
@@ -1,6 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M3.875 5.75h16.25c.833 0 1.25.417 1.25 1.25v10c0 .833-.417 1.25-1.25 1.25H3.875c-.833 0-1.25-.417-1.25-1.25V7c0-.833.417-1.25 1.25-1.25zm11.197 4.562 3.178 2.938m-9.323-2.938L5.75 13.25"/>
-    <path d="m21.067 6.178-7.928 5.467c-.76.524-1.519.524-2.278 0L2.933 6.178"/>
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M2.614 4.558 12 14l9.385-9.441"/>
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20.182 4H3.818a1.84 1.84 0 0 0-1.285.52A1.758 1.758 0 0 0 2 5.779v12.444c0 .472.192.924.533 1.257.34.334.803.521 1.285.521h16.364a1.84 1.84 0 0 0 1.286-.52c.34-.334.532-.786.532-1.258V5.778a1.76 1.76 0 0 0-.532-1.257A1.84 1.84 0 0 0 20.181 4Z"/>
 </svg>

--- a/packages/koenig-lexical/src/assets/icons/kg-indicator-html.svg
+++ b/packages/koenig-lexical/src/assets/icons/kg-indicator-html.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-  <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M1 12V7m3 5V7M1 9.472h2.364M14 12V7l-1.5 2.472L11 7v5m8 0h-2.5V7m-9 5V7M6 7h3"/>
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8.2 5 1 12l7.2 7m7.6-14 7.2 7-7.2 7"/>
 </svg>

--- a/packages/koenig-lexical/src/assets/icons/kg-indicator-markdown.svg
+++ b/packages/koenig-lexical/src/assets/icons/kg-indicator-markdown.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-  <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M2 14V6l4 4 4-4v8m6-7.93v7.916M13.5 11.5l2.48 2.525L18.5 11.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 25 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21.073 5.727v11.75m-3.346-1.959 3.137 2.755L24 15.518m-10.454 2.755V5.727h-.966l-4.825 11.65H6.79L1.965 5.726H1v12.546"/>
 </svg>

--- a/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
@@ -46,8 +46,8 @@ export const CardWrapper = React.forwardRef(({
     return (
         <>
             {IndicatorIcon &&
-                <div className="sticky top-0">
-                    <IndicatorIcon className="absolute left-[-6rem] top-[.6rem] size-6 text-grey" />
+                <div className="sticky top-0 lg:top-8">
+                    <IndicatorIcon className="absolute left-[-6rem] top-[.6rem] size-5 text-grey" />
                 </div>
             }
             <div

--- a/packages/koenig-lexical/src/components/ui/cards/EmailCtaCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/EmailCtaCard.jsx
@@ -54,7 +54,7 @@ export function EmailCtaCard({
         <>
             <div className="w-full pb-6">
                 {/* Segment */}
-                <div className="pb-7 pt-1 font-sans text-xs font-semibold uppercase leading-8 tracking-normal text-grey dark:text-grey-800">
+                <div className="pb-7 pt-[.6rem] font-sans text-xs font-semibold uppercase leading-8 tracking-normal text-grey dark:text-grey-800">
                     {segmentName}
                 </div>
 

--- a/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
@@ -138,11 +138,11 @@ test.describe('Email card', async () => {
 
             await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
-                <div class="sticky top-0"><svg></svg></div>
+                <div class="sticky top-0 lg:top-8"><svg></svg></div>
                 <div class="relative border-transparent caret-grey-800 z-10 hover:shadow-[0_0_0_1px] hover:shadow-green hover:-mx-3 hover:px-3"
                     data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="email-cta">
                     <div class="w-full pb-6">
-                        <div class="pb-7 pt-1 font-sans text-xs font-semibold uppercase leading-8 tracking-normal text-grey dark:text-grey-800">Free members</div>
+                        <div class="pb-7 pt-[.6rem] font-sans text-xs font-semibold uppercase leading-8 tracking-normal text-grey dark:text-grey-800">Free members</div>
                         <div
                             class="koenig-lexical kg-inherit-styles w-full bg-transparent whitespace-normal font-serif text-xl text-grey-900 dark:text-grey-200 text-center mx-auto [&amp;:has(.placeholder)]:w-fit [&amp;:has(.placeholder)]:text-left">
                             <div data-kg="editor">


### PR DESCRIPTION
No ref
- Replaced the email, html, and markdown indicator icons so that they correspond with the icons used in the card menu.