### PR TITLE
Expanded visibility controls to cover web segments

### DIFF
--- a/packages/kg-default-nodes/lib/generate-decorator-node.js
+++ b/packages/kg-default-nodes/lib/generate-decorator-node.js
@@ -1,5 +1,6 @@
 import {KoenigDecoratorNode} from './KoenigDecoratorNode';
 import readTextContent from './utils/read-text-content';
+import {ALL_MEMBERS_SEGMENT, usesOldVisibilityFormat} from './utils/visibility';
 /**
  * Validates the required arguments passed to `generateDecoratorNode`
 */
@@ -227,9 +228,17 @@ export function generateDecoratorNode({nodeType, properties = [], version = 1}) 
             }
 
             const self = this.getLatest();
-            return self.__visibility.showOnEmail === false
-                || self.__visibility.showOnWeb === false
-                || self.__visibility.segment !== '';
+            const visibility = self.__visibility;
+
+            if (usesOldVisibilityFormat(visibility)) {
+                return visibility.showOnEmail === false
+                    || visibility.showOnWeb === false
+                    || visibility.segment !== '';
+            } else {
+                return visibility.web.nonMember === false
+                    || visibility.web.memberSegment !== ALL_MEMBERS_SEGMENT
+                    || visibility.email.memberSegment !== ALL_MEMBERS_SEGMENT;
+            }
         }
     }
 

--- a/packages/kg-default-nodes/lib/kg-default-nodes.js
+++ b/packages/kg-default-nodes/lib/kg-default-nodes.js
@@ -63,6 +63,11 @@ export * from './nodes/TKNode';
 export * from './nodes/at-link/index.js';
 export * from './nodes/zwnj/ZWNJNode';
 
