### PR TITLE
🐛 Removed empty paragraphs when copy/pasting multiple linebreaks from Doc

### DIFF
--- a/packages/kg-default-nodes/lib/serializers/linebreak.js
+++ b/packages/kg-default-nodes/lib/serializers/linebreak.js
@@ -7,12 +7,16 @@ export default {
 
             // Remove empty paragraphs when copy/pasting from Google docs:
             // - Between two paragraphs (P and P)
+            // - Between multiple linebreaks (BR and BR)
             // - Between a list and a paragraph (UL/OL/DL and P), and vice versa
             // - Between a heading and a paragraph (H1-H6 and P), and vice versa
             if (isGoogleDocs) {
                 if ((
                     node.previousElementSibling?.nodeName === 'P' &&
                     node.nextElementSibling?.nodeName === 'P'
+                ) || (
+                    node.previousElementSibling?.nodeName === 'BR' ||
+                    node.nextElementSibling?.nodeName === 'BR'
                 ) || (
                     [...headings, ...lists].includes(node.previousElementSibling?.nodeName) &&
                     node.nextElementSibling?.nodeName === 'P'

--- a/packages/kg-default-nodes/lib/serializers/linebreak.js
+++ b/packages/kg-default-nodes/lib/serializers/linebreak.js
@@ -2,6 +2,8 @@ export default {
     import: {
         br: (node) => {
             const isGoogleDocs = !!node.closest('[id^="docs-internal-guid-"]');
+            const previousNodeName = node.previousElementSibling?.nodeName;
+            const nextNodeName = node.nextElementSibling?.nodeName;
             const headings = ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
             const lists = ['UL', 'OL', 'DL'];
 
@@ -11,19 +13,12 @@ export default {
             // - Between a list and a paragraph (UL/OL/DL and P), and vice versa
             // - Between a heading and a paragraph (H1-H6 and P), and vice versa
             if (isGoogleDocs) {
-                if ((
-                    node.previousElementSibling?.nodeName === 'P' &&
-                    node.nextElementSibling?.nodeName === 'P'
-                ) || (
-                    node.previousElementSibling?.nodeName === 'BR' ||
-                    node.nextElementSibling?.nodeName === 'BR'
-                ) || (
-                    [...headings, ...lists].includes(node.previousElementSibling?.nodeName) &&
-                    node.nextElementSibling?.nodeName === 'P'
-                ) || (
-                    node.previousElementSibling?.nodeName === 'P' &&
-                    [...headings, ...lists].includes(node.nextElementSibling?.nodeName)
-                )) {
+                if (
+                    (previousNodeName === 'P' && nextNodeName === 'P') ||
+                    (previousNodeName === 'BR' || nextNodeName === 'BR') ||
+                    ([...headings, ...lists].includes(previousNodeName) && nextNodeName === 'P') ||
+                    (previousNodeName === 'P' && [...headings, ...lists].includes(nextNodeName))
+                ) {
                     return {
                         conversion: () => null,
                         priority: 1

--- a/packages/kg-default-nodes/test/serializers/linebreak.test.js
+++ b/packages/kg-default-nodes/test/serializers/linebreak.test.js
@@ -209,102 +209,127 @@ describe('Serializers: linebreak', function () {
                 should.equal(nodes[1].getType(), 'extended-heading');
                 should.equal(nodes[2].getType(), 'paragraph');
             }));
+
+            it('(non GDoc) default conversion for a linebreak between a H3 and paragraph', editorTest(function () {
+                const htmlString = '<p>Paragraph></p><br><h3>Heading</h3><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 5);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'linebreak');
+                should.equal(nodes[2].getType(), 'extended-heading');
+                should.equal(nodes[3].getType(), 'linebreak');
+                should.equal(nodes[4].getType(), 'paragraph');
+            }));
+
+            it('(GDoc) skips linebreaks between H3 and paragraph', editorTest(function () {
+                const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><h3>Heading</h3><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 3);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'extended-heading');
+                should.equal(nodes[2].getType(), 'paragraph');
+            }));
+
+            it('(non GDoc) default conversion for a linebreak between a H4 and paragraph', editorTest(function () {
+                const htmlString = '<p>Paragraph></p><br><h4>Heading</h4><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 5);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'linebreak');
+                should.equal(nodes[2].getType(), 'extended-heading');
+                should.equal(nodes[3].getType(), 'linebreak');
+                should.equal(nodes[4].getType(), 'paragraph');
+            }));
+
+            it('(GDoc) skips linebreaks between H4 and paragraph', editorTest(function () {
+                const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><h4>Heading</h4><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 3);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'extended-heading');
+                should.equal(nodes[2].getType(), 'paragraph');
+            }));
+
+            it('(non GDoc) default conversion for a linebreak between a H5 and paragraph', editorTest(function () {
+                const htmlString = '<p>Paragraph></p><br><h5>Heading</h5><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 5);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'linebreak');
+                should.equal(nodes[2].getType(), 'extended-heading');
+                should.equal(nodes[3].getType(), 'linebreak');
+                should.equal(nodes[4].getType(), 'paragraph');
+            }));
+
+            it('(GDoc) skips linebreaks between H5 and paragraph', editorTest(function () {
+                const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><h5>Heading</h5><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 3);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'extended-heading');
+                should.equal(nodes[2].getType(), 'paragraph');
+            }));
+
+            it('(non GDoc) default conversion for a linebreak between a H6 and paragraph', editorTest(function () {
+                const htmlString = '<p>Paragraph></p><br><h6>Heading</h6><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 5);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'linebreak');
+                should.equal(nodes[2].getType(), 'extended-heading');
+                should.equal(nodes[3].getType(), 'linebreak');
+                should.equal(nodes[4].getType(), 'paragraph');
+            }));
+
+            it('(GDoc) skips linebreaks between H6 and paragraph', editorTest(function () {
+                const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><h6>Heading</h6><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
+
+                should.equal(nodes.length, 3);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'extended-heading');
+                should.equal(nodes[2].getType(), 'paragraph');
+            }));
         });
 
-        it('(non GDoc) default conversion for a linebreak between a H3 and paragraph', editorTest(function () {
-            const htmlString = '<p>Paragraph></p><br><h3>Heading</h3><br><p>Paragraph></p>';
-            const document = createDocument(htmlString);
-            const nodes = $generateNodesFromDOM(editor, document);
+        describe('Multiple linebreaks', function () {
+            it('(non GDoc) default conversion for multiple linebreaks between paragraphs', editorTest(function () {
+                const htmlString = '<p>Paragraph></p><br><br><br><p>Paragraph></p>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
 
-            should.equal(nodes.length, 5);
-            should.equal(nodes[0].getType(), 'paragraph');
-            should.equal(nodes[1].getType(), 'linebreak');
-            should.equal(nodes[2].getType(), 'extended-heading');
-            should.equal(nodes[3].getType(), 'linebreak');
-            should.equal(nodes[4].getType(), 'paragraph');
-        }));
+                should.equal(nodes.length, 5);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'linebreak');
+                should.equal(nodes[2].getType(), 'linebreak');
+                should.equal(nodes[3].getType(), 'linebreak');
+                should.equal(nodes[4].getType(), 'paragraph');
+            }));
 
-        it('(GDoc) skips linebreaks between H3 and paragraph', editorTest(function () {
-            const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><h3>Heading</h3><br><p>Paragraph></p>';
-            const document = createDocument(htmlString);
-            const nodes = $generateNodesFromDOM(editor, document);
+            it('(GDoc) skips empty paragraphs if there are multiple linebreaks', editorTest(function () {
+                const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><br><br><p>Paragraph></p></div>';
+                const document = createDocument(htmlString);
+                const nodes = $generateNodesFromDOM(editor, document);
 
-            should.equal(nodes.length, 3);
-            should.equal(nodes[0].getType(), 'paragraph');
-            should.equal(nodes[1].getType(), 'extended-heading');
-            should.equal(nodes[2].getType(), 'paragraph');
-        }));
-
-        it('(non GDoc) default conversion for a linebreak between a H4 and paragraph', editorTest(function () {
-            const htmlString = '<p>Paragraph></p><br><h4>Heading</h4><br><p>Paragraph></p>';
-            const document = createDocument(htmlString);
-            const nodes = $generateNodesFromDOM(editor, document);
-
-            should.equal(nodes.length, 5);
-            should.equal(nodes[0].getType(), 'paragraph');
-            should.equal(nodes[1].getType(), 'linebreak');
-            should.equal(nodes[2].getType(), 'extended-heading');
-            should.equal(nodes[3].getType(), 'linebreak');
-            should.equal(nodes[4].getType(), 'paragraph');
-        }));
-
-        it('(GDoc) skips linebreaks between H4 and paragraph', editorTest(function () {
-            const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><h4>Heading</h4><br><p>Paragraph></p>';
-            const document = createDocument(htmlString);
-            const nodes = $generateNodesFromDOM(editor, document);
-
-            should.equal(nodes.length, 3);
-            should.equal(nodes[0].getType(), 'paragraph');
-            should.equal(nodes[1].getType(), 'extended-heading');
-            should.equal(nodes[2].getType(), 'paragraph');
-        }));
-
-        it('(non GDoc) default conversion for a linebreak between a H5 and paragraph', editorTest(function () {
-            const htmlString = '<p>Paragraph></p><br><h5>Heading</h5><br><p>Paragraph></p>';
-            const document = createDocument(htmlString);
-            const nodes = $generateNodesFromDOM(editor, document);
-
-            should.equal(nodes.length, 5);
-            should.equal(nodes[0].getType(), 'paragraph');
-            should.equal(nodes[1].getType(), 'linebreak');
-            should.equal(nodes[2].getType(), 'extended-heading');
-            should.equal(nodes[3].getType(), 'linebreak');
-            should.equal(nodes[4].getType(), 'paragraph');
-        }));
-
-        it('(GDoc) skips linebreaks between H5 and paragraph', editorTest(function () {
-            const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><h5>Heading</h5><br><p>Paragraph></p>';
-            const document = createDocument(htmlString);
-            const nodes = $generateNodesFromDOM(editor, document);
-
-            should.equal(nodes.length, 3);
-            should.equal(nodes[0].getType(), 'paragraph');
-            should.equal(nodes[1].getType(), 'extended-heading');
-            should.equal(nodes[2].getType(), 'paragraph');
-        }));
-
-        it('(non GDoc) default conversion for a linebreak between a H6 and paragraph', editorTest(function () {
-            const htmlString = '<p>Paragraph></p><br><h6>Heading</h6><br><p>Paragraph></p>';
-            const document = createDocument(htmlString);
-            const nodes = $generateNodesFromDOM(editor, document);
-
-            should.equal(nodes.length, 5);
-            should.equal(nodes[0].getType(), 'paragraph');
-            should.equal(nodes[1].getType(), 'linebreak');
-            should.equal(nodes[2].getType(), 'extended-heading');
-            should.equal(nodes[3].getType(), 'linebreak');
-            should.equal(nodes[4].getType(), 'paragraph');
-        }));
-
-        it('(GDoc) skips linebreaks between H6 and paragraph', editorTest(function () {
-            const htmlString = '<div id="docs-internal-guid-1234"><p>Paragraph></p><br><h6>Heading</h6><br><p>Paragraph></p>';
-            const document = createDocument(htmlString);
-            const nodes = $generateNodesFromDOM(editor, document);
-
-            should.equal(nodes.length, 3);
-            should.equal(nodes[0].getType(), 'paragraph');
-            should.equal(nodes[1].getType(), 'extended-heading');
-            should.equal(nodes[2].getType(), 'paragraph');
-        }));
+                should.equal(nodes.length, 2);
+                should.equal(nodes[0].getType(), 'paragraph');
+                should.equal(nodes[1].getType(), 'paragraph');
+            }));
+        });
     });
 });

