### PR TITLE
Removed unnecessary constructor in CallToActionNode

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
@@ -16,33 +16,7 @@ export class CallToActionNode extends generateDecoratorNode({nodeType: 'call-to-
         {name: 'imageUrl', default: ''}
     ]}
 ) {
-    /* override */
-    constructor({
-        layout,
-        textValue,
-        showButton,
-        buttonText,
-        buttonUrl,
-        buttonColor,
-        buttonTextColor,
-        hasSponsorLabel,
-        backgroundColor,
-        hasImage,
-        imageUrl
-    } = {}, key) {
-        super(key);
-        this.__layout = layout ?? 'minimal';
-        this.__textValue = textValue ?? '';
-        this.__showButton = showButton ?? false;
-        this.__buttonText = buttonText ?? '';
-        this.__buttonUrl = buttonUrl ?? '';
-        this.__buttonColor = buttonColor ?? 'none';
-        this.__buttonTextColor = buttonTextColor ?? 'none';
-        this.__hasSponsorLabel = hasSponsorLabel ?? true;
-        this.__backgroundColor = backgroundColor ?? 'grey';
-        this.__hasImage = hasImage ?? false;
-        this.__imageUrl = imageUrl ?? '';
-    }
+    /* overrides */
 }
 
 export const $createCallToActionNode = (dataset) => {

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -90,11 +90,11 @@ describe('CallToActionNode', function () {
             callToActionNode.buttonUrl = 'http://blog.com/post1';
             callToActionNode.buttonUrl.should.equal('http://blog.com/post1');
 
-            callToActionNode.buttonColor.should.equal('none');
+            callToActionNode.buttonColor.should.equal('');
             callToActionNode.buttonColor = 'red';
             callToActionNode.buttonColor.should.equal('red');
 
-            callToActionNode.buttonTextColor.should.equal('none');
+            callToActionNode.buttonTextColor.should.equal('');
             callToActionNode.buttonTextColor = 'black';
             callToActionNode.buttonTextColor.should.equal('black');
 

--- a/packages/koenig-lexical/src/components/ui/cards/CtaCard.stories.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CtaCard.stories.jsx
@@ -62,13 +62,13 @@ const Template = ({display, value, ...args}) => {
         <div>
             <div className="kg-prose">
                 <div className="mx-auto my-8 min-w-[initial] max-w-[740px]">
-                    <CardWrapper 
+                    <CardWrapper
                         IndicatorIcon={VisibilityIndicatorIcon}
                         indicatorPosition={{
                             top: '1.2rem'
                         }}
-                        {...(args.color === 'none' && {wrapperStyle: 'wide'})} 
-                        {...display} 
+                        {...(args.color === '' && {wrapperStyle: 'wide'})}
+                        {...display}
                         {...args}
                     >
                         <CtaCard {...display} {...args} htmlEditor={htmlEditor} />
@@ -77,10 +77,10 @@ const Template = ({display, value, ...args}) => {
             </div>
             {/* <div className="kg-prose dark bg-black px-4 py-8">
                 <div className="mx-auto my-8 min-w-[initial] max-w-[740px]">
-                    <CardWrapper 
-                        IndicatorIcon={VisibilityIndicatorIcon} 
-                        {...(args.color === 'none' && {wrapperStyle: 'wide'})} 
-                        {...display} 
+                    <CardWrapper
+                        IndicatorIcon={VisibilityIndicatorIcon}
+                        {...(args.color === 'none' && {wrapperStyle: 'wide'})}
+                        {...display}
                         {...args}
                     >
                         <CtaCard {...display} {...args} htmlEditor={htmlEditor} />

--- a/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
@@ -77,7 +77,7 @@ export class CallToActionNode extends BaseCallToActionNode {
         return (
             <KoenigCardWrapper
                 nodeKey={this.getKey()}
-                wrapperStyle={this.backgroundColor === 'none' ? 'wide' : 'regular'}
+                wrapperStyle={this.backgroundColor ? 'regular' : 'wide'}
             >
                 <CallToActionNodeComponent
                     backgroundColor={this.backgroundColor}


### PR DESCRIPTION
no issue

- `generateDecoratorNode()` already handles constructor creation with property assignment based on the properties array passed to it
- fixes an inconsistency in default values between the array passed to `generateDecoratorNode()` and the overridden constructor
  - switched to `''` in place of `'none'` to match other cards, updated related usage