### PR TITLE
Added changing background colour handling to CTA Card

### DIFF
--- a/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
@@ -63,6 +63,13 @@ export const CallToActionNodeComponent = ({
         });
     };
 
+    const handleBackgroundColorChange = (val) => {
+        editor.update(() => {
+            const node = $getNodeByKey(nodeKey);
+            node.backgroundColor = val;
+        });
+    };
+
     return (
         <>
             <CtaCard
@@ -72,7 +79,7 @@ export const CallToActionNodeComponent = ({
                 buttonUrl={buttonUrl}
                 color={backgroundColor}
                 handleButtonColor={handleButtonColorChange}
-                handleColorChange={() => {}}
+                handleColorChange={handleBackgroundColorChange}
                 hasBackground={hasBackground}
                 hasImage={hasImage}
                 hasSponsorLabel={hasSponsorLabel}

--- a/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
@@ -177,6 +177,8 @@ test.describe('Call To Action Card', async () => {
 
     test('can change background colours', async function () {
         const colors = [
+            {testId: 'color-picker-none', expectedClass: 'bg-transparent border-transparent'},
+            {testId: 'color-picker-white', expectedClass: 'bg-transparent border-grey'},
             {testId: 'color-picker-grey', expectedClass: 'bg-grey'},
             {testId: 'color-picker-green', expectedClass: 'bg-green'},
             {testId: 'color-picker-blue', expectedClass: 'bg-blue'},
@@ -185,8 +187,9 @@ test.describe('Call To Action Card', async () => {
         ];
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
-        const firstChildSelector = '[data-kg-card="call-to-action"] > :first-child';
 
+        const firstChildSelector = '[data-kg-card="call-to-action"] > :first-child';
+        await expect(page.locator(firstChildSelector)).not.toHaveClass(/bg-(grey|green|blue|yellow|red)/); // shouldn't have any of the classes yet
         for (const color of colors) {
             await page.click(`[data-test-id="${color.testId}"]`);
             await expect(page.locator(firstChildSelector)).toHaveClass(new RegExp(color.expectedClass));

--- a/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
@@ -174,4 +174,22 @@ test.describe('Call To Action Card', async () => {
         await page.click('[data-testid="cta-button-color"] button[title="Black"]');
         expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('color: rgb(0, 0, 0);');
     });
+
+    test('can change background colours', async function () {
+        const colors = [
+            {testId: 'color-picker-grey', expectedClass: 'bg-grey'},
+            {testId: 'color-picker-green', expectedClass: 'bg-green'},
+            {testId: 'color-picker-blue', expectedClass: 'bg-blue'},
+            {testId: 'color-picker-yellow', expectedClass: 'bg-yellow'},
+            {testId: 'color-picker-red', expectedClass: 'bg-red'}
+        ];
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        const firstChildSelector = '[data-kg-card="call-to-action"] > :first-child';
+
+        for (const color of colors) {
+            await page.click(`[data-test-id="${color.testId}"]`);
+            await expect(page.locator(firstChildSelector)).toHaveClass(new RegExp(color.expectedClass));
+        }
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-317/implement-background-colour-handling-to-cta-card

- Adds a background colour changing handler that would update the node and UI when the user toggles different colours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Call To Action (CTA) card with dynamic background color selection.
	- Added ability to change CTA card background colors (transparent, white, grey, green, blue, yellow, red).

- **Tests**
	- Added comprehensive test coverage for CTA card background color functionality, including various color options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->