### PR TITLE
Updated toggle settings to be clickable on their label

### DIFF
--- a/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
+++ b/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
@@ -32,7 +32,7 @@ export function SettingsPanel({children, darkMode, cardWidth}) {
 
 export function ToggleSetting({label, description, isChecked, onChange, dataTestId}) {
     return (
-        <div className="mt-2 flex min-h-[3rem] w-full items-center justify-between text-[1.3rem] first:mt-0">
+        <label className="mt-2 flex min-h-[3rem] w-full items-center justify-between text-[1.3rem] first:mt-0">
             <div>
                 <div className="font-bold text-grey-900 dark:text-grey-300">{label}</div>
                 {description &&
@@ -42,7 +42,7 @@ export function ToggleSetting({label, description, isChecked, onChange, dataTest
             <div className="flex shrink-0 pl-2">
                 <Toggle dataTestId={dataTestId} isChecked={isChecked} onChange={onChange} />
             </div>
-        </div>
+        </label>
     );
 }
 

--- a/packages/koenig-lexical/src/components/ui/VisibilityDropdown.jsx
+++ b/packages/koenig-lexical/src/components/ui/VisibilityDropdown.jsx
@@ -15,13 +15,13 @@ export function VisibilityDropdown({editor, nodeKey, visibility, isActive, visib
         return (
             <div className="not-kg-prose absolute left-1/2 top-0 z-[1001] flex w-[254px] -translate-x-1/2 flex-col gap-1 rounded-lg bg-white p-6 shadow-md" data-kg-allow-clickthrough="false" data-testid="visibility-settings">
                 <ToggleSetting
-                    dataTestId='visibility-toggle-web-only'
+                    dataTestId='visibility-show-on-web'
                     isChecked={webVisibility}
                     label="Show on web"
                     onChange={e => toggleWeb(e)} />
                 <hr className="mt-1 border-grey-250 pb-1 dark:border-white/5" />
                 <ToggleSetting
-                    dataTestId='visibility-toggle-email-only'
+                    dataTestId='visibility-show-on-email'
                     isChecked={emailVisibility}
                     label="Show in email"
                     onChange={e => toggleEmail(e)} />
@@ -44,11 +44,11 @@ export function VisibilityDropdown({editor, nodeKey, visibility, isActive, visib
 
 function ToggleSetting({label, isChecked, onChange, dataTestId}) {
     return (
-        <div className="flex min-h-[3rem] w-full items-center justify-between text-sm">
-            <label className="text-grey-900 dark:text-grey-300">{label}</label>
+        <label className="flex min-h-[3rem] w-full items-center justify-between text-sm" data-testid={dataTestId}>
+            <span className="block text-grey-900 dark:text-grey-300">{label}</span>
             <div className="flex shrink-0 pl-2">
-                <Toggle dataTestId={dataTestId} isChecked={isChecked} onChange={onChange} />
+                <Toggle dataTestId={`${dataTestId}-Toggle`} isChecked={isChecked} onChange={onChange} />
             </div>
-        </div>
+        </label>
     );
 }

--- a/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
@@ -213,7 +213,7 @@ test.describe('Email card', async () => {
             await focusEditor(page);
             await insertEmailCard(page);
 
-            await expect(await page.getByTestId('settings-panel')).toBeVisible();
+            await expect(page.getByTestId('settings-panel')).toBeVisible();
         });
 
         test('allows to center content', async function () {
@@ -236,7 +236,7 @@ test.describe('Email card', async () => {
             // Dividers are enabled by default
             const dividersSettings = await page.getByTestId('dividers-settings');
             await expect(dividersSettings).toBeVisible();
-            await expect(await page.locator('[data-testid="dividers-settings"] input').isChecked()).toBeTruthy();
+            await expect(page.locator('[data-testid="dividers-settings"] input')).toBeChecked();
 
             // Check that the dividers are rendered
             const topDivider = await page.getByTestId('top-divider');
@@ -252,6 +252,24 @@ test.describe('Email card', async () => {
             await expect(bottomDivider).toBeHidden();
         });
 
+        test('allows click on toggle label to toggle checkbox', async function () {
+            await focusEditor(page);
+            await insertEmailCard(page);
+
+            // Dividers are enabled by default
+            const dividersSettings = await page.getByTestId('dividers-settings');
+            await expect(dividersSettings).toBeVisible();
+            await expect(page.locator('[data-testid="dividers-settings"] input')).toBeChecked();
+
+            await page.getByText('Separators').click();
+
+            await expect(page.locator('[data-testid="dividers-settings"] input')).not.toBeChecked();
+
+            await page.getByText('Separators').click();
+
+            await expect(page.locator('[data-testid="dividers-settings"] input')).toBeChecked();
+        });
+
         test('allows to show/hide a button', async function () {
             await focusEditor(page);
             await insertEmailCard(page);
@@ -259,7 +277,7 @@ test.describe('Email card', async () => {
             // Button is disabled by default
             const buttonSettings = await page.getByTestId('button-settings');
             await expect(buttonSettings).toBeVisible();
-            await expect(await page.locator('[data-testid="button-settings"] input').isChecked()).toBeFalsy();
+            await expect(page.locator('[data-testid="button-settings"] input')).not.toBeChecked();
 
             // Check that the button is hidden by default
             const button = await page.getByTestId('cta-button');
@@ -328,7 +346,7 @@ test.describe('Email card', async () => {
                                 </div>
                             </div>
                         </div>
-                        <div>
+                        <label>
                             <div>
                                 <div>Separators</div>
                             </div>
@@ -338,9 +356,9 @@ test.describe('Email card', async () => {
                                   <div></div>
                                 </label>
                             </div>
-                        </div>
+                        </label>
                         <hr>
-                        <div>
+                        <label>
                             <div>
                                 <div>Button</div>
                             </div>
@@ -350,7 +368,7 @@ test.describe('Email card', async () => {
                                   <div></div>
                                 </label>
                             </div>
-                        </div>
+                        </label>
                     </div>
                 </div>
             </div>
@@ -431,7 +449,7 @@ test.describe('Email card', async () => {
         await page.keyboard.type('/snippet');
         await page.waitForSelector('[data-kg-cardmenu-selected="true"]');
         await page.keyboard.press('Enter');
-        await expect(await page.locator('[data-kg-card="email-cta"]')).toHaveCount(2);
+        await expect(page.locator('[data-kg-card="email-cta"]')).toHaveCount(2);
     });
 
     test('keeps focus on previous editor when changing size opts', async function () {

--- a/packages/koenig-lexical/test/e2e/cards/product-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/product-card.test.js
@@ -53,7 +53,7 @@ test.describe('Product card', async () => {
                     data-kg-card="product">
                     <div>
                         <div>
-                            <img 
+                            <img
                                 alt="Product thumbnail"
                                 src="/content/images/2022/11/koenig-lexical.jpg" />
                         </div>
@@ -305,7 +305,7 @@ test.describe('Product card', async () => {
                     </div>
                     <div>
                         <div draggable="true">
-                            <div>
+                            <label>
                                 <div><div>Rating</div></div>
                                 <div>
                                     <label id="product-rating-toggle">
@@ -313,9 +313,9 @@ test.describe('Product card', async () => {
                                         <div></div>
                                     </label>
                                 </div>
-                            </div>
+                            </label>
                             <hr />
-                            <div>
+                            <label>
                                 <div><div>Button</div></div>
                                 <div>
                                     <label id="product-button-toggle">
@@ -323,7 +323,7 @@ test.describe('Product card', async () => {
                                         <div></div>
                                     </label>
                                 </div>
-                            </div>
+                            </label>
                         </div>
                     </div>
                 </div>

--- a/packages/koenig-lexical/test/e2e/content-visibility.test.js
+++ b/packages/koenig-lexical/test/e2e/content-visibility.test.js
@@ -17,12 +17,17 @@ test.describe('Content Visibility', async () => {
     });
 
     test.describe('HTML card', async function () {
-        test('toolbar shows content visibility icon', async function () {
+        async function insertHtmlCard() {
             await focusEditor(page);
             await insertCard(page, {cardName: 'html'});
             await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
             await page.keyboard.type('Testing');
             await page.keyboard.press('Meta+Enter');
+            return page.locator('[data-kg-card="html"]');
+        }
+
+        test('toolbar shows content visibility icon', async function () {
+            await insertHtmlCard();
 
             await expect(page.locator('[data-kg-card="html"]')).toHaveAttribute('data-kg-card-selected', 'true');
             await expect(page.locator('[data-kg-card="html"]')).toHaveAttribute('data-kg-card-editing', 'false');
@@ -31,13 +36,7 @@ test.describe('Content Visibility', async () => {
         });
 
         test('toolbar shows visibility options on click', async function () {
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'html'});
-            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
-            await page.keyboard.type('Testing');
-            await page.keyboard.press('Meta+Enter');
-
-            const card = page.locator('[data-kg-card="html"]');
+            const card = await insertHtmlCard();
 
             await card.locator('[aria-label="Visibility"]').click();
 
@@ -46,13 +45,7 @@ test.describe('Content Visibility', async () => {
         });
 
         test('clicking on settings does not transition into edit mode', async function () {
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'html'});
-            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
-            await page.keyboard.type('Testing');
-            await page.keyboard.press('Meta+Enter');
-
-            const card = page.locator('[data-kg-card="html"]');
+            const card = await insertHtmlCard();
 
             await card.locator('[aria-label="Visibility"]').click();
             await card.getByTestId('visibility-settings').click();
@@ -61,32 +54,20 @@ test.describe('Content Visibility', async () => {
         });
 
         test('changing a setting puts icon in active state', async function () {
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'html'});
-            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
-            await page.keyboard.type('Testing');
-            await page.keyboard.press('Meta+Enter');
-
-            const card = page.locator('[data-kg-card="html"]');
+            const card = await insertHtmlCard();
 
             // button is not highlighted
             await expect(card.locator('[aria-label="Visibility"]')).toHaveAttribute('data-kg-active', 'false');
 
             await card.locator('[aria-label="Visibility"]').click();
-            await card.locator('[data-testid="visibility-toggle-email-only"]').click();
+            await card.getByTestId('visibility-show-on-email-Toggle').click();
 
             // button is highlighted
             await expect(card.locator('[aria-label="Visibility"]')).toHaveAttribute('data-kg-active', 'true');
         });
 
         test('visibility settings - defaults to show on email and web and all subscribers', async function () {
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'html'});
-            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
-            await page.keyboard.type('Testing');
-            await page.keyboard.press('Meta+Enter');
-
-            const card = page.locator('[data-kg-card="html"]');
+            const card = await insertHtmlCard();
 
             await card.locator('[aria-label="Visibility"]').click();
 
@@ -94,45 +75,27 @@ test.describe('Content Visibility', async () => {
         });
 
         test('can toggle visibility settings - show on web is off', async function () {
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'html'});
-            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
-            await page.keyboard.type('Testing');
-            await page.keyboard.press('Meta+Enter');
-
-            const card = page.locator('[data-kg-card="html"]');
+            const card = await insertHtmlCard();
 
             await card.locator('[aria-label="Visibility"]').click();
 
-            await card.locator('[data-testid="visibility-toggle-web-only"]').click();
+            await card.getByTestId('visibility-show-on-web-Toggle').click();
 
             await expect(card.getByTestId('visibility-message')).toContainText('Shown in email only');
         });
 
         test('can toggle visibility settings - show on email is off', async function () {
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'html'});
-            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
-            await page.keyboard.type('Testing');
-            await page.keyboard.press('Meta+Enter');
-
-            const card = page.locator('[data-kg-card="html"]');
+            const card = await insertHtmlCard();
 
             await card.locator('[aria-label="Visibility"]').click();
 
-            await card.locator('[data-testid="visibility-toggle-email-only"]').click();
+            await card.getByTestId('visibility-show-on-email-Toggle').click();
 
             await expect(card.getByTestId('visibility-message')).toContainText('Shown on web only');
         });
 
         test('can toggle visibility settings - show on email and web and all subscribers', async function () {
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'html'});
-            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
-            await page.keyboard.type('Testing');
-            await page.keyboard.press('Meta+Enter');
-
-            const card = page.locator('[data-kg-card="html"]');
+            const card = await insertHtmlCard();
 
             await card.locator('[aria-label="Visibility"]').click();
 
@@ -140,17 +103,11 @@ test.describe('Content Visibility', async () => {
         });
 
         test('can toggle visibility settings segments - free subscribers', async function () {
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'html'});
-            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
-            await page.keyboard.type('Testing');
-            await page.keyboard.press('Meta+Enter');
-
-            const card = page.locator('[data-kg-card="html"]');
+            const card = await insertHtmlCard();
 
             await card.locator('[aria-label="Visibility"]').click();
 
-            await card.locator('[data-testid="visibility-dropdown-segment"]').click();
+            await card.getByTestId('visibility-dropdown-segment').click();
 
             await card.locator('[data-test-value="status:free"]').click();
 
@@ -158,68 +115,54 @@ test.describe('Content Visibility', async () => {
         });
 
         test('can toggle visibility settings segments - paid subscribers', async function () {
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'html'});
-            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
-            await page.keyboard.type('Testing');
-            await page.keyboard.press('Meta+Enter');
-
-            const card = page.locator('[data-kg-card="html"]');
+            const card = await insertHtmlCard();
 
             await card.locator('[aria-label="Visibility"]').click();
 
-            await card.locator('[data-testid="visibility-dropdown-segment"]').click();
+            await card.getByTestId('visibility-dropdown-segment').click();
             await card.locator('[data-test-value="status:-free"]').click();
 
             await expect(card.getByTestId('visibility-message')).toContainText('Shown on web and email to paid members');
         });
 
         test('can toggle visibility settings segments - all subscribers', async function () {
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'html'});
-            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
-            await page.keyboard.type('Testing');
-            await page.keyboard.press('Meta+Enter');
-
-            const card = page.locator('[data-kg-card="html"]');
+            const card = await insertHtmlCard();
 
             await card.locator('[aria-label="Visibility"]').click();
 
-            await card.locator('[data-testid="visibility-dropdown-segment"]').click();
+            await card.getByTestId('visibility-dropdown-segment').click();
             await card.locator('[data-test-value=""]').click();
 
             await expect(card.getByTestId('visibility-message')).not.toBeVisible();
         });
 
         test('can toggle visibility - disable everything', async function () {
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'html'});
-            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
-            await page.keyboard.type('Testing');
-            await page.keyboard.press('Meta+Enter');
-
-            const card = page.locator('[data-kg-card="html"]');
+            const card = await insertHtmlCard();
 
             await card.locator('[aria-label="Visibility"]').click();
 
-            await card.locator('[data-testid="visibility-toggle-web-only"]').click();
-            await card.locator('[data-testid="visibility-toggle-email-only"]').click();
+            await card.getByTestId('visibility-show-on-web-Toggle').click();
+            await card.getByTestId('visibility-show-on-email-Toggle').click();
 
             await expect(card.getByTestId('visibility-message')).toContainText('Hidden from both email and web');
         });
 
         test('can toggle visibility - subscriber settings hidden when stripe is not enabled', async function () {
             await initialize({page, uri: '/#/?content=false&labs=contentVisibility&stripe=false'});
-            await focusEditor(page);
-            await insertCard(page, {cardName: 'html'});
-            await expect(await page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
-            await page.keyboard.type('Testing');
-            await page.keyboard.press('Meta+Enter');
-
-            const card = page.locator('[data-kg-card="html"]');
+            const card = await insertHtmlCard();
 
             await card.locator('[aria-label="Visibility"]').click();
-            await expect(card.locator('[data-testid="visibility-dropdown-segment"]')).not.toBeVisible();
+            await expect(card.getByTestId('visibility-dropdown-segment')).not.toBeVisible();
+        });
+
+        test('can click toggle label to change visibility settings', async function () {
+            const card = await insertHtmlCard();
+            await card.locator('[aria-label="Visibility"]').click();
+
+            await expect(page.getByTestId('visibility-show-on-web-Toggle').locator('input')).toBeChecked();
+            // click on the surrounding label rather than the inner label/input
+            await page.getByTestId('visibility-show-on-web').click();
+            await expect(page.getByTestId('visibility-show-on-web-Toggle').locator('input')).not.toBeChecked();
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PLG-171

- wrapped full toggle components in a `<label>` so the browser passes clicks through to the `<input>` element
  - not ideal because `<label>` should not be nested but we're already breaking the HTML spec by having `<div>` inside a `<label>`
  - tested in all major browsers and found to be working
  - interim solution whilst looking at a more complete valid+accessible solution
- simplified content visibility tests by extracting repeated steps to a helper function
