### PR TITLE
Fixed click on visibility settings switching to edit mode

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -41,8 +41,9 @@ const KoenigCardWrapper = ({nodeKey, width, wrapperStyle, IndicatorIcon, childre
                     if (!skipClick.current && containerRef.current.contains(event.target)) {
                         const cardNode = $getNodeByKey(nodeKey);
                         const clickedDifferentEditor = !cardNode;
+                        const clickedToolbar = event.target.closest('[data-kg-allow-clickthrough="false"]');
 
-                        if (isSelected && (cardNode?.hasEditMode?.() && !isEditing)) {
+                        if (isSelected && (cardNode?.hasEditMode?.() && !isEditing && !clickedToolbar)) {
                             editor.dispatchCommand(EDIT_CARD_COMMAND, {cardKey: nodeKey, focusEditor: !clickedDifferentEditor});
                         } else if (!isSelected) {
                             editor.dispatchCommand(SELECT_CARD_COMMAND, {cardKey: nodeKey, focusEditor: !clickedDifferentEditor});

--- a/packages/koenig-lexical/src/components/ui/VisibilityDropdown.jsx
+++ b/packages/koenig-lexical/src/components/ui/VisibilityDropdown.jsx
@@ -11,7 +11,7 @@ export function VisibilityDropdown({editor, nodeKey, visibility, isActive}) {
 
     if (isActive) {
         return (
-            <div className="absolute left-1/2 top-0 z-[1001] flex w-[254px] -translate-x-1/2 flex-col gap-1 rounded-lg bg-white p-6 shadow-md">
+            <div className="absolute left-1/2 top-0 z-[1001] flex w-[254px] -translate-x-1/2 flex-col gap-1 rounded-lg bg-white p-6 shadow-md" data-kg-allow-clickthrough="false" data-testid="visibility-settings">
                 <div className="text-sm font-bold">Visibility</div>
                 <ToggleSetting
                     dataTestId='visibility-toggle-email-only'

--- a/packages/koenig-lexical/src/nodes/HtmlNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/HtmlNodeComponent.jsx
@@ -64,9 +64,7 @@ export function HtmlNodeComponent({nodeKey, html, visibility}) {
             {
                 isContentVisibilityEnabled &&
                 (
-
                     <VisibilityDropdown editor={editor} isActive={showVisibilityDropdown} nodeKey={nodeKey} visibility={visibility} />
-
                 )
             }
 

--- a/packages/koenig-lexical/test/e2e/content-visibility.test.js
+++ b/packages/koenig-lexical/test/e2e/content-visibility.test.js
@@ -29,5 +29,38 @@ test.describe('Content Visibility', async () => {
             await expect(page.locator('[data-kg-card-toolbar="html"]')).toBeVisible();
             await expect(page.locator('[data-kg-card-toolbar="html"] [aria-label="Visibility"]')).toBeVisible();
         });
+
+        test('toolbar shows visibility options on click', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'html'});
+            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
+            await page.keyboard.type('Testing');
+            await page.keyboard.press('Meta+Enter');
+
+            const card = page.locator('[data-kg-card="html"]');
+
+            await card.locator('[aria-label="Visibility"]').click();
+
+            // button is highlighted
+            await expect(card.locator('[aria-label="Visibility"]')).toHaveAttribute('data-kg-active', 'true');
+
+            // settings are visible
+            await expect(card.getByTestId('visibility-settings')).toBeVisible();
+        });
+
+        test('clicking on settings does not transition into edit mode', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'html'});
+            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
+            await page.keyboard.type('Testing');
+            await page.keyboard.press('Meta+Enter');
+
+            const card = page.locator('[data-kg-card="html"]');
+
+            await card.locator('[aria-label="Visibility"]').click();
+            await card.getByTestId('visibility-settings').click();
+
+            await expect(card).toHaveAttribute('data-kg-card-editing', 'false');
+        });
     });
 });


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/PLG-111

- updated card wrapper to ignore clicks when element or a parent has `data-kg-allow-clickthrough="false"`
- added `data-kg-allow-clickthrough="false"` to the visibility dropdown component
