### PR TITLE
Increase maximum number of images uploadable to galleries from 9 to 30

### DIFF
--- a/packages/koenig-lexical/src/nodes/GalleryNode.jsx
+++ b/packages/koenig-lexical/src/nodes/GalleryNode.jsx
@@ -10,7 +10,7 @@ import {populateNestedEditor, setupNestedEditor} from '../utils/nested-editors';
 
 export const INSERT_GALLERY_COMMAND = createCommand();
 
-export const MAX_IMAGES = 9;
+export const MAX_IMAGES = 30;
 export const MAX_PER_ROW = 3;
 
 // ensure we don't save client-side only properties such as preview blob urls to the server

--- a/packages/koenig-lexical/src/nodes/GalleryNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/GalleryNodeComponent.jsx
@@ -57,7 +57,7 @@ export function GalleryNodeComponent({nodeKey, captionEditor, captionEditorIniti
 
         const strippedFiles = Array.prototype.slice.call(files, 0, allowedCount);
         if (strippedFiles.length < files.length) {
-            setErrorMessage('Galleries are limited to 9 images');
+            setErrorMessage(`Galleries are limited to ${MAX_IMAGES} images`);
         }
 
         if (strippedFiles.length === 0) {


### PR DESCRIPTION
This PR is based on #1407.

I believe that the original gallery component might have been limited to a maximum of 9 images for a legitimate reason (e.g. bandwidth or performance). But in everyday use, I come across cases where I would like to upload more images than this.

This PR simply increases this one constant from 9 to 30. It also changes one hard-coded string to mirror this number, which is a trivial but helpful change (even if the count increase is not what the project wishes).

I am hoping that the original constraints that led to the initial limit of 9 do not hold today. Please consider this PR!