### PR TITLE
Fixed incorrect usage of .should.be.true/false in tests

### DIFF
--- a/packages/kg-default-cards/test/lib/utils/is-local-content-image.test.js
+++ b/packages/kg-default-cards/test/lib/utils/is-local-content-image.test.js
@@ -7,34 +7,34 @@ const isLocalContentImage = require('../../../lib/utils/is-local-content-image')
 describe('Utils: isLocalContentImage', function () {
     describe('relative url', function () {
         it('returns true for root content image path', function () {
-            isLocalContentImage('/content/images/test.jpg').should.be.true;
+            isLocalContentImage('/content/images/test.jpg').should.be.true();
         });
 
         it('returns true for subdir content image path', function () {
-            isLocalContentImage('/subdir/content/images/test.jpg').should.be.true;
-            isLocalContentImage('/subdir/nested/content/images/test.jpg').should.be.true;
+            isLocalContentImage('/subdir/content/images/test.jpg').should.be.true();
+            isLocalContentImage('/subdir/nested/content/images/test.jpg').should.be.true();
         });
 
         it('returns false for non-matching content image path', function () {
-            isLocalContentImage('/images/test.jpg').should.be.false;
+            isLocalContentImage('/images/test.jpg').should.be.false();
         });
     });
 
     describe('absolute url', function () {
         it('returns true for local image if matching siteUrl is supplied', function () {
-            isLocalContentImage('https://test.com/content/images/test.jpg', 'https://test.com').should.be.true;
+            isLocalContentImage('https://test.com/content/images/test.jpg', 'https://test.com').should.be.true();
         });
 
         it('returns true for local image if matching siteUrl is supplied with trailing slash', function () {
-            isLocalContentImage('https://test.com/content/images/test.jpg', 'https://test.com/').should.be.true;
+            isLocalContentImage('https://test.com/content/images/test.jpg', 'https://test.com/').should.be.true();
         });
 
         it('returns false for local image if non-matching siteUrl is supplied', function () {
-            isLocalContentImage('https://test.com/content/images/test.jpg', 'https://example.com').should.be.false;
+            isLocalContentImage('https://test.com/content/images/test.jpg', 'https://example.com').should.be.false();
         });
 
         it('returns false for local image if siteUrl is not supplied', function () {
-            isLocalContentImage('https://test.com/content/images/test.jpg').should.be.false;
+            isLocalContentImage('https://test.com/content/images/test.jpg').should.be.false();
         });
     });
 });

--- a/packages/kg-default-cards/test/lib/utils/is-unsplash-image.test.js
+++ b/packages/kg-default-cards/test/lib/utils/is-unsplash-image.test.js
@@ -6,10 +6,10 @@ const isUnsplashImage = require('../../../lib/utils/is-unsplash-image');
 
 describe('Utils: isUnsplashImage', function () {
     it('returns true when url matches unsplash url', function () {
-        isUnsplashImage('https://images.unsplash.com/test').should.be.true;
+        isUnsplashImage('https://images.unsplash.com/test').should.be.true();
     });
 
     it('returns false when url does not match unsplash url', function () {
-        isUnsplashImage('https://images.example.com/test').should.be.false;
+        isUnsplashImage('https://images.example.com/test').should.be.false();
     });
 });

