### PR TITLE
✅✨Allow br tags in more elements, add tests 

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/HeaderCard/v2/HeaderCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/HeaderCard/v2/HeaderCard.jsx
@@ -314,6 +314,7 @@ export function HeaderCard({alignment,
                         {/* Subheading */}
                         {<KoenigNestedEditor
                             dataTestId="header-subheader-editor"
+                            defaultKoenigEnterBehavior={true}
                             hasSettingsPanel={true}
                             initialEditor={subheaderTextEditor}
                             initialEditorState={subheaderTextEditorInitialState}

--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
@@ -336,6 +336,7 @@ export function SignupCard({alignment,
                         {/* Disclaimer */}
                         <KoenigNestedEditor
                             dataTestId="signup-disclaimer-editor"
+                            defaultKoenigEnterBehaviour={true}
                             hasSettingsPanel={true}
                             initialEditor={disclaimerTextEditor}
                             initialEditorState={disclaimerTextEditorInitialState}

--- a/packages/koenig-lexical/src/nodes/ProductNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ProductNode.jsx
@@ -68,7 +68,7 @@ export class ProductNode extends BaseProductNode {
         if (this.__productTitleEditor) {
             this.__productTitleEditor.getEditorState().read(() => {
                 const html = $generateHtmlFromNodes(this.__productTitleEditor, null);
-                const cleanedHtml = cleanBasicHtml(html, {firstChildInnerContent: true});
+                const cleanedHtml = cleanBasicHtml(html, {firstChildInnerContent: true, allowBr: true});
                 json.productTitle = cleanedHtml;
             });
         }

--- a/packages/koenig-lexical/src/nodes/ToggleNode.jsx
+++ b/packages/koenig-lexical/src/nodes/ToggleNode.jsx
@@ -67,7 +67,7 @@ export class ToggleNode extends BaseToggleNode {
         if (this.__headingEditor) {
             this.__headingEditor.getEditorState().read(() => {
                 const html = $generateHtmlFromNodes(this.__headingEditor, null);
-                const cleanedHtml = cleanBasicHtml(html, {firstChildInnerContent: true});
+                const cleanedHtml = cleanBasicHtml(html, {firstChildInnerContent: true, allowBr: true});
                 json.heading = cleanedHtml;
             });
         }

--- a/packages/koenig-lexical/src/utils/generateEditorState.js
+++ b/packages/koenig-lexical/src/utils/generateEditorState.js
@@ -14,7 +14,7 @@ export default function generateEditorState({editor, initialHtml}) {
             // https://github.com/facebook/lexical/issues/2807
             // https://github.com/facebook/lexical/issues/3677
             // As a temporary fix, checking node content to remove additional spaces and br
-            const filteredNodes = nodes.filter(n => n.getTextContent().trim());
+            const filteredNodes = nodes.filter(n => n.getType() === 'linebreak' || n.getTextContent().trim());
 
             // Select the root
             $getRoot().select();

--- a/packages/koenig-lexical/src/utils/generateEditorState.js
+++ b/packages/koenig-lexical/src/utils/generateEditorState.js
@@ -16,7 +16,6 @@ export default function generateEditorState({editor, initialHtml}) {
         editor.update(() => {
             const nodes = _$generateNodesFromHTML(editor, initialHtml);
 
-
             // Select the root
             $getRoot().select();
             // Clear existing content (we initialize an editor with an empty p node so it is focusable if there's no content)

--- a/packages/koenig-lexical/test/e2e/cards/product-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/product-card.test.js
@@ -454,6 +454,293 @@ test.describe('Product card', async () => {
             <p><br /></p>
         `, {ignoreCardToolbarContents: true, ignoreInnerSVG: true});
     });
+    test('can import serialized product card nodes with a br', async function () {
+        const contentParam = encodeURIComponent(JSON.stringify({
+            root: {
+                children: [{
+                    type: 'product',
+                    productImageSrc: '/content/images/2022/11/koenig-lexical.jpg',
+                    productTitle: '<span>This is <em>title</em></span><br /><span>Second line</span>',
+                    productDescription: '<p dir="ltr"><span>Description</span><br /><span>Moar description</span></p>',
+                    productUrl: 'https://google.com/',
+                    productButton: 'Button',
+                    productButtonEnabled: true,
+                    productRatingEnabled: true,
+                    productStarRating: 4
+                }],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        }));
+
+        await initialize({page, uri: `/#/?content=${contentParam}`});
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div
+                    data-kg-card-editing="false"
+                    data-kg-card-selected="false"
+                    data-kg-card="product">
+                    <div>
+                        <div>
+                            <img
+                                alt="Product thumbnail"
+                                src="/content/images/2022/11/koenig-lexical.jpg" />
+                        </div>
+                        <div>
+                            <div>
+                                <div>
+                                    <div data-kg="editor">
+                                        <div
+                                            contenteditable="false"
+                                            role="textbox"
+                                            spellcheck="true"
+                                            data-lexical-editor="true"
+                                            aria-autocomplete="none"
+                                            aria-readonly="true">
+                                            <p dir="ltr">
+                                                <span data-lexical-text="true">This is</span>
+                                                <em data-lexical-text="true">title</em>
+                                                <br />
+                                                <span data-lexical-text="true">Second line</span>
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div>
+                                <button type="button"><svg></svg></button>
+                                <button type="button"><svg></svg></button>
+                                <button type="button"><svg></svg></button>
+                                <button type="button"><svg></svg></button>
+                                <button type="button"><svg></svg></button>
+                            </div>
+                        </div>
+                        <div>
+                            <div>
+                                <div data-kg="editor">
+                                    <div
+                                        contenteditable="false"
+                                        role="textbox"
+                                        spellcheck="true"
+                                        data-lexical-editor="true"
+                                        aria-autocomplete="none"
+                                        aria-readonly="true">
+                                        <p dir="ltr">
+                                            <span data-lexical-text="true">Description</span>
+                                            <br />
+                                            <span data-lexical-text="true">Moar description</span>
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <a href="https://google.com/"><span>Button</span></a>
+                        </div>
+                    </div>
+                    <div></div>
+                </div>
+            </div>
+            `, {ignoreCardToolbarContents: true, ignoreInnerSVG: true});
+    });
+    test('handles receiving titles wrapped in p', async function () {
+        const contentParam = encodeURIComponent(JSON.stringify({
+            root: {
+                children: [{
+                    type: 'product',
+                    productImageSrc: '/content/images/2022/11/koenig-lexical.jpg',
+                    productTitle: '<p class="optional"><span>This is <em>title</em></span><br /><span>Second line</span></p>',
+                    productDescription: '<p dir="ltr"><span>Description</span><br /><span>Moar description</span></p>',
+                    productUrl: 'https://google.com/',
+                    productButton: 'Button',
+                    productButtonEnabled: true,
+                    productRatingEnabled: true,
+                    productStarRating: 4
+                }],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        }));
+
+        await initialize({page, uri: `/#/?content=${contentParam}`});
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div
+                    data-kg-card-editing="false"
+                    data-kg-card-selected="false"
+                    data-kg-card="product">
+                    <div>
+                        <div>
+                            <img
+                                alt="Product thumbnail"
+                                src="/content/images/2022/11/koenig-lexical.jpg" />
+                        </div>
+                        <div>
+                            <div>
+                                <div>
+                                    <div data-kg="editor">
+                                        <div
+                                            contenteditable="false"
+                                            role="textbox"
+                                            spellcheck="true"
+                                            data-lexical-editor="true"
+                                            aria-autocomplete="none"
+                                            aria-readonly="true">
+                                            <p dir="ltr">
+                                                <span data-lexical-text="true">This is</span>
+                                                <em data-lexical-text="true">title</em>
+                                                <br />
+                                                <span data-lexical-text="true">Second line</span>
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div>
+                                <button type="button"><svg></svg></button>
+                                <button type="button"><svg></svg></button>
+                                <button type="button"><svg></svg></button>
+                                <button type="button"><svg></svg></button>
+                                <button type="button"><svg></svg></button>
+                            </div>
+                        </div>
+                        <div>
+                            <div>
+                                <div data-kg="editor">
+                                    <div
+                                        contenteditable="false"
+                                        role="textbox"
+                                        spellcheck="true"
+                                        data-lexical-editor="true"
+                                        aria-autocomplete="none"
+                                        aria-readonly="true">
+                                        <p dir="ltr">
+                                            <span data-lexical-text="true">Description</span>
+                                            <br />
+                                            <span data-lexical-text="true">Moar description</span>
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <a href="https://google.com/"><span>Button</span></a>
+                        </div>
+                    </div>
+                    <div></div>
+                </div>
+            </div>
+            `, {ignoreCardToolbarContents: true, ignoreInnerSVG: true});
+    });
+    test('can handle new shift-enter in title and description', async () => {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'product'});
+
+        await page.keyboard.type('Test title');
+        await page.keyboard.press('Shift+Enter');
+        await page.keyboard.type('Second line of title');
+
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('Test description');
+        await page.keyboard.press('Shift+Enter');
+        await page.keyboard.type('Second line of description');
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div
+                    data-kg-card-editing="true"
+                    data-kg-card-selected="true"
+                    data-kg-card="product">
+                    <div>
+                        <div>
+                            <div>
+                                <div>
+                                    <button name="placeholder-button" type="button">
+                                        <svg></svg>
+                                        <p>Click to select a product image</p>
+                                    </button>
+                                </div>
+                            </div>
+                            <form>
+                                <input
+                                    accept="image/gif,image/jpg,image/jpeg,image/png,image/svg+xml,image/webp"
+                                    hidden=""
+                                    name="image-input"
+                                    type="file" />
+                            </form>
+                        </div>
+                        <div>
+                            <div>
+                                <div>
+                                    <div data-kg="editor">
+                                        <div
+                                            contenteditable="true"
+                                            role="textbox"
+                                            spellcheck="true"
+                                            data-lexical-editor="true"
+                                        >
+                                            <p dir="ltr">
+                                                <span data-lexical-text="true">Test title</span>
+                                                <br />
+                                                <span data-lexical-text="true">Second line of title</span>
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div>
+                                <div data-kg="editor">
+                                    <div
+                                        contenteditable="true"
+                                        role="textbox"
+                                        spellcheck="true"
+                                        data-lexical-editor="true"
+                                    >
+                                        <p dir="ltr"><span data-lexical-text="true">Test description</span>
+                                            <br />
+                                            <span data-lexical-text="true">Second line of description</span>
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div>
+                        <div draggable="true">
+                            <label>
+                                <div><div>Rating</div></div>
+                                <div>
+                                    <label id="product-rating-toggle">
+                                        <input type="checkbox" />
+                                        <div></div>
+                                    </label>
+                                </div>
+                            </label>
+                            <label>
+                                <div><div>Button</div></div>
+                                <div>
+                                    <label id="product-button-toggle">
+                                        <input type="checkbox" />
+                                        <div></div>
+                                    </label>
+                                </div>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <p><br /></p>
+            `, {ignoreCardToolbarContents: true, ignoreInnerSVG: true});
+    });
 });
 
 async function uploadImg(page, src = 'large-image.png') {

--- a/packages/koenig-lexical/test/e2e/cards/signup-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/signup-card.test.js
@@ -510,7 +510,163 @@ test.describe('Signup card', async () => {
         const swappedContainer = await page.locator('[data-testid="signup-card-content"]');
         await expect(swappedContainer).toHaveClass(/sm:flex-row-reverse/);
     });
-
+    test('can import when brs are present in the serialized content', async function () {
+        const contentParam = encodeURIComponent(JSON.stringify({
+            root: {
+                children: [{
+                    alignment: 'left',
+                    backgroundColor: 'accent',
+                    backgroundImageSrc: '__GHOST_URL__/content/images/2023/05/fake-image.jpg',
+                    buttonColor: '#ffffff',
+                    buttonText: '',
+                    buttonTextColor: '#000000',
+                    disclaimer: '<span>Disclaimer</span><br /><span>Moar legal stuffz</span>',
+                    header: '<span>Header</span><br /><span>More header</span>',
+                    labels: [],
+                    layout: 'split',
+                    subheader: '<span>Subheader</span><br /><span>More subheader</span>',
+                    textColor: '#FFFFFF',
+                    type: 'signup',
+                    swaped: false,
+                    version: 1
+                }],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        }));
+        await initialize({page, uri: `/#/?content=${contentParam}`});
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false" data-kg-card-width="full">
+                <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="signup">
+                    <div>
+                        <div>
+                            <div>
+                                <img alt="Background image"
+                                    src="__GHOST_URL__/content/images/2023/05/fake-image.jpg" />
+                                <div></div>
+                                <div>
+                                    <button aria-label="Contain" type="button">
+                                        <svg></svg>
+                                        <div><span>Contain</span></div>
+                                    </button>
+                                    <button aria-label="Delete" type="button">
+                                        <svg></svg>
+                                        <div><span>Delete</span></div>
+                                    </button>
+                                </div>
+                            </div>
+                            <div>
+                                <div>
+                                    <div data-kg="editor">
+                                        <div contenteditable="false" role="textbox" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none" aria-readonly="true">
+                                            <p dir="ltr"><span data-lexical-text="true">Header</span>
+                                            <br />
+                                            <span data-lexical-text="true">More header</span>
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div>
+                                    <div data-kg="editor">
+                                        <div contenteditable="false" role="textbox" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none" aria-readonly="true">
+                                            <p dir="ltr"><span data-lexical-text="true">Subheader</span>
+                                            <br />
+                                            <span data-lexical-text="true">More subheader</span>
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div>
+                                    <div>
+                                        <input placeholder="Your email" tabindex="-1" readonly="" value="" />
+                                        <button disabled="" type="button"><span>Subscribe</span></button>
+                                    </div>
+                                </div>
+                                <div>
+                                    <div data-kg="editor">
+                                        <div contenteditable="false" role="textbox" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none" aria-readonly="true">
+                                            <p dir="ltr"><span data-lexical-text="true">Disclaimer</span>
+                                            <br />
+                                            <span data-lexical-text="true">Moar legal stuffz</span>
+                                            </p>
+                                        </div>
+                                    </div>
+                                    </div>
+                                </div>
+                            </div><div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        `);
+    });
+    test('can put a br anywhere', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'signup'});
+        await page.keyboard.press('Shift+Enter');
+        await page.keyboard.type('line two');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Shift+Enter');
+        await page.keyboard.type('line two');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Shift+Enter');
+        await page.keyboard.type('pickles');
+        await page.keyboard.press('Escape');
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false" data-kg-card-width="wide">
+                <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="signup">
+                    <div>
+                        <div>
+                            <div>
+                                <div>
+                                    <div data-kg="editor">
+                                        <div contenteditable="false" role="textbox" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none" aria-readonly="true">
+                                            <p dir="ltr"><span data-lexical-text="true">Sign up for Koenig Lexical</span>
+                                            <br />
+                                            <span data-lexical-text="true">line two</span>
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div>
+                                    <div data-kg="editor">
+                                        <div contenteditable="false" role="textbox" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none" aria-readonly="true">
+                                            <p dir="ltr"><span data-lexical-text="true">There's a whole lot to discover in this editor. Let us help you settle in.</span>
+                                            <br />
+                                            <span data-lexical-text="true">line two</span>
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div>
+                                    <div>
+                                        <input placeholder="Your email" tabindex="-1" readonly="" value="" />
+                                        <button disabled="" type="button"><span>Subscribe</span></button>
+                                    </div>
+                                </div>
+                                <div>
+                                    <div data-kg="editor">
+                                        <div contenteditable="false" role="textbox" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none" aria-readonly="true">
+                                            <p dir="ltr"><span data-lexical-text="true">No spam. Unsubscribe anytime.</span>
+                                            <br />
+                                            <span data-lexical-text="true">pickles</span>
+                                            </p>
+                                        </div>
+                                    </div>
+                                    </div>
+                                </div>
+                            </div><div>
+                        </div>
+                    </div>
+                    <div data-kg-card-toolbar="signup"></div>
+                </div>
+            </div>
+            <p><br /></p>
+        `, {ignoreCardToolbarContents: true});
+    });
     /*test('can undo/redo without losing nested editor content', async () => {
         await focusEditor(page);
         await insertCard(page, {cardName: 'signup'});

--- a/packages/koenig-lexical/test/unit/headerCardv2.test.js
+++ b/packages/koenig-lexical/test/unit/headerCardv2.test.js
@@ -1,0 +1,87 @@
+import {$createHeaderNode, HeaderNode} from '../../src/nodes/HeaderNode';
+const {createHeadlessEditor} = require('@lexical/headless');
+
+const editorNodes = [HeaderNode];
+
+describe('HeaderNode v2', function () {
+    let editor;
+    let dataset;
+
+    const editorTest = testFn => function () {
+        let resolve, reject;
+        const promise = new Promise((resolve_, reject_) => {
+            resolve = resolve_;
+            reject = reject_;
+        });
+
+        editor.update(() => {
+            try {
+                testFn();
+                resolve();
+            } catch (error) {
+                reject(error);
+            }
+        });
+
+        return promise;
+    };
+
+    beforeEach(function () {
+        editor = createHeadlessEditor({nodes: editorNodes});
+
+        dataset = {
+            type: 'header',
+            version: 2,
+            size: 'small',
+            style: 'dark',
+            buttonEnabled: false,
+            buttonUrl: '',
+            buttonText: '',
+            header: '<span style="white-space: pre-wrap;">Hello header</span><br><span style="white-space: pre-wrap;">On two lines, even.</span>',
+            subheader: '<p dir="ltr"><span style="white-space: pre-wrap;">Subheadings are awesome</span><br><span style="white-space: pre-wrap;">I like them a lot.</span></p>',
+            backgroundImageSrc: '',
+            accentColor: '#ff0095',
+            alignment: 'center',
+            backgroundColor: '#000000',
+            backgroundImageWidth: null,
+            backgroundImageHeight: null,
+            backgroundSize: 'cover',
+            textColor: '#FFFFFF',
+            buttonColor: '#ffffff',
+            buttonTextColor: '#000000',
+            layout: 'full',
+            swapped: false
+        };
+    });
+
+    describe('Content load and export testing', function () {     
+        it('handles titles with extra br', editorTest(function () {
+            dataset.header = '<span>Product title!</span> <br><span>Hello part 2</span>';
+            const headerNode = $createHeaderNode(dataset);
+            const json = headerNode.exportJSON();
+            const heading = json.header;
+            expect(heading).toEqual('<span style="white-space: pre-wrap;">Product title!</span><br><span style="white-space: pre-wrap;">Hello part 2</span>');
+        }));
+        it('loads and unwraps headers when wrapped with p', editorTest(function () {
+            dataset.header = '<p><span>Product title!</span> <br><span>Hello part 2</span></p>';
+            const headerNode = $createHeaderNode(dataset);
+            const json = headerNode.exportJSON();
+            const heading = json.header;
+            expect(heading).toEqual('<span style="white-space: pre-wrap;">Product title!</span><br><span style="white-space: pre-wrap;">Hello part 2</span>');
+        }));
+        it('allows br tags in subheaders', editorTest(function () {
+            dataset.subheader = '<span>Product title!</span> <br><span>Hello part 2</span>';
+            const headerNode = $createHeaderNode(dataset);
+            const json = headerNode.exportJSON();
+            const subheading = json.subheader;
+            expect(subheading).toEqual('<span style="white-space: pre-wrap;">Product title!</span><br><span style="white-space: pre-wrap;">Hello part 2</span>');
+        }));
+        it('can handle subheaders that are wrapped in p tags', editorTest(function () {
+            dataset.subheader = '<p><span>Product title!</span> <br><span>Hello part 2</span></p>';
+            const headerNode = $createHeaderNode(dataset);
+            const json = headerNode.exportJSON();
+            const subheading = json.subheader;
+            expect(subheading).toEqual('<span style="white-space: pre-wrap;">Product title!</span><br><span style="white-space: pre-wrap;">Hello part 2</span>');
+        }));
+    });
+});

--- a/packages/koenig-lexical/test/unit/productCard.test.js
+++ b/packages/koenig-lexical/test/unit/productCard.test.js
@@ -1,0 +1,75 @@
+import {$createProductNode, ProductNode} from '../../src/nodes/ProductNode';
+const {createHeadlessEditor} = require('@lexical/headless');
+
+const editorNodes = [ProductNode];
+
+describe('ProductNode', function () {
+    let editor;
+    let dataset;
+
+    const editorTest = testFn => function () {
+        let resolve, reject;
+        const promise = new Promise((resolve_, reject_) => {
+            resolve = resolve_;
+            reject = reject_;
+        });
+
+        editor.update(() => {
+            try {
+                testFn();
+                resolve();
+            } catch (error) {
+                reject(error);
+            }
+        });
+
+        return promise;
+    };
+
+    beforeEach(function () {
+        editor = createHeadlessEditor({nodes: editorNodes});
+
+        dataset = {
+            productImageSrc: '/content/images/2022/11/koenig-lexical.jpg',
+            productImageWidth: 200,
+            productImageHeight: 100,
+            productTitle: 'This is a <b>title</b>',
+            productDescription: 'This is a <b>description</b>',
+            productRatingEnabled: true,
+            productButtonEnabled: true,
+            productButton: 'Button text',
+            productUrl: 'https://google.com/'
+        };
+    });
+
+    describe('load and export testing', function () {     
+        it('handles titles with extra br', editorTest(function () {
+            dataset.productTitle = '<span>Product title!</span> <br><span>Hello part 2</span>';
+            const productNode = $createProductNode(dataset);
+            const json = productNode.exportJSON();
+            const title = json.productTitle;
+            expect(title).toEqual('<span style="white-space: pre-wrap;">Product title!</span><br><span style="white-space: pre-wrap;">Hello part 2</span>');
+        }));
+        it('loads and unwraps titles when wrapped with p', editorTest(function () {
+            dataset.productTitle = '<p><span>Product title!</span> <br><span>Hello part 2</span></p>';
+            const productNode = $createProductNode(dataset);
+            const json = productNode.exportJSON();
+            const title = json.productTitle;
+            expect(title).toEqual('<span style="white-space: pre-wrap;">Product title!</span><br><span style="white-space: pre-wrap;">Hello part 2</span>');
+        }));
+        it('combines adjacent spans', editorTest(function () {
+            dataset.productTitle = '<span>Product title!</span> <span>Hello part 2</span>';
+            const productNode = $createProductNode(dataset);
+            const json = productNode.exportJSON();
+            const title = json.productTitle;
+            expect(title).toEqual('<span style="white-space: pre-wrap;">Product title! Hello part 2</span>');
+        }));
+        it('handles italics correctly', editorTest(function () {
+            dataset.productTitle = `<span style="white-space: pre-wrap;">Hello title</span><i><em class="italic" style="white-space: pre-wrap;"> land </em></i><span style="white-space: pre-wrap;">baaaabeee.</span>`;
+            const productNode = $createProductNode(dataset);
+            const json = productNode.exportJSON();
+            const title = json.productTitle;
+            expect(title).toEqual('<span style="white-space: pre-wrap;">Hello title</span><i><em style="white-space: pre-wrap;"> land </em></i><span style="white-space: pre-wrap;">baaaabeee.</span>');
+        }));
+    });
+});

--- a/packages/koenig-lexical/test/unit/signupCard.test.js
+++ b/packages/koenig-lexical/test/unit/signupCard.test.js
@@ -1,0 +1,103 @@
+import {$createSignupNode, SignupNode} from '../../src/nodes/SignupNode';
+const {createHeadlessEditor} = require('@lexical/headless');
+
+const editorNodes = [SignupNode];
+
+describe('SignupNode', function () {
+    let editor;
+    let dataset;
+
+    const editorTest = testFn => function () {
+        let resolve, reject;
+        const promise = new Promise((resolve_, reject_) => {
+            resolve = resolve_;
+            reject = reject_;
+        });
+
+        editor.update(() => {
+            try {
+                testFn();
+                resolve();
+            } catch (error) {
+                reject(error);
+            }
+        });
+
+        return promise;
+    };
+
+    beforeEach(function () {
+        editor = createHeadlessEditor({nodes: editorNodes});
+        dataset = {
+            type: 'signup',
+            version: 1,
+            alignment: 'left',
+            backgroundColor: '#F0F0F0',
+            backgroundImageSrc: '',
+            backgroundSize: 'cover',
+            textColor: '#000000',
+            buttonColor: 'accent',
+            buttonTextColor: '#FFFFFF',
+            buttonText: 'Subscribe',
+            disclaimer: '<span style="white-space: pre-wrap;">No spam. Unsubscribe anytime.</span>',
+            header: '<span style="white-space: pre-wrap;">Sign up for Koenig Lexical</span>',
+            labels: [],
+            layout: 'wide',
+            subheader: '<span style="white-space: pre-wrap;">There\'s a whole lot to discover in this editor. Let us help you settle in.</span>',
+            successMessage: 'Email sent! Check your inbox to complete your signup.',
+            swapped: false
+        };
+    });
+
+    describe('Content load and export testing', function () {  
+        it('handles "normal" content', editorTest(function () {
+            const signupNode = $createSignupNode(dataset);
+            const json = signupNode.exportJSON();
+            expect(json.header).toEqual('<span style="white-space: pre-wrap;">Sign up for Koenig Lexical</span>');
+            expect(json.subheader).toEqual('<span style="white-space: pre-wrap;">There\'s a whole lot to discover in this editor. Let us help you settle in.</span>');
+            expect(json.disclaimer).toEqual('<span style="white-space: pre-wrap;">No spam. Unsubscribe anytime.</span>');
+        }));  
+        it('handles headers with extra br', editorTest(function () {
+            dataset.header = '<span style="white-space: pre-wrap;">Sign up for </span><br><span style="white-space: pre-wrap;">Koenig Lexical</span>';
+            const signupNode = $createSignupNode(dataset);
+            const json = signupNode.exportJSON();
+            const header = json.header;
+            expect(header).toEqual('<span style="white-space: pre-wrap;">Sign up for </span><br><span style="white-space: pre-wrap;">Koenig Lexical</span>');
+        }));
+        it('loads and unwraps headers when wrapped with p', editorTest(function () {
+            dataset.header = '<p><span style="white-space: pre-wrap;">Sign up for </span><br><span style="white-space: pre-wrap;">Koenig Lexical</span></p>';
+            const signupNode = $createSignupNode(dataset);
+            const json = signupNode.exportJSON();
+            const header = json.header;
+            expect(header).toEqual('<span style="white-space: pre-wrap;">Sign up for </span><br><span style="white-space: pre-wrap;">Koenig Lexical</span>');
+        }));
+        it('allows br tags in subheaders', editorTest(function () {
+            dataset.subheader = '<span>Product title!</span> <br><span>Hello part 2</span>';
+            const signupNode = $createSignupNode(dataset);
+            const json = signupNode.exportJSON();
+            const subheader = json.subheader;
+            expect(subheader).toEqual('<span style="white-space: pre-wrap;">Product title!</span><br><span style="white-space: pre-wrap;">Hello part 2</span>');
+        }));
+        it('can handle subheaders that are wrapped in p tags', editorTest(function () {
+            dataset.subheader = '<p><span>Product title!</span> <br><span>Hello part 2</span></p>';
+            const signupNode = $createSignupNode(dataset);
+            const json = signupNode.exportJSON();
+            const subheader = json.subheader;
+            expect(subheader).toEqual('<span style="white-space: pre-wrap;">Product title!</span><br><span style="white-space: pre-wrap;">Hello part 2</span>');
+        }));
+        it('handles disclaimers with extra br', editorTest(function () {
+            dataset.disclaimer = '<span style="white-space: pre-wrap;">No spam. </span><br><span style="white-space: pre-wrap;">Unsubscribe anytime.</span>';
+            const signupNode = $createSignupNode(dataset);
+            const json = signupNode.exportJSON();
+            const disclaimer = json.disclaimer;
+            expect(disclaimer).toEqual('<span style="white-space: pre-wrap;">No spam. </span><br><span style="white-space: pre-wrap;">Unsubscribe anytime.</span>');
+        }));
+        it('loads and unwraps disclaimers when wrapped with p', editorTest(function () {
+            dataset.disclaimer = '<p><span style="white-space: pre-wrap;">No spam. </span><br><span style="white-space: pre-wrap;">Unsubscribe anytime.</span></p>';
+            const signupNode = $createSignupNode(dataset);
+            const json = signupNode.exportJSON();
+            const disclaimer = json.disclaimer;
+            expect(disclaimer).toEqual('<span style="white-space: pre-wrap;">No spam. </span><br><span style="white-space: pre-wrap;">Unsubscribe anytime.</span>');
+        }));
+    });
+});

--- a/packages/koenig-lexical/test/unit/toggleCard.test.js
+++ b/packages/koenig-lexical/test/unit/toggleCard.test.js
@@ -1,0 +1,67 @@
+import {$createToggleNode, ToggleNode} from '../../src/nodes/ToggleNode';
+const {createHeadlessEditor} = require('@lexical/headless');
+
+const editorNodes = [ToggleNode];
+
+describe('ToggleNode', function () {
+    let editor;
+    let dataset;
+
+    const editorTest = testFn => function () {
+        let resolve, reject;
+        const promise = new Promise((resolve_, reject_) => {
+            resolve = resolve_;
+            reject = reject_;
+        });
+
+        editor.update(() => {
+            try {
+                testFn();
+                resolve();
+            } catch (error) {
+                reject(error);
+            }
+        });
+
+        return promise;
+    };
+
+    beforeEach(function () {
+        editor = createHeadlessEditor({nodes: editorNodes});
+        dataset = {
+            type: 'toggle',
+            version: 1,
+            heading: '<span style="white-space: pre-wrap;">Hello</span><br><span style="white-space: pre-wrap;">I am a two-line toggle</span>',
+            content: '<p dir="ltr"><span style="white-space: pre-wrap;">And I\'m actually pretty awesome</span></p><p dir="ltr"><span style="white-space: pre-wrap;">If I do say so myself.</span></p><p dir="ltr"><span style="white-space: pre-wrap;">And I do.</span></p>'
+        };
+    });
+
+    describe('Content load and export testing', function () {  
+        it('handles "normal" content', editorTest(function () {
+            const toggleNode = $createToggleNode(dataset);
+            const json = toggleNode.exportJSON();
+            expect(json.heading).toEqual('<span style="white-space: pre-wrap;">Hello</span><br><span style="white-space: pre-wrap;">I am a two-line toggle</span>');
+            expect(json.content).toEqual('<p><span style="white-space: pre-wrap;">And I\'m actually pretty awesome</span></p><p><span style="white-space: pre-wrap;">If I do say so myself.</span></p><p><span style="white-space: pre-wrap;">And I do.</span></p>');
+        }));
+        it('handles less messy html', editorTest(function () {
+            dataset.heading = '<span>Hello</span>';
+            dataset.content = '<p>And I\'m actually pretty awesome</p><p>If I do say so myself.</p><p>And I do.</p>';
+            const toggleNode = $createToggleNode(dataset);
+            const json = toggleNode.exportJSON();
+            expect(json.heading).toEqual('<span style="white-space: pre-wrap;">Hello</span>');
+            expect(json.content).toEqual('<p><span style="white-space: pre-wrap;">And I\'m actually pretty awesome</span></p><p><span style="white-space: pre-wrap;">If I do say so myself.</span></p><p><span style="white-space: pre-wrap;">And I do.</span></p>');
+        }));
+        it('handles headers with extra br', editorTest(function () {
+            dataset.heading = '<span style="white-space: pre-wrap;">Toggle for </span><br><span style="white-space: pre-wrap;">Koenig Lexical</span>';
+            const toggleNode = $createToggleNode(dataset);
+            const json = toggleNode.exportJSON();
+            expect(json.heading).toEqual('<span style="white-space: pre-wrap;">Toggle for </span><br><span style="white-space: pre-wrap;">Koenig Lexical</span>');
+        }));
+        it('loads and unwraps headers when wrapped with p', editorTest(function () {
+            dataset.heading = '<p><span style="white-space: pre-wrap;">Toggle for </span><br><span style="white-space: pre-wrap;">Koenig Lexical</span></p>';
+            const toggleNode = $createToggleNode(dataset);
+            const json = toggleNode.exportJSON();
+            expect(json.heading).toEqual('<span style="white-space: pre-wrap;">Toggle for </span><br><span style="white-space: pre-wrap;">Koenig Lexical</span>');
+        }));
+    });
+});


### PR DESCRIPTION
Closes https://github.com/TryGhost/Ghost/issues/20027

Current situation (prior to merge of #1404 and this PR):

Quirk 1: Some card editor components respond to shift-enter by creating what looks like a second line in the editor, but it saves as two spans (not separated by a br). Upon reload of the post in the editor, the two spans are combined. (Editor components affected: Product card title, toggle title.)
Quirk 2: Shift enter results in two lines in the editor that save as two spans with a br, but upon reload in the editor, the two are mashed into a single span. (Editor components affected: Header title and subheading, all three signup card components.)

Both behaviors are undesirable, because they cause the appearance of the card in the editor not to match what appears on the published page, and because re-opening a post should not change those components that are not edited.

Enabling shift-enter in additional components also allows a little more flexibility/extensibility of these cards. (For example, a product card 'title' could be used to show a heading and subheading.)

In my first attempt to address the problem (#21076, now reverted), I ran afoul of a gap in the testing setup. Tests of the exporting function were only in kg-default-nodes, but koenig-lexical extends the exportJSON behavior to include an additional cleaning step. These changes were not covered by the existing koenig-lexical test setup, which is predominantly browser-based, and never triggers the exportJSON function.

I've also added a **new set of unit tests to koenig-lexical** that specifically test loading strings into the editor (in headless form) and exporting them for saving via the exportJSON functions defined in that package. These tests should be much closer to what's really going to happen in the Ghost editor than what's available in kg-default-nodes.

**Suggested TODO** (not in this PR): Add additional unit tests in koenig-lexical for any other nodes that are extending exportJSON. 

Tests revealed an additional problem with span smooshing fixed over in #1404  (Thanks Kevin!)