### PR TITLE
🐛 Fixed image dimensions being reset on render

### DIFF
--- a/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ImageNodeComponent.jsx
@@ -99,7 +99,9 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, captionE
 
         uploadInitialFile(initialFile);
 
-        // If we're given a URL instead of a file, populate the image dimensions
+        // Populate missing image dimensions, occurs when images are
+        // pasted/dragged/inserted as external or when loaded from serialized
+        // state that has missing images
         const populateImageDimensions = async () => {
             if (src && !initialFile && !triggerFileDialog) {
                 const {width, height} = await getImageDimensions(src);
@@ -111,7 +113,17 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, captionE
             }
         };
 
-        populateImageDimensions();
+        const hasMissingDimensions = editor.getEditorState().read(() => {
+            const node = $getNodeByKey(nodeKey);
+            if (!node.width || !node.height) {
+                return true;
+            }
+            return false;
+        });
+
+        if (hasMissingDimensions) {
+            populateImageDimensions();
+        }
 
         // We only do this for init
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/koenig-lexical/test/utils/e2e.js
+++ b/packages/koenig-lexical/test/utils/e2e.js
@@ -252,12 +252,19 @@ export async function assertPosition(page, selector, expectedBox, {threshold = 0
     });
 }
 
-export async function assertRootChildren(page, expectedState) {
-    let actualState = await page.evaluate(() => {
+export async function getEditorStateJSON(page) {
+    const json = await page.evaluate(() => {
         const rootElement = document.querySelector('div[contenteditable="true"]');
         const editor = rootElement.__lexicalEditor;
-        return JSON.stringify(editor.getEditorState().toJSON().root.children);
+        return JSON.stringify(editor.getEditorState().toJSON());
     });
+
+    return json;
+}
+
+export async function assertRootChildren(page, expectedState) {
+    const state = await getEditorStateJSON(page);
+    const actualState = JSON.stringify(JSON.parse(state).root.children);
 
     const actual = prettifyJSON(actualState);
     const expected = prettifyJSON(expectedState);


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-1532

- when an image is inserted into the editor we store the original image dimensions in the node state
- when an image is first rendered from a serialized state we were re-populating the image dimensions based on the loaded image
- Ghost by default resizes images shown in the editor to a max-width of 2000px meaning opening a post in the editor could cause an immediate re-save or switch to an "unsaved" state for an already published post
- Ghost's secondary editor instance used to detect and ignore change-on-render changes for published posts was being tripped up by this particular change as it would only occur in the visible editor because the secondary hidden editor doesn't load images and won't trigger the `onload` event used to extract displayed image dimensions therefore unexpectedly showing the "unsaved changes" modal when trying to leave a published post without editing anything
- updated the logic to only fetch image dimensions when we don't already have serialized data to avoid unstable editor state and to prevent limiting our resize behaviour to the default 2000px for future use-cases
