### PR TITLE
Fixes invisible link selection within editor in dark mode

### DIFF
--- a/packages/koenig-lexical/src/components/ui/LinkInput.jsx
+++ b/packages/koenig-lexical/src/components/ui/LinkInput.jsx
@@ -52,7 +52,7 @@ export function LinkInput({href, update, cancel}) {
         <div ref={containerRef} className="relative m-0 flex items-center justify-evenly gap-1 rounded-lg bg-white p-1 font-sans text-md font-normal text-black shadow-md dark:bg-grey-950">
             <input
                 ref={inputRef}
-                className="mb-[1px] h-8 w-full pl-3 pr-9 leading-loose text-grey-900 selection:bg-grey/40 dark:bg-grey-950"
+                className="mb-[1px] h-8 w-full pl-3 pr-9 leading-loose text-grey-900 selection:bg-grey/40 dark:bg-grey-950 dark:text-grey-300 dark:selection:bg-grey-800/40 dark:selection:text-grey-100"
                 data-testid="link-input"
                 placeholder="Enter url"
                 value={_href}

--- a/packages/koenig-lexical/src/components/ui/LinkInputWithSearch.jsx
+++ b/packages/koenig-lexical/src/components/ui/LinkInputWithSearch.jsx
@@ -84,7 +84,7 @@ export function LinkInputWithSearch({href, update, cancel}) {
         <div ref={containerRef} className="relative m-0 flex w-full flex-col rounded-lg bg-white p-1 px-2 font-sans text-sm font-medium shadow-md dark:bg-grey-950">
             <Input
                 autoFocus={true}
-                className="my-1 h-auto w-full rounded-md border border-transparent bg-grey-100 px-4 py-2 text-left text-sm font-medium leading-snug text-black placeholder:text-sm placeholder:font-medium placeholder:leading-snug placeholder:text-grey-500 focus:border-green focus:bg-white focus:shadow-[0_0_0_2px_rgba(48,207,67,.25)] dark:border-grey-800/80 dark:bg-grey-900 dark:text-white dark:focus:border-green dark:focus:bg-grey-900"
+                className="my-1 h-auto w-full rounded-md border border-transparent bg-grey-100 px-4 py-2 text-left text-sm font-medium leading-snug text-black placeholder:text-sm placeholder:font-medium placeholder:leading-snug placeholder:text-grey-500 focus:border-green focus:bg-white focus:shadow-[0_0_0_2px_rgba(48,207,67,.25)] dark:border-grey-800/80 dark:bg-grey-900 dark:text-white dark:selection:bg-grey-600/40 dark:selection:text-grey-100 dark:focus:border-green dark:focus:bg-grey-900"
                 dataTestId={testId}
                 placeholder="Search or enter URL to link"
                 value={_href}


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/DES-924/text-selection-color-non-existent-for-editing-links-in-dark-mode

In dark mode, when you'd edit your link and select the text, it would be invisible. That's no longer the case.


https://github.com/user-attachments/assets/900c4093-6f0b-4871-93ed-fad27970cdcf

