### PR TITLE
Updated CTA card icon in card menu

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
@@ -10,9 +10,8 @@ export class CallToActionNode extends generateDecoratorNode({nodeType: 'call-to-
         {name: 'buttonUrl', default: ''},
         {name: 'buttonColor', default: ''},
         {name: 'buttonTextColor', default: ''},
-        {name: 'hasSponsorLabel', default: false},
-        {name: 'hasBackground', default: false},
-        {name: 'backgroundColor', default: 'none'},
+        {name: 'hasSponsorLabel', default: true},
+        {name: 'backgroundColor', default: 'grey'},
         {name: 'hasImage', default: false},
         {name: 'imageUrl', default: ''}
     ]}
@@ -27,24 +26,22 @@ export class CallToActionNode extends generateDecoratorNode({nodeType: 'call-to-
         buttonColor,
         buttonTextColor,
         hasSponsorLabel,
-        hasBackground,
         backgroundColor,
         hasImage,
         imageUrl
     } = {}, key) {
         super(key);
-        this.__layout = layout || 'minimal';
-        this.__textValue = textValue || '';
-        this.__showButton = showButton || false;
-        this.__buttonText = buttonText || '';
-        this.__buttonUrl = buttonUrl || '';
-        this.__buttonColor = buttonColor || 'none';
-        this.__buttonTextColor = buttonTextColor || 'none';
-        this.__hasSponsorLabel = hasSponsorLabel || false;
-        this.__hasBackground = hasBackground || false;
-        this.__backgroundColor = backgroundColor || 'none';
-        this.__hasImage = hasImage || false;
-        this.__imageUrl = imageUrl || '';
+        this.__layout = layout ?? 'minimal';
+        this.__textValue = textValue ?? '';
+        this.__showButton = showButton ?? false;
+        this.__buttonText = buttonText ?? '';
+        this.__buttonUrl = buttonUrl ?? '';
+        this.__buttonColor = buttonColor ?? 'none';
+        this.__buttonTextColor = buttonTextColor ?? 'none';
+        this.__hasSponsorLabel = hasSponsorLabel ?? true;
+        this.__backgroundColor = backgroundColor ?? 'grey';
+        this.__hasImage = hasImage ?? false;
+        this.__imageUrl = imageUrl ?? '';
     }
 }
 

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -98,10 +98,11 @@ describe('CallToActionNode', function () {
             callToActionNode.buttonTextColor = 'black';
             callToActionNode.buttonTextColor.should.equal('black');
 
+            callToActionNode.hasSponsorLabel.should.equal(true);
+            callToActionNode.hasSponsorLabel = false;
             callToActionNode.hasSponsorLabel.should.equal(false);
-            callToActionNode.hasSponsorLabel = true;
 
-            callToActionNode.backgroundColor.should.equal('none');
+            callToActionNode.backgroundColor.should.equal('grey');
             callToActionNode.backgroundColor = '#654321';
             callToActionNode.backgroundColor.should.equal('#654321');
 

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -36,7 +36,6 @@ describe('CallToActionNode', function () {
             buttonColor: 'none',
             buttonTextColor: 'none',
             hasSponsorLabel: true,
-            hasBackground: true,
             backgroundColor: 'none',
             hasImage: true,
             imageUrl: 'http://blog.com/image1.jpg'
@@ -63,7 +62,6 @@ describe('CallToActionNode', function () {
             callToActionNode.buttonColor.should.equal(dataset.buttonColor);
             callToActionNode.buttonTextColor.should.equal(dataset.buttonTextColor);
             callToActionNode.hasSponsorLabel.should.equal(dataset.hasSponsorLabel);
-            callToActionNode.hasBackground.should.equal(dataset.hasBackground);
             callToActionNode.backgroundColor.should.equal(dataset.backgroundColor);
             callToActionNode.hasImage.should.equal(dataset.hasImage);
             callToActionNode.imageUrl.should.equal(dataset.imageUrl);
@@ -102,9 +100,6 @@ describe('CallToActionNode', function () {
 
             callToActionNode.hasSponsorLabel.should.equal(false);
             callToActionNode.hasSponsorLabel = true;
-
-            callToActionNode.hasBackground.should.equal(false);
-            callToActionNode.hasBackground = true;
 
             callToActionNode.backgroundColor.should.equal('none');
             callToActionNode.backgroundColor = '#654321';

--- a/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
@@ -70,7 +70,6 @@ export function CtaCard({
     htmlEditorInitialState,
     imageSrc,
     isEditing,
-    isSelected,
     layout,
     showButton,
     updateButtonText,
@@ -221,8 +220,8 @@ export function CtaCard({
                 'w-full rounded-lg border',
                 CTA_COLORS[color],
                 {
-                    'py-3': (isEditing || isSelected) && color === 'none' && !hasSponsorLabel,
-                    'pb-3': color === 'none' && !((isEditing || isSelected) && !hasSponsorLabel)
+                    'py-3': color === 'none' && !hasSponsorLabel,
+                    'pb-3': color === 'none' && hasSponsorLabel
                 }
             )} data-cta-layout={layout}>
                 {/* Sponsor label */}
@@ -324,7 +323,6 @@ CtaCard.propTypes = {
     hasSponsorLabel: PropTypes.bool,    
     imageSrc: PropTypes.string,
     isEditing: PropTypes.bool,
-    isSelected: PropTypes.bool,
     layout: PropTypes.oneOf(['minimal', 'immersive']),
     showButton: PropTypes.bool,
     htmlEditor: PropTypes.object,
@@ -350,7 +348,6 @@ CtaCard.defaultProps = {
     hasSponsorLabel: false,
     imageSrc: '',
     isEditing: false,
-    isSelected: false,
     layout: 'immersive',
     showButton: false,
     updateHasSponsorLabel: () => {},

--- a/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
@@ -1,10 +1,10 @@
-import CalloutCardIcon from '../assets/icons/kg-card-type-callout.svg?react';
+import EmailCtaCardIcon from '../assets/icons/kg-card-type-email-cta.svg?react';
 import KoenigCardWrapper from '../components/KoenigCardWrapper';
 import {BASIC_NODES} from '../index.js';
 import {CallToActionNode as BaseCallToActionNode} from '@tryghost/kg-default-nodes';
 import {CallToActionNodeComponent} from './CallToActionNodeComponent';
 import {createCommand} from 'lexical';
-import {populateNestedEditor, setupNestedEditor} from '../utils/nested-editors';
+import {setupNestedEditor} from '../utils/nested-editors';
 
 export const INSERT_CTA_COMMAND = createCommand();
 
@@ -15,7 +15,7 @@ export class CallToActionNode extends BaseCallToActionNode {
     static kgMenu = {
         label: 'Call to Action',
         desc: 'Add a call to action to your post',
-        Icon: CalloutCardIcon, // TODO: Replace with correct icon
+        Icon: EmailCtaCardIcon,
         insertCommand: INSERT_CTA_COMMAND,
         matches: ['cta', 'call-to-action'],
         priority: 10,
@@ -30,8 +30,7 @@ export class CallToActionNode extends BaseCallToActionNode {
     }
 
     getIcon() {
-        // TODO: replace with correct icon
-        return CalloutCardIcon;
+        return EmailCtaCardIcon;
     }
 
     constructor(dataset = {}, key) {
@@ -39,18 +38,13 @@ export class CallToActionNode extends BaseCallToActionNode {
 
         // set up nested editor instances
         setupNestedEditor(this, '__htmlEditor', {editor: dataset.htmlEditor, nodes: BASIC_NODES});
-
-        // populate nested editors on initial construction
-        if (!dataset.htmlEditor) {
-            populateNestedEditor(this, '__htmlEditor', dataset.html || '<p>Hey <code>{first_name, "there"}</code>,</p>');
-        }
     }
 
     decorate() {
         return (
             <KoenigCardWrapper
                 nodeKey={this.getKey()}
-                wrapperStyle="wide"
+                wrapperStyle={this.backgroundColor === 'none' ? 'wide' : 'regular'}
             >
                 <CallToActionNodeComponent
                     backgroundColor={this.backgroundColor}
@@ -58,7 +52,6 @@ export class CallToActionNode extends BaseCallToActionNode {
                     buttonText={this.buttonText}
                     buttonTextColor={this.buttonTextColor}
                     buttonUrl={this.buttonUrl}
-                    hasBackground={this.hasBackground}
                     hasImage={this.hasImage}
                     hasSponsorLabel={this.hasSponsorLabel}
                     htmlEditor={this.__htmlEditor}

--- a/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
@@ -13,7 +13,6 @@ export const CallToActionNodeComponent = ({
     backgroundColor,
     buttonText,
     buttonUrl,
-    hasBackground,
     hasImage,
     hasSponsorLabel,
     imageUrl,
@@ -119,7 +118,6 @@ export const CallToActionNodeComponent = ({
                 color={backgroundColor}
                 handleButtonColor={handleButtonColorChange}
                 handleColorChange={handleBackgroundColorChange}
-                hasBackground={hasBackground}
                 hasImage={hasImage}
                 hasSponsorLabel={hasSponsorLabel}
                 htmlEditor={htmlEditor}

--- a/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
@@ -179,14 +179,14 @@ test.describe('Call To Action Card', async () => {
         expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('color: rgb(0, 0, 0);');
     });
 
-    test('can toggle has sponsor label', async function () {
+    test('can toggle sponsor label', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
         await page.click('[data-testid="sponsor-label-toggle"]');
-        expect(await page.isVisible('[data-testid="sponsor-label"]')).toBe(true);
+        expect(await page.isVisible('[data-testid="sponsor-label"]')).toBe(false);
 
         await page.click('[data-testid="sponsor-label-toggle"]');
-        expect(await page.isVisible('[data-testid="sponsor-label"]')).toBe(false);
+        expect(await page.isVisible('[data-testid="sponsor-label"]')).toBe(true);
     });
 
     test('can change background colours', async function () {
@@ -203,7 +203,7 @@ test.describe('Call To Action Card', async () => {
         await insertCard(page, {cardName: 'call-to-action'});
 
         const firstChildSelector = '[data-kg-card="call-to-action"] > :first-child';
-        await expect(page.locator(firstChildSelector)).not.toHaveClass(/bg-(grey|green|blue|yellow|red)/); // shouldn't have any of the classes yet
+        await expect(page.locator(firstChildSelector)).not.toHaveClass(/bg-(green|blue|yellow|red)/); // shouldn't have any of the classes yet
         for (const color of colors) {
             await page.click(`[data-test-id="${color.testId}"]`);
             await expect(page.locator(firstChildSelector)).toHaveClass(new RegExp(color.expectedClass));


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PLG-320/improve-cta-card-kg-menu-preview-meta
- This card will replace the Email CTA card, so it can use the same icon
- Changed default background color to grey and sponsor label to true
- Removed hasBackground property as this isn't needed
- Removed prefilled content in nested editor
- Updated card spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
    - Updated Call to Action (CTA) node with improved default settings.
    - Changed default CTA icon to Email CTA icon.

- **Bug Fixes**
    - Simplified CTA component prop handling.
    - Adjusted wrapper style logic for CTA nodes.

- **Refactor**
    - Removed `hasBackground` property from CTA components.
    - Updated default values for CTA node properties.
    - Streamlined CTA node and component logic.
    - Enhanced test cases for clarity and correctness related to CTA functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->