### PR TITLE
Updated content visibility toolbar icon to change when settings change

### DIFF
--- a/packages/kg-default-nodes/lib/generate-decorator-node.js
+++ b/packages/kg-default-nodes/lib/generate-decorator-node.js
@@ -78,6 +78,17 @@ export function generateDecoratorNode({nodeType, properties = [], version = 1}) 
         }
 
         /**
+         * Returns default values for any properties, allowing our editor code
+         * to detect when a property has been changed
+         */
+        static getPropertyDefaults() {
+            return properties.reduce((obj, prop) => {
+                obj[prop.name] = prop.default;
+                return obj;
+            }, {});
+        }
+
+        /**
          * Transforms URLs contained in the payload to relative paths (`__GHOST_URL__/relative/path/`),
          * so that URLs to be changed without having to update the database
          * @see https://github.com/TryGhost/SDK/tree/main/packages/url-utils

--- a/packages/kg-default-nodes/test/nodes/html.test.js
+++ b/packages/kg-default-nodes/test/nodes/html.test.js
@@ -95,6 +95,20 @@ describe('HtmlNode', function () {
         }));
     });
 
+    describe('getPropertyDefaults', function () {
+        it('returns the correct default values', editorTest(function () {
+            const defaults = HtmlNode.getPropertyDefaults();
+
+            defaults.should.deepEqual({
+                html: '',
+                visibility: {
+                    emailOnly: false,
+                    segment: ''
+                }
+            });
+        }));
+    });
+
     describe('clone', function () {
         it('returns a copy of the current node', editorTest(function () {
             const htmlNode = $createHtmlNode(dataset);
@@ -190,7 +204,7 @@ describe('HtmlNode', function () {
             const options = {
                 target: 'email'
             };
-            const mergedOptions = {...exportOptions, ...options}; 
+            const mergedOptions = {...exportOptions, ...options};
             const {element, type} = htmlNode.exportDOM(mergedOptions);
             type.should.equal('html');
 

--- a/packages/koenig-lexical/src/assets/icons/kg-eye-closed.svg
+++ b/packages/koenig-lexical/src/assets/icons/kg-eye-closed.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M9 20.421c.94.364 1.943.579 3 .579 5.181 0 9.054-5.164 10.627-7.67A2.52 2.52 0 0 0 23 12c0-.476-.13-.94-.373-1.33-.4-.637-.947-1.445-1.627-2.296M5.632 18.363c-1.962-1.652-3.43-3.712-4.26-5.032A2.528 2.528 0 0 1 1 12c0-.476.13-.94.373-1.33C2.946 8.163 6.819 3 12 3c2.412 0 4.541 1.12 6.286 2.569"/>
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M17 12a5 5 0 0 1-5 5m-3.57-1.5a5 5 0 0 1 7.07-7.07M2 22 22 2"/>
+</svg>

--- a/packages/koenig-lexical/src/components/ui/ToolbarMenu.jsx
+++ b/packages/koenig-lexical/src/components/ui/ToolbarMenu.jsx
@@ -1,6 +1,7 @@
 import AddIcon from '../../assets/icons/kg-add.svg?react';
 import BoldIcon from '../../assets/icons/kg-bold.svg?react';
 import EditIcon from '../../assets/icons/kg-edit.svg?react';
+import EyeClosedIcon from '../../assets/icons/kg-eye-closed.svg?react';
 import EyeIcon from '../../assets/icons/kg-eye.svg?react';
 import HeadingThreeIcon from '../../assets/icons/kg-heading-3.svg?react';
 import HeadingTwoIcon from '../../assets/icons/kg-heading-2.svg?react';
@@ -35,6 +36,7 @@ export const TOOLBAR_ICONS = {
     edit: EditIcon,
     wand: WandIcon,
     visibility: EyeIcon,
+    visibilityActive: EyeClosedIcon,
     snippet: SnippetIcon,
     remove: TrashIcon
 };

--- a/packages/koenig-lexical/src/nodes/HtmlNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/HtmlNodeComponent.jsx
@@ -5,6 +5,7 @@ import {$getNodeByKey} from 'lexical';
 import {ActionToolbar} from '../components/ui/ActionToolbar.jsx';
 import {DESELECT_CARD_COMMAND, EDIT_CARD_COMMAND} from '../plugins/KoenigBehaviourPlugin.jsx';
 import {HtmlCard} from '../components/ui/cards/HtmlCard';
+import {HtmlNode} from './HtmlNode.jsx';
 import {SnippetActionToolbar} from '../components/ui/SnippetActionToolbar.jsx';
 import {ToolbarMenu, ToolbarMenuItem, ToolbarMenuSeparator} from '../components/ui/ToolbarMenu.jsx';
 import {VisibilityDropdown} from '../components/ui/VisibilityDropdown.jsx';
@@ -14,9 +15,12 @@ export function HtmlNodeComponent({nodeKey, html, visibility}) {
     const [editor] = useLexicalComposerContext();
     const cardContext = React.useContext(CardContext);
     const {cardConfig, darkMode} = React.useContext(KoenigComposerContext);
+
     const [showSnippetToolbar, setShowSnippetToolbar] = React.useState(false);
-    const isContentVisibilityEnabled = cardConfig?.feature?.contentVisibility || false;
     const [showVisibilityDropdown, setShowVisibilityDropdown] = React.useState(false);
+
+    const isContentVisibilityEnabled = cardConfig?.feature?.contentVisibility || false;
+    const isContentVisibilityActive = JSON.stringify(visibility) !== JSON.stringify(HtmlNode.getPropertyDefaults().visibility);
 
     const updateHtml = (value) => {
         editor.update(() => {
@@ -85,7 +89,12 @@ export function HtmlNodeComponent({nodeKey, html, visibility}) {
                     {
                         isContentVisibilityEnabled &&
                         <>
-                            <ToolbarMenuItem icon="visibility" isActive={showVisibilityDropdown && cardContext.isSelected} label="Visibility" onClick={handleVisibilityToggle} />
+                            <ToolbarMenuItem
+                                icon={isContentVisibilityActive ? 'visibilityActive' : 'visibility'}
+                                isActive={isContentVisibilityActive}
+                                label="Visibility"
+                                onClick={handleVisibilityToggle}
+                            />
                             <ToolbarMenuSeparator hide={!cardConfig.createSnippet} />
                         </>
                     }

--- a/packages/koenig-lexical/test/e2e/content-visibility.test.js
+++ b/packages/koenig-lexical/test/e2e/content-visibility.test.js
@@ -41,9 +41,6 @@ test.describe('Content Visibility', async () => {
 
             await card.locator('[aria-label="Visibility"]').click();
 
-            // button is highlighted
-            await expect(card.locator('[aria-label="Visibility"]')).toHaveAttribute('data-kg-active', 'true');
-
             // settings are visible
             await expect(card.getByTestId('visibility-settings')).toBeVisible();
         });
@@ -61,6 +58,25 @@ test.describe('Content Visibility', async () => {
             await card.getByTestId('visibility-settings').click();
 
             await expect(card).toHaveAttribute('data-kg-card-editing', 'false');
+        });
+
+        test('changing a setting puts icon in active state', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'html'});
+            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
+            await page.keyboard.type('Testing');
+            await page.keyboard.press('Meta+Enter');
+
+            const card = page.locator('[data-kg-card="html"]');
+
+            // button is not highlighted
+            await expect(card.locator('[aria-label="Visibility"]')).toHaveAttribute('data-kg-active', 'false');
+
+            await card.locator('[aria-label="Visibility"]').click();
+            await card.locator('[data-testid="visibility-toggle-email-only"]').click();
+
+            // button is highlighted
+            await expect(card.locator('[aria-label="Visibility"]')).toHaveAttribute('data-kg-active', 'true');
         });
     });
 });


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/PLG-108

- added static `getPropertyDefaults()` method to our default decorator node factory
  - returns an object with the property names as the key and its default value as the value
- updated the html card toolbar's visibility icon to be active when the visibility settings have diverged from the default
- updated the toolbar icon to switch to an eye-closed icon when active
