### PR TITLE
Fixed defaultProps warning for CtaCard

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
@@ -60,28 +60,28 @@ export const ctaColorPicker = [
 ];
 
 export function CtaCard({
-    buttonText,
-    buttonUrl,
-    buttonColor,
-    buttonTextColor,
-    color,
-    hasSponsorLabel,
+    buttonColor = '',
+    buttonText = '',
+    buttonTextColor = '',
+    buttonUrl = '',
+    color = 'none',
+    hasSponsorLabel = false,
     htmlEditor,
     htmlEditorInitialState,
-    imageSrc,
-    isEditing,
-    layout,
-    showButton,
-    updateButtonText,
-    updateButtonUrl,
-    updateShowButton,
-    updateHasSponsorLabel,
-    updateLayout,
-    handleColorChange,
-    handleButtonColor,
-    onFileChange,
-    setFileInputRef,
-    onRemoveMedia
+    imageSrc = '',
+    isEditing = false,
+    layout = 'immersive',
+    showButton = false,
+    handleButtonColor = () => {},
+    handleColorChange = () => {},
+    onFileChange = () => {},
+    onRemoveMedia = () => {},
+    setFileInputRef = () => {},
+    updateButtonText = () => {},
+    updateButtonUrl = () => {},
+    updateHasSponsorLabel = () => {},
+    updateLayout = () => {},
+    updateShowButton = () => {}
 }) {
     const [buttonColorPickerExpanded, setButtonColorPickerExpanded] = useState(false);
 
@@ -339,25 +339,4 @@ CtaCard.propTypes = {
     onFileChange: PropTypes.func,
     setFileInputRef: PropTypes.func,
     onRemoveMedia: PropTypes.func
-};
-
-CtaCard.defaultProps = {
-    buttonText: '',
-    buttonUrl: '',
-    buttonColor: '',
-    buttonTextColor: '',
-    color: 'none',
-    hasSponsorLabel: false,
-    imageSrc: '',
-    isEditing: false,
-    layout: 'immersive',
-    showButton: false,
-    updateHasSponsorLabel: () => {},
-    updateShowButton: () => {},
-    updateLayout: () => {},
-    handleColorChange: () => {},
-    handleButtonColor: () => {},
-    onFileChange: () => {},
-    setFileInputRef: () => {},
-    onRemoveMedia: () => {}
 };


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-347

- React throws console errors in development any time a component uses `defaultProps` which is rather noisy
- switched to specifying parameter defaults using standard JS
