### PR TITLE
🐛 Removed extra paragraphs around dividers when copy/pasting from gdoc

### DIFF
--- a/packages/kg-default-nodes/lib/kg-default-nodes.js
+++ b/packages/kg-default-nodes/lib/kg-default-nodes.js
@@ -28,6 +28,7 @@ import * as atLink from './nodes/at-link/index.js';
 import * as zwnj from './nodes/zwnj/ZWNJNode.js';
 
 import linebreakSerializers from './serializers/linebreak';
+import paragraphSerializers from './serializers/paragraph';
 
 // re-export everything for easier importing
 export * from './KoenigDecoratorNode';
@@ -61,13 +62,15 @@ export * from './nodes/at-link/index.js';
 export * from './nodes/zwnj/ZWNJNode';
 
 export const serializers = {
-    linebreak: linebreakSerializers
+    linebreak: linebreakSerializers,
+    paragraph: paragraphSerializers
 };
 
 export const DEFAULT_CONFIG = {
     html: {
         import: {
-            ...serializers.linebreak.import
+            ...serializers.linebreak.import,
+            ...serializers.paragraph.import
         }
     }
 };

--- a/packages/kg-default-nodes/lib/serializers/paragraph.js
+++ b/packages/kg-default-nodes/lib/serializers/paragraph.js
@@ -1,0 +1,18 @@
+export default {
+    import: {
+        p: (node) => {
+            const isGoogleDocs = !!node.closest('[id^="docs-internal-guid-"]');
+
+            // Google docs wraps dividers in paragraphs, without text content
+            // Remove them to avoid creating empty paragraphs in the editor
+            if (isGoogleDocs && node.textContent === '') {
+                return {
+                    conversion: () => null,
+                    priority: 1
+                };
+            }
+
+            return null;
+        }
+    }
+};

--- a/packages/kg-default-nodes/test/serializers/paragraph.test.js
+++ b/packages/kg-default-nodes/test/serializers/paragraph.test.js
@@ -1,0 +1,70 @@
+const {createDocument} = require('../utils');
+const {createHeadlessEditor} = require('@lexical/headless');
+const {$generateNodesFromDOM} = require('@lexical/html');
+const {DEFAULT_CONFIG, DEFAULT_NODES} = require('../../cjs/kg-default-nodes');
+
+describe('Serializers: linebreak', function () {
+    let editor;
+
+    const editorTest = testFn => function (done) {
+        editor.update(() => {
+            try {
+                testFn();
+                done();
+            } catch (e) {
+                done(e);
+            }
+        });
+    };
+
+    beforeEach(function () {
+        editor = createHeadlessEditor({nodes: DEFAULT_NODES, html: DEFAULT_CONFIG.html});
+    });
+
+    describe('import', function () {
+        it('(non GDoc) keeps empty paragraphs', editorTest(function () {
+            const htmlString = '<p>Hello World</p><p></p><p>After</p>';
+            const document = createDocument(htmlString);
+            const nodes = $generateNodesFromDOM(editor, document);
+
+            should.equal(nodes.length, 3);
+            should.equal(nodes[0].getType(), 'paragraph');
+            should.equal(nodes[1].getType(), 'paragraph');
+            should.equal(nodes[2].getType(), 'paragraph');
+        }));
+
+        it('(GDoc) removes empty paragraphs', editorTest(function () {
+            const htmlString = '<div id="docs-internal-guid-1234"><p>Hello World</p><p></p><p>After</p></div>';
+            const document = createDocument(htmlString);
+            const nodes = $generateNodesFromDOM(editor, document);
+
+            should.equal(nodes.length, 2);
+            should.equal(nodes[0].getType(), 'paragraph');
+            should.equal(nodes[1].getType(), 'paragraph');
+        }));
+
+        it('(non GDoc) keeps empty paragraphs around dividers', editorTest(function () {
+            const htmlString = '<p>Hello World</p><p><hr></p><p>After</p>';
+            const document = createDocument(htmlString);
+            const nodes = $generateNodesFromDOM(editor, document);
+
+            should.equal(nodes.length, 5);
+            should.equal(nodes[0].getType(), 'paragraph');
+            should.equal(nodes[1].getType(), 'paragraph');
+            should.equal(nodes[2].getType(), 'horizontalrule');
+            should.equal(nodes[3].getType(), 'paragraph');
+            should.equal(nodes[4].getType(), 'paragraph');
+        }));
+
+        it('(GDoc) removes empty paragraphs around dividers', editorTest(function () {
+            const htmlString = '<div id="docs-internal-guid-1234"><p>Hello World</p><p><hr></p><p>After</p></div>';
+            const document = createDocument(htmlString);
+            const nodes = $generateNodesFromDOM(editor, document);
+
+            should.equal(nodes.length, 3);
+            should.equal(nodes[0].getType(), 'paragraph');
+            should.equal(nodes[1].getType(), 'horizontalrule');
+            should.equal(nodes[2].getType(), 'paragraph');
+        }));
+    });
+});

