### PR TITLE
[draft] make embedded video in html cards work in email

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/html/html-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/html/html-renderer.js
@@ -1,16 +1,48 @@
 import {addCreateDocumentOption} from '../../utils/add-create-document-option';
 import {renderEmptyContainer} from '../../utils/render-empty-container';
+import * as cheerio from 'cheerio';
 
+function rewriteVideoEmbeds(html, postUrl) {
+    try {
+        // quick check that there's a video tag in the html
+        const videoTagRegex = /<video.*?>/g;
+        if (!videoTagRegex.test(html)) {
+            return html;
+        }
+        const $ = cheerio.load(html);
+        // check the html for one or more video tags
+        const videoTags = $('video');
+        if (videoTags.length === 0 || !postUrl) {
+            return html;
+        }
+        // loop over video tags, looking for any with the poster attribute
+        videoTags.each((index, videoTag) => {
+            const $videoTag = $(videoTag);
+            const poster = $videoTag.attr('poster');
+            // if a poster attribute is found, replace the video with a linked image
+            if (poster) {
+                const title = $videoTag.attr('title') || 'Click to play video';
+                $videoTag.replaceWith(`<a href="${postUrl}"><img src="${poster}" title="${title}" alt="${title}" /></a>`);
+            } 
+        });
+        return $.html();
+    } catch (err) {
+        return html;
+    }
+}
+   
 export function renderHtmlNode(node, options = {}) {
     addCreateDocumentOption(options);
     const document = options.createDocument();
 
-    const html = node.html;
+    let html = node.html;
 
     if (!html) {
         return renderEmptyContainer(document);
     }
-
+    if (options.target === 'email') {
+        html = rewriteVideoEmbeds(html, options.postUrl);
+    }
     const wrappedHtml = `\n<!--kg-card-begin: html-->\n${html}\n<!--kg-card-end: html-->\n`;
 
     const textarea = document.createElement('textarea');

--- a/packages/kg-default-nodes/package.json
+++ b/packages/kg-default-nodes/package.json
@@ -51,6 +51,7 @@
     "@lexical/utils": "0.13.1",
     "@tryghost/kg-clean-basic-html": "4.1.4",
     "@tryghost/kg-markdown-html-renderer": "7.0.7",
+    "cheerio": "^1.0.0",
     "html-minifier": "^4.0.0",
     "jsdom": "^24.1.0",
     "lexical": "0.13.1",


### PR DESCRIPTION
Some Ghost users host videos externally (i.e. on AWS) and use the html card to paste in a video tag.  Email clients generally show nothing, not even the poster.

This patch adjusts the write-out of the html card (only for email, not for web), identifying video tags with the poster attribute set, and replacing them with the poster image and a link to the published post.

I'm using cheerio for this proof of concept, but happy to swap it for something else.  (It would be a new dependency for Koenig.)