### PR TITLE
Added sponsor label toggle to CTA Card

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
@@ -125,6 +125,7 @@ export function CtaCard({
             />
             {/* Sponsor label setting */}
             <ToggleSetting
+                dataTestId="sponsor-label-toggle"
                 isChecked={hasSponsorLabel}
                 label='Sponsor label'
                 onChange={updateHasSponsorLabel}
@@ -224,7 +225,7 @@ export function CtaCard({
                         'not-kg-prose py-3',
                         {'mx-5': color !== 'none'}
                     )}>
-                        <p className="font-sans text-2xs font-semibold uppercase leading-8 tracking-normal text-grey-900/40 dark:text-grey-100/40">Sponsored</p>
+                        <p className="font-sans text-2xs font-semibold uppercase leading-8 tracking-normal text-grey-900/40 dark:text-grey-100/40" data-testid="sponsor-label">Sponsored</p>
                     </div>
                 )}
 

--- a/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
@@ -67,6 +67,8 @@ export const CallToActionNodeComponent = ({
             const node = $getNodeByKey(nodeKey);
             // get the current value and toggle it
             node.hasSponsorLabel = !node.hasSponsorLabel;
+        });
+    };
     const handleBackgroundColorChange = (val) => {
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);

--- a/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
@@ -63,6 +63,14 @@ export const CallToActionNodeComponent = ({
         });
     };
 
+    const handleHasSponsorLabelChange = (val) => {
+        editor.update(() => {
+            const node = $getNodeByKey(nodeKey);
+            // get the current value and toggle it
+            node.hasSponsorLabel = !node.hasSponsorLabel;
+        });
+    };
+
     return (
         <>
             <CtaCard
@@ -86,7 +94,7 @@ export const CallToActionNodeComponent = ({
                 text={textValue}
                 updateButtonText={handleButtonTextChange}
                 updateButtonUrl={handleButtonUrlChange}
-                updateHasSponsorLabel={() => {}}
+                updateHasSponsorLabel={handleHasSponsorLabelChange}
                 updateLayout={() => {}}
                 updateShowButton={toggleShowButton}
             />

--- a/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
@@ -174,4 +174,14 @@ test.describe('Call To Action Card', async () => {
         await page.click('[data-testid="cta-button-color"] button[title="Black"]');
         expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('color: rgb(0, 0, 0);');
     });
+
+    test('can toggle has sponsor label', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        await page.click('[data-testid="sponsor-label-toggle"]');
+        expect(await page.isVisible('[data-testid="sponsor-label"]')).toBe(true);
+
+        await page.click('[data-testid="sponsor-label-toggle"]');
+        expect(await page.isVisible('[data-testid="sponsor-label"]')).toBe(false);
+    });
 });

--- a/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
@@ -204,6 +204,5 @@ test.describe('Call To Action Card', async () => {
             await page.click(`[data-test-id="${color.testId}"]`);
             await expect(page.locator(firstChildSelector)).toHaveClass(new RegExp(color.expectedClass));
         }
-
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-314/add-sponsor-label-toggle-on-cta-card

- Wired up the Sponsor Label toggle to the CTA card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added ability to toggle a sponsor label for Call To Action (CTA) cards.
	- Improved testability of CTA card components with specific test identifiers.

- **Tests**
	- Added new end-to-end test to verify sponsor label toggle functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->