### PR TITLE
Fixed flaky upload progress indicator checks in tests

### DIFF
--- a/packages/koenig-lexical/demo/utils/useFileUpload.js
+++ b/packages/koenig-lexical/demo/utils/useFileUpload.js
@@ -88,7 +88,7 @@ export function useFileUpload({isMultiplayer = false} = {}) {
             let stepDelay = 200;
             // adjust when testing to speed up tests
             if (isTestEnv) {
-                stepDelay = 0;
+                stepDelay = 1;
             }
 
             setProgress(30);


### PR DESCRIPTION
no issue

- when testing we were setting the demo app's upload step delay to 0, with recent dependency/browser updates this had the effect of making the display of upload progress indicators undetectable in tests
- switched to a step delay of 1 so the UI updates still occur and can be picked up in tests