+import * as visibilityUtils from './utils/visibility';
+export const utils = {
+    visibility: visibilityUtils
+};
+
 export const serializers = {
     linebreak: linebreakSerializers,
     paragraph: paragraphSerializers

--- a/packages/kg-default-nodes/lib/nodes/html/HtmlNode.js
+++ b/packages/kg-default-nodes/lib/nodes/html/HtmlNode.js
@@ -2,20 +2,32 @@
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {renderHtmlNode} from './html-renderer';
 import {parseHtmlNode} from './html-parser';
+import {DEFAULT_VISIBILITY, usesOldVisibilityFormat, migrateOldVisibilityFormat} from '../../utils/visibility';
 
 export class HtmlNode extends generateDecoratorNode({nodeType: 'html',
     properties: [
         {name: 'html', default: '', urlType: 'html', wordCount: true},
-        {name: 'visibility', default: {showOnEmail: true, showOnWeb: true, segment: ''}}
+        {name: 'visibility', default: {...DEFAULT_VISIBILITY}}
     ]}
 ) {
     constructor({
         html = '',
-        visibility = {showOnEmail: true, showOnWeb: true, segment: ''}
+        visibility = {...DEFAULT_VISIBILITY}
     } = {}, key) {
         super(key);
         this.html = html;
         this.visibility = visibility;
+    }
+
+    static importJSON(serializedNode) {
+        const {visibility} = serializedNode;
+
+        // migrate older nodes that were saved with an earlier version of the visibility format
+        if (visibility && usesOldVisibilityFormat(visibility)) {
+            migrateOldVisibilityFormat(visibility);
+        }
+
+        return super.importJSON(serializedNode);
     }
 
     static importDOM() {

--- a/packages/kg-default-nodes/lib/nodes/html/html-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/html/html-renderer.js
@@ -1,5 +1,6 @@
 import {addCreateDocumentOption} from '../../utils/add-create-document-option';
 import {renderEmptyContainer} from '../../utils/render-empty-container';
+import {ALL_MEMBERS_SEGMENT, usesOldVisibilityFormat, migrateOldVisibilityFormat, NO_MEMBERS_SEGMENT} from '../../utils/visibility';
 
 export function renderHtmlNode(node, options = {}) {
     addCreateDocumentOption(options);
@@ -16,64 +17,43 @@ export function renderHtmlNode(node, options = {}) {
     const textarea = document.createElement('textarea');
     textarea.value = wrappedHtml;
 
-    if (!options.feature?.contentVisibility) {
+    if (!options.feature?.contentVisibility || !node.visibility) {
         // `type: 'value'` will render the value of the textarea element
         return {element: textarea, type: 'value'};
     }
 
-    const segment = node.visibility.segment || '';
+    const visibility = node.visibility;
+    const oldVisibilityFormat = usesOldVisibilityFormat(visibility);
 
-    const showOnEmail = node.visibility.showOnEmail;
-    const showOnWeb = node.visibility.showOnWeb;
-
-    if (segment) {
-        textarea.setAttribute('data-gh-segment', segment);
+    if (oldVisibilityFormat) {
+        migrateOldVisibilityFormat(visibility);
     }
 
-    const isEmailOnly = !showOnWeb && showOnEmail;
-    const isWebOnly = showOnWeb && !showOnEmail;
-    const showOnWebAndEmail = showOnEmail && showOnWeb;
-    const showNowhere = !showOnEmail && !showOnWeb;
+    if (options.target === 'email') {
+        if (visibility.email.memberSegment === NO_MEMBERS_SEGMENT) {
+            return renderEmptyContainer(document);
+        }
 
-    if (showNowhere) {
-        return renderEmptyContainer(document);
-    }
+        if (visibility.email.memberSegment === ALL_MEMBERS_SEGMENT) {
+            return {element: textarea, type: 'value'};
+        }
 
-    if (isWebOnly && options.target !== 'email') {
-        return {element: textarea, type: 'value'};
-    }
-
-    if (isWebOnly && options.target === 'email') {
-        return renderEmptyContainer(document);
-    }
-
-    if (isEmailOnly && options.target !== 'email') {
-        return renderEmptyContainer(document);
-    }
-
-    if (isEmailOnly && options.target === 'email') {
         const container = document.createElement('div');
         container.innerHTML = wrappedHtml;
-        if (segment) {
-            container.setAttribute('data-gh-segment', segment);
-        }
+        container.setAttribute('data-gh-segment', visibility.email.memberSegment);
         return {element: container, type: 'html'};
     }
 
-    if (isWebOnly && options.target === 'email') {
+    if (visibility.web.nonMember === false && visibility.web.memberSegment === NO_MEMBERS_SEGMENT) {
         return renderEmptyContainer(document);
     }
 
-    if (showOnWebAndEmail) {
-        if (options.target === 'email') {
-            const container = document.createElement('div');
-            container.innerHTML = wrappedHtml;
-            if (segment) {
-                container.setAttribute('data-gh-segment', segment);
-            }
-            return {element: container, type: 'html'};
-        }
-
-        return {element: textarea, type: 'value'};
+    // If there are restrictions on web visibility, wrap the HTML in a gated block comment
+    if (visibility.web.nonMember !== true || visibility.web.memberSegment !== ALL_MEMBERS_SEGMENT) {
+        const {nonMember, memberSegment} = visibility.web;
+        const visibilityWrappedHtml = `\n<!--kg-gated-block:begin nonMember:${nonMember} memberSegment:"${memberSegment}" -->${textarea.value}<!--kg-gated-block:end-->\n`;
+        textarea.value = visibilityWrappedHtml;
     }
+
+    return {element: textarea, type: 'value'};
 }

--- a/packages/kg-default-nodes/lib/utils/visibility.js
+++ b/packages/kg-default-nodes/lib/utils/visibility.js
@@ -1,0 +1,31 @@
+export const ALL_MEMBERS_SEGMENT = 'status:free,status:-free';
+export const NO_MEMBERS_SEGMENT = '';
+
+export const DEFAULT_VISIBILITY = {
+    web: {
+        nonMember: true,
+        memberSegment: 'status:free,status:-free'
+    },
+    email: {
+        memberSegment: 'status:free,status:-free'
+    }
+};
+
+export function usesOldVisibilityFormat(visibility) {
+    return !Object.prototype.hasOwnProperty.call(visibility, 'web')
+        || !Object.prototype.hasOwnProperty.call(visibility, 'email')
+        || !Object.prototype.hasOwnProperty.call(visibility.web, 'nonMember');
+}
+
+export function migrateOldVisibilityFormat(visibility) {
+    visibility.web ??= {};
+    visibility.web.nonMember ??= visibility.showOnWeb;
+    visibility.web.memberSegment ??= visibility.showOnWeb ? ALL_MEMBERS_SEGMENT : NO_MEMBERS_SEGMENT;
+
+    visibility.email ??= {};
+    if (visibility.showOnEmail) {
+        visibility.email.memberSegment ??= visibility.segment ? visibility.segment : ALL_MEMBERS_SEGMENT;
+    } else {
+        visibility.email.memberSegment = NO_MEMBERS_SEGMENT;
+    }
+}

--- a/packages/kg-default-nodes/test/utils/visibility.test.js
+++ b/packages/kg-default-nodes/test/utils/visibility.test.js
@@ -1,0 +1,60 @@
+const {utils} = require('../../');
+const {usesOldVisibilityFormat, migrateOldVisibilityFormat} = utils.visibility;
+
+describe('Utils: visibility', function () {
+    describe('usesOldVisibilityFormat', function () {
+        it('returns true if visibility object does not have web property', function () {
+            const visibility = {showOnWeb: true, email: {memberSegment: 'status:free,status:-free'}};
+            usesOldVisibilityFormat(visibility).should.be.true();
+        });
+
+        it('returns true if visibility object does not have email property', function () {
+            const visibility = {web: {nonMember: true, memberSegment: 'status:free,status:-free'}, showOnEmail: true};
+            usesOldVisibilityFormat(visibility).should.be.true();
+        });
+
+        it('returns true if web object is missing nonMember property', function () {
+            const visibility = {web: {memberSegment: 'status:free,status:-free'}, email: {memberSegment: 'status:free,status:-free'}};
+            usesOldVisibilityFormat(visibility).should.be.true();
+        });
+    });
+
+    describe('migrateOldVisibilityFormat', function () {
+        it('creates new web property from showOnWeb:false', function () {
+            const visibility = {showOnWeb: false};
+            migrateOldVisibilityFormat(visibility);
+            visibility.web.should.eql({nonMember: false, memberSegment: ''});
+        });
+
+        it('creates new web property from showOnWeb:true', function () {
+            const visibility = {showOnWeb: true};
+            migrateOldVisibilityFormat(visibility);
+            visibility.web.should.eql({nonMember: true, memberSegment: 'status:free,status:-free'});
+        });
+
+        it('creates new email property from showOnEmail: false', function () {
+            const visibility = {showOnEmail: false, segment: 'status:free'};
+            migrateOldVisibilityFormat(visibility);
+            visibility.email.should.eql({memberSegment: ''});
+        });
+
+        it('creates new email property from showOnEmail: true, segment:""', function () {
+            const visibility = {showOnEmail: true, segment: ''};
+            migrateOldVisibilityFormat(visibility);
+            visibility.email.should.eql({memberSegment: 'status:free,status:-free'});
+        });
+
+        it('creates new email property from showOnEmail: true, segment:"status:free"', function () {
+            const visibility = {showOnEmail: true, segment: 'status:free'};
+            migrateOldVisibilityFormat(visibility);
+            visibility.email.should.eql({memberSegment: 'status:free'});
+        });
+
+        it('leaves existing properties alone', function () {
+            const visibility = {showOnWeb: true, segment: 'status:free'};
+            migrateOldVisibilityFormat(visibility);
+            visibility.showOnWeb.should.be.true();
+            visibility.segment.should.eql('status:free');
+        });
+    });
+});

--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -51,7 +51,7 @@ const defaultCardConfig = {
         collections: true,
         collectionsCard: true,
         contentVisibility: true,
-        contentVisibilityAlpha: true
+        contentVisibilityAlpha: false
     },
     deprecated: {
         headerV1: process.env.NODE_ENV === 'test' ? false : true // show header v1 only for tests
@@ -310,7 +310,8 @@ function DemoComposer({editorType, isMultiplayer, setWordCount, setTKCount}) {
         fetchCollectionPosts,
         feature: {
             ...defaultCardConfig.feature,
-            contentVisibility: searchParams.get('labs')?.includes('contentVisibility') || defaultCardConfig.feature.contentVisibility
+            contentVisibility: searchParams.get('labs')?.includes('contentVisibility') || defaultCardConfig.feature.contentVisibility,
+            contentVisibilityAlpha: searchParams.get('labs')?.includes('contentVisibilityAlpha') || defaultCardConfig.feature.contentVisibilityAlpha
         },
         searchLinks: searchParams.get('searchLinks') === 'false' ? undefined : defaultCardConfig.searchLinks,
         stripeEnabled: searchParams.get('stripe') === 'false' ? false : defaultCardConfig.stripeEnabled

--- a/packages/koenig-lexical/src/components/ui/VisibilitySettings.jsx
+++ b/packages/koenig-lexical/src/components/ui/VisibilitySettings.jsx
@@ -1,0 +1,113 @@
+import {DropdownSetting, ToggleSetting} from './SettingsPanel';
+
+// original beta visibility settings updated to use alpha visibility format
+export function VisibilitySettings({isStripeEnabled, updateVisibility, visibilityData}) {
+    const webIsChecked = visibilityData.web.nonMembers && visibilityData.web.freeMembers && visibilityData.web.paidMembers;
+
+    function toggleWeb() {
+        const value = !webIsChecked;
+        const newVisibilityData = structuredClone(visibilityData);
+        newVisibilityData.web.nonMembers = value;
+        newVisibilityData.web.freeMembers = value;
+        newVisibilityData.web.paidMembers = value;
+        updateVisibility(newVisibilityData);
+    }
+
+    const emailIsChecked = visibilityData.email.freeMembers || visibilityData.email.paidMembers;
+
+    function toggleEmail() {
+        const value = !emailIsChecked;
+        const newVisibilityData = structuredClone(visibilityData);
+        newVisibilityData.email.freeMembers = value;
+        newVisibilityData.email.paidMembers = value;
+        updateVisibility(newVisibilityData);
+    }
+
+    let emailSegment = '';
+    if (visibilityData.email.freeMembers && visibilityData.email.paidMembers) {
+        emailSegment = 'status:free,status:-free';
+    } else if (visibilityData.email.freeMembers && !visibilityData.email.paidMembers) {
+        emailSegment = 'status:free';
+    } else if (!visibilityData.email.freeMembers && visibilityData.email.paidMembers) {
+        emailSegment = 'status:-free';
+    }
+
+    const dropdownOptions = [{
+        label: 'All members',
+        name: 'status:free,status:-free'
+    }, {
+        label: 'Free members',
+        name: 'status:free'
+    }, {
+        label: 'Paid members',
+        name: 'status:-free'
+    }];
+
+    function toggleEmailSegment(segment) {
+        const newVisibilityData = structuredClone(visibilityData);
+
+        if (segment === 'status:free,status:-free') {
+            newVisibilityData.email.freeMembers = true;
+            newVisibilityData.email.paidMembers = true;
+        } else if (segment === 'status:free') {
+            newVisibilityData.email.freeMembers = true;
+            newVisibilityData.email.paidMembers = false;
+        } else if (segment === 'status:-free') {
+            newVisibilityData.email.freeMembers = false;
+            newVisibilityData.email.paidMembers = true;
+        }
+
+        updateVisibility(newVisibilityData);
+    }
+
+    return (
+        <>
+            <ToggleSetting
+                dataTestId="visibility-show-on-web"
+                isChecked={webIsChecked}
+                label="Show on web"
+                onChange={toggleWeb}
+            />
+            <ToggleSetting
+                dataTestId="visibility-show-on-email"
+                isChecked={emailIsChecked}
+                label="Show in email newsletter"
+                onChange={toggleEmail}
+            />
+            {emailIsChecked && isStripeEnabled && (
+                <DropdownSetting
+                    dataTestId="visibility-dropdown-segment"
+                    label="Email audience"
+                    menu={dropdownOptions}
+                    value={emailSegment}
+                    onChange={segment => toggleEmailSegment(segment)}
+                />
+            )}
+        </>
+    );
+}
+
+export function VisibilitySettingsAlpha({visibilityOptions, toggleVisibility}) {
+    const settingGroups = visibilityOptions.map((group) => {
+        const toggles = group.toggles.map((toggle) => {
+            return (
+                <ToggleSetting
+                    key={toggle.key}
+                    dataTestId={`visibility-toggle-${group.key}-${toggle.key}`}
+                    isChecked={toggle.checked}
+                    label={toggle.label}
+                    onChange={() => toggleVisibility(group.key, toggle.key, !toggle.checked)}
+                />
+            );
+        });
+
+        return (
+            <div key={group.key} className="flex w-full flex-col justify-between gap-1">
+                <div className="text-sm font-medium tracking-normal text-grey-900 dark:text-grey-300">{group.label}</div>
+                {toggles}
+            </div>
+        );
+    });
+
+    return settingGroups;
+}

--- a/packages/koenig-lexical/src/nodes/HtmlNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/HtmlNodeComponent.jsx
@@ -4,10 +4,11 @@ import React from 'react';
 import {$getNodeByKey} from 'lexical';
 import {ActionToolbar} from '../components/ui/ActionToolbar.jsx';
 import {DESELECT_CARD_COMMAND, EDIT_CARD_COMMAND} from '../plugins/KoenigBehaviourPlugin.jsx';
-import {DropdownSetting, SettingsPanel, ToggleSetting} from '../components/ui/SettingsPanel.jsx';
 import {HtmlCard} from '../components/ui/cards/HtmlCard';
+import {SettingsPanel} from '../components/ui/SettingsPanel.jsx';
 import {SnippetActionToolbar} from '../components/ui/SnippetActionToolbar.jsx';
 import {ToolbarMenu, ToolbarMenuItem, ToolbarMenuSeparator} from '../components/ui/ToolbarMenu.jsx';
+import {VisibilitySettings, VisibilitySettingsAlpha} from '../components/ui/VisibilitySettings.jsx';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useVisibilityToggle} from '../hooks/useVisibilityToggle.js';
 
@@ -18,52 +19,24 @@ export function HtmlNodeComponent({nodeKey, html}) {
     const [showSnippetToolbar, setShowSnippetToolbar] = React.useState(false);
 
     const isContentVisibilityEnabled = cardConfig?.feature?.contentVisibility || false;
-    const [toggleEmail, toggleSegment, toggleWeb, segment, emailVisibility, webVisibility, dropdownOptions, visibilityMessage] = useVisibilityToggle(editor, nodeKey, cardConfig);
-    const handleSettingChange = settingFunction => (value) => {
-        if (typeof value === 'string') {
-            // This is for the dropdown
-            settingFunction(value);
-        } else {
-            // This is for the toggles
-            settingFunction();
-        }
-        editor.update(() => {
-            const node = $getNodeByKey(nodeKey);
-            if (node.select) {
-                node.select();
-            }
-        });
-    };
+    const isContentVisibilityAlphaEnabled = cardConfig?.feature?.contentVisibilityAlpha || false;
 
-    const tabs = [
+    const {visibilityData, visibilityOptions, visibilityMessage, toggleVisibility, updateVisibility} = useVisibilityToggle(editor, nodeKey, cardConfig);
+
+    const settingsTabs = [
         {id: 'visibility', label: 'Visibility'}
     ];
 
-    const visibilitySettings = (
-        <>
-            <ToggleSetting
-                dataTestId="visibility-show-on-web"
-                isChecked={webVisibility}
-                label="Show on web"
-                onChange={handleSettingChange(toggleWeb)}
-            />
-            <ToggleSetting
-                dataTestId="visibility-show-on-email"
-                isChecked={emailVisibility}
-                label="Show in email newsletter"
-                onChange={handleSettingChange(toggleEmail)}
-            />
-            {emailVisibility && dropdownOptions && (
-                <DropdownSetting
-                    dataTestId="visibility-dropdown-segment"
-                    label="Email audience"
-                    menu={dropdownOptions}
-                    value={segment}
-                    onChange={value => handleSettingChange(toggleSegment)(value)}
-                />
-            )}
-        </>
-    );
+    let visibilitySettings;
+    if (isContentVisibilityAlphaEnabled) {
+        visibilitySettings = <VisibilitySettingsAlpha toggleVisibility={toggleVisibility} visibilityOptions={visibilityOptions} />;
+    } else {
+        visibilitySettings = <VisibilitySettings isStripeEnabled={cardConfig?.stripeEnabled} updateVisibility={updateVisibility} visibilityData={visibilityData} />;
+    }
+
+    const settingsTabContents = {
+        visibility: visibilitySettings
+    };
 
     const updateHtml = (value) => {
         editor.update(() => {
@@ -129,15 +102,13 @@ export function HtmlNodeComponent({nodeKey, html}) {
             </ActionToolbar>
 
             {cardContext.isEditing && isContentVisibilityEnabled && (
-                <SettingsPanel 
-                    darkMode={darkMode} 
+                <SettingsPanel
+                    darkMode={darkMode}
                     defaultTab="visibility"
-                    tabs={tabs}
+                    tabs={settingsTabs}
                     onMouseDown={e => e.preventDefault()}
                 >
-                    {{
-                        visibility: visibilitySettings
-                    }}
+                    {settingsTabContents}
                 </SettingsPanel>
             )}
         </>

--- a/packages/koenig-lexical/src/utils/visibility.js
+++ b/packages/koenig-lexical/src/utils/visibility.js
@@ -1,0 +1,219 @@
+import {utils} from '@tryghost/kg-default-nodes';
+
+const DEFAULT_VISIBILITY = utils.visibility.DEFAULT_VISIBILITY;
+
+export function parseVisibilityToToggles(visibility) {
+    return {
+        web: {
+            nonMembers: visibility.web.nonMember,
+            freeMembers: visibility.web.memberSegment.indexOf('status:free') !== -1,
+            paidMembers: visibility.web.memberSegment.indexOf('status:-free') !== -1
+        },
+        email: {
+            freeMembers: visibility.email.memberSegment.indexOf('status:free') !== -1,
+            paidMembers: visibility.email.memberSegment.indexOf('status:-free') !== -1
+        }
+    };
+}
+
+export function serializeTogglesToVisibility(toggles) {
+    const webSegments = [];
+    if (toggles.web.freeMembers) {
+        webSegments.push('status:free');
+    }
+    if (toggles.web.paidMembers) {
+        webSegments.push('status:-free');
+    }
+
+    const emailSegments = [];
+    if (toggles.email.freeMembers) {
+        emailSegments.push('status:free');
+    }
+    if (toggles.email.paidMembers) {
+        emailSegments.push('status:-free');
+    }
+
+    return {
+        web: {
+            nonMember: toggles.web.nonMembers,
+            memberSegment: webSegments.join(',')
+        },
+        email: {
+            memberSegment: emailSegments.join(',')
+        }
+    };
+}
+
+// used for building UI
+export function getVisibilityOptions(visibility = DEFAULT_VISIBILITY, {isStripeEnabled = true} = {}) {
+    const toggles = parseVisibilityToToggles(visibility);
+
+    // use arrays to ensure consistent order when using to build UI
+    const options = [
+        {
+            label: 'Web',
+            key: 'web',
+            toggles: [
+                {key: 'nonMembers', label: 'Anonymous visitors', checked: toggles.web.nonMembers},
+                {key: 'freeMembers', label: 'Free members', checked: toggles.web.freeMembers},
+                {key: 'paidMembers', label: 'Paid members', checked: toggles.web.paidMembers}
+            ]
+        },
+        {
+            label: 'Email',
+            key: 'email',
+            toggles: [
+                {key: 'freeMembers', label: 'Free members', checked: toggles.email.freeMembers},
+                {key: 'paidMembers', label: 'Paid members', checked: toggles.email.paidMembers}
+            ]
+        }
+    ];
+
+    if (!isStripeEnabled) {
+        options[0].toggles = options[0].toggles.filter(t => t.key !== 'paidMembers');
+        options[1].toggles = options[1].toggles.filter(t => t.key !== 'paidMembers');
+    }
+
+    return options;
+}
+
+export function serializeOptionsToVisibility(options) {
+    const webToggles = options.find(group => group.key === 'web').toggles;
+    const webSegments = [];
+    if (webToggles.find(t => t.key === 'freeMembers')?.checked) {
+        webSegments.push('status:free');
+    }
+    if (webToggles.find(t => t.key === 'paidMembers')?.checked) {
+        webSegments.push('status:-free');
+    }
+
+    const emailToggles = options.find(group => group.key === 'email').toggles;
+    const emailSegments = [];
+    if (emailToggles.find(t => t.key === 'freeMembers')?.checked) {
+        emailSegments.push('status:free');
+    }
+    if (emailToggles.find(t => t.key === 'paidMembers')?.checked) {
+        emailSegments.push('status:-free');
+    }
+
+    return {
+        web: {
+            nonMember: webToggles.find(t => t.key === 'nonMembers')?.checked || false,
+            memberSegment: webSegments.join(',')
+        },
+        email: {
+            memberSegment: emailSegments.join(',')
+        }
+    };
+}
+
+export function generateVisibilityMessage(visibility) {
+    const toggles = parseVisibilityToToggles(visibility);
+    const showOnWeb = toggles.web.nonMembers || toggles.web.freeMembers || toggles.web.paidMembers;
+    const showOnEmail = toggles.email.freeMembers || toggles.email.paidMembers;
+
+    let hiddenNewsletter;
+    if (!toggles.email.paidMembers && toggles.email.freeMembers) {
+        hiddenNewsletter = 'paid newsletter';
+    } else if (toggles.email.paidMembers && !toggles.email.freeMembers) {
+        hiddenNewsletter = 'free newsletter';
+    }
+
+    let message = '';
+
+    if (!showOnWeb && !showOnEmail) {
+        message = 'Hidden on website and newsletter';
+    } else if (showOnWeb && !showOnEmail) {
+        message = 'Hidden in newsletter';
+    } else if (showOnWeb && showOnEmail && hiddenNewsletter) {
+        message = `Hidden in ${hiddenNewsletter}`;
+    } else if (!showOnWeb && showOnEmail && !hiddenNewsletter) {
+        message = 'Hidden on website';
+    } else if (!showOnWeb && showOnEmail && hiddenNewsletter) {
+        message = `Hidden on website and ${hiddenNewsletter}`;
+    }
+
+    return message;
+}
+
+export function generateVisibilityMessageAlpha(visibility) {
+    const toggles = parseVisibilityToToggles(visibility);
+    const {web, email} = toggles;
+
+    const allWeb = web.nonMembers && web.freeMembers && web.paidMembers;
+    const noWeb = !web.nonMembers && !web.freeMembers && !web.paidMembers;
+    const allWebMembers = web.freeMembers && web.paidMembers;
+    const noWebMembers = !web.freeMembers && !web.paidMembers;
+    const allEmail = email.freeMembers && email.paidMembers;
+    const noEmail = !email.freeMembers && !email.paidMembers;
+    const shownToAll = allWeb && allEmail;
+    const shownToNone = noWeb && noEmail;
+
+    if (shownToAll) {
+        return 'Visible to all web and email';
+    }
+
+    if (shownToNone) {
+        return 'Not visible on web or email';
+    }
+
+    let message = 'Visible to ';
+
+    if (allWeb) {
+        message += 'all web';
+
+        if (!noEmail) {
+            message += ', ';
+        }
+    } else if (!noWeb) {
+        if (web.nonMembers) {
+            message += 'anonymous';
+
+            if (!noWebMembers) {
+                message += ' and ';
+            }
+        }
+
+        if (allWebMembers) {
+            message += 'logged in';
+        } else {
+            if (web.freeMembers) {
+                message += 'free';
+
+                if (web.paidMembers) {
+                    message += ', ';
+                }
+            }
+
+            if (web.paidMembers) {
+                message += 'paid';
+            }
+        }
+
+        message += ' web';
+
+        if (!noEmail) {
+            message += ', ';
+        }
+    }
+
+    if (allEmail) {
+        message += 'all email recipients';
+    } else if (!noEmail) {
+        if (email.freeMembers) {
+            message += 'free';
+
+            if (email.paidMembers) {
+                message += ', ';
+            }
+        }
+
+        if (email.paidMembers) {
+            message += 'paid';
+        }
+
+        message += ' email';
+    }
+
+    return message;
+}

--- a/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
@@ -13,7 +13,7 @@ test.describe('Call To Action Card', async () => {
     });
 
     test.beforeEach(async () => {
-        await initialize({page});
+        await initialize({page, uri: '/#/?content=false&labs=contentVisibility,contentVisibilityAlpha'});
     });
 
     test.afterAll(async () => {

--- a/packages/koenig-lexical/test/unit/utils/visibility.test.js
+++ b/packages/koenig-lexical/test/unit/utils/visibility.test.js
@@ -1,0 +1,330 @@
+import {expect} from 'vitest';
+import {
+    generateVisibilityMessageAlpha,
+    getVisibilityOptions,
+    parseVisibilityToToggles
+} from '../../../src/utils/visibility';
+
+describe('parseVisibilityToToggles', function () {
+    it('should return correct truthy toggles based on the visibility object', function () {
+        const visibility = {
+            web: {
+                nonMember: true,
+                memberSegment: 'status:free,status:-free'
+            },
+            email: {
+                memberSegment: 'status:free,status:-free'
+            }
+        };
+
+        const result = parseVisibilityToToggles(visibility);
+
+        expect(result).toEqual({
+            web: {
+                nonMembers: true,
+                freeMembers: true,
+                paidMembers: true
+            },
+            email: {
+                freeMembers: true,
+                paidMembers: true
+            }
+        });
+    });
+
+    it('should return correct falsy toggles based on the visibility object', function () {
+        const visibility = {
+            web: {
+                nonMember: false,
+                memberSegment: ''
+            },
+            email: {
+                memberSegment: ''
+            }
+        };
+
+        const result = parseVisibilityToToggles(visibility);
+
+        expect(result).toEqual({
+            web: {
+                nonMembers: false,
+                freeMembers: false,
+                paidMembers: false
+            },
+            email: {
+                freeMembers: false,
+                paidMembers: false
+            }
+        });
+    });
+
+    it('handles partial member segments', function () {
+        const visibility = {
+            web: {
+                nonMember: false,
+                memberSegment: 'status:free'
+            },
+            email: {
+                memberSegment: 'status:-free'
+            }
+        };
+
+        const result = parseVisibilityToToggles(visibility);
+
+        expect(result).toEqual({
+            web: {
+                nonMembers: false,
+                freeMembers: true,
+                paidMembers: false
+            },
+            email: {
+                freeMembers: false,
+                paidMembers: true
+            }
+        });
+    });
+});
+
+describe('generateVisibilityMessageAlpha', function () {
+    it('should return correct message for all web and email', function () {
+        const visibility = {
+            web: {
+                nonMember: true,
+                memberSegment: 'status:free,status:-free'
+            },
+            email: {
+                memberSegment: 'status:free,status:-free'
+            }
+        };
+
+        const result = generateVisibilityMessageAlpha(visibility);
+
+        expect(result).toBe('Visible to all web and email');
+    });
+
+    it('should return correct message for no web or email', function () {
+        const visibility = {
+            web: {
+                nonMember: false,
+                memberSegment: ''
+            },
+            email: {
+                memberSegment: ''
+            }
+        };
+
+        const result = generateVisibilityMessageAlpha(visibility);
+
+        expect(result).toBe('Not visible on web or email');
+    });
+
+    it('should return correct message for all web visitors', function () {
+        const visibility = {
+            web: {
+                nonMember: true,
+                memberSegment: 'status:free,status:-free'
+            },
+            email: {
+                memberSegment: ''
+            }
+        };
+
+        const result = generateVisibilityMessageAlpha(visibility);
+
+        expect(result).toBe('Visible to all web');
+    });
+
+    it('should return correct message for anonymous and free web visitors', function () {
+        const visibility = {
+            web: {
+                nonMember: true,
+                memberSegment: 'status:free'
+            },
+            email: {
+                memberSegment: ''
+            }
+        };
+
+        const result = generateVisibilityMessageAlpha(visibility);
+
+        expect(result).toBe('Visible to anonymous and free web');
+    });
+
+    it('should return correct message for logged-in web visitors', function () {
+        const visibility = {
+            web: {
+                nonMember: false,
+                memberSegment: 'status:free,status:-free'
+            },
+            email: {
+                memberSegment: ''
+            }
+        };
+
+        const result = generateVisibilityMessageAlpha(visibility);
+
+        expect(result).toBe('Visible to logged in web');
+    });
+
+    it('should return correct message for free web visitors', function () {
+        const visibility = {
+            web: {
+                nonMember: false,
+                memberSegment: 'status:free'
+            },
+            email: {
+                memberSegment: ''
+            }
+        };
+
+        const result = generateVisibilityMessageAlpha(visibility);
+
+        expect(result).toBe('Visible to free web');
+    });
+
+    it('should return correct message for email-only', function () {
+        const visibility = {
+            web: {
+                nonMember: false,
+                memberSegment: ''
+            },
+            email: {
+                memberSegment: 'status:free,status:-free'
+            }
+        };
+
+        const result = generateVisibilityMessageAlpha(visibility);
+
+        expect(result).toBe('Visible to all email recipients');
+    });
+
+    it('should return correct message for free email recipients', function () {
+        const visibility = {
+            web: {
+                nonMember: false,
+                memberSegment: ''
+            },
+            email: {
+                memberSegment: 'status:free'
+            }
+        };
+
+        const result = generateVisibilityMessageAlpha(visibility);
+
+        expect(result).toBe('Visible to free email');
+    });
+
+    it('should return correct message for all web and free email', function () {
+        const visibility = {
+            web: {
+                nonMember: true,
+                memberSegment: 'status:free,status:-free'
+            },
+            email: {
+                memberSegment: 'status:free'
+            }
+        };
+
+        const result = generateVisibilityMessageAlpha(visibility);
+
+        expect(result).toBe('Visible to all web, free email');
+    });
+
+    it('should return correct message for web members and all email', function () {
+        const visibility = {
+            web: {
+                nonMember: false,
+                memberSegment: 'status:free,status:-free'
+            },
+            email: {
+                memberSegment: 'status:free,status:-free'
+            }
+        };
+
+        const result = generateVisibilityMessageAlpha(visibility);
+
+        expect(result).toBe('Visible to logged in web, all email recipients');
+    });
+});
+
+describe('getVisibilityOptions', function () {
+    it('has correct default options', function () {
+        const options = getVisibilityOptions();
+
+        expect(options).toEqual([
+            {
+                label: 'Web',
+                key: 'web',
+                toggles: [
+                    {key: 'nonMembers', label: 'Anonymous visitors', checked: true},
+                    {key: 'freeMembers', label: 'Free members', checked: true},
+                    {key: 'paidMembers', label: 'Paid members', checked: true}
+                ]
+            },
+            {
+                label: 'Email',
+                key: 'email',
+                toggles: [
+                    {key: 'freeMembers', label: 'Free members', checked: true},
+                    {key: 'paidMembers', label: 'Paid members', checked: true}
+                ]
+            }
+        ]);
+    });
+
+    it('removes paid options if stripe is disabled', function () {
+        const options = getVisibilityOptions(undefined, {isStripeEnabled: false});
+
+        expect(options).toEqual([
+            {
+                label: 'Web',
+                key: 'web',
+                toggles: [
+                    {key: 'nonMembers', label: 'Anonymous visitors', checked: true},
+                    {key: 'freeMembers', label: 'Free members', checked: true}
+                ]
+            },
+            {
+                label: 'Email',
+                key: 'email',
+                toggles: [
+                    {key: 'freeMembers', label: 'Free members', checked: true}
+                ]
+            }
+        ]);
+    });
+
+    it('updates option checked values based on visibility', function () {
+        const visibility = {
+            web: {
+                nonMember: false,
+                memberSegment: 'status:free'
+            },
+            email: {
+                memberSegment: 'status:-free'
+            }
+        };
+
+        const options = getVisibilityOptions(visibility);
+
+        expect(options).toEqual([
+            {
+                label: 'Web',
+                key: 'web',
+                toggles: [
+                    {key: 'nonMembers', label: 'Anonymous visitors', checked: false},
+                    {key: 'freeMembers', label: 'Free members', checked: true},
+                    {key: 'paidMembers', label: 'Paid members', checked: false}
+                ]
+            },
+            {
+                label: 'Email',
+                key: 'email',
+                toggles: [
+                    {key: 'freeMembers', label: 'Free members', checked: false},
+                    {key: 'paidMembers', label: 'Paid members', checked: true}
+                ]
+            }
+        ]);
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-327

Updated visibility settings to include toggles for controlling anonymous and free/paid web visibility.

- changed the `visibility` object format
  - old: `{showOnWeb: false, showOnEmail: true, memberSegment: 'status:free'}`
  - new: `{web: {nonMembers: false, memberSegment: ''}, email: {memberSegment: 'status:free'}}`
- added utility for migrating the old format to the new
- added automatic migration of format in HTML node's `importJSON` method so within the editor we're always dealing with the new format
- updated HTML node rendering for email to work with the new visibility format
- updated HTML node rendering for web to output gated block comments
  - e.g.: `<!--kg-gated-block:begin nonMembers:false memberSegment:'status:free'-->...<!--kg-gated-blog:end-->`
- added utility functions for parsing/serializing the `visibility` object to structures that are more useful when working with UI
- updated existing beta UI to work with the new visibility format
- added alpha UI with the additional toggles
- added `contentVisibilityAlpha` flag support to demo app (disabled by default)