--- a/packages/kg-html-to-lexical/test/sources/google-docs.test.ts
+++ b/packages/kg-html-to-lexical/test/sources/google-docs.test.ts
@@ -248,18 +248,24 @@ describe('HTMLtoLexical: Google Docs', function () {
         const input = html`
             <b style="font-weight:normal;" id="docs-internal-guid-53c161b0-7fff-55f3-a893-721115583111">
                 <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
-                    <span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Start of the article. Here is the 1st paragraph, followed by a line break then a paragraph.</span>
+                    <span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Start of the article. Here is the 1st paragraph, followed by two line breaks then a paragraph.</span>
                 </p>
                 <br />
-                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 2nd paragraph, followed by a linebreak then a heading.</span></p><br />
-                <h1 dir="ltr" style="line-height:1.38;margin-top:20pt;margin-bottom:6pt;"><span style="font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Heading 1</span></h1><br />
-                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 3rd paragraph, followed by a linebreak and a list.</span></p><br />
+                <br />
+                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 2nd paragraph, followed by a linebreak then a heading.</span></p>
+                <br />
+                <h1 dir="ltr" style="line-height:1.38;margin-top:20pt;margin-bottom:6pt;"><span style="font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Heading 1</span></h1>
+                <br />
+                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 3rd paragraph, followed by a linebreak and a list.</span></p>
+                <br />
                 <ul style="margin-top:0;margin-bottom:0;padding-inline-start:48px;">
                     <li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">List item 1</span></p></li>
                     <li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">List item 2</span></p></li>
                 </ul>
                 <br />
-                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 4th paragraph, NOT followed by linebreaks.</span></p>
+                <br />
+                <br />
+                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 4th paragraph, with 3 line breaks before but 0 linebreaks after.</span></p>
                 <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 5th paragraph. End of the article.</span></p>
             </b>
             <br class="Apple-interchange-newline">
@@ -277,7 +283,7 @@ describe('HTMLtoLexical: Google Docs', function () {
                                 format: 0,
                                 mode: 'normal',
                                 style: '',
-                                text: 'Start of the article. Here is the 1st paragraph, followed by a line break then a paragraph.',
+                                text: 'Start of the article. Here is the 1st paragraph, followed by two line breaks then a paragraph.',
                                 type: 'extended-text',
                                 version: 1
                             }
@@ -402,7 +408,7 @@ describe('HTMLtoLexical: Google Docs', function () {
                                 format: 0,
                                 mode: 'normal',
                                 style: '',
-                                text: 'Here is the 4th paragraph, NOT followed by linebreaks.',
+                                text: 'Here is the 4th paragraph, with 3 line breaks before but 0 linebreaks after.',
                                 type: 'extended-text',
                                 version: 1
                             }

--- a/packages/koenig-lexical/test/e2e/fixtures/paste/google-docs-empty-paragraphs.html
+++ b/packages/koenig-lexical/test/e2e/fixtures/paste/google-docs-empty-paragraphs.html
@@ -5,6 +5,7 @@
         <span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Start of the article. Here is the 1st paragraph, followed by a line break then a paragraph.</span>
     </p>
     <br />
+    <br />
     <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 2nd paragraph, followed by a linebreak then a heading.</span></p><br />
     <h1 dir="ltr" style="line-height:1.38;margin-top:20pt;margin-bottom:6pt;"><span style="font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Heading 1</span></h1><br />
     <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 3rd paragraph, followed by a linebreak and a list.</span></p><br />
@@ -16,6 +17,8 @@
             <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">List item 2</span></p>
         </li>
     </ul>
+    <br />
+    <br />
     <br />
     <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 4th paragraph, NOT followed by linebreaks.</span></p>
     <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 5th paragraph. End of the article.</span></p>


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/ENG-1481

- if a google document has multiple line breaks, we now skip those when copy/pasting into the editor, to avoid creating empty paragraphs