--- a/packages/kg-html-to-lexical/test/sources/google-docs.test.ts
+++ b/packages/kg-html-to-lexical/test/sources/google-docs.test.ts
@@ -246,29 +246,26 @@ describe('HTMLtoLexical: Google Docs', function () {
 
     it('removes extra empty paragraphs', function () {
         const input = html`
-            <b style="font-weight:normal;" id="docs-internal-guid-53c161b0-7fff-55f3-a893-721115583111">
-                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
-                    <span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Start of the article. Here is the 1st paragraph, followed by two line breaks then a paragraph.</span>
-                </p>
+            <meta charset='utf-8'>
+            <meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-3430d4a2-7fff-f2cd-a74a-2f333b387ed3">
+                <p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Start of the article. Here is the 1st paragraph, followed by two line breaks then a paragraph.</span></p>
                 <br />
                 <br />
-                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 2nd paragraph, followed by a linebreak then a heading.</span></p>
+                <p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 2nd paragraph, followed by a line break then a heading.</span></p>
                 <br />
-                <h1 dir="ltr" style="line-height:1.38;margin-top:20pt;margin-bottom:6pt;"><span style="font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Heading 1</span></h1>
+                <h1 dir="ltr" style="line-height:1.656;margin-top:20pt;margin-bottom:6pt;"><span style="font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Heading 1</span></h1>
                 <br />
-                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 3rd paragraph, followed by a linebreak and a list.</span></p>
+                <p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 3rd paragraph, with a line break before and a line break after, followed by a list.</span></p>
                 <br />
                 <ul style="margin-top:0;margin-bottom:0;padding-inline-start:48px;">
                     <li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">List item 1</span></p></li>
                     <li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">List item 2</span></p></li>
                 </ul>
                 <br />
-                <br />
-                <br />
-                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 4th paragraph, with 3 line breaks before but 0 linebreaks after.</span></p>
-                <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 5th paragraph. End of the article.</span></p>
+                <p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 4th paragraph, with a line break before and a divider after.</span></p>
+                <p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><hr /></p>
+                <p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 5th paragraph. End of the article.</span></p><br />
             </b>
-            <br class="Apple-interchange-newline">
         `;
 
         const lexical = converter.htmlToLexical(input, editorConfig);
@@ -301,7 +298,7 @@ describe('HTMLtoLexical: Google Docs', function () {
                                 format: 0,
                                 mode: 'normal',
                                 style: '',
-                                text: 'Here is the 2nd paragraph, followed by a linebreak then a heading.',
+                                text: 'Here is the 2nd paragraph, followed by a line break then a heading.',
                                 type: 'extended-text',
                                 version: 1
                             }
@@ -338,7 +335,7 @@ describe('HTMLtoLexical: Google Docs', function () {
                                 format: 0,
                                 mode: 'normal',
                                 style: '',
-                                text: 'Here is the 3rd paragraph, followed by a linebreak and a list.',
+                                text: 'Here is the 3rd paragraph, with a line break before and a line break after, followed by a list.',
                                 type: 'extended-text',
                                 version: 1
                             }
@@ -408,7 +405,7 @@ describe('HTMLtoLexical: Google Docs', function () {
                                 format: 0,
                                 mode: 'normal',
                                 style: '',
-                                text: 'Here is the 4th paragraph, with 3 line breaks before but 0 linebreaks after.',
+                                text: 'Here is the 4th paragraph, with a line break before and a divider after.',
                                 type: 'extended-text',
                                 version: 1
                             }
@@ -417,6 +414,10 @@ describe('HTMLtoLexical: Google Docs', function () {
                         format: '',
                         indent: 0,
                         type: 'paragraph',
+                        version: 1
+                    },
+                    {
+                        type: 'horizontalrule',
                         version: 1
                     },
                     {

--- a/packages/koenig-lexical/test/e2e/fixtures/paste/google-docs-empty-paragraphs.html
+++ b/packages/koenig-lexical/test/e2e/fixtures/paste/google-docs-empty-paragraphs.html
@@ -1,14 +1,9 @@
 <meta charset='utf-8'>
-<meta charset="utf-8">
-<b style="font-weight:normal;" id="docs-internal-guid-53c161b0-7fff-55f3-a893-721115583111">
-    <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
-        <span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Start of the article. Here is the 1st paragraph, followed by a line break then a paragraph.</span>
-    </p>
-    <br />
-    <br />
-    <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 2nd paragraph, followed by a linebreak then a heading.</span></p><br />
-    <h1 dir="ltr" style="line-height:1.38;margin-top:20pt;margin-bottom:6pt;"><span style="font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Heading 1</span></h1><br />
-    <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 3rd paragraph, followed by a linebreak and a list.</span></p><br />
+<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-3430d4a2-7fff-f2cd-a74a-2f333b387ed3">
+    <p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Start of the article. Here is the 1st paragraph, followed by two line breaks then a paragraph.</span></p><br /><br />
+    <p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 2nd paragraph, followed by a line break then a heading.</span></p><br />
+    <h1 dir="ltr" style="line-height:1.656;margin-top:20pt;margin-bottom:6pt;"><span style="font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Heading 1</span></h1><br />
+    <p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 3rd paragraph, with a line break before and a line break after, followed by a list.</span></p><br />
     <ul style="margin-top:0;margin-bottom:0;padding-inline-start:48px;">
         <li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1">
             <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">List item 1</span></p>
@@ -16,11 +11,8 @@
         <li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1">
             <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">List item 2</span></p>
         </li>
-    </ul>
-    <br />
-    <br />
-    <br />
-    <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 4th paragraph, NOT followed by linebreaks.</span></p>
-    <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 5th paragraph. End of the article.</span></p>
+    </ul><br />
+    <p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 4th paragraph, with a line break before and a divider after.</span></p>
+    <p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><hr /></p>
+    <p dir="ltr" style="line-height:1.656;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Here is the 5th paragraph. End of the article.</span></p><br />
 </b>
-<br class="Apple-interchange-newline">

--- a/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
@@ -377,18 +377,18 @@ test.describe('Paste behaviour', async () => {
             await assertHTML(page, html`
                 <p dir="ltr">
                 <span data-lexical-text="true">
-                    Start of the article. Here is the 1st paragraph, followed by a line break then a paragraph.
+                    Start of the article. Here is the 1st paragraph, followed by two line breaks then a paragraph.
                 </span>
                 </p>
                 <p dir="ltr">
                 <span data-lexical-text="true">
-                    Here is the 2nd paragraph, followed by a linebreak then a heading.
+                    Here is the 2nd paragraph, followed by a line break then a heading.
                 </span>
                 </p>
                 <h1 dir="ltr"><span data-lexical-text="true">Heading 1</span></h1>
                 <p dir="ltr">
                 <span data-lexical-text="true">
-                    Here is the 3rd paragraph, followed by a linebreak and a list.
+                    Here is the 3rd paragraph, with a line break before and a line break after, followed by a list.
                 </span>
                 </p>
                 <ul>
@@ -407,9 +407,17 @@ test.describe('Paste behaviour', async () => {
                 </ul>
                 <p dir="ltr">
                 <span data-lexical-text="true">
-                    Here is the 4th paragraph, NOT followed by linebreaks.
+                    Here is the 4th paragraph, with a line break before and a divider after.
                 </span>
                 </p>
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div
+                        data-kg-card-editing="false"
+                        data-kg-card-selected="false"
+                        data-kg-card="horizontalrule">
+                        <hr />
+                    </div>
+                </div>
                 <p dir="ltr">
                 <span data-lexical-text="true">
                     Here is the 5th paragraph. End of the article.


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/ENG-1488

- Gdoc wraps dividers in an empty paragraph
- With this change, we remove empty paragraphs before pasting the content from Gdoc to the editor