### PR TITLE
Added CTA Card import serialization

### DIFF
--- a/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
@@ -52,7 +52,7 @@ export class CallToActionNode extends BaseCallToActionNode {
         // client-side only data properties such as nested editors
         const self = this.getLatest();
         dataset.ctaHtmlEditor = self.__ctaHtmlEditor;
-        dataset.ctaHtmlEditorIntitialState = self.__ctaHtmlEditorInitialState;
+        dataset.ctaHtmlEditorInitialState = self.__ctaHtmlEditorInitialState;
 
         return dataset;
     }

--- a/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
@@ -49,7 +49,6 @@ export class CallToActionNode extends BaseCallToActionNode {
 
     getDataset() {
         const dataset = super.getDataset();
-        console.log('dataset', dataset);
         // client-side only data properties such as nested editors
         const self = this.getLatest();
         dataset.ctaHtmlEditor = self.__ctaHtmlEditor;

--- a/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
@@ -1,17 +1,19 @@
 import EmailCtaCardIcon from '../assets/icons/kg-card-type-email-cta.svg?react';
 import KoenigCardWrapper from '../components/KoenigCardWrapper';
+import cleanBasicHtml from '@tryghost/kg-clean-basic-html';
+import {$generateHtmlFromNodes} from '@lexical/html';
 import {BASIC_NODES} from '../index.js';
 import {CallToActionNode as BaseCallToActionNode} from '@tryghost/kg-default-nodes';
 import {CallToActionNodeComponent} from './CallToActionNodeComponent';
 import {createCommand} from 'lexical';
-import {setupNestedEditor} from '../utils/nested-editors';
+import {populateNestedEditor, setupNestedEditor} from '../utils/nested-editors';
 
 export const INSERT_CTA_COMMAND = createCommand();
 
 export class CallToActionNode extends BaseCallToActionNode {
-    __htmlEditor;
-    __htmlEditorInitialState;
-    // TODO: Improve the copy of the menu item
+    __ctaHtmlEditor;
+    __ctaHtmlEditorInitialState;
+
     static kgMenu = {
         label: 'Call to Action',
         desc: 'Add a call to action to your post',
@@ -37,7 +39,39 @@ export class CallToActionNode extends BaseCallToActionNode {
         super(dataset, key);
 
         // set up nested editor instances
-        setupNestedEditor(this, '__htmlEditor', {editor: dataset.htmlEditor, nodes: BASIC_NODES});
+        setupNestedEditor(this, '__ctaHtmlEditor', {editor: dataset.ctaHtmlEditor, nodes: BASIC_NODES});
+
+        // populate nested editors on initial construction
+        if (!dataset.ctaHtmlEditor && dataset.textValue) {
+            populateNestedEditor(this, '__ctaHtmlEditor', `${dataset.textValue}`); // we serialize with no wrapper
+        }
+    }
+
+    getDataset() {
+        const dataset = super.getDataset();
+        console.log('dataset', dataset);
+        // client-side only data properties such as nested editors
+        const self = this.getLatest();
+        dataset.ctaHtmlEditor = self.__ctaHtmlEditor;
+        dataset.ctaHtmlEditorIntitialState = self.__ctaHtmlEditorInitialState;
+
+        return dataset;
+    }
+
+    exportJSON() {
+        const json = super.exportJSON();
+
+        // convert nested editor instance back into HTML because `text` may not
+        // be automatically updated when the nested editor changes
+        if (this.__ctaHtmlEditor) {
+            this.__ctaHtmlEditor.getEditorState().read(() => {
+                const html = $generateHtmlFromNodes(this.__ctaHtmlEditor, null);
+                const cleanedHtml = cleanBasicHtml(html, {allowBr: true});
+                json.textValue = cleanedHtml;
+            });
+        }
+
+        return json;
     }
 
     decorate() {
@@ -54,7 +88,8 @@ export class CallToActionNode extends BaseCallToActionNode {
                     buttonUrl={this.buttonUrl}
                     hasImage={this.hasImage}
                     hasSponsorLabel={this.hasSponsorLabel}
-                    htmlEditor={this.__htmlEditor}
+                    htmlEditor={this.__ctaHtmlEditor}
+                    htmlEditorInitialState={this.__ctaHtmlEditorInitialState}
                     imageUrl={this.imageUrl}
                     layout={this.layout}
                     nodeKey={this.getKey()}

--- a/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
@@ -21,6 +21,7 @@ export const CallToActionNodeComponent = ({
     textValue,
     buttonColor,
     htmlEditor,
+    htmlEditorInitialState,
     buttonTextColor
 }) => {
     const [editor] = useLexicalComposerContext();
@@ -108,6 +109,10 @@ export const CallToActionNodeComponent = ({
         });
     };
 
+    React.useEffect(() => {
+        htmlEditor.setEditable(isEditing);
+    }, [isEditing, htmlEditor]);
+
     return (
         <>
             <CtaCard
@@ -121,6 +126,7 @@ export const CallToActionNodeComponent = ({
                 hasImage={hasImage}
                 hasSponsorLabel={hasSponsorLabel}
                 htmlEditor={htmlEditor}
+                htmlEditorInitialState={htmlEditorInitialState}
                 imageSrc={imageUrl}
                 imageUploader={imageUploader}
                 isEditing={isEditing}

--- a/packages/koenig-lexical/src/nodes/CalloutNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CalloutNode.jsx
@@ -59,7 +59,6 @@ export class CalloutNode extends BaseCalloutNode {
 
     getDataset() {
         const dataset = super.getDataset();
-
         // client-side only data properties such as nested editors
         const self = this.getLatest();
         dataset.calloutTextEditor = self.__calloutTextEditor;

--- a/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
@@ -20,6 +20,87 @@ test.describe('Call To Action Card', async () => {
         await page.close();
     });
 
+    test('can import serialized CTA card nodes', async function () {
+        const contentParam = encodeURIComponent(JSON.stringify({
+            root: {
+                children: [{
+                    type: 'call-to-action',
+                    backgroundColor: 'green',
+                    buttonColor: '#F0F0F0',
+                    buttonText: 'Get access now',
+                    buttonTextColor: '#000000',
+                    buttonUrl: 'http://someblog.com/somepost',
+                    hasImage: true,
+                    hasSponsorLabel: true,
+                    imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
+                    layout: 'minimal',
+                    showButton: true,
+                    textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card.</span></p>'
+                }],
+                direction: null,
+                format: '',
+                indent: 0,
+                type: 'root',
+                version: 1
+            }
+        }));
+
+        await initialize({page, uri: `/#/?content=${contentParam}`});
+        const ctaCardHtml = html`
+<div data-lexical-decorator="true" contenteditable="false" data-koenig-dnd-draggable="true" data-koenig-dnd-droppable="true">
+    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="call-to-action">
+        <div data-cta-layout="minimal">
+            <div>
+                <p data-testid="sponsor-label">Sponsored</p>
+            </div>
+            <div>
+                <div>
+                    <img alt="Placeholder" src="/content/images/2022/11/koenig-lexical.jpg">
+                </div>
+                <div>
+                    <div data-koenig-dnd-disabled="true" data-testid="cta-card-content-editor">
+                        <div data-kg="editor">
+                            <div contenteditable="false" role="textbox" spellcheck="true" data-lexical-editor="true" aria-autocomplete="none" aria-readonly="true">
+                                <p dir="ltr">
+                                    <span data-lexical-text="true">This is a new CTA Card.</span>
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div data-test-cta-button-current-url="http://someblog.com/somepost">
+                        <button data-testid="cta-button" type="button">
+                            <span data-testid="cta-button-span">Get access now</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div></div>
+        </div>
+        <div data-kg-card-toolbar="button">
+            <ul>
+                <li>
+                    <button aria-label="Edit" data-kg-active="false" data-testid="edit-button-card" type="button">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m14.2 4.3 5.5 5.5m-11 11L1 23l2.2-7.7L16.856 1.644a2.2 2.2 0 0 1 3.11 0l2.39 2.39a2.2 2.2 0 0 1 0 3.11L8.7 20.8Z"></path>
+                        </svg>
+                    </button>
+                </li>
+                <li></li>
+                <li>
+                    <button aria-label="Save as snippet" data-kg-active="false" data-testid="create-snippet" type="button">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M22 13.667V4a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h9.667M22 13.667 13.667 22M22 13.667h-6.333a2 2 0 0 0-2 2V22"></path>
+                        </svg>
+                    </button>
+                </li>
+            </ul>
+        </div>
+    </div>
+</div>
+`;
+        await assertHTML(page, ctaCardHtml, {ignoreCardContents: true});
+    });
+
     test('renders CTA Card', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-326/make-cta-content-persist

- We didn't add CTA content serialisation to be able to load content from the DB / JSON into the CTA Card and have the card rendered in the editor.
- This mainly updates the node editor to handle `getDataset`, `exportJSON`, and fixes the constructor.