### PR TITLE
Added editable Sponsored Label to CTA Card

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
@@ -14,6 +14,7 @@ export class CallToActionNode extends generateDecoratorNode({
         {name: 'buttonColor', default: ''},
         {name: 'buttonTextColor', default: ''},
         {name: 'hasSponsorLabel', default: true},
+        {name: 'customSponsorLabel', default: '<p>Sponsored</p>'},
         {name: 'backgroundColor', default: 'grey'},
         {name: 'hasImage', default: false},
         {name: 'imageUrl', default: ''}

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
@@ -14,7 +14,7 @@ export class CallToActionNode extends generateDecoratorNode({
         {name: 'buttonColor', default: ''},
         {name: 'buttonTextColor', default: ''},
         {name: 'hasSponsorLabel', default: true},
-        {name: 'sponsorLabel', default: '<p>Sponsored</p>'},
+        {name: 'sponsorLabel', default: '<p><span style="white-space: pre-wrap;">SPONSORED</span></p>'},
         {name: 'backgroundColor', default: 'grey'},
         {name: 'hasImage', default: false},
         {name: 'imageUrl', default: ''}

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
@@ -14,7 +14,7 @@ export class CallToActionNode extends generateDecoratorNode({
         {name: 'buttonColor', default: ''},
         {name: 'buttonTextColor', default: ''},
         {name: 'hasSponsorLabel', default: true},
-        {name: 'customSponsorLabel', default: '<p>Sponsored</p>'},
+        {name: 'sponsorLabel', default: '<p>Sponsored</p>'},
         {name: 'backgroundColor', default: 'grey'},
         {name: 'hasImage', default: false},
         {name: 'imageUrl', default: ''}

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -20,7 +20,7 @@ function ctaCardTemplate(dataset) {
             ` : ''}
             ${dataset.hasSponsorLabel ? `
                 <div class="kg-sponsor-label">
-                    ${dataset.customSponsorLabel}
+                    ${dataset.sponsorLabel}
                 </div>
             ` : ''}
         </div>
@@ -48,7 +48,7 @@ function emailCTATemplate(dataset) {
             ` : ''}
             ${dataset.hasSponsorLabel ? `
                 <div class="sponsor-label" style="margin-top: 8px; font-size: 12px; color: #888;">
-                    ${dataset.customSponsorLabel}
+                    ${dataset.sponsorLabel}
                 </div>
             ` : ''}
         </div>
@@ -69,7 +69,7 @@ export function renderCallToActionNode(node, options = {}) {
         buttonTextColor: node.buttonTextColor,
         hasSponsorLabel: node.hasSponsorLabel,
         backgroundColor: node.backgroundColor,
-        customSponsorLabel: node.customSponsorLabel,
+        sponsorLabel: node.sponsorLabel,
         hasImage: node.hasImage,
         imageUrl: node.imageUrl,
         textColor: node.textColor

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -20,7 +20,7 @@ function ctaCardTemplate(dataset) {
             ` : ''}
             ${dataset.hasSponsorLabel ? `
                 <div class="kg-sponsor-label">
-                    Sponsored
+                    ${dataset.customSponsorLabel}
                 </div>
             ` : ''}
         </div>
@@ -48,7 +48,7 @@ function emailCTATemplate(dataset) {
             ` : ''}
             ${dataset.hasSponsorLabel ? `
                 <div class="sponsor-label" style="margin-top: 8px; font-size: 12px; color: #888;">
-                    Sponsored
+                    ${dataset.customSponsorLabel}
                 </div>
             ` : ''}
         </div>
@@ -69,6 +69,7 @@ export function renderCallToActionNode(node, options = {}) {
         buttonTextColor: node.buttonTextColor,
         hasSponsorLabel: node.hasSponsorLabel,
         backgroundColor: node.backgroundColor,
+        customSponsorLabel: node.customSponsorLabel,
         hasImage: node.hasImage,
         imageUrl: node.imageUrl,
         textColor: node.textColor

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -28,6 +28,7 @@ describe('CallToActionNode', function () {
         dataset = {
             layout: 'minimal',
             textValue: 'This is a cool advertisement',
+            customSponsorLabel: '<p>Sponsored</p>',
             showButton: true,
             buttonText: 'click me',
             buttonUrl: 'http://blog.com/post1',
@@ -61,6 +62,7 @@ describe('CallToActionNode', function () {
             callToActionNode.buttonColor.should.equal(dataset.buttonColor);
             callToActionNode.buttonTextColor.should.equal(dataset.buttonTextColor);
             callToActionNode.hasSponsorLabel.should.equal(dataset.hasSponsorLabel);
+            callToActionNode.customSponsorLabel.should.equal(dataset.customSponsorLabel);
             callToActionNode.backgroundColor.should.equal(dataset.backgroundColor);
             callToActionNode.hasImage.should.equal(dataset.hasImage);
             callToActionNode.imageUrl.should.equal(dataset.imageUrl);
@@ -89,6 +91,10 @@ describe('CallToActionNode', function () {
             callToActionNode.buttonUrl.should.equal('');
             callToActionNode.buttonUrl = 'http://blog.com/post1';
             callToActionNode.buttonUrl.should.equal('http://blog.com/post1');
+
+            callToActionNode.customSponsorLabel.should.equal('<p>Sponsored</p>');
+            callToActionNode.customSponsorLabel = 'This post is brought to you by our sponsors';
+            callToActionNode.customSponsorLabel.should.equal('This post is brought to you by our sponsors');
 
             callToActionNode.buttonColor.should.equal('');
             callToActionNode.buttonColor = 'red';
@@ -184,11 +190,13 @@ describe('CallToActionNode', function () {
                 buttonUrl: 'http://someblog.com/somepost',
                 hasImage: true,
                 hasSponsorLabel: true,
+                customSponsorLabel: '<p>Sponsored by</p>',
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                 layout: 'minimal',
                 showButton: true,
                 textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card.</span></p>'
             };
+
             const callToActionNode = new CallToActionNode(dataset);
             const {element} = callToActionNode.exportDOM(exportOptions);
 
@@ -200,7 +208,7 @@ describe('CallToActionNode', function () {
             html.should.containEql('http://someblog.com/somepost');
             html.should.containEql('/content/images/2022/11/koenig-lexical.jpg');// because hasImage is true
             html.should.containEql('This is a new CTA Card.');
-            html.should.containEql('Sponsored'); // because hasSponsorLabel is true
+            html.should.containEql('Sponsored by'); // because hasSponsorLabel is true
             html.should.containEql('cta-card');
         }));
 
@@ -214,6 +222,7 @@ describe('CallToActionNode', function () {
                 buttonUrl: 'http://someblog.com/somepost',
                 hasImage: true,
                 hasSponsorLabel: true,
+                customSponsorLabel: '<p>Sponsored</p>',
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                 layout: 'minimal',
                 showButton: true,
@@ -228,6 +237,7 @@ describe('CallToActionNode', function () {
             html.should.containEql('background-color: #F0F0F0');
             html.should.containEql('Get access now');
             html.should.containEql('http://someblog.com/somepost');
+            html.should.containEql('Sponsored'); // because hasSponsorLabel is true
             html.should.containEql('/content/images/2022/11/koenig-lexical.jpg'); // because hasImage is true
             html.should.containEql('This is a new CTA Card via email.');
         }));
@@ -268,6 +278,7 @@ describe('CallToActionNode', function () {
                 buttonUrl: 'http://someblog.com/somepost',
                 hasImage: true,
                 hasSponsorLabel: true,
+                customSponsorLabel: '<p>This post is brought to you by our sponsors</p>',
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                 layout: 'minimal',
                 showButton: true,
@@ -286,6 +297,7 @@ describe('CallToActionNode', function () {
                 buttonUrl: 'http://someblog.com/somepost',
                 hasImage: true,
                 hasSponsorLabel: true,
+                customSponsorLabel: '<p>This post is brought to you by our sponsors</p>',
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                 layout: 'minimal',
                 showButton: true,
@@ -316,6 +328,7 @@ describe('CallToActionNode', function () {
                         buttonUrl: 'http://someblog.com/somepost',
                         hasImage: true,
                         hasSponsorLabel: true,
+                        customSponsorLabel: '<p>This post is brought to you by our sponsors</p>',
                         imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                         layout: 'minimal',
                         showButton: true,

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -28,7 +28,7 @@ describe('CallToActionNode', function () {
         dataset = {
             layout: 'minimal',
             textValue: 'This is a cool advertisement',
-            customSponsorLabel: '<p>Sponsored</p>',
+            sponsorLabel: '<p>Sponsored</p>',
             showButton: true,
             buttonText: 'click me',
             buttonUrl: 'http://blog.com/post1',
@@ -62,7 +62,7 @@ describe('CallToActionNode', function () {
             callToActionNode.buttonColor.should.equal(dataset.buttonColor);
             callToActionNode.buttonTextColor.should.equal(dataset.buttonTextColor);
             callToActionNode.hasSponsorLabel.should.equal(dataset.hasSponsorLabel);
-            callToActionNode.customSponsorLabel.should.equal(dataset.customSponsorLabel);
+            callToActionNode.sponsorLabel.should.equal(dataset.sponsorLabel);
             callToActionNode.backgroundColor.should.equal(dataset.backgroundColor);
             callToActionNode.hasImage.should.equal(dataset.hasImage);
             callToActionNode.imageUrl.should.equal(dataset.imageUrl);
@@ -92,9 +92,9 @@ describe('CallToActionNode', function () {
             callToActionNode.buttonUrl = 'http://blog.com/post1';
             callToActionNode.buttonUrl.should.equal('http://blog.com/post1');
 
-            callToActionNode.customSponsorLabel.should.equal('<p>Sponsored</p>');
-            callToActionNode.customSponsorLabel = 'This post is brought to you by our sponsors';
-            callToActionNode.customSponsorLabel.should.equal('This post is brought to you by our sponsors');
+            callToActionNode.sponsorLabel.should.equal('<p>Sponsored</p>');
+            callToActionNode.sponsorLabel = 'This post is brought to you by our sponsors';
+            callToActionNode.sponsorLabel.should.equal('This post is brought to you by our sponsors');
 
             callToActionNode.buttonColor.should.equal('');
             callToActionNode.buttonColor = 'red';
@@ -190,7 +190,7 @@ describe('CallToActionNode', function () {
                 buttonUrl: 'http://someblog.com/somepost',
                 hasImage: true,
                 hasSponsorLabel: true,
-                customSponsorLabel: '<p>Sponsored by</p>',
+                sponsorLabel: '<p>Sponsored by</p>',
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                 layout: 'minimal',
                 showButton: true,
@@ -222,7 +222,7 @@ describe('CallToActionNode', function () {
                 buttonUrl: 'http://someblog.com/somepost',
                 hasImage: true,
                 hasSponsorLabel: true,
-                customSponsorLabel: '<p>Sponsored</p>',
+                sponsorLabel: '<p>Sponsored</p>',
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                 layout: 'minimal',
                 showButton: true,
@@ -278,7 +278,7 @@ describe('CallToActionNode', function () {
                 buttonUrl: 'http://someblog.com/somepost',
                 hasImage: true,
                 hasSponsorLabel: true,
-                customSponsorLabel: '<p>This post is brought to you by our sponsors</p>',
+                sponsorLabel: '<p>This post is brought to you by our sponsors</p>',
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                 layout: 'minimal',
                 showButton: true,
@@ -297,7 +297,7 @@ describe('CallToActionNode', function () {
                 buttonUrl: 'http://someblog.com/somepost',
                 hasImage: true,
                 hasSponsorLabel: true,
-                customSponsorLabel: '<p>This post is brought to you by our sponsors</p>',
+                sponsorLabel: '<p>This post is brought to you by our sponsors</p>',
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                 layout: 'minimal',
                 showButton: true,
@@ -328,7 +328,7 @@ describe('CallToActionNode', function () {
                         buttonUrl: 'http://someblog.com/somepost',
                         hasImage: true,
                         hasSponsorLabel: true,
-                        customSponsorLabel: '<p>This post is brought to you by our sponsors</p>',
+                        sponsorLabel: '<p>This post is brought to you by our sponsors</p>',
                         imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                         layout: 'minimal',
                         showButton: true,

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -28,7 +28,7 @@ describe('CallToActionNode', function () {
         dataset = {
             layout: 'minimal',
             textValue: 'This is a cool advertisement',
-            sponsorLabel: '<p>Sponsored</p>',
+            sponsorLabel: '<p><span style="white-space: pre-wrap;">SPONSORED</span></p>',
             showButton: true,
             buttonText: 'click me',
             buttonUrl: 'http://blog.com/post1',
@@ -92,7 +92,7 @@ describe('CallToActionNode', function () {
             callToActionNode.buttonUrl = 'http://blog.com/post1';
             callToActionNode.buttonUrl.should.equal('http://blog.com/post1');
 
-            callToActionNode.sponsorLabel.should.equal('<p>Sponsored</p>');
+            callToActionNode.sponsorLabel.should.equal('<p><span style="white-space: pre-wrap;">SPONSORED</span></p>');
             callToActionNode.sponsorLabel = 'This post is brought to you by our sponsors';
             callToActionNode.sponsorLabel.should.equal('This post is brought to you by our sponsors');
 
@@ -222,7 +222,7 @@ describe('CallToActionNode', function () {
                 buttonUrl: 'http://someblog.com/somepost',
                 hasImage: true,
                 hasSponsorLabel: true,
-                sponsorLabel: '<p>Sponsored</p>',
+                sponsorLabel: '<p><span style="white-space: pre-wrap;">SPONSORED</span></p>',
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                 layout: 'minimal',
                 showButton: true,
@@ -237,7 +237,7 @@ describe('CallToActionNode', function () {
             html.should.containEql('background-color: #F0F0F0');
             html.should.containEql('Get access now');
             html.should.containEql('http://someblog.com/somepost');
-            html.should.containEql('Sponsored'); // because hasSponsorLabel is true
+            html.should.containEql('<p><span style="white-space: pre-wrap;">SPONSORED</span></p>'); // because hasSponsorLabel is true
             html.should.containEql('/content/images/2022/11/koenig-lexical.jpg'); // because hasImage is true
             html.should.containEql('This is a new CTA Card via email.');
         }));

--- a/packages/koenig-lexical/src/components/KoenigComposableEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigComposableEditor.jsx
@@ -42,6 +42,7 @@ const KoenigComposableEditor = ({
     inheritStyles = false,
     isSnippetsEnabled = true,
     hiddenFormats = [],
+    useDefaultClasses = true,
     dataTestId
 }) => {
     const {historyState} = useSharedHistoryContext();
@@ -89,14 +90,14 @@ const KoenigComposableEditor = ({
     return (
         <div
             ref={onWrapperRef}
-            className={`koenig-lexical ${inheritStyles ? 'kg-inherit-styles' : ''} ${darkMode ? 'dark' : ''} ${className}`}
+            className={`${useDefaultClasses ? 'koenig-lexical' : ''} ${inheritStyles ? 'kg-inherit-styles' : ''} ${darkMode ? 'dark' : ''} ${className}`}
             data-koenig-dnd-disabled={!isDragEnabled}
             data-testid={dataTestId}
         >
             <RichTextPlugin
                 contentEditable={
                     <div ref={onContentEditableRef} data-kg="editor">
-                        <ContentEditable className="kg-prose" readOnly={readOnly} />
+                        <ContentEditable className={useDefaultClasses ? 'kg-prose' : ''} readOnly={readOnly} />
                     </div>
                 }
                 ErrorBoundary={KoenigErrorBoundary}

--- a/packages/koenig-lexical/src/components/KoenigNestedEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigNestedEditor.jsx
@@ -15,6 +15,7 @@ const Placeholder = ({text = 'Type here', className = ''}) => {
 const KoenigNestedEditor = ({
     initialEditor,
     initialEditorState,
+    initialTheme,
     nodes = 'basic',
     placeholderText = '',
     textClassName = '',
@@ -37,6 +38,7 @@ const KoenigNestedEditor = ({
             initialEditor={initialEditor}
             initialEditorState={initialEditorState}
             initialNodes={initialNodes}
+            initialTheme={initialTheme}
         >
             <KoenigComposableEditor
                 className={textClassName}

--- a/packages/koenig-lexical/src/components/KoenigNestedEditor.jsx
+++ b/packages/koenig-lexical/src/components/KoenigNestedEditor.jsx
@@ -25,6 +25,7 @@ const KoenigNestedEditor = ({
     hasSettingsPanel = false,
     defaultKoenigEnterBehaviour = false,
     hiddenFormats = [],
+    useDefaultClasses = true,
     dataTestId,
     children
 }) => {
@@ -45,6 +46,7 @@ const KoenigNestedEditor = ({
                 isDragEnabled={false}
                 markdownTransformers={markdownTransformers}
                 placeholder={<Placeholder className={placeholderClassName} text={placeholderText} />}
+                useDefaultClasses={useDefaultClasses}
             >
                 {singleParagraph && <RestrictContentPlugin paragraphs={1} />}
 

--- a/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
@@ -241,8 +241,9 @@ export function CtaCard({
                             initialEditorState={sponsorLabelHtmlEditorInitialState}
                             nodes='basic'
                             textClassName={clsx(
-                                'kg-prose w-full whitespace-normal bg-transparent font-sans !text-2xs text-grey-900/40 dark:text-grey-100/40'
+                                'not-kg-prose w-full whitespace-normal bg-transparent font-sans !text-2xs text-grey-900/40 dark:text-grey-100/40'
                             )}
+                            useDefaultClasses={false}
                         >
                             <ReplacementStringsPlugin />
                         </KoenigNestedEditor>
@@ -261,13 +262,13 @@ export function CtaCard({
                             'block',
                             layout === 'immersive' ? 'w-full' : 'w-16 shrink-0'
                         )}>
-                            <img 
-                                alt="Placeholder" 
+                            <img
+                                alt="Placeholder"
                                 className={clsx(
                                     layout === 'immersive' ? 'h-auto w-full' : 'aspect-square w-16 object-cover',
                                     'rounded-md'
-                                )} 
-                                src={imageSrc} 
+                                )}
+                                src={imageSrc}
                             />
                         </div>
                     )}
@@ -293,10 +294,10 @@ export function CtaCard({
                         {/* Button */}
                         { (showButton && (isEditing || (buttonText && buttonUrl))) &&
                             <div data-test-cta-button-current-url={buttonUrl}>
-                                <Button 
-                                    color={'accent'} 
-                                    dataTestId="cta-button" 
-                                    placeholder="Add button text" 
+                                <Button
+                                    color={'accent'}
+                                    dataTestId="cta-button"
+                                    placeholder="Add button text"
                                     size={layout === 'immersive' ? 'medium' : 'small'}
                                     style={buttonColor ? {
                                         backgroundColor: buttonColor === 'accent' ? 'var(--accent-color)' : buttonColor,
@@ -336,7 +337,7 @@ CtaCard.propTypes = {
     buttonColor: PropTypes.string,
     buttonTextColor: PropTypes.string,
     color: PropTypes.oneOf(['none', 'grey', 'white', 'blue', 'green', 'yellow', 'red']),
-    hasSponsorLabel: PropTypes.bool,    
+    hasSponsorLabel: PropTypes.bool,
     imageSrc: PropTypes.string,
     isEditing: PropTypes.bool,
     layout: PropTypes.oneOf(['minimal', 'immersive']),

--- a/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
@@ -352,7 +352,9 @@ CtaCard.propTypes = {
     handleButtonColor: PropTypes.func,
     onFileChange: PropTypes.func,
     setFileInputRef: PropTypes.func,
-    onRemoveMedia: PropTypes.func
+    onRemoveMedia: PropTypes.func,
+    sponsorLabelHtmlEditor: PropTypes.object,
+    sponsorLabelHtmlEditorInitialState: PropTypes.object
 };
 
 CtaCard.defaultProps = {

--- a/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
@@ -351,7 +351,9 @@ CtaCard.propTypes = {
     setFileInputRef: PropTypes.func,
     onRemoveMedia: PropTypes.func,
     sponsorLabelHtmlEditor: PropTypes.object,
-    sponsorLabelHtmlEditorInitialState: PropTypes.object
+    sponsorLabelHtmlEditorInitialState: PropTypes.object,
+    visibilityOptions: PropTypes.object,
+    toggleVisibility: PropTypes.func
 };
 
 CtaCard.defaultProps = {

--- a/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import ReplacementStringsPlugin from '../../../plugins/ReplacementStringsPlugin';
 import clsx from 'clsx';
+import defaultTheme from '../../../themes/default';
 import {Button} from '../Button';
 import {ButtonGroupSetting, ColorOptionSetting, ColorPickerSetting, InputSetting, InputUrlSetting, MediaUploadSetting, SettingsPanel, ToggleSetting} from '../SettingsPanel';
 import {ReadOnlyOverlay} from '../ReadOnlyOverlay';
@@ -19,6 +20,11 @@ export const CTA_COLORS = {
     green: 'bg-green/10 border-transparent',
     yellow: 'bg-yellow/10 border-transparent',
     red: 'bg-red/10 border-transparent'
+};
+
+const sponsoredLabelTheme = {
+    ...defaultTheme,
+    link: 'text-grey-900/40 dark:text-grey-100/40'
 };
 
 export const ctaColorPicker = [
@@ -239,6 +245,7 @@ export function CtaCard({
                             hasSettingsPanel={true}
                             initialEditor={sponsorLabelHtmlEditor}
                             initialEditorState={sponsorLabelHtmlEditorInitialState}
+                            initialTheme={sponsoredLabelTheme}
                             nodes='basic'
                             textClassName={clsx(
                                 'not-kg-prose w-full whitespace-normal bg-transparent font-sans !text-2xs text-grey-900/40 dark:text-grey-100/40'

--- a/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
@@ -68,6 +68,8 @@ export function CtaCard({
     hasSponsorLabel,
     htmlEditor,
     htmlEditorInitialState,
+    sponsorLabelHtmlEditor,
+    sponsorLabelHtmlEditorInitialState,
     imageSrc,
     isEditing,
     layout,
@@ -225,13 +227,25 @@ export function CtaCard({
                     'pb-3': color === 'none' && hasSponsorLabel
                 }
             )} data-cta-layout={layout}>
+
                 {/* Sponsor label */}
                 {hasSponsorLabel && (
                     <div className={clsx(
-                        'not-kg-prose py-3',
-                        {'mx-6': color !== 'none'}
+                        'mx-6 py-3',
                     )}>
-                        <p className="font-sans text-2xs font-semibold uppercase leading-8 tracking-normal text-grey-900/40 dark:text-grey-100/40" data-testid="sponsor-label">Sponsored</p>
+                        <KoenigNestedEditor
+                            autoFocus={true}
+                            dataTestId={'sponsor-label-editor'}
+                            hasSettingsPanel={true}
+                            initialEditor={sponsorLabelHtmlEditor}
+                            initialEditorState={sponsorLabelHtmlEditorInitialState}
+                            nodes='basic'
+                            textClassName={clsx(
+                                'kg-prose w-full whitespace-normal bg-transparent font-sans !text-2xs text-grey-900/40 dark:text-grey-100/40'
+                            )}
+                        >
+                            <ReplacementStringsPlugin />
+                        </KoenigNestedEditor>
                     </div>
                 )}
 

--- a/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CtaCard.jsx
@@ -9,6 +9,7 @@ import defaultTheme from '../../../themes/default';
 import {Button} from '../Button';
 import {ButtonGroupSetting, ColorOptionSetting, ColorPickerSetting, InputSetting, InputUrlSetting, MediaUploadSetting, SettingsPanel, ToggleSetting} from '../SettingsPanel';
 import {ReadOnlyOverlay} from '../ReadOnlyOverlay';
+import {RestrictContentPlugin} from '../../../index.js';
 import {getAccentColor} from '../../../utils/getAccentColor';
 import {textColorForBackgroundColor} from '@tryghost/color-utils';
 
@@ -24,7 +25,7 @@ export const CTA_COLORS = {
 
 const sponsoredLabelTheme = {
     ...defaultTheme,
-    link: 'text-grey-900/40 dark:text-grey-100/40'
+    link: 'text-accent'
 };
 
 export const ctaColorPicker = [
@@ -237,7 +238,8 @@ export function CtaCard({
                 {/* Sponsor label */}
                 {hasSponsorLabel && (
                     <div className={clsx(
-                        'mx-6 py-3',
+                        'py-3',
+                        {'mx-6': color !== 'none'}
                     )}>
                         <KoenigNestedEditor
                             autoFocus={true}
@@ -248,11 +250,11 @@ export function CtaCard({
                             initialTheme={sponsoredLabelTheme}
                             nodes='basic'
                             textClassName={clsx(
-                                'not-kg-prose w-full whitespace-normal bg-transparent font-sans !text-2xs text-grey-900/40 dark:text-grey-100/40'
+                                'not-kg-prose w-full whitespace-normal font-sans !text-xs font-semibold uppercase leading-8 tracking-normal text-grey-900/40 dark:text-grey-100/40'
                             )}
                             useDefaultClasses={false}
                         >
-                            <ReplacementStringsPlugin />
+                            <RestrictContentPlugin allowBr={false} paragraphs={1} />
                         </KoenigNestedEditor>
                     </div>
                 )}

--- a/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
@@ -13,6 +13,8 @@ export const INSERT_CTA_COMMAND = createCommand();
 export class CallToActionNode extends BaseCallToActionNode {
     __ctaHtmlEditor;
     __ctaHtmlEditorInitialState;
+    __sponsorLabelHtmlEditor;
+    __sponsorLabelHtmlEditorInitialState;
 
     static kgMenu = {
         label: 'Call to Action',
@@ -40,10 +42,14 @@ export class CallToActionNode extends BaseCallToActionNode {
 
         // set up nested editor instances
         setupNestedEditor(this, '__ctaHtmlEditor', {editor: dataset.ctaHtmlEditor, nodes: BASIC_NODES});
+        setupNestedEditor(this, '__sponsorLabelHtmlEditor', {editor: dataset.sponsorLabelHtmlEditor, nodes: BASIC_NODES});
 
         // populate nested editors on initial construction
         if (!dataset.ctaHtmlEditor && dataset.textValue) {
             populateNestedEditor(this, '__ctaHtmlEditor', `${dataset.textValue}`); // we serialize with no wrapper
+        }
+        if (!dataset.sponsorLabelHtmlEditor) {
+            populateNestedEditor(this, '__sponsorLabelHtmlEditor', `${dataset.sponsorLabel || '<p><span style="white-space: pre-wrap;">SPONSORED</span></p>'}`);
         }
     }
 
@@ -53,6 +59,8 @@ export class CallToActionNode extends BaseCallToActionNode {
         const self = this.getLatest();
         dataset.ctaHtmlEditor = self.__ctaHtmlEditor;
         dataset.ctaHtmlEditorInitialState = self.__ctaHtmlEditorInitialState;
+        dataset.sponsorLabelHtmlEditor = self.__sponsorLabelHtmlEditor;
+        dataset.sponsorLabelHtmlEditorInitialState = self.__sponsorLabelHtmlEditorInitialState;
 
         return dataset;
     }
@@ -67,6 +75,14 @@ export class CallToActionNode extends BaseCallToActionNode {
                 const html = $generateHtmlFromNodes(this.__ctaHtmlEditor, null);
                 const cleanedHtml = cleanBasicHtml(html, {allowBr: true});
                 json.textValue = cleanedHtml;
+            });
+        }
+
+        if (this.__sponsorLabelHtmlEditor) {
+            this.__sponsorLabelHtmlEditor.getEditorState().read(() => {
+                const html = $generateHtmlFromNodes(this.__sponsorLabelHtmlEditor, null);
+                const cleanedHtml = cleanBasicHtml(html, {allowBr: false});
+                json.sponsorLabel = cleanedHtml;
             });
         }
 
@@ -93,6 +109,8 @@ export class CallToActionNode extends BaseCallToActionNode {
                     layout={this.layout}
                     nodeKey={this.getKey()}
                     showButton={this.showButton}
+                    sponsorLabelHtmlEditor={this.__sponsorLabelHtmlEditor}
+                    sponsorLabelHtmlEditorInitialState={this.__sponsorLabelHtmlEditorInitialState}
                     textValue={this.textValue}
                 />
             </KoenigCardWrapper>

--- a/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
@@ -22,7 +22,9 @@ export const CallToActionNodeComponent = ({
     buttonColor,
     htmlEditor,
     htmlEditorInitialState,
-    buttonTextColor
+    buttonTextColor,
+    sponsorLabelHtmlEditor,
+    sponsorLabelHtmlEditorInitialState
 }) => {
     const [editor] = useLexicalComposerContext();
     const {isEditing, isSelected, setEditing} = React.useContext(CardContext);
@@ -111,7 +113,7 @@ export const CallToActionNodeComponent = ({
 
     React.useEffect(() => {
         htmlEditor.setEditable(isEditing);
-    }, [isEditing, htmlEditor]);
+    }, [isEditing, htmlEditor, sponsorLabelHtmlEditor]);
 
     return (
         <>
@@ -135,6 +137,8 @@ export const CallToActionNodeComponent = ({
                 setEditing={setEditing}
                 setFileInputRef={ref => fileInputRef.current = ref}
                 showButton={showButton}
+                sponsorLabelHtmlEditor={sponsorLabelHtmlEditor}
+                sponsorLabelHtmlEditorInitialState={sponsorLabelHtmlEditorInitialState}
                 text={textValue}
                 updateButtonText={handleButtonTextChange}
                 updateButtonUrl={handleButtonUrlChange}

--- a/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
@@ -113,7 +113,7 @@ export const CallToActionNodeComponent = ({
 
     React.useEffect(() => {
         htmlEditor.setEditable(isEditing);
-    }, [isEditing, htmlEditor, sponsorLabelHtmlEditor]);
+    }, [isEditing, htmlEditor]);
 
     return (
         <>

--- a/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
@@ -32,6 +32,7 @@ test.describe('Call To Action Card', async () => {
                     buttonUrl: 'http://someblog.com/somepost',
                     hasImage: true,
                     hasSponsorLabel: true,
+                    sponsorLabel: '<p><span style="white-space: pre-wrap;">SPONSORED</span></p>',
                     imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                     layout: 'minimal',
                     showButton: true,
@@ -264,10 +265,54 @@ test.describe('Call To Action Card', async () => {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
         await page.click('[data-testid="sponsor-label-toggle"]');
-        expect(await page.isVisible('[data-testid="sponsor-label"]')).toBe(false);
-
+        expect(await page.isVisible('[data-testid="sponsor-label-editor"]')).toBe(false);
         await page.click('[data-testid="sponsor-label-toggle"]');
-        expect(await page.isVisible('[data-testid="sponsor-label"]')).toBe(true);
+        expect(await page.isVisible('[data-testid="sponsor-label-editor"]')).toBe(true);
+    });
+
+    test('sponsor label is active by default', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        const sponsorLabel = await page.locator('[data-testid="sponsor-label-editor"]');
+        await expect(sponsorLabel).toBeVisible();
+    });
+
+    test('sponsor label text is SPONSORED by default', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        const sponsorLabel = await page.locator('[data-testid="sponsor-label-editor"]');
+        await expect(sponsorLabel).toContainText('SPONSORED');
+    });
+
+    test('can modify sponsor label text', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        const sponsorEditor = await page.locator('[data-testid="sponsor-label-editor"]');
+        await page.click('[data-testid="sponsor-label-editor"]');
+        // clear the default text by hitting backspace 9 times
+        for (let i = 0; i < 9; i++) {
+            await page.keyboard.press('Backspace');
+        }
+        await expect(sponsorEditor).toContainText('');
+        await page.keyboard.type('Sponsored by Ghost');
+        const content = page.locator('[data-testid="sponsor-label-editor"]');
+        await expect(content).toContainText('Sponsored by Ghost');
+    });
+
+    test('content editor placeholder is visible', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        const contentEditor = await page.locator('[data-testid="cta-card-content-editor"]');
+        await expect(contentEditor).toContainText('Write something worth clicking...');
+    });
+
+    test('can modify content editor text', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        await page.click('[data-testid="cta-card-content-editor"]');
+        await page.keyboard.type('This is a new CTA Card.');
+        const content = page.locator('[data-testid="cta-card-content-editor"]');
+        await expect(content).toContainText('This is a new CTA Card.');
     });
 
     test('can change background colours', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-325/turn-sponsored-into-editable-text

- Introduced `sponsorLabel` node for customisable sponsor text.
- Updated `CallToActionNode` to support `sponsorLabel` as an editable field.
- Adjusted `CtaCard.jsx` to render the sponsored label dynamically.
- Modified tests to cover scenarios where `sponsorLabel` is present or absent.
- Added `useDefaultClasses` prop to composable editor components.
- Allowed passing Lexical theme config to `KoenigNestedEditor`
- Updated Sponsored Label styles