### PR TITLE
🐛Fix an extra p accidentally introduced in headings. 

### DIFF
--- a/packages/koenig-lexical/src/nodes/HeaderNode.jsx
+++ b/packages/koenig-lexical/src/nodes/HeaderNode.jsx
@@ -76,7 +76,7 @@ export class HeaderNode extends BaseHeaderNode {
         if (this.__headerTextEditor) {
             this.__headerTextEditor.getEditorState().read(() => {
                 const html = $generateHtmlFromNodes(this.__headerTextEditor, null);
-                const cleanedHtml = cleanBasicHtml(html, {firstChildInnerContent: false, allowBr: true});
+                const cleanedHtml = cleanBasicHtml(html, {firstChildInnerContent: true, allowBr: true});
                 json.header = cleanedHtml;
             });
         }

--- a/packages/koenig-lexical/src/nodes/ProductNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ProductNode.jsx
@@ -68,7 +68,7 @@ export class ProductNode extends BaseProductNode {
         if (this.__productTitleEditor) {
             this.__productTitleEditor.getEditorState().read(() => {
                 const html = $generateHtmlFromNodes(this.__productTitleEditor, null);
-                const cleanedHtml = cleanBasicHtml(html, {firstChildInnerContent: false, allowBr: true});
+                const cleanedHtml = cleanBasicHtml(html, {firstChildInnerContent: true, allowBr: true});
                 json.productTitle = cleanedHtml;
             });
         }

--- a/packages/koenig-lexical/src/nodes/SignupNode.jsx
+++ b/packages/koenig-lexical/src/nodes/SignupNode.jsx
@@ -79,7 +79,7 @@ export class SignupNode extends BaseSignupNode {
         if (this.__headerTextEditor) {
             this.__headerTextEditor.getEditorState().read(() => {
                 const html = $generateHtmlFromNodes(this.__headerTextEditor, null);
-                const cleanedHtml = cleanBasicHtml(html, {firstChildInnerContent: false, allowBr: true});
+                const cleanedHtml = cleanBasicHtml(html, {firstChildInnerContent: true, allowBr: true});
                 json.header = cleanedHtml;
             });
         }


### PR DESCRIPTION
This corrects my previous PR, which accidentally added an extra p element around the content in a couple of headings.  
