### PR TITLE
🐛 Removed extra paragraphs around headings/lists when pasting from Gdoc

### DIFF
--- a/packages/kg-default-nodes/lib/serializers/linebreak.js
+++ b/packages/kg-default-nodes/lib/serializers/linebreak.js
@@ -3,17 +3,26 @@ export default {
         br: (node) => {
             const isGoogleDocs = !!node.closest('[id^="docs-internal-guid-"]');
 
-            // render nothing for GDoc line breaks in-between paragraphs
-            // otherwise we end up with empty paragraphs
-            if (
-                isGoogleDocs &&
-                node.previousElementSibling?.nodeName === 'P' &&
-                node.nextElementSibling?.nodeName === 'P'
-            ) {
-                return {
-                    conversion: () => null,
-                    priority: 1
-                };
+            // Remove empty paragraphs when copy/pasting from Google docs:
+            // - Between two paragraphs (P and P)
+            // - Between a list and a paragraph (UL/OL and P), and vice versa
+            // - Between a heading and a paragraph (H1-H6 and P), and vice versa
+            if (isGoogleDocs) {
+                if ((
+                    node.previousElementSibling?.nodeName === 'P' &&
+                    node.nextElementSibling?.nodeName === 'P'
+                ) || (
+                    ['UL', 'OL', 'DL', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(node.previousElementSibling?.nodeName) &&
+                    node.nextElementSibling?.nodeName === 'P'
+                ) || (
+                    node.previousElementSibling?.nodeName === 'P' &&
+                    ['UL', 'OL', 'DL', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(node.nextElementSibling?.nodeName)
+                )) {
+                    return {
+                        conversion: () => null,
+                        priority: 1
+                    };
+                }
             }
 
             // allow lower priority converter to handle (i.e. default LineBreakNode.importDOM)

--- a/packages/kg-default-nodes/lib/serializers/linebreak.js
+++ b/packages/kg-default-nodes/lib/serializers/linebreak.js
@@ -2,21 +2,23 @@ export default {
     import: {
         br: (node) => {
             const isGoogleDocs = !!node.closest('[id^="docs-internal-guid-"]');
+            const headings = ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
+            const lists = ['UL', 'OL', 'DL'];
 
             // Remove empty paragraphs when copy/pasting from Google docs:
             // - Between two paragraphs (P and P)
-            // - Between a list and a paragraph (UL/OL and P), and vice versa
+            // - Between a list and a paragraph (UL/OL/DL and P), and vice versa
             // - Between a heading and a paragraph (H1-H6 and P), and vice versa
             if (isGoogleDocs) {
                 if ((
                     node.previousElementSibling?.nodeName === 'P' &&
                     node.nextElementSibling?.nodeName === 'P'
                 ) || (
-                    ['UL', 'OL', 'DL', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(node.previousElementSibling?.nodeName) &&
+                    [...headings, ...lists].includes(node.previousElementSibling?.nodeName) &&
                     node.nextElementSibling?.nodeName === 'P'
                 ) || (
                     node.previousElementSibling?.nodeName === 'P' &&
-                    ['UL', 'OL', 'DL', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(node.nextElementSibling?.nodeName)
+                    [...headings, ...lists].includes(node.nextElementSibling?.nodeName)
                 )) {
                     return {
                         conversion: () => null,

--- a/packages/kg-default-nodes/test/serializers/linebreak.test.js
+++ b/packages/kg-default-nodes/test/serializers/linebreak.test.js
@@ -22,65 +22,289 @@ describe('Serializers: linebreak', function () {
     });
 
     describe('import', function () {
-        it('(non GDoc) default conversion between text', editorTest(function () {
-            const htmlString = 'Before<br>After';
+        describe('Inside a paragraph', function () {
+            it('(non GDoc) default conversion between text', editorTest(function () {
+                const htmlString = 'Before<br>After';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 3);
+                should.equal(nodes[0].getType(), 'extended-text');
+                should.equal(nodes[1].getType(), 'linebreak');
+                should.equal(nodes[2].getType(), 'extended-text');
+            }));
+
+            it('(GDoc) default conversion for breaks inside paragraphs', editorTest(function () {
+                const htmlString = '<div id="docs-internal-guid-1234"><p>Before<br>After</p></div>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 1);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[0].getChildren().length, 3);
+                should.equal(nodes[0].getChildren()[0].getType(), 'extended-text');
+                should.equal(nodes[0].getChildren()[1].getType(), 'linebreak');
+                should.equal(nodes[0].getChildren()[2].getType(), 'extended-text');
+            }));
+        });
+
+        describe('Between paragraphs', function () {
+            it('(non GDoc) default conversion between paragraphs', editorTest(function () {
+                const htmlString = '<p>Before</p><br><p>After</p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 3);
+
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[0].getChildren().length, 1);
+                should.equal(nodes[0].getChildren()[0].getType(), 'extended-text');
+                should.equal(nodes[0].getChildren()[0].getTextContent(), 'Before');
+
+                should.equal(nodes[1].getType(), 'linebreak');
+
+                should.equal(nodes[2].getType(), 'paragraph');
+                should.equal(nodes[2].getChildren().length, 1);
+                should.equal(nodes[2].getChildren()[0].getType(), 'extended-text');
+                should.equal(nodes[2].getChildren()[0].getTextContent(), 'After');
+            }));
+
+            it('(GDoc) no conversion for breaks between paragraphs', editorTest(function () {
+                const htmlString = '<div id="docs-internal-guid-1234"><p>Before</p><br><p>After</p></div>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 2);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[0].getChildren().length, 1);
+                should.equal(nodes[0].getChildren()[0].getType(), 'extended-text');
+                should.equal(nodes[0].getChildren()[0].getTextContent(), 'Before');
+
+                should.equal(nodes[1].getType(), 'paragraph');
+                should.equal(nodes[1].getChildren().length, 1);
+                should.equal(nodes[1].getChildren()[0].getType(), 'extended-text');
+                should.equal(nodes[1].getChildren()[0].getTextContent(), 'After');
+            }));
+        });
+
+        describe('Between lists and paragraphs', function () {
+            it('(non GDoc) default conversion for linebreaks between unordered list and paragraph', editorTest(function () {
+                const htmlString = '<p>Paragraph></p><br><ul><li>Item</li></ul><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 5);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'linebreak');
+                should.equal(nodes[2].getType(), 'extended-text');
+                should.equal(nodes[3].getType(), 'linebreak');
+                should.equal(nodes[4].getType(), 'paragraph');
+            }));
+
+            it('(GDoc) skips linebreaks between unordered list and paragraph', editorTest(function () {
+                const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><ul><li>Item</li></ul><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 3);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'extended-text');
+                should.equal(nodes[2].getType(), 'paragraph');
+            }));
+
+            it('(non GDoc) default conversion for linebreaks between ordered list and paragraph', editorTest(function () {
+                const htmlString = '<p>Paragraph></p><br><ol><li>Item</li></ol><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 5);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'linebreak');
+                should.equal(nodes[2].getType(), 'extended-text');
+                should.equal(nodes[3].getType(), 'linebreak');
+                should.equal(nodes[4].getType(), 'paragraph');
+            }));
+
+            it('(GDoc) skips linebreaks between ordered list and paragraph', editorTest(function () {
+                const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><ol><li>Item</li></ol><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 3);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'extended-text');
+                should.equal(nodes[2].getType(), 'paragraph');
+            }));
+
+            it('(non GDoc) default conversion for linebreaks between description list and paragraph', editorTest(function () {
+                const htmlString = '<p>Paragraph></p><br><dl><li>Item</li></dl><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 5);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'linebreak');
+                should.equal(nodes[2].getType(), 'extended-text');
+                should.equal(nodes[3].getType(), 'linebreak');
+                should.equal(nodes[4].getType(), 'paragraph');
+            }));
+
+            it('(GDoc) skips linebreaks between description list and paragraph', editorTest(function () {
+                const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><dl><li>Item</li></dl><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 3);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'extended-text');
+                should.equal(nodes[2].getType(), 'paragraph');
+            }));
+        });
+
+        describe('Between headings and paragraphs', function () {
+            it('(non GDoc) default conversion for a linebreak between a H1 and paragraph', editorTest(function () {
+                const htmlString = '<p>Paragraph></p><br><h1>Heading</h1><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 5);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'linebreak');
+                should.equal(nodes[2].getType(), 'extended-heading');
+                should.equal(nodes[3].getType(), 'linebreak');
+                should.equal(nodes[4].getType(), 'paragraph');
+            }));
+
+            it('(GDoc) skips linebreaks between H1 and paragraph', editorTest(function () {
+                const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><h1>Heading</h1><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 3);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'extended-heading');
+                should.equal(nodes[2].getType(), 'paragraph');
+            }));
+
+            it('(non GDoc) default conversion for a linebreak between a H2 and paragraph', editorTest(function () {
+                const htmlString = '<p>Paragraph></p><br><h2>Heading</h2><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 5);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'linebreak');
+                should.equal(nodes[2].getType(), 'extended-heading');
+                should.equal(nodes[3].getType(), 'linebreak');
+                should.equal(nodes[4].getType(), 'paragraph');
+            }));
+
+            it('(GDoc) skips linebreaks between H2 and paragraph', editorTest(function () {
+                const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><h2>Heading</h2><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 3);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'extended-heading');
+                should.equal(nodes[2].getType(), 'paragraph');
+            }));
+        });
+
+        it('(non GDoc) default conversion for a linebreak between a H3 and paragraph', editorTest(function () {
+            const htmlString = '<p>Paragraph></p><br><h3>Heading</h3><br><p>Paragraph></p>';
             const document = createDocument(htmlString);
             const nodes = $generateNodesFromDOM(editor, document);
 
-            should.equal(nodes.length, 3);
-            should.equal(nodes[0].getType(), 'extended-text');
+            should.equal(nodes.length, 5);
+            should.equal(nodes[0].getType(), 'paragraph');
             should.equal(nodes[1].getType(), 'linebreak');
-            should.equal(nodes[2].getType(), 'extended-text');
+            should.equal(nodes[2].getType(), 'extended-heading');
+            should.equal(nodes[3].getType(), 'linebreak');
+            should.equal(nodes[4].getType(), 'paragraph');
         }));
 
-        it('(non GDoc) default conversion between paragraphs', editorTest(function () {
-            const htmlString = '<p>Before</p><br><p>After</p>';
+        it('(GDoc) skips linebreaks between H3 and paragraph', editorTest(function () {
+            const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><h3>Heading</h3><br><p>Paragraph></p>';
             const document = createDocument(htmlString);
             const nodes = $generateNodesFromDOM(editor, document);
 
             should.equal(nodes.length, 3);
-
             should.equal(nodes[0].getType(), 'paragraph');
-            should.equal(nodes[0].getChildren().length, 1);
-            should.equal(nodes[0].getChildren()[0].getType(), 'extended-text');
-            should.equal(nodes[0].getChildren()[0].getTextContent(), 'Before');
-
-            should.equal(nodes[1].getType(), 'linebreak');
-
+            should.equal(nodes[1].getType(), 'extended-heading');
             should.equal(nodes[2].getType(), 'paragraph');
-            should.equal(nodes[2].getChildren().length, 1);
-            should.equal(nodes[2].getChildren()[0].getType(), 'extended-text');
-            should.equal(nodes[2].getChildren()[0].getTextContent(), 'After');
         }));
 
-        it('(GDoc) default conversion for breaks inside paragraphs', editorTest(function () {
-            const htmlString = '<div id="docs-internal-guid-1234"><p>Before<br>After</p></div>';
+        it('(non GDoc) default conversion for a linebreak between a H4 and paragraph', editorTest(function () {
+            const htmlString = '<p>Paragraph></p><br><h4>Heading</h4><br><p>Paragraph></p>';
             const document = createDocument(htmlString);
             const nodes = $generateNodesFromDOM(editor, document);
 
-            should.equal(nodes.length, 1);
+            should.equal(nodes.length, 5);
             should.equal(nodes[0].getType(), 'paragraph');
-            should.equal(nodes[0].getChildren().length, 3);
-            should.equal(nodes[0].getChildren()[0].getType(), 'extended-text');
-            should.equal(nodes[0].getChildren()[1].getType(), 'linebreak');
-            should.equal(nodes[0].getChildren()[2].getType(), 'extended-text');
+            should.equal(nodes[1].getType(), 'linebreak');
+            should.equal(nodes[2].getType(), 'extended-heading');
+            should.equal(nodes[3].getType(), 'linebreak');
+            should.equal(nodes[4].getType(), 'paragraph');
         }));
 
-        it('(GDoc) no conversion for breaks between paragraphs', editorTest(function () {
-            const htmlString = '<div id="docs-internal-guid-1234"><p>Before</p><br><p>After</p></div>';
+        it('(GDoc) skips linebreaks between H4 and paragraph', editorTest(function () {
+            const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><h4>Heading</h4><br><p>Paragraph></p>';
             const document = createDocument(htmlString);
             const nodes = $generateNodesFromDOM(editor, document);
 
-            should.equal(nodes.length, 2);
+            should.equal(nodes.length, 3);
             should.equal(nodes[0].getType(), 'paragraph');
-            should.equal(nodes[0].getChildren().length, 1);
-            should.equal(nodes[0].getChildren()[0].getType(), 'extended-text');
-            should.equal(nodes[0].getChildren()[0].getTextContent(), 'Before');
+            should.equal(nodes[1].getType(), 'extended-heading');
+            should.equal(nodes[2].getType(), 'paragraph');
+        }));
 
-            should.equal(nodes[1].getType(), 'paragraph');
-            should.equal(nodes[1].getChildren().length, 1);
-            should.equal(nodes[1].getChildren()[0].getType(), 'extended-text');
-            should.equal(nodes[1].getChildren()[0].getTextContent(), 'After');
+        it('(non GDoc) default conversion for a linebreak between a H5 and paragraph', editorTest(function () {
+            const htmlString = '<p>Paragraph></p><br><h5>Heading</h5><br><p>Paragraph></p>';
+            const document = createDocument(htmlString);
+            const nodes = $generateNodesFromDOM(editor, document);
+
+            should.equal(nodes.length, 5);
+            should.equal(nodes[0].getType(), 'paragraph');
+            should.equal(nodes[1].getType(), 'linebreak');
+            should.equal(nodes[2].getType(), 'extended-heading');
+            should.equal(nodes[3].getType(), 'linebreak');
+            should.equal(nodes[4].getType(), 'paragraph');
+        }));
+
+        it('(GDoc) skips linebreaks between H5 and paragraph', editorTest(function () {
+            const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><h5>Heading</h5><br><p>Paragraph></p>';
+            const document = createDocument(htmlString);
+            const nodes = $generateNodesFromDOM(editor, document);
+
+            should.equal(nodes.length, 3);
+            should.equal(nodes[0].getType(), 'paragraph');
+            should.equal(nodes[1].getType(), 'extended-heading');
+            should.equal(nodes[2].getType(), 'paragraph');
+        }));
+
+        it('(non GDoc) default conversion for a linebreak between a H6 and paragraph', editorTest(function () {
+            const htmlString = '<p>Paragraph></p><br><h6>Heading</h6><br><p>Paragraph></p>';
+            const document = createDocument(htmlString);
+            const nodes = $generateNodesFromDOM(editor, document);
+
+            should.equal(nodes.length, 5);
+            should.equal(nodes[0].getType(), 'paragraph');
+            should.equal(nodes[1].getType(), 'linebreak');
+            should.equal(nodes[2].getType(), 'extended-heading');
+            should.equal(nodes[3].getType(), 'linebreak');
+            should.equal(nodes[4].getType(), 'paragraph');
+        }));
+
+        it('(GDoc) skips linebreaks between H6 and paragraph', editorTest(function () {
+            const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><h6>Heading</h6><br><p>Paragraph></p>';
+            const document = createDocument(htmlString);
+            const nodes = $generateNodesFromDOM(editor, document);
+
+            should.equal(nodes.length, 3);
+            should.equal(nodes[0].getType(), 'paragraph');
+            should.equal(nodes[1].getType(), 'extended-heading');
+            should.equal(nodes[2].getType(), 'paragraph');
         }));
     });
 });

--- a/packages/kg-html-to-lexical/test/sources/google-docs.test.ts
+++ b/packages/kg-html-to-lexical/test/sources/google-docs.test.ts
@@ -246,17 +246,21 @@ describe('HTMLtoLexical: Google Docs', function () {
 
     it('removes extra empty paragraphs', function () {
         const input = html`
-            <b style="font-weight:normal;" id="docs-internal-guid-c78cbc4e-7fff-3259-7cfe-a58c824763cf">
+            <b style="font-weight:normal;" id="docs-internal-guid-53c161b0-7fff-55f3-a893-721115583111">
                 <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
-                    <span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the start of an article</span>
+                    <span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Start of the article. Here is the 1st paragraph, followed by a line break then a paragraph.</span>
                 </p>
                 <br />
-                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
-                    <span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the next paragraph with an extra line break since you need to do that in Google docs.</span>
-                </p>
-                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
-                    <span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is a paragraph without an extra line break.</span>
-                </p>
+                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 2nd paragraph, followed by a linebreak then a heading.</span></p><br />
+                <h1 dir="ltr" style="line-height:1.38;margin-top:20pt;margin-bottom:6pt;"><span style="font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Heading 1</span></h1><br />
+                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 3rd paragraph, followed by a linebreak and a list.</span></p><br />
+                <ul style="margin-top:0;margin-bottom:0;padding-inline-start:48px;">
+                    <li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">List item 1</span></p></li>
+                    <li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">List item 2</span></p></li>
+                </ul>
+                <br />
+                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 4th paragraph, NOT followed by linebreaks.</span></p>
+                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 5th paragraph. End of the article.</span></p>
             </b>
             <br class="Apple-interchange-newline">
         `;
@@ -273,7 +277,7 @@ describe('HTMLtoLexical: Google Docs', function () {
                                 format: 0,
                                 mode: 'normal',
                                 style: '',
-                                text: 'Here is the start of an article',
+                                text: 'Start of the article. Here is the 1st paragraph, followed by a line break then a paragraph.',
                                 type: 'extended-text',
                                 version: 1
                             }
@@ -291,7 +295,7 @@ describe('HTMLtoLexical: Google Docs', function () {
                                 format: 0,
                                 mode: 'normal',
                                 style: '',
-                                text: 'Here is the next paragraph with an extra line break since you need to do that in Google docs.',
+                                text: 'Here is the 2nd paragraph, followed by a linebreak then a heading.',
                                 type: 'extended-text',
                                 version: 1
                             }
@@ -309,7 +313,114 @@ describe('HTMLtoLexical: Google Docs', function () {
                                 format: 0,
                                 mode: 'normal',
                                 style: '',
-                                text: 'Here is a paragraph without an extra line break.',
+                                text: 'Heading 1',
+                                type: 'extended-text',
+                                version: 1
+                            }
+                        ],
+                        direction: null,
+                        format: '',
+                        indent: 0,
+                        type: 'extended-heading',
+                        version: 1,
+                        tag: 'h1'
+                    },
+                    {
+                        children: [
+                            {
+                                detail: 0,
+                                format: 0,
+                                mode: 'normal',
+                                style: '',
+                                text: 'Here is the 3rd paragraph, followed by a linebreak and a list.',
+                                type: 'extended-text',
+                                version: 1
+                            }
+                        ],
+                        direction: null,
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    },
+                    {
+                        children: [
+                            {
+                                checked: undefined,
+                                children: [
+                                    {
+                                        detail: 0,
+                                        format: 0,
+                                        mode: 'normal',
+                                        style: '',
+                                        text: 'List item 1',
+                                        type: 'extended-text',
+                                        version: 1
+                                    }
+                                ],
+                                direction: null,
+                                format: '',
+                                indent: 0,
+                                type: 'listitem',
+                                version: 1,
+                                value: 1
+                            },
+                            {
+                                checked: undefined,
+                                children: [
+                                    {
+                                        detail: 0,
+                                        format: 0,
+                                        mode: 'normal',
+                                        style: '',
+                                        text: 'List item 2',
+                                        type: 'extended-text',
+                                        version: 1
+                                    }
+                                ],
+                                direction: null,
+                                format: '',
+                                indent: 0,
+                                type: 'listitem',
+                                version: 1,
+                                value: 2
+                            }
+                        ],
+                        direction: null,
+                        format: '',
+                        indent: 0,
+                        type: 'list',
+                        version: 1,
+                        listType: 'bullet',
+                        start: 1,
+                        tag: 'ul'
+                    },
+                    {
+                        children: [
+                            {
+                                detail: 0,
+                                format: 0,
+                                mode: 'normal',
+                                style: '',
+                                text: 'Here is the 4th paragraph, NOT followed by linebreaks.',
+                                type: 'extended-text',
+                                version: 1
+                            }
+                        ],
+                        direction: null,
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    },
+                    {
+                        children: [
+                            {
+                                detail: 0,
+                                format: 0,
+                                mode: 'normal',
+                                style: '',
+                                text: 'Here is the 5th paragraph. End of the article.',
                                 type: 'extended-text',
                                 version: 1
                             }

--- a/packages/koenig-lexical/test/e2e/fixtures/paste/google-docs-empty-paragraphs.html
+++ b/packages/koenig-lexical/test/e2e/fixtures/paste/google-docs-empty-paragraphs.html
@@ -1,1 +1,23 @@
-<meta charset='utf-8'><meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-55e5ddb5-7fff-ca77-c112-9a2b907182f6"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">First</span></p><br /><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Second</span></p></b><br class="Apple-interchange-newline">
+<meta charset='utf-8'>
+<meta charset="utf-8">
+<b style="font-weight:normal;" id="docs-internal-guid-53c161b0-7fff-55f3-a893-721115583111">
+    <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
+        <span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Start of the article. Here is the 1st paragraph, followed by a line break then a paragraph.</span>
+    </p>
+    <br />
+    <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 2nd paragraph, followed by a linebreak then a heading.</span></p><br />
+    <h1 dir="ltr" style="line-height:1.38;margin-top:20pt;margin-bottom:6pt;"><span style="font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Heading 1</span></h1><br />
+    <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 3rd paragraph, followed by a linebreak and a list.</span></p><br />
+    <ul style="margin-top:0;margin-bottom:0;padding-inline-start:48px;">
+        <li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1">
+            <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">List item 1</span></p>
+        </li>
+        <li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1">
+            <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">List item 2</span></p>
+        </li>
+    </ul>
+    <br />
+    <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 4th paragraph, NOT followed by linebreaks.</span></p>
+    <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 5th paragraph. End of the article.</span></p>
+</b>
+<br class="Apple-interchange-newline">

--- a/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
@@ -376,10 +376,44 @@ test.describe('Paste behaviour', async () => {
 
             await assertHTML(page, html`
                 <p dir="ltr">
-                    <span data-lexical-text="true">First</span>
+                <span data-lexical-text="true">
+                    Start of the article. Here is the 1st paragraph, followed by a line break then a paragraph.
+                </span>
                 </p>
                 <p dir="ltr">
-                    <span data-lexical-text="true">Second</span>
+                <span data-lexical-text="true">
+                    Here is the 2nd paragraph, followed by a linebreak then a heading.
+                </span>
+                </p>
+                <h1 dir="ltr"><span data-lexical-text="true">Heading 1</span></h1>
+                <p dir="ltr">
+                <span data-lexical-text="true">
+                    Here is the 3rd paragraph, followed by a linebreak and a list.
+                </span>
+                </p>
+                <ul>
+                <li value="1" dir="ltr">
+                    <br />
+                    <span data-lexical-text="true">List item 1</span>
+                    <br />
+                    <span data-lexical-text="true"></span>
+                </li>
+                <li value="2" dir="ltr">
+                    <br />
+                    <span data-lexical-text="true">List item 2</span>
+                    <br />
+                    <span data-lexical-text="true"></span>
+                </li>
+                </ul>
+                <p dir="ltr">
+                <span data-lexical-text="true">
+                    Here is the 4th paragraph, NOT followed by linebreaks.
+                </span>
+                </p>
+                <p dir="ltr">
+                <span data-lexical-text="true">
+                    Here is the 5th paragraph. End of the article.
+                </span>
                 </p>
                 <p><br /></p>
             `);


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/ENG-1480
fixes https://linear.app/tryghost/issue/ENG-1479

- when copy/pasting from Google Docs, empty paragraphs are sometimes created between:
    a) paragraphs and lists
    b) paragraphs and headings
- with this change, single linebreaks between paragraphs and headings/lists are removed when copy/pasting from Gdoc, to avoid creating empty paragraphs