### PR TITLE
Added link button to CTA Card toolbar

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
@@ -16,7 +16,8 @@ export class CallToActionNode extends generateDecoratorNode({
         {name: 'hasSponsorLabel', default: true},
         {name: 'backgroundColor', default: 'grey'},
         {name: 'hasImage', default: false},
-        {name: 'imageUrl', default: ''}
+        {name: 'imageUrl', default: ''},
+        {name: 'href', default: '', urlType: 'url'}
     ]
 }) {
     /* overrides */

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -36,7 +36,8 @@ describe('CallToActionNode', function () {
             hasSponsorLabel: true,
             backgroundColor: 'none',
             hasImage: true,
-            imageUrl: 'http://blog.com/image1.jpg'
+            imageUrl: 'http://blog.com/image1.jpg',
+            href: ''
         };
         exportOptions = {
             exportFormat: 'html',
@@ -65,6 +66,7 @@ describe('CallToActionNode', function () {
             callToActionNode.hasImage.should.equal(dataset.hasImage);
             callToActionNode.imageUrl.should.equal(dataset.imageUrl);
             callToActionNode.visibility.should.deepEqual(utils.visibility.buildDefaultVisibility());
+            callToActionNode.href.should.equal(dataset.href);
         }));
 
         it('has setters for all properties', editorTest(function () {
@@ -113,6 +115,10 @@ describe('CallToActionNode', function () {
             callToActionNode.imageUrl.should.equal('');
             callToActionNode.imageUrl = 'http://blog.com/image1.jpg';
             callToActionNode.imageUrl.should.equal('http://blog.com/image1.jpg');
+
+            callToActionNode.href.should.equal('');
+            callToActionNode.href = 'http://blog.com/post1';
+            callToActionNode.href.should.equal('http://blog.com/post1');
 
             callToActionNode.visibility.should.deepEqual(utils.visibility.buildDefaultVisibility());
             callToActionNode.visibility = {
@@ -296,7 +302,8 @@ describe('CallToActionNode', function () {
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                 layout: 'minimal',
                 showButton: true,
-                textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card.</span></p>'
+                textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card.</span></p>',
+                href: ''
             };
             const callToActionNode = new CallToActionNode(dataset);
             const json = callToActionNode.exportJSON();
@@ -315,6 +322,7 @@ describe('CallToActionNode', function () {
                 layout: 'minimal',
                 showButton: true,
                 textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card.</span></p>',
+                href: '',
                 visibility: {
                     web: {
                         nonMember: true,

--- a/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
@@ -87,6 +87,7 @@ export class CallToActionNode extends BaseCallToActionNode {
                     buttonUrl={this.buttonUrl}
                     hasImage={this.hasImage}
                     hasSponsorLabel={this.hasSponsorLabel}
+                    href={this.href}
                     htmlEditor={this.__ctaHtmlEditor}
                     htmlEditorInitialState={this.__ctaHtmlEditorInitialState}
                     imageUrl={this.imageUrl}

--- a/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
@@ -157,7 +157,6 @@ export const CallToActionNodeComponent = ({
                 imageSrc={imageUrl}
                 imageUploader={imageUploader}
                 isEditing={isEditing}
-                isSelected={isSelected}
                 layout={layout}
                 setEditing={setEditing}
                 setFileInputRef={ref => fileInputRef.current = ref}
@@ -182,7 +181,7 @@ export const CallToActionNodeComponent = ({
             </ActionToolbar>
 
             <ActionToolbar
-                data-kg-card-toolbar="image"
+                data-kg-card-toolbar="link"
                 isVisible={showLink}
             >
                 <LinkInput
@@ -197,7 +196,7 @@ export const CallToActionNodeComponent = ({
 
             <ActionToolbar
                 data-kg-card-toolbar="button"
-                isVisible={isSelected && !isEditing}
+                isVisible={isSelected && !isEditing && !showSnippetToolbar && !showLink}
             >
                 <ToolbarMenu>
                     <ToolbarMenuItem dataTestId="edit-button-card" icon="edit" isActive={false} label="Edit" onClick={handleToolbarEdit} />

--- a/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
@@ -440,4 +440,14 @@ test.describe('Call To Action Card', async () => {
         await expect(page.getByTestId('visibility-toggle-email-freeMembers')).toBeChecked();
         await expect(page.getByTestId('visibility-toggle-email-paidMembers')).not.toBeChecked();
     });
+
+    test('CTA card toolbar has Link button and link input', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        await page.keyboard.press('Escape');
+        const toolbarLinkButton = await page.locator('[aria-label="Link"]');
+        await expect(toolbarLinkButton).toBeVisible();
+        await toolbarLinkButton.click();
+        await expect(page.getByTestId('link-input')).toBeVisible();
+    });
 });

--- a/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
@@ -450,4 +450,14 @@ test.describe('Call To Action Card', async () => {
         await toolbarLinkButton.click();
         await expect(page.getByTestId('link-input')).toBeVisible();
     });
+
+    test('Settings panel does not show when using link editor', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        await page.keyboard.press('Escape');
+        const toolbarLinkButton = await page.locator('[aria-label="Link"]');
+        await toolbarLinkButton.click();
+        await expect(page.getByTestId('link-input')).toBeVisible();
+        await expect(page.getByTestId('button-settings')).not.toBeVisible();
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-329/add-ability-to-add-url-to-cta-card

- Added a new href node property to the CTA Node
- wired up the href node prop to Koenig-Lexcal
- Implemented an add link Action button in the toolbar.