### PR TITLE
Hides free/paid choice if Stripe not is connected from Content Visibility

### DIFF
--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -46,6 +46,7 @@ const defaultCardConfig = {
     siteDescription: `There's a whole lot to discover in this editor. Let us help you settle in.`,
     siteUrl: window.location.origin,
     membersEnabled: true,
+    stripeEnabled: true,
     feature: {
         collections: true,
         collectionsCard: true,
@@ -307,9 +308,11 @@ function DemoComposer({editorType, isMultiplayer, setWordCount, setTKCount}) {
         collections,
         fetchCollectionPosts,
         feature: {
-            ...defaultCardConfig.feature
+            ...defaultCardConfig.feature,
+            contentVisibility: searchParams.get('labs')?.includes('contentVisibility') || defaultCardConfig.feature.contentVisibility
         },
-        searchLinks: searchParams.get('searchLinks') === 'false' ? undefined : defaultCardConfig.searchLinks
+        searchLinks: searchParams.get('searchLinks') === 'false' ? undefined : defaultCardConfig.searchLinks,
+        stripeEnabled: searchParams.get('stripe') === 'false' ? false : defaultCardConfig.stripeEnabled
     };
 
     return (

--- a/packages/koenig-lexical/src/components/ui/VisibilityDropdown.jsx
+++ b/packages/koenig-lexical/src/components/ui/VisibilityDropdown.jsx
@@ -26,7 +26,7 @@ export function VisibilityDropdown({editor, nodeKey, visibility, isActive, visib
                     label="Show in email"
                     onChange={e => toggleEmail(e)} />
                 {
-                    emailVisibility && (
+                    emailVisibility && dropdownOptions && (
                         <>
                             <Dropdown
                                 dataTestId={'visibility-dropdown-segment'}

--- a/packages/koenig-lexical/src/hooks/useVisibilityToggle.js
+++ b/packages/koenig-lexical/src/hooks/useVisibilityToggle.js
@@ -1,21 +1,28 @@
 import {$getNodeByKey} from 'lexical';
 import {useEffect, useState} from 'react';
-export const useVisibilityToggle = (editor, nodeKey, initialVisibility) => {
+
+export const useVisibilityToggle = (editor, nodeKey, initialVisibility, cardConfig) => {
     const [emailVisibility, setEmailVisibility] = useState(initialVisibility.showOnEmail);
     const [webVisibility, setWebVisibility] = useState(initialVisibility.showOnWeb);
     const [segment, setSegment] = useState(initialVisibility.segment);
     const [message, setMessage] = useState('');
 
-    const dropdownOptions = [{
-        label: 'All subscribers',
-        name: ''
-    }, {
-        label: 'Free subscribers',
-        name: 'status:free'
-    }, {
-        label: 'Paid subscribers',
-        name: 'status:-free'
-    }];
+    const isStripeEnabled = cardConfig?.stripeEnabled;
+
+    const dropdownOptions = () => {
+        if (isStripeEnabled) {
+            return [{
+                label: 'All subscribers',
+                name: ''
+            }, {
+                label: 'Free subscribers',
+                name: 'status:free'
+            }, {
+                label: 'Paid subscribers',
+                name: 'status:-free'
+            }];
+        }
+    };
 
     const updateMessage = () => {
         let segmentLabel = 'all subscribers';
@@ -70,5 +77,5 @@ export const useVisibilityToggle = (editor, nodeKey, initialVisibility) => {
         });
     };
 
-    return [toggleEmail, toggleSegment, toggleWeb, segment, emailVisibility, webVisibility, dropdownOptions, message];
+    return [toggleEmail, toggleSegment, toggleWeb, segment, emailVisibility, webVisibility, dropdownOptions(), message];
 };

--- a/packages/koenig-lexical/src/nodes/HtmlNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/HtmlNodeComponent.jsx
@@ -15,7 +15,6 @@ export function HtmlNodeComponent({nodeKey, html, visibility}) {
     const [editor] = useLexicalComposerContext();
     const cardContext = React.useContext(CardContext);
     const {cardConfig, darkMode} = React.useContext(KoenigComposerContext);
-
     const [showSnippetToolbar, setShowSnippetToolbar] = React.useState(false);
     const [showVisibilityDropdown, setShowVisibilityDropdown] = React.useState(false);
 
@@ -24,7 +23,7 @@ export function HtmlNodeComponent({nodeKey, html, visibility}) {
         return $getNodeByKey(nodeKey).getIsVisibilityActive();
     });
 
-    const [toggleEmail, toggleSegment, toggleWeb, segment, emailVisibility, webVisibility, dropdownOptions, message] = useVisibilityToggle(editor, nodeKey, visibility);
+    const [toggleEmail, toggleSegment, toggleWeb, segment, emailVisibility, webVisibility, dropdownOptions, message] = useVisibilityToggle(editor, nodeKey, visibility, cardConfig);
 
     const visibilityProps = {
         toggleEmail,

--- a/packages/koenig-lexical/test/e2e/content-visibility.test.js
+++ b/packages/koenig-lexical/test/e2e/content-visibility.test.js
@@ -209,5 +209,19 @@ test.describe('Content Visibility', async () => {
 
             await expect(card.locator('div').first()).toContainText('Hidden from both email and web');
         });
+
+        test('can toggle visibility - subscriber settings hidden when stripe is not enabled', async function () {
+            await initialize({page, uri: '/#/?content=false&labs=contentVisibility&stripe=false'});
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'html'});
+            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
+            await page.keyboard.type('Testing');
+            await page.keyboard.press('Meta+Enter');
+
+            const card = page.locator('[data-kg-card="html"]');
+
+            await card.locator('[aria-label="Visibility"]').click();
+            await expect(card.locator('[data-testid="visibility-dropdown-segment"]')).not.toBeVisible();
+        });
     });
 });

--- a/packages/koenig-lexical/test/unit/hooks/useVisibilityToggle.test.js
+++ b/packages/koenig-lexical/test/unit/hooks/useVisibilityToggle.test.js
@@ -12,6 +12,7 @@ describe('useVisibilityToggle', () => {
     let editor;
     let node;
     let initialVisibility;
+    let cardConfig;
 
     beforeEach(() => {
         node = {
@@ -29,6 +30,10 @@ describe('useVisibilityToggle', () => {
             showOnWeb: true,
             segment: ''
         };
+
+        cardConfig = {
+            stripeEnabled: true
+        };
     });
 
     // These are the return values of useVisibilityToggle
@@ -45,7 +50,7 @@ describe('useVisibilityToggle', () => {
     // 7 is message state
 
     it('should initialize visibility states based on initialVisibility', () => {
-        const {result} = renderHook(() => useVisibilityToggle(editor, 'testKey', initialVisibility));
+        const {result} = renderHook(() => useVisibilityToggle(editor, 'testKey', initialVisibility, cardConfig));
 
         expect(result.current[3]).toBe(initialVisibility.segment); // segment
         expect(result.current[4]).toBe(initialVisibility.showOnEmail); // emailVisibility
@@ -61,7 +66,7 @@ describe('useVisibilityToggle', () => {
     });
 
     it('should toggleEmail and be able to update the node', () => {
-        const {result} = renderHook(() => useVisibilityToggle(editor, 'testKey', initialVisibility));
+        const {result} = renderHook(() => useVisibilityToggle(editor, 'testKey', initialVisibility, cardConfig));
 
         act(() => {
             result.current[0]({target: {checked: false}}); // toggleEmail
@@ -73,7 +78,7 @@ describe('useVisibilityToggle', () => {
     });
 
     it('should toggleWeb and be able to update the node', () => {
-        const {result} = renderHook(() => useVisibilityToggle(editor, 'testKey', initialVisibility));
+        const {result} = renderHook(() => useVisibilityToggle(editor, 'testKey', initialVisibility, cardConfig));
 
         act(() => {
             result.current[2]({target: {checked: false}}); // toggleWeb
@@ -85,7 +90,7 @@ describe('useVisibilityToggle', () => {
     });
 
     it('should toggleSegment and be able to update the node', () => {
-        const {result} = renderHook(() => useVisibilityToggle(editor, 'testKey', initialVisibility));
+        const {result} = renderHook(() => useVisibilityToggle(editor, 'testKey', initialVisibility, cardConfig));
 
         act(() => {
             result.current[1]('status:free'); // toggleSegment
@@ -97,7 +102,7 @@ describe('useVisibilityToggle', () => {
     });
 
     it('should update the message correctly when both toggles are off', () => {
-        const {result} = renderHook(() => useVisibilityToggle(editor, 'testKey', initialVisibility));
+        const {result} = renderHook(() => useVisibilityToggle(editor, 'testKey', initialVisibility, cardConfig));
 
         act(() => {
             result.current[0]({target: {checked: false}}); // toggleEmail
@@ -107,5 +112,13 @@ describe('useVisibilityToggle', () => {
         expect(result.current[4]).toBe(false); // emailVisibility
         expect(result.current[5]).toBe(false); // webVisibility
         expect(result.current[7]).toBe('Hidden from both email and web'); // message
+    });
+
+    it('does not return dropdownOptions if stripe is not enabled', () => {
+        cardConfig.stripeEnabled = false;
+
+        const {result} = renderHook(() => useVisibilityToggle(editor, 'testKey', initialVisibility, cardConfig));
+
+        expect(result.current[6]).toBeUndefined(); // dropdownOptions
     });
 });


### PR DESCRIPTION
ref PLG-109

- Updated `useVisibilityToggle` to conditionally provide dropdown options based on Stripe connection status.
- Adjusted `VisibilityDropdown` to hide segment options when Stripe is disabled.
- Modified `HtmlNodeComponent` to pass `cardConfig` for visibility logic.
- Added end-to-end and unit tests to verify the visibility toggle behavior when Stripe is not enabled.