### PR TITLE
Switched to object matching in generateEditorState test

### DIFF
--- a/packages/koenig-lexical/test/unit/utils/generateEditorState.test.js
+++ b/packages/koenig-lexical/test/unit/utils/generateEditorState.test.js
@@ -21,69 +21,92 @@ describe('Utils: generateEditorState', () => {
         const html = '<p>Test</p>';
         const editorState = runGenerateEditorState(html);
 
-        expect(editorState.root.children.length).toEqual(1);
-        expect(editorState.root.children[0].type).toEqual('paragraph');
-        expect(editorState.root.children[0].children[0].text).toEqual('Test');
+        expect(editorState.root.children).toHaveLength(1);
+        expect(editorState.root).toMatchObject({
+            children: [
+                {type: 'paragraph', children: [{text: 'Test'}]}
+            ]
+        });
     });
 
     test('handles whitespace between paragraphs', function () {
         const html = '<p>Test</p> <p>Test2</p>';
         const editorState = runGenerateEditorState(html);
 
-        expect(editorState.root.children.length).toEqual(2);
-        expect(editorState.root.children[0].type).toEqual('paragraph');
-        expect(editorState.root.children[0].children[0].text).toEqual('Test');
-        expect(editorState.root.children[1].type).toEqual('paragraph');
-        expect(editorState.root.children[1].children[0].text).toEqual('Test2');
+        expect(editorState.root.children).toHaveLength(2);
+        expect(editorState.root).toMatchObject({
+            children: [
+                {type: 'paragraph', children: [{text: 'Test'}]},
+                {type: 'paragraph', children: [{text: 'Test2'}]}
+            ]
+        });
     });
 
     test('handles multiple spans inside paragraph', function () {
         const html = '<p><span>Test</span> <span>Test2</span></p>';
         const editorState = runGenerateEditorState(html);
 
-        expect(editorState.root.children[0].children.length).toEqual(1);
-        expect(editorState.root.children[0].children[0].text).toEqual('Test Test2');
+        expect(editorState.root).toMatchObject({
+            children: [
+                {type: 'paragraph', children: [{text: 'Test Test2'}]}
+            ]
+        });
     });
 
     test('handles multiple spans with no wrapper', function () {
         const html = '<span>Test</span> <span>Test2</span>';
         const editorState = runGenerateEditorState(html);
 
-        expect(editorState.root.children.length).toEqual(1);
-        expect(editorState.root.children[0].children.length).toEqual(1);
-        expect(editorState.root.children[0].children[0].text).toEqual('Test Test2');
+        expect(editorState.root.children).toHaveLength(1);
+        expect(editorState.root).toMatchObject({
+            children: [
+                {type: 'paragraph', children: [{text: 'Test Test2'}]}
+            ]
+        });
     });
 
     test('handles line breaks inside paragraph', function () {
         const html = '<p>Test<br>Test2</p>';
         const editorState = runGenerateEditorState(html);
 
-        expect(editorState.root.children[0].children.length).toEqual(3);
-        expect(editorState.root.children[0].children[0].text).toEqual('Test');
-        expect(editorState.root.children[0].children[1].type).toEqual('linebreak');
-        expect(editorState.root.children[0].children[2].text).toEqual('Test2');
+        expect(editorState.root.children[0]).toMatchObject({
+            type: 'paragraph',
+            children: [
+                {text: 'Test'},
+                {type: 'linebreak'},
+                {text: 'Test2'}
+            ]
+        });
     });
 
     test('handles line breaks with no wrapper', function () {
         const html = 'Test<br>Test2';
         const editorState = runGenerateEditorState(html);
 
-        expect(editorState.root.children.length).toEqual(1);
-        expect(editorState.root.children[0].type).toEqual('paragraph');
-        expect(editorState.root.children[0].children[0].text).toEqual('Test');
-        expect(editorState.root.children[0].children[1].type).toEqual('linebreak');
-        expect(editorState.root.children[0].children[2].text).toEqual('Test2');
+        expect(editorState.root.children).toHaveLength(1);
+        expect(editorState.root.children[0]).toMatchObject({
+            type: 'paragraph',
+            children: [
+                {text: 'Test'},
+                {type: 'linebreak'},
+                {text: 'Test2'}
+            ]
+        });
     });
 
     test('handles line breaks and spans with no wrapper', function () {
         const html = '<span>Test</span><br><span>Test2</span>';
         const editorState = runGenerateEditorState(html);
 
-        expect(editorState.root.children.length).toEqual(1);
-        expect(editorState.root.children[0].type).toEqual('paragraph');
-        expect(editorState.root.children[0].children[0].text).toEqual('Test');
-        expect(editorState.root.children[0].children[1].type).toEqual('linebreak');
-        expect(editorState.root.children[0].children[2].text).toEqual('Test2');
+        expect(editorState.root.children).toHaveLength(1);
+        expect(editorState.root.children[0]).toMatchObject({
+            type: 'paragraph',
+            children: [
+                {text: 'Test'},
+                {type: 'linebreak'},
+                {text: 'Test2'}
+            ]
+        });
     });
 
     // https://github.com/facebook/lexical/issues/2807
@@ -91,13 +114,15 @@ describe('Utils: generateEditorState', () => {
         const html = '<ul><li>Test</li> <li>Test2</li></ul>';
         const editorState = runGenerateEditorState(html);
 
-        expect(editorState.root.children.length).toEqual(1);
-        expect(editorState.root.children[0].type).toEqual('list');
-        expect(editorState.root.children[0].children.length).toEqual(2);
-        expect(editorState.root.children[0].children[0].type).toEqual('listitem');
-        expect(editorState.root.children[0].children[1].type).toEqual('listitem');
-        expect(editorState.root.children[0].children[0].children[0].text).toEqual('Test');
-        expect(editorState.root.children[0].children[1].children[0].text).toEqual('Test2');
+        expect(editorState.root.children).toHaveLength(1);
+        expect(editorState.root.children[0].children).toHaveLength(2);
+        expect(editorState.root.children[0]).toMatchObject({
+            type: 'list',
+            children: [
+                {type: 'listitem', children: [{text: 'Test'}]},
+                {type: 'listitem', children: [{text: 'Test2'}]}
+            ]
+        });
     });
 
     describe('_$generateNodesFromHTML', () => {


### PR DESCRIPTION
no issue

- using `expect.toMatchObject()` gives an easier to read test and a better idea of expected object shape