--- a/packages/kg-default-nodes/test/nodes/aside.test.js
+++ b/packages/kg-default-nodes/test/nodes/aside.test.js
@@ -32,7 +32,7 @@ describe('AsideNode', function () {
 
     it('matches node with $isAsideNode', editorTest(function () {
         const asideNode = $createAsideNode();
-        $isAsideNode(asideNode).should.be.true;
+        $isAsideNode(asideNode).should.be.true();
     }));
 
     describe('importDOM', function () {

--- a/packages/kg-default-nodes/test/nodes/at-link-search.test.js
+++ b/packages/kg-default-nodes/test/nodes/at-link-search.test.js
@@ -39,7 +39,7 @@ describe('AtLinkSearchNode', function () {
 
     it('matches node with $isAtLinkSearchNode', editorTest(function () {
         const atLinkSearchNode = $createAtLinkSearchNode();
-        $isAtLinkSearchNode(atLinkSearchNode).should.be.true;
+        $isAtLinkSearchNode(atLinkSearchNode).should.be.true();
     }));
 
     it('can be constructed with text and placeholder', editorTest(function () {
@@ -80,8 +80,8 @@ describe('AtLinkSearchNode', function () {
     it('renders using theme classes and default placeholder', editorTest(function () {
         const atLinkNode = $createAtLinkSearchNode();
         const dom = atLinkNode.createDOM(config);
-        dom.classList.contains('multiple').should.be.true;
-        dom.classList.contains('classes').should.be.true;
+        dom.classList.contains('multiple').should.be.true();
+        dom.classList.contains('classes').should.be.true();
         dom.dataset.placeholder.should.equal('Find a post, tag or author');
     }));
 
@@ -134,7 +134,7 @@ describe('AtLinkSearchNode', function () {
 
     it('cannot have format', editorTest(function () {
         const atLinkSearchNode = $createAtLinkSearchNode();
-        atLinkSearchNode.canHaveFormat().should.be.false;
+        atLinkSearchNode.canHaveFormat().should.be.false();
     }));
 
     it('can set custom placeholder', editorTest(function () {

--- a/packages/kg-default-nodes/test/nodes/at-link.test.js
+++ b/packages/kg-default-nodes/test/nodes/at-link.test.js
@@ -39,7 +39,7 @@ describe('AtLinkNode', function () {
 
     it('matches node with $isAtLinkNode', editorTest(function () {
         const atLinkNode = $createAtLinkNode();
-        $isAtLinkNode(atLinkNode).should.be.true;
+        $isAtLinkNode(atLinkNode).should.be.true();
     }));
 
     it('can be constructed with link format', editorTest(function () {
@@ -79,13 +79,13 @@ describe('AtLinkNode', function () {
             {theme: {atLink: 'multiple classes'}},
             editor
         );
-        dom.classList.contains('multiple').should.be.true;
-        dom.classList.contains('classes').should.be.true;
+        dom.classList.contains('multiple').should.be.true();
+        dom.classList.contains('classes').should.be.true();
     }));
 
     it('never updates dom after creation', editorTest(function () {
         const atLinkNode = $createAtLinkNode();
-        atLinkNode.updateDOM().should.be.false;
+        atLinkNode.updateDOM().should.be.false();
     }));
 
     it('can get and set link format', editorTest(function () {
@@ -110,11 +110,11 @@ describe('AtLinkNode', function () {
 
     it('is inline', editorTest(function () {
         const atLinkNode = $createAtLinkNode();
-        atLinkNode.isInline().should.be.true;
+        atLinkNode.isInline().should.be.true();
     }));
 
     it('cannot be empty', editorTest(function () {
         const atLinkNode = $createAtLinkNode();
-        atLinkNode.canBeEmpty().should.be.false;
+        atLinkNode.canBeEmpty().should.be.false();
     }));
 });

--- a/packages/kg-default-nodes/test/nodes/audio.test.js
+++ b/packages/kg-default-nodes/test/nodes/audio.test.js
@@ -44,7 +44,7 @@ describe('AudioNode', function () {
 
     it('matches node with $isAudioNode', editorTest(function () {
         const audioNode = $createAudioNode(dataset);
-        $isAudioNode(audioNode).should.be.true;
+        $isAudioNode(audioNode).should.be.true();
     }));
 
     describe('data access', function () {
@@ -120,7 +120,7 @@ describe('AudioNode', function () {
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const audioNode = $createAudioNode(dataset);
-            audioNode.hasEditMode().should.be.true;
+            audioNode.hasEditMode().should.be.true();
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/bookmark.test.js
+++ b/packages/kg-default-nodes/test/nodes/bookmark.test.js
@@ -50,7 +50,7 @@ describe('BookmarkNode', function () {
 
     it('matches node with $isBookmarkNode', editorTest(function () {
         const bookmarkNode = $createBookmarkNode(dataset);
-        $isBookmarkNode(bookmarkNode).should.be.true;
+        $isBookmarkNode(bookmarkNode).should.be.true();
     }));
 
     describe('data access', function () {
@@ -143,7 +143,7 @@ describe('BookmarkNode', function () {
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const bookmarkNode = $createBookmarkNode(dataset);
-            bookmarkNode.hasEditMode().should.be.true;
+            bookmarkNode.hasEditMode().should.be.true();
         }));
     });
 
@@ -151,9 +151,9 @@ describe('BookmarkNode', function () {
         it('returns true if url is empty', editorTest(function () {
             const bookmarkNode = $createBookmarkNode(dataset);
 
-            bookmarkNode.isEmpty().should.be.false;
+            bookmarkNode.isEmpty().should.be.false();
             bookmarkNode.url = '';
-            bookmarkNode.isEmpty().should.be.true;
+            bookmarkNode.isEmpty().should.be.true();
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/button.test.js
+++ b/packages/kg-default-nodes/test/nodes/button.test.js
@@ -40,7 +40,7 @@ describe('ButtonNode', function () {
 
     it('matches node with $isButtonNode', editorTest(function () {
         const buttonNode = $createButtonNode(dataset);
-        $isButtonNode(buttonNode).should.be.true;
+        $isButtonNode(buttonNode).should.be.true();
     }));
 
     describe('data access', function () {
@@ -106,7 +106,7 @@ describe('ButtonNode', function () {
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const buttonNode = $createButtonNode(dataset);
-            buttonNode.hasEditMode().should.be.true;
+            buttonNode.hasEditMode().should.be.true();
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/callout.test.js
+++ b/packages/kg-default-nodes/test/nodes/callout.test.js
@@ -43,7 +43,7 @@ describe('CalloutNode', function () {
 
     it('can match node with calloutNode', editorTest(function () {
         const node = $createCalloutNode(dataset);
-        $isCalloutNode(node).should.be.true;
+        $isCalloutNode(node).should.be.true();
     }));
 
     describe('data access', function (){
@@ -97,7 +97,7 @@ describe('CalloutNode', function () {
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const calloutNode = $createCalloutNode(dataset);
-            calloutNode.hasEditMode().should.be.true;
+            calloutNode.hasEditMode().should.be.true();
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/codeblock.test.js
+++ b/packages/kg-default-nodes/test/nodes/codeblock.test.js
@@ -48,7 +48,7 @@ describe('CodeBlockNode', function () {
 
     it('matches node with $isCodeBlockNode', editorTest(function () {
         const codeBlockNode = $createCodeBlockNode({language, code, caption});
-        $isCodeBlockNode(codeBlockNode).should.be.true;
+        $isCodeBlockNode(codeBlockNode).should.be.true();
     }));
 
     describe('importJSON', function () {
@@ -156,9 +156,9 @@ describe('CodeBlockNode', function () {
         it('returns true if markdown is empty', editorTest(function () {
             const codeBlockNode = $createCodeBlockNode(dataset);
 
-            codeBlockNode.isEmpty().should.be.false;
-            codeBlockNode.markdown = '';
-            codeBlockNode.isEmpty().should.be.true;
+            codeBlockNode.isEmpty().should.be.false();
+            codeBlockNode.code = '';
+            codeBlockNode.isEmpty().should.be.true();
         }));
     });
 
@@ -190,7 +190,7 @@ describe('CodeBlockNode', function () {
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const codeBlockNode = $createCodeBlockNode(dataset);
-            codeBlockNode.hasEditMode().should.be.true;
+            codeBlockNode.hasEditMode().should.be.true();
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/collection.test.js
+++ b/packages/kg-default-nodes/test/nodes/collection.test.js
@@ -73,7 +73,7 @@ describe('CollectionNode', function () {
 
     it('matches node with $isCollectionNode', editorTest(function () {
         const collectionNode = $createCollectionNode(dataset);
-        $isCollectionNode(collectionNode).should.be.true;
+        $isCollectionNode(collectionNode).should.be.true();
     }));
 
     describe('data access', function () {
@@ -127,7 +127,7 @@ describe('CollectionNode', function () {
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const collectionNode = $createCollectionNode(dataset);
-            collectionNode.hasEditMode().should.be.true;
+            collectionNode.hasEditMode().should.be.true();
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/email-cta.test.js
+++ b/packages/kg-default-nodes/test/nodes/email-cta.test.js
@@ -44,7 +44,7 @@ describe('EmailCtaNode', function () {
 
     it('matches node with $isEmailCtaNode', editorTest(function () {
         const emailCtaNode = $createEmailCtaNode(dataset);
-        $isEmailCtaNode(emailCtaNode).should.be.true;
+        $isEmailCtaNode(emailCtaNode).should.be.true();
     }));
 
     describe('data access', function () {
@@ -131,7 +131,7 @@ describe('EmailCtaNode', function () {
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const emailCtaNode = $createEmailCtaNode(dataset);
-            emailCtaNode.hasEditMode().should.be.true;
+            emailCtaNode.hasEditMode().should.be.true();
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/email.test.js
+++ b/packages/kg-default-nodes/test/nodes/email.test.js
@@ -38,7 +38,7 @@ describe('EmailNode', function () {
 
     it('matches node with $isEmailNode', editorTest(function () {
         const emailNode = $createEmailNode(dataset);
-        $isEmailNode(emailNode).should.be.true;
+        $isEmailNode(emailNode).should.be.true();
     }));
 
     describe('data access', function () {
@@ -94,7 +94,7 @@ describe('EmailNode', function () {
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const emailNode = $createEmailNode(dataset);
-            emailNode.hasEditMode().should.be.true;
+            emailNode.hasEditMode().should.be.true();
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/embed.test.js
+++ b/packages/kg-default-nodes/test/nodes/embed.test.js
@@ -64,7 +64,7 @@ describe('EmbedNode', function () {
 
     it('matches node with $isEmbedNode', editorTest(function () {
         const embedNode = $createEmbedNode(dataset);
-        $isEmbedNode(embedNode).should.be.true;
+        $isEmbedNode(embedNode).should.be.true();
     }));
 
     describe('data access', function () {
@@ -140,20 +140,20 @@ describe('EmbedNode', function () {
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const embedNode = $createEmbedNode(dataset);
-            embedNode.hasEditMode().should.be.true;
+            embedNode.hasEditMode().should.be.true();
         }));
     });
 
     describe('isEmpty', function () {
-        it('returns true if url or html are empty', editorTest(function () {
+        it('returns true if url and html are empty', editorTest(function () {
             const embedNode = $createEmbedNode(dataset);
 
-            embedNode.isEmpty().should.be.false;
+            embedNode.isEmpty().should.be.false();
             embedNode.url = '';
-            embedNode.isEmpty().should.be.true;
-            embedNode.url = dataset.url;
+            embedNode.isEmpty().should.be.false();
+            embedNode.url = '';
             embedNode.html = '';
-            embedNode.isEmpty().should.be.true;
+            embedNode.isEmpty().should.be.true();
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/file.test.js
+++ b/packages/kg-default-nodes/test/nodes/file.test.js
@@ -44,7 +44,7 @@ describe('FileNode', function () {
 
     it('can match node with FileNode', editorTest(function () {
         const node = $createFileNode(dataset);
-        $isFileNode(node).should.be.true;
+        $isFileNode(node).should.be.true();
     }));
 
     describe('data access', function (){
@@ -117,7 +117,7 @@ describe('FileNode', function () {
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const fileNode = $createFileNode(dataset);
-            fileNode.hasEditMode().should.be.true;
+            fileNode.hasEditMode().should.be.true();
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/gallery.test.js
+++ b/packages/kg-default-nodes/test/nodes/gallery.test.js
@@ -175,7 +175,7 @@ describe('GalleryNode', function () {
     describe('hasEditMode', function () {
         it('returns false', editorTest(function () {
             const galleryNode = $createGalleryNode(dataset);
-            galleryNode.hasEditMode().should.be.false;
+            galleryNode.hasEditMode().should.be.false();
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/header.test.js
+++ b/packages/kg-default-nodes/test/nodes/header.test.js
@@ -45,7 +45,7 @@ describe('HeaderNode', function () {
 
         it('matches node with $isHeaderNode', editorTest(function () {
             const headerNode = $createHeaderNode(dataset);
-            $isHeaderNode(headerNode).should.be.true;
+            $isHeaderNode(headerNode).should.be.true();
         }));
 
         describe('data access', function () {
@@ -128,7 +128,7 @@ describe('HeaderNode', function () {
         describe('hasEditMode', function () {
             it('returns true', editorTest(function () {
                 const headerNode = $createHeaderNode(dataset);
-                headerNode.hasEditMode().should.be.true;
+                headerNode.hasEditMode().should.be.true();
             }));
         });
 
@@ -210,7 +210,7 @@ describe('HeaderNode', function () {
                 node.backgroundImageSrc.should.equal('https://example.com/image.jpg');
                 node.header.should.equal('Header');
                 node.subheader.should.equal('Subheader');
-                node.buttonEnabled.should.be.true;
+                node.buttonEnabled.should.be.true();
                 node.buttonUrl.should.equal('https://example.com');
                 node.buttonText.should.equal('Button');
             }));
@@ -298,7 +298,7 @@ describe('HeaderNode', function () {
 
         it('matches node with $isHeaderNode', editorTest(function () {
             const headerNode = $createHeaderNode(dataset);
-            $isHeaderNode(headerNode).should.be.true;
+            $isHeaderNode(headerNode).should.be.true();
         }));
 
         describe('data access', function () {
@@ -306,7 +306,7 @@ describe('HeaderNode', function () {
                 const node = $createHeaderNode(dataset);
                 node.version.should.equal(2);
                 node.backgroundImageSrc.should.equal('https://example.com/image.jpg');
-                node.buttonEnabled.should.be.true;
+                node.buttonEnabled.should.be.true();
                 node.buttonText.should.equal('The button');
                 node.buttonUrl.should.equal('https://example.com/');
                 node.header.should.equal('This is the header card');
@@ -318,7 +318,7 @@ describe('HeaderNode', function () {
                 node.buttonColor.should.equal('#000000');
                 node.buttonTextColor.should.equal('#FFFFFF');
                 node.layout.should.equal('full');
-                node.swapped.should.be.false;
+                node.swapped.should.be.false();
             }));
 
             it('has setters for all properties', editorTest(function () {
@@ -339,7 +339,7 @@ describe('HeaderNode', function () {
                 node.swapped = true;
 
                 node.backgroundImageSrc.should.equal('https://example.com/image2.jpg');
-                node.buttonEnabled.should.be.false;
+                node.buttonEnabled.should.be.false();
                 node.buttonText.should.equal('The button 2');
                 node.buttonUrl.should.equal('https://example.com/2');
                 node.header.should.equal('This is the header card 2');
@@ -351,7 +351,7 @@ describe('HeaderNode', function () {
                 node.buttonColor.should.equal('#000001');
                 node.buttonTextColor.should.equal('#FFFFFF');
                 node.layout.should.equal('full');
-                node.swapped.should.be.true;
+                node.swapped.should.be.true();
             }));
         });
 
@@ -380,7 +380,7 @@ describe('HeaderNode', function () {
                 node.textColor.should.equal('#abcdef');
                 node.header.should.equal('Header');
                 node.subheader.should.equal('Subheader');
-                node.buttonEnabled.should.be.true;
+                node.buttonEnabled.should.be.true();
                 node.buttonUrl.should.equal('https://example.com');
                 node.buttonText.should.equal('Button');
                 node.buttonTextColor.should.equal('#abcdef');
@@ -433,7 +433,7 @@ describe('HeaderNode', function () {
         describe('hasEditMode', function () {
             it('returns true', editorTest(function () {
                 const headerNode = $createHeaderNode(dataset);
-                headerNode.hasEditMode().should.be.true;
+                headerNode.hasEditMode().should.be.true();
             }));
         });
 

--- a/packages/kg-default-nodes/test/nodes/horizontalrule.test.js
+++ b/packages/kg-default-nodes/test/nodes/horizontalrule.test.js
@@ -37,7 +37,7 @@ describe('HorizontalNode', function () {
 
     it('matches node with $isHorizontalRuleNode', editorTest(function () {
         const hrNode = $createHorizontalRuleNode();
-        $isHorizontalRuleNode(hrNode).should.be.true;
+        $isHorizontalRuleNode(hrNode).should.be.true();
     }));
 
     describe('exportDOM', function () {

--- a/packages/kg-default-nodes/test/nodes/html.test.js
+++ b/packages/kg-default-nodes/test/nodes/html.test.js
@@ -39,7 +39,7 @@ describe('HtmlNode', function () {
 
     it('matches node with $isImageNode', editorTest(function () {
         const htmlNode = $createHtmlNode(dataset);
-        $isHtmlNode(htmlNode).should.be.true;
+        $isHtmlNode(htmlNode).should.be.true();
     }));
 
     describe('data access', function () {
@@ -74,9 +74,9 @@ describe('HtmlNode', function () {
         it('has isEmpty() convenience method', editorTest(function () {
             const htmlNode = $createHtmlNode(dataset);
 
-            htmlNode.isEmpty().should.be.false;
+            htmlNode.isEmpty().should.be.false();
             htmlNode.html = '';
-            htmlNode.isEmpty().should.be.true;
+            htmlNode.isEmpty().should.be.true();
         }));
     });
 
@@ -84,9 +84,9 @@ describe('HtmlNode', function () {
         it('returns true if markdown is empty', editorTest(function () {
             const htmlNode = $createHtmlNode(dataset);
 
-            htmlNode.isEmpty().should.be.false;
-            htmlNode.markdown = '';
-            htmlNode.isEmpty().should.be.true;
+            htmlNode.isEmpty().should.be.false();
+            htmlNode.html = '';
+            htmlNode.isEmpty().should.be.true();
         }));
     });
 
@@ -133,7 +133,7 @@ describe('HtmlNode', function () {
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const htmlNode = $createHtmlNode(dataset);
-            htmlNode.hasEditMode().should.be.true;
+            htmlNode.hasEditMode().should.be.true();
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/image.test.js
+++ b/packages/kg-default-nodes/test/nodes/image.test.js
@@ -54,7 +54,7 @@ describe('ImageNode', function () {
 
     it('matches node with $isImageNode', editorTest(function () {
         const imageNode = $createImageNode(dataset);
-        $isImageNode(imageNode).should.be.true;
+        $isImageNode(imageNode).should.be.true();
     }));
 
     describe('data access', function () {

--- a/packages/kg-default-nodes/test/nodes/markdown.test.js
+++ b/packages/kg-default-nodes/test/nodes/markdown.test.js
@@ -38,7 +38,7 @@ describe('MarkdownNode', function () {
 
     it('matches node with $isImageNode', editorTest(function () {
         const markdownNode = $createMarkdownNode(dataset);
-        $isMarkdownNode(markdownNode).should.be.true;
+        $isMarkdownNode(markdownNode).should.be.true();
     }));
 
     describe('data access', function () {
@@ -70,9 +70,9 @@ describe('MarkdownNode', function () {
         it('returns true if markdown is empty', editorTest(function () {
             const markdownNode = $createMarkdownNode(dataset);
 
-            markdownNode.isEmpty().should.be.false;
+            markdownNode.isEmpty().should.be.false();
             markdownNode.markdown = '';
-            markdownNode.isEmpty().should.be.true;
+            markdownNode.isEmpty().should.be.true();
         }));
     });
 
@@ -104,7 +104,7 @@ describe('MarkdownNode', function () {
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const markdownNode = $createMarkdownNode(dataset);
-            markdownNode.hasEditMode().should.be.true;
+            markdownNode.hasEditMode().should.be.true();
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/paywall.test.js
+++ b/packages/kg-default-nodes/test/nodes/paywall.test.js
@@ -40,7 +40,7 @@ describe('PaywallNode', function () {
 
     it('matches node with $isPaywallNode', editorTest(function () {
         const paywallNode = $createPaywallNode(dataset);
-        $isPaywallNode(paywallNode).should.be.true;
+        $isPaywallNode(paywallNode).should.be.true();
     }));
 
     describe('exportJSON', function () {

--- a/packages/kg-default-nodes/test/nodes/product.test.js
+++ b/packages/kg-default-nodes/test/nodes/product.test.js
@@ -60,7 +60,7 @@ describe('ProductNode', function () {
 
     it('matches node with $isProductNode', editorTest(function () {
         const productNode = $createProductNode(dataset);
-        $isProductNode(productNode).should.be.true;
+        $isProductNode(productNode).should.be.true();
     }));
 
     describe('data access', function () {

--- a/packages/kg-default-nodes/test/nodes/signup.test.js
+++ b/packages/kg-default-nodes/test/nodes/signup.test.js
@@ -50,7 +50,7 @@ describe('SignupNode', function () {
 
     it('matches node with $isSignupNode', editorTest(function () {
         const signupNode = $createSignupNode(dataset);
-        $isSignupNode(signupNode).should.be.true;
+        $isSignupNode(signupNode).should.be.true();
     }));
 
     describe('clone', function () {
@@ -66,7 +66,7 @@ describe('SignupNode', function () {
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const signupNode = $createSignupNode(dataset);
-            signupNode.hasEditMode().should.be.true;
+            signupNode.hasEditMode().should.be.true();
         }));
     });
 
@@ -674,7 +674,7 @@ describe('SignupNode', function () {
                 try {
                     const [signupNode] = $getRoot().getChildren();
 
-                    $isSignupNode(signupNode).should.be.true;
+                    $isSignupNode(signupNode).should.be.true();
                     done();
                 } catch (e) {
                     done(e);

--- a/packages/kg-default-nodes/test/nodes/tk.test.js
+++ b/packages/kg-default-nodes/test/nodes/tk.test.js
@@ -27,17 +27,17 @@ describe('TKNode', function () {
 
     it('matches node with $isTKNode', editorTest(function () {
         const tkNode = $createTKNode();
-        $isTKNode(tkNode).should.be.true;
+        $isTKNode(tkNode).should.be.true();
     }));
 
     it('is a text entity', editorTest(function () {
         const tkNode = $createTKNode();
-        tkNode.isTextEntity().should.be.true;
+        tkNode.isTextEntity().should.be.true();
     }));
 
     it('can not insert text before', editorTest(function () {
         const tkNode = $createTKNode();
-        tkNode.canInsertTextBefore().should.be.false;
+        tkNode.canInsertTextBefore().should.be.false();
     }));
 
     describe('exportJSON', function () {

--- a/packages/kg-default-nodes/test/nodes/toggle.test.js
+++ b/packages/kg-default-nodes/test/nodes/toggle.test.js
@@ -43,7 +43,7 @@ describe('ToggleNode', function () {
 
     it('matches node with $isToggleNode', editorTest(function () {
         const toggleNode = $createToggleNode(dataset);
-        $isToggleNode(toggleNode).should.be.true;
+        $isToggleNode(toggleNode).should.be.true();
     }));
 
     describe('data access', function () {
@@ -105,7 +105,7 @@ describe('ToggleNode', function () {
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const toggleNode = $createToggleNode(dataset);
-            toggleNode.hasEditMode().should.be.true;
+            toggleNode.hasEditMode().should.be.true();
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/video.test.js
+++ b/packages/kg-default-nodes/test/nodes/video.test.js
@@ -49,7 +49,7 @@ describe('VideoNode', function () {
 
     it('matches node with $isVideoNode', editorTest(function () {
         const videoNode = $createVideoNode(dataset);
-        $isVideoNode(videoNode).should.be.true;
+        $isVideoNode(videoNode).should.be.true();
     }));
 
     describe('data access', function () {
@@ -68,7 +68,7 @@ describe('VideoNode', function () {
             videoNode.thumbnailWidth.should.equal(dataset.thumbnailWidth);
             videoNode.thumbnailHeight.should.equal(dataset.thumbnailHeight);
             videoNode.cardWidth.should.equal('regular');
-            videoNode.loop.should.be.false;
+            videoNode.loop.should.be.false();
         }));
 
         it('has setters for all properties', editorTest(function () {
@@ -122,9 +122,9 @@ describe('VideoNode', function () {
             videoNode.cardWidth = 'wide';
             videoNode.cardWidth.should.equal('wide');
 
-            videoNode.loop.should.be.false;
+            videoNode.loop.should.be.false();
             videoNode.loop = true;
-            videoNode.loop.should.be.true;
+            videoNode.loop.should.be.true();
         }));
 
         it('has getDataset() convenience method', editorTest(function () {
@@ -219,7 +219,7 @@ describe('VideoNode', function () {
                     videoNode.thumbnailWidth.should.equal(dataset.thumbnailWidth);
                     videoNode.thumbnailHeight.should.equal(dataset.thumbnailHeight);
                     videoNode.cardWidth.should.equal('wide');
-                    videoNode.loop.should.be.true;
+                    videoNode.loop.should.be.true();
 
                     done();
                 } catch (e) {
@@ -373,7 +373,7 @@ describe('VideoNode', function () {
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const videoNode = $createVideoNode(dataset);
-            videoNode.hasEditMode().should.be.true;
+            videoNode.hasEditMode().should.be.true();
         }));
     });
 
@@ -390,7 +390,7 @@ describe('VideoNode', function () {
             nodes[0].thumbnailSrc.should.equal('/content/images/2022/11/koenig-lexical.jpg');
             nodes[0].customThumbnailSrc.should.equal('');
             nodes[0].duration.should.equal(60);
-            nodes[0].loop.should.be.false;
+            nodes[0].loop.should.be.false();
             nodes[0].caption.should.equal('Video caption');
             nodes[0].cardWidth.should.equal('regular');
         }));

--- a/packages/kg-default-nodes/test/nodes/zwnj.test.js
+++ b/packages/kg-default-nodes/test/nodes/zwnj.test.js
@@ -27,6 +27,6 @@ describe('ZWNJNode', function () {
 
     it('matches node with $isZWNJNode', editorTest(function () {
         const zwnjNode = $createZWNJNode();
-        $isZWNJNode(zwnjNode).should.be.true;
+        $isZWNJNode(zwnjNode).should.be.true();
     }));
 });


### PR DESCRIPTION
no issue

- it's necessary to use `.true()` or `.false()` otherwise the test assertion will always pass
- replaced all uses of the direct property with function calls
- updated tests that had incorrect previously-passing assertions
