### PR TITLE
Updated content visibility card messages

### DIFF
--- a/packages/kg-default-nodes/lib/generate-decorator-node.js
+++ b/packages/kg-default-nodes/lib/generate-decorator-node.js
@@ -224,7 +224,8 @@ export function generateDecoratorNode({nodeType, properties = [], version = 1}) 
 
             const self = this.getLatest();
             return self.__visibility.showOnEmail === false
-                || self.__visibility.showOnWeb === false;
+                || self.__visibility.showOnWeb === false
+                || self.__visibility.segment !== '';
         }
     }
 

--- a/packages/kg-default-nodes/test/nodes/html.test.js
+++ b/packages/kg-default-nodes/test/nodes/html.test.js
@@ -383,19 +383,25 @@ describe('HtmlNode', function () {
     describe('getIsVisibilityActive', function () {
         it('returns true when showOnEmail is false', editorTest(function () {
             const node = $createHtmlNode();
-            node.visibility = {showOnEmail: false, showOnWeb: true, segment: 'status:-free'};
+            node.visibility = {showOnEmail: false, showOnWeb: true, segment: ''};
             node.getIsVisibilityActive().should.be.true();
         }));
 
         it('returns true when showOnWeb is false', editorTest(function () {
             const node = $createHtmlNode();
-            node.visibility = {showOnEmail: true, showOnWeb: false, segment: 'status:-free'};
+            node.visibility = {showOnEmail: true, showOnWeb: false, segment: ''};
             node.getIsVisibilityActive().should.be.true();
         }));
 
-        it('returns false when both showOnEmail and showOnWeb is true', editorTest(function () {
+        it('returns true when segment is not empty', editorTest(function () {
             const node = $createHtmlNode();
             node.visibility = {showOnEmail: true, showOnWeb: true, segment: 'status:-free'};
+            node.getIsVisibilityActive().should.be.true();
+        }));
+
+        it('returns false when both showOnEmail and showOnWeb are true and segment is blank', editorTest(function () {
+            const node = $createHtmlNode();
+            node.visibility = {showOnEmail: true, showOnWeb: true, segment: ''};
             node.getIsVisibilityActive().should.be.false();
         }));
     });

--- a/packages/koenig-lexical/src/components/ui/CardVisibilityMessage.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardVisibilityMessage.jsx
@@ -1,0 +1,11 @@
+export function CardVisibilityMessage({message}) {
+    if (!message) {
+        return null;
+    }
+
+    return (
+        <div className="py-[.6rem] font-sans text-xs font-semibold uppercase leading-8 tracking-normal text-grey dark:text-grey-800" data-testid="visibility-message">
+            {message}
+        </div>
+    );
+}

--- a/packages/koenig-lexical/src/components/ui/cards/HtmlCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/HtmlCard.jsx
@@ -3,6 +3,7 @@ import HtmlEditor from './HtmlCard/HtmlEditor';
 import KoenigComposerContext from '../../../context/KoenigComposerContext.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {CardVisibilityMessage} from '../CardVisibilityMessage.jsx';
 import {sanitizeHtml} from '../../../utils/sanitize-html';
 
 export function HtmlCard({html, updateHtml, isEditing, darkMode, visibilityMessage}) {
@@ -22,10 +23,7 @@ export function HtmlCard({html, updateHtml, isEditing, darkMode, visibilityMessa
                     </>
                 )
                 : <div>
-                    {isContentVisibilityEnabled &&
-                        <div className="py-[.6rem] font-sans text-xs font-semibold uppercase leading-8 tracking-normal text-grey dark:text-grey-800">
-                            {visibilityMessage ? visibilityMessage : 'Shown in email to free subscribers'}
-                        </div>}
+                    {isContentVisibilityEnabled && <CardVisibilityMessage message={visibilityMessage} />}
                     <HtmlDisplay html={html} />
                     <div className="absolute inset-0 z-50 mt-0"></div>
                 </div>

--- a/packages/koenig-lexical/src/nodes/HtmlNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/HtmlNodeComponent.jsx
@@ -23,7 +23,7 @@ export function HtmlNodeComponent({nodeKey, html, visibility}) {
         return $getNodeByKey(nodeKey).getIsVisibilityActive();
     });
 
-    const [toggleEmail, toggleSegment, toggleWeb, segment, emailVisibility, webVisibility, dropdownOptions, message] = useVisibilityToggle(editor, nodeKey, visibility, cardConfig);
+    const [toggleEmail, toggleSegment, toggleWeb, segment, emailVisibility, webVisibility, dropdownOptions, visibilityMessage] = useVisibilityToggle(editor, nodeKey, cardConfig);
 
     const visibilityProps = {
         toggleEmail,
@@ -75,14 +75,20 @@ export function HtmlNodeComponent({nodeKey, html, visibility}) {
                 nodeKey={nodeKey}
                 unsplashConf={cardConfig.unsplash}
                 updateHtml={updateHtml}
-                visibilityMessage={message}
+                visibilityMessage={visibilityMessage}
                 onBlur={onBlur}
             />
 
             {
                 isContentVisibilityEnabled &&
                 (
-                    <VisibilityDropdown editor={editor} isActive={showVisibilityDropdown} nodeKey={nodeKey} visibility={visibility} visibilityProps={visibilityProps} />
+                    <VisibilityDropdown
+                        editor={editor}
+                        isActive={showVisibilityDropdown}
+                        nodeKey={nodeKey}
+                        visibility={visibility}
+                        visibilityProps={visibilityProps}
+                    />
                 )
             }
 

--- a/packages/koenig-lexical/test/e2e/cards/html-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/html-card.test.js
@@ -41,7 +41,6 @@ test.describe('Html card', async () => {
                 <div><svg></svg></div>
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="html">
                     <div>
-                        <div>Shown on web and in email to all subscribers</div>
                         <div><p>test content</p></div>
                         <div></div>
                     </div>
@@ -75,7 +74,6 @@ test.describe('Html card', async () => {
                 <div><svg></svg></div>
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="html">
                     <div>
-                        <div>Shown on web and in email to all subscribers</div>
                         <div><div><span style="fullscreen-inner">Loading...</span></div></div>
                         <div></div>
                     </div>
@@ -167,7 +165,6 @@ test.describe('Html card', async () => {
                 <div><svg></svg></div>
                 <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="html">
                     <div>
-                        <div>Shown on web and in email to all subscribers</div>
                         <div class="min-h-[3.5vh] whitespace-normal">
                             Here are some words
                         </div>

--- a/packages/koenig-lexical/test/e2e/content-visibility.test.js
+++ b/packages/koenig-lexical/test/e2e/content-visibility.test.js
@@ -90,7 +90,7 @@ test.describe('Content Visibility', async () => {
 
             await card.locator('[aria-label="Visibility"]').click();
 
-            await expect(card.locator('div').first()).toContainText('Shown on web and in email to all subscribers');
+            await expect(card.getByTestId('visibility-message')).not.toBeVisible();
         });
 
         test('can toggle visibility settings - show on web is off', async function () {
@@ -105,9 +105,8 @@ test.describe('Content Visibility', async () => {
             await card.locator('[aria-label="Visibility"]').click();
 
             await card.locator('[data-testid="visibility-toggle-web-only"]').click();
-            // it should now contain the message "Only shown in email to all subscribers"
 
-            await expect(card.locator('div').first()).toContainText('Only shown in email to all subscribers');
+            await expect(card.getByTestId('visibility-message')).toContainText('Shown in email only');
         });
 
         test('can toggle visibility settings - show on email is off', async function () {
@@ -122,9 +121,8 @@ test.describe('Content Visibility', async () => {
             await card.locator('[aria-label="Visibility"]').click();
 
             await card.locator('[data-testid="visibility-toggle-email-only"]').click();
-            // it should now contain the message "Only shown on web"
 
-            await expect(card.locator('div').first()).toContainText('Only shown on web');
+            await expect(card.getByTestId('visibility-message')).toContainText('Shown on web only');
         });
 
         test('can toggle visibility settings - show on email and web and all subscribers', async function () {
@@ -138,7 +136,7 @@ test.describe('Content Visibility', async () => {
 
             await card.locator('[aria-label="Visibility"]').click();
 
-            await expect(card.locator('div').first()).toContainText('Shown on web and in email to all subscribers');
+            await expect(card.getByTestId('visibility-message')).not.toBeVisible();
         });
 
         test('can toggle visibility settings segments - free subscribers', async function () {
@@ -156,7 +154,7 @@ test.describe('Content Visibility', async () => {
 
             await card.locator('[data-test-value="status:free"]').click();
 
-            await expect(card.locator('div').first()).toContainText('Shown on web and in email to free subscribers');
+            await expect(card.getByTestId('visibility-message')).toContainText('Shown on web and email to free members');
         });
 
         test('can toggle visibility settings segments - paid subscribers', async function () {
@@ -173,7 +171,7 @@ test.describe('Content Visibility', async () => {
             await card.locator('[data-testid="visibility-dropdown-segment"]').click();
             await card.locator('[data-test-value="status:-free"]').click();
 
-            await expect(card.locator('div').first()).toContainText('Shown on web and in email to paid subscribers');
+            await expect(card.getByTestId('visibility-message')).toContainText('Shown on web and email to paid members');
         });
 
         test('can toggle visibility settings segments - all subscribers', async function () {
@@ -190,7 +188,7 @@ test.describe('Content Visibility', async () => {
             await card.locator('[data-testid="visibility-dropdown-segment"]').click();
             await card.locator('[data-test-value=""]').click();
 
-            await expect(card.locator('div').first()).toContainText('Shown on web and in email to all subscribers');
+            await expect(card.getByTestId('visibility-message')).not.toBeVisible();
         });
 
         test('can toggle visibility - disable everything', async function () {
@@ -207,7 +205,7 @@ test.describe('Content Visibility', async () => {
             await card.locator('[data-testid="visibility-toggle-web-only"]').click();
             await card.locator('[data-testid="visibility-toggle-email-only"]').click();
 
-            await expect(card.locator('div').first()).toContainText('Hidden from both email and web');
+            await expect(card.getByTestId('visibility-message')).toContainText('Hidden from both email and web');
         });
 
         test('can toggle visibility - subscriber settings hidden when stripe is not enabled', async function () {


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/PLG-168

- refactored `useVisibilityToggle` to use derived state from the Lexical editor state rather than duplicating source-of-truth. Simplifies code and prevents divergence on undo/redo and allows for easier reading of properties/methods from the underlying node instance
- extracted `<CardVisibilityMessage>` ready for use in other cards
- updated `.getIsVisibilityActive()` to return `true` when a segment has been specified
- updated messages
