### PR TITLE
Organised CTA card settings panel

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
@@ -8,10 +8,10 @@ export class CallToActionNode extends generateDecoratorNode({
     properties: [
         {name: 'layout', default: 'minimal'},
         {name: 'textValue', default: '', wordCount: true},
-        {name: 'showButton', default: false},
-        {name: 'buttonText', default: ''},
+        {name: 'showButton', default: true},
+        {name: 'buttonText', default: 'Learn more'},
         {name: 'buttonUrl', default: ''},
-        {name: 'buttonColor', default: ''},
+        {name: 'buttonColor', default: 'black'},
         {name: 'buttonTextColor', default: ''},
         {name: 'hasSponsorLabel', default: true},
         {name: 'sponsorLabel', default: '<p><span style="white-space: pre-wrap;">SPONSORED</span></p>'},

--- a/packages/koenig-lexical/src/components/ui/ButtonGroup.jsx
+++ b/packages/koenig-lexical/src/components/ui/ButtonGroup.jsx
@@ -7,7 +7,7 @@ import {usePreviousFocus} from '../../hooks/usePreviousFocus';
 export function ButtonGroup({buttons = [], selectedName, onClick}) {
     return (
         <div className="flex">
-            <ul className="flex items-center justify-evenly gap-[.6rem] rounded-lg font-sans text-md font-normal text-white">
+            <ul className="flex items-center justify-evenly rounded-lg bg-grey-100 font-sans text-md font-normal text-white">
                 {buttons.map(({label, name, Icon, dataTestId}) => (
                     <IconButton
                         key={`${name}-${label}`}
@@ -33,7 +33,7 @@ export function IconButton({dataTestId, onClick, label, name, selectedName, Icon
         <li className="mb-0">
             <button
                 aria-label={label}
-                className={`group relative flex h-7 w-8 cursor-pointer items-center justify-center rounded-lg hover:bg-grey-150 dark:hover:bg-grey-900 ${isActive ? 'bg-grey-150 text-green-600 dark:bg-grey-900 dark:text-white' : 'text-black dark:text-white' } ${Icon ? '' : 'text-[1.3rem] font-bold'}`}
+                className={`group relative flex h-7 w-8 cursor-pointer items-center justify-center rounded-lg text-black dark:text-white dark:hover:bg-grey-900 ${isActive ? 'border border-grey-300 bg-white shadow-xs dark:bg-grey-900' : '' } ${Icon ? '' : 'text-[1.3rem] font-bold'}`}
                 data-testid={dataTestId}
                 type="button"
                 onClick={handleClick}

--- a/packages/koenig-lexical/src/components/ui/ColorOptionButtons.jsx
+++ b/packages/koenig-lexical/src/components/ui/ColorOptionButtons.jsx
@@ -1,31 +1,62 @@
 import PlusIcon from '../../assets/icons/plus.svg?react';
-import React from 'react';
+import React, {useState} from 'react';
 import {Tooltip} from './Tooltip';
 import {usePreviousFocus} from '../../hooks/usePreviousFocus';
 
 export function ColorOptionButtons({buttons = [], selectedName, onClick}) {
-    return (
-        <div className="flex">
-            <ul className="flex w-full items-center justify-between rounded-md font-sans text-md font-normal text-white">
-                {buttons.map(({label, name, color}) => (
-                    name !== 'image' ?
-                        <ColorButton
-                            key={`${name}-${label}`}
-                            color={color}
-                            label={label}
-                            name={name}
-                            selectedName={selectedName}
-                            onClick={onClick}
-                        />
-                        :
-                        <li key='background-image' className={`flex size-[3rem] cursor-pointer items-center justify-center rounded-full border-2 ${selectedName === name ? 'border-green' : 'border-transparent'}`} data-testid="background-image-color-button" type="button" onClick={() => onClick(name)}>
-                            <span className="border-1 flex size-6 items-center justify-center rounded-full border border-black/5">
-                                <PlusIcon className="size-3 stroke-grey-700 stroke-2 dark:stroke-grey-500 dark:group-hover:stroke-grey-100" />
-                            </span>
-                        </li>
+    const [isOpen, setIsOpen] = useState(false);
+    const selectedButton = buttons.find(button => button.name === selectedName);
 
-                ))}
-            </ul>
+    return (
+        <div className="relative">
+            <button
+                className={`relative size-6 cursor-pointer rounded-full ${selectedName ? 'p-[2px]' : 'border border-grey-200 dark:border-grey-800'}`}
+                type="button"
+                onClick={() => setIsOpen(!isOpen)}
+            >
+                {selectedName && (
+                    <div className="absolute inset-0 rounded-full bg-clip-content p-[3px]" style={{
+                        background: 'conic-gradient(hsl(360,100%,50%),hsl(315,100%,50%),hsl(270,100%,50%),hsl(225,100%,50%),hsl(180,100%,50%),hsl(135,100%,50%),hsl(90,100%,50%),hsl(45,100%,50%),hsl(0,100%,50%))',
+                        WebkitMask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+                        WebkitMaskComposite: 'xor',
+                        mask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+                        maskComposite: 'exclude'
+                    }} />
+                )}
+                <span
+                    className={`${selectedButton?.color || ''} block size-full rounded-full border-2 border-white`}
+                ></span>
+            </button>
+
+            {/* Color options popover */}
+            {isOpen && (
+                <div className="absolute -right-3 bottom-full z-10 mb-2 rounded-lg bg-white px-3 py-2 shadow">
+                    <div className="flex">
+                        <ul className="flex w-full items-center justify-between rounded-md font-sans text-md font-normal text-white">
+                            {buttons.map(({label, name, color}) => (
+                                name !== 'image' ?
+                                    <ColorButton
+                                        key={`${name}-${label}`}
+                                        color={color}
+                                        label={label}
+                                        name={name}
+                                        selectedName={selectedName}
+                                        onClick={(name) => {
+                                            onClick(name);
+                                            setIsOpen(false);
+                                        }}
+                                    />
+                                    :
+                                    <li key='background-image' className={`mb-0 flex size-[3rem] cursor-pointer items-center justify-center rounded-full border-2 ${selectedName === name ? 'border-green' : 'border-transparent'}`} data-testid="background-image-color-button" type="button" onClick={() => onClick(name)}>
+                                        <span className="border-1 flex size-6 items-center justify-center rounded-full border border-black/5">
+                                            <PlusIcon className="size-3 stroke-grey-700 stroke-2 dark:stroke-grey-500 dark:group-hover:stroke-grey-100" />
+                                        </span>
+                                    </li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }
@@ -35,7 +66,7 @@ export function ColorButton({onClick, label, name, color, selectedName}) {
 
     const {handleMousedown, handleClick} = usePreviousFocus(onClick, name);
     return (
-        <li>
+        <li className="mb-0">
             <button
                 aria-label={label}
                 className={`group relative flex size-6 cursor-pointer items-center justify-center rounded-full border-2 ${isActive ? 'border-green' : 'border-transparent'}`}

--- a/packages/koenig-lexical/src/components/ui/ColorPicker.jsx
+++ b/packages/koenig-lexical/src/components/ui/ColorPicker.jsx
@@ -1,12 +1,12 @@
 import EyedropperIcon from '../../assets/icons/kg-eyedropper.svg?react';
-import React, {Fragment, useCallback, useEffect, useRef} from 'react';
+import React, {Fragment, useCallback, useEffect, useRef, useState} from 'react';
 import clsx from 'clsx';
 import {Button} from './Button';
 import {HexColorInput, HexColorPicker} from 'react-colorful';
 import {Tooltip} from './Tooltip';
 import {getAccentColor} from '../../utils/getAccentColor';
 
-export function ColorPicker({value, eyedropper, hasTransparentOption, onChange}) {
+export function ColorPicker({value, eyedropper, hasTransparentOption, onChange, children}) {
     // HexColorInput doesn't support adding a ref on the input itself
     const inputWrapperRef = useRef(null);
 
@@ -76,7 +76,7 @@ export function ColorPicker({value, eyedropper, hasTransparentOption, onChange})
     }, []);
 
     return (
-        <div className="mt-2" onMouseDown={stopPropagation} onTouchStart={stopPropagation}>
+        <div onMouseDown={stopPropagation} onTouchStart={stopPropagation}>
             <HexColorPicker color={hexValue || '#ffffff'} onChange={onChange} onMouseDown={startUsingColorPicker} onTouchStart={startUsingColorPicker} />
             <div className="mt-3 flex gap-2">
                 <div ref={inputWrapperRef} className={`relative flex w-full items-center rounded-lg border border-grey-100 bg-grey-100 px-3 py-1.5 font-sans text-sm font-normal text-grey-900 transition-colors placeholder:text-grey-500 focus-within:border-green focus-within:bg-white focus-within:shadow-[0_0_0_2px_rgba(48,207,67,.25)] focus-within:outline-none dark:border-transparent dark:bg-grey-900 dark:text-white dark:selection:bg-grey-800 dark:placeholder:text-grey-700 dark:focus-within:border-green dark:hover:bg-grey-925 dark:focus:bg-grey-925`} onClick={focusHexInputOnClick}>
@@ -94,6 +94,7 @@ export function ColorPicker({value, eyedropper, hasTransparentOption, onChange})
                 </div>
 
                 {hasTransparentOption && <Button color='grey' value='Clear' onClick={() => onChange('transparent')} />}
+                {children}
             </div>
         </div>
     );
@@ -134,9 +135,28 @@ function ColorSwatch({hex, accent, transparent, title, isSelected, onSelect}) {
     );
 }
 
-export function ColorIndicator({value, swatches, onSwatchChange, onTogglePicker, isExpanded}) {
+export function ColorIndicator({value, swatches, onSwatchChange, onTogglePicker, onChange, isExpanded, eyedropper, hasTransparentOption, children}) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [showColorPicker, setShowColorPicker] = useState(false);
+    const [showChildren, setShowChildren] = useState(false);
+    const popoverRef = useRef(null);
+    
+    const stopPropagation = useCallback((e) => {
+        e.stopPropagation();
+        e.preventDefault();
+    }, []);
+
+    useEffect(() => {
+        if (isExpanded) {
+            setIsOpen(true);
+            setShowChildren(true);
+            setShowColorPicker(false);
+        }
+    }, [isExpanded]);
+
     let backgroundColor = value;
     let selectedSwatch = swatches.find(swatch => swatch.hex === value)?.title;
+    
     if (value === 'accent') {
         backgroundColor = getAccentColor();
         selectedSwatch = swatches.find(swatch => swatch.accent)?.title;
@@ -149,22 +169,110 @@ export function ColorIndicator({value, swatches, onSwatchChange, onTogglePicker,
         selectedSwatch = null;
     }
 
+    const handleColorPickerChange = (newValue) => {
+        onChange(newValue);
+        // Don't close the popover when using the color picker
+    };
+
     return (
-        <div className='flex gap-1'>
-            <div className={`flex items-center gap-1`}>
-                {swatches.map(({customContent, ...swatch}) => (
-                    customContent ? <Fragment key={swatch.title}>{customContent}</Fragment> : <ColorSwatch key={swatch.title} isSelected={selectedSwatch === swatch.title} onSelect={onSwatchChange} {...swatch} />
-                ))}
-            </div>
-            <button aria-label="Pick color" className="group relative size-6 rounded-full border border-grey-200 dark:border-grey-800" type="button" onClick={onTogglePicker}>
-                <div className='absolute inset-0 rounded-full bg-[conic-gradient(hsl(360,100%,50%),hsl(315,100%,50%),hsl(270,100%,50%),hsl(225,100%,50%),hsl(180,100%,50%),hsl(135,100%,50%),hsl(90,100%,50%),hsl(45,100%,50%),hsl(0,100%,50%))]' />
-                {value && !selectedSwatch && (
-                    <div className="absolute inset-[3px] overflow-hidden rounded-full border border-white dark:border-grey-950" style={{backgroundColor}}>
-                        {value === 'transparent' && <div className="absolute left-[3px] top-[3px] z-10 w-[136%] origin-left rotate-45 border-b border-b-red" />}
-                    </div>
+        <div className="relative">
+            <button 
+                className={`relative size-6 cursor-pointer rounded-full ${value ? 'p-[2px]' : 'border border-grey-200 dark:border-grey-800'}`}
+                type="button"
+                onClick={() => {
+                    setIsOpen(!isOpen);
+                    setShowColorPicker(false);
+                    setShowChildren(false);
+                }}
+            >
+                {value && (
+                    <div className="absolute inset-0 rounded-full bg-clip-content p-[3px]" style={{
+                        background: 'conic-gradient(hsl(360,100%,50%),hsl(315,100%,50%),hsl(270,100%,50%),hsl(225,100%,50%),hsl(180,100%,50%),hsl(135,100%,50%),hsl(90,100%,50%),hsl(45,100%,50%),hsl(0,100%,50%))',
+                        WebkitMask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+                        WebkitMaskComposite: 'xor',
+                        mask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+                        maskComposite: 'exclude'
+                    }} />
                 )}
-                <Tooltip label='Pick color' />
+                <span 
+                    className="block size-full rounded-full border-2 border-white"
+                    style={{backgroundColor}}
+                >
+                    {value === 'transparent' && <div className="absolute left-[3px] top-[3px] z-10 w-[136%] origin-left rotate-45 border-b border-b-red" />}
+                </span>
             </button>
+
+            {isOpen && (
+                <div 
+                    ref={popoverRef}
+                    className={clsx(
+                        'absolute -right-3 bottom-full z-10 mb-2 flex flex-col gap-3 rounded-lg bg-white p-3 shadow transition-[width] duration-200 ease-in-out dark:bg-grey-950',
+                        (showColorPicker || showChildren) && 'min-w-[296px]'
+                    )}
+                    onClick={stopPropagation}
+                    onMouseDown={stopPropagation}
+                    onTouchStart={stopPropagation}
+                >
+                    {showColorPicker && (
+                        <ColorPicker 
+                            eyedropper={eyedropper}
+                            hasTransparentOption={hasTransparentOption}
+                            value={value}
+                            onChange={handleColorPickerChange}
+                        />
+                    )}
+                    {showChildren && children}
+                    <div className="flex justify-end gap-1">
+                        <div className={`flex items-center gap-1`}>
+                            {swatches.map(({customContent, ...swatch}) => (
+                                customContent ? 
+                                    <Fragment key={swatch.title}>{customContent}</Fragment> : 
+                                    <ColorSwatch 
+                                        key={swatch.title} 
+                                        isSelected={selectedSwatch === swatch.title} 
+                                        onSelect={(value) => {
+                                            onSwatchChange(value);
+                                            setShowColorPicker(false);
+                                            setIsOpen(false);
+                                        }} 
+                                        {...swatch} 
+                                    />
+                            ))}
+                        </div>
+                        <button 
+                            aria-label="Pick color" 
+                            className={`group relative size-6 rounded-full ${!selectedSwatch ? 'p-[2px]' : 'border border-grey-200 dark:border-grey-800'}`}
+                            type="button" 
+                            onClick={() => {
+                                setShowColorPicker(!showColorPicker);
+                                setShowChildren(false);
+                                onTogglePicker();
+                            }}
+                        >
+                            {!selectedSwatch ? (
+                                <>
+                                    <div className="absolute inset-0 rounded-full bg-clip-content p-[3px]" style={{
+                                        background: 'conic-gradient(hsl(360,100%,50%),hsl(315,100%,50%),hsl(270,100%,50%),hsl(225,100%,50%),hsl(180,100%,50%),hsl(135,100%,50%),hsl(90,100%,50%),hsl(45,100%,50%),hsl(0,100%,50%))',
+                                        WebkitMask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+                                        WebkitMaskComposite: 'xor',
+                                        mask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+                                        maskComposite: 'exclude'
+                                    }} />
+                                    <span 
+                                        className="block size-full rounded-full border-2 border-white"
+                                        style={{backgroundColor: value}}
+                                    >
+                                        {value === 'transparent' && <div className="absolute left-[3px] top-[3px] z-10 w-[136%] origin-left rotate-45 border-b border-b-red" />}
+                                    </span>
+                                </>
+                            ) : (
+                                <div className='absolute inset-0 rounded-full bg-[conic-gradient(hsl(360,100%,50%),hsl(315,100%,50%),hsl(270,100%,50%),hsl(225,100%,50%),hsl(180,100%,50%),hsl(135,100%,50%),hsl(90,100%,50%),hsl(45,100%,50%),hsl(0,100%,50%))]' />
+                            )}
+                            <Tooltip label='Pick color' />
+                        </button>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/packages/koenig-lexical/src/components/ui/MediaPlaceholder.jsx
+++ b/packages/koenig-lexical/src/components/ui/MediaPlaceholder.jsx
@@ -6,6 +6,7 @@ import ProductPlaceholderIcon from '../../assets/icons/kg-product-placeholder.sv
 import PropTypes from 'prop-types';
 import React from 'react';
 import VideoPlaceholderIcon from '../../assets/icons/kg-video-placeholder.svg?react';
+import clsx from 'clsx';
 
 export const PLACEHOLDER_ICONS = {
     image: ImgPlaceholderIcon,
@@ -16,17 +17,24 @@ export const PLACEHOLDER_ICONS = {
     product: ProductPlaceholderIcon
 };
 
-export const CardText = ({text}) => {
-    return (
-        <span className="font-sans text-sm font-bold text-grey-800 transition-all group-hover:text-grey-800" data-kg-card-drag-text>{text}</span>
-    );
-};
+export const CardText = ({text, type}) => (
+    <span 
+        className={clsx(
+            'text-center font-sans text-sm font-semibold text-grey-800 transition-all group-hover:text-grey-800',
+            type === 'button' && 'px-3 py-1'
+        )}
+        data-kg-card-drag-text
+    >
+        {text}
+    </span>
+);
 
 export function MediaPlaceholder({
     desc,
     icon,
     filePicker,
     size,
+    type,
     borderStyle,
     isDraggedOver,
     errors = [],
@@ -38,33 +46,99 @@ export function MediaPlaceholder({
 }) {
     const Icon = PLACEHOLDER_ICONS[icon];
 
+    const containerClasses = clsx(
+        'relative flex h-full items-center justify-center',
+        type === 'button' ? 'rounded-lg bg-grey-100' : 'border bg-grey-50',
+        size === 'xsmall' && type !== 'button' && 'before:pb-[12.5%] dark:bg-grey-900',
+        size !== 'xsmall' && type !== 'button' && 'before:pb-[62.5%] dark:bg-grey-950',
+        borderStyle === 'rounded' && type !== 'button' && 'rounded-lg border-grey/20 dark:border-transparent',
+        borderStyle !== 'rounded' && type !== 'button' && 'border-grey/20 dark:border-grey/10'
+    );
+
+    const iconClasses = clsx(
+        'shrink-0 opacity-80 transition-all ease-linear hover:scale-105 group-hover:opacity-100',
+        size === 'large' && 'size-20 text-grey',
+        size === 'small' && 'size-14 text-grey',
+        size === 'xsmall' && 'size-5 text-grey-700',
+        !['large', 'small', 'xsmall'].includes(size) && 'size-16 text-grey',
+        (size === 'xsmall' && desc) && 'mr-3'
+    );
+
+    const descriptionClasses = clsx(
+        'flex min-w-[auto] !font-sans !text-sm !font-normal text-grey-700 opacity-80 transition-all group-hover:opacity-100',
+        size === 'xsmall' && '!mt-0',
+        size !== 'xsmall' && '!mt-4'
+    );
+
+    const buttonClasses = clsx(
+        'group flex cursor-pointer select-none items-center justify-center',
+        size === 'xsmall' && 'p-4',
+        size !== 'xsmall' && 'flex-col p-20'
+    );
+
+    const errorClasses = clsx(
+        'font-sans text-sm font-semibold text-red',
+        size !== 'xsmall' && 'mt-3 max-w-[65%]'
+    );
+
     return (
         <div
             ref={placeholderRef}
-            className="not-kg-prose size-full" {...props}
+            className="not-kg-prose size-full"
+            {...props}
             data-testid={dataTestId}
         >
-            <div className={`relative flex h-full items-center justify-center border bg-grey-50 ${size === 'xsmall' ? 'before:pb-[12.5%] dark:bg-grey-900' : 'before:pb-[62.5%] dark:bg-grey-950'} ${borderStyle === 'rounded' ? 'rounded-lg border-grey/20 dark:border-transparent' : 'border-grey/20 dark:border-grey/10'}`}>
-                {isDraggedOver ?
-                    <CardText text={`Drop ${multiple ? '\'em' : 'it'} like it's hot 🔥`} /> :
+            <div className={containerClasses}>
+                {isDraggedOver ? (
+                    <CardText text={`Drop ${multiple ? '\'em' : 'it'} like it's hot 🔥`} type={type} />
+                ) : (
                     <>
-                        <button className={`group flex cursor-pointer select-none items-center justify-center ${size === 'xsmall' ? 'p-4' : 'flex-col p-20'}`} name="placeholder-button" type="button" onClick={filePicker}>
-                            {(size === 'xsmall' && errors.length > 0) ||
-                                <>
-                                    <Icon className={`shrink-0 opacity-80 transition-all ease-linear hover:scale-105 group-hover:opacity-100 ${size === 'large' ? 'size-20 text-grey' : size === 'small' ? 'size-14 text-grey' : size === 'xsmall' ? 'size-5 text-grey-700' : 'size-16 text-grey'} ${(size === 'xsmall') && desc ? 'mr-3' : ''}`} />
-                                    <p className={`flex min-w-[auto] !font-sans !text-sm !font-normal text-grey-700 opacity-80 transition-all group-hover:opacity-100 ${size === 'xsmall' ? '!mt-0' : '!mt-4'}`}>{desc}</p>
-                                </>
-                            }
-                            {errors.map(error => (
-                                <span
-                                    key={error.message}
-                                    className={`font-sans text-sm font-semibold text-red ${size === 'xsmall' || 'mt-3 max-w-[65%]'}`}
-                                    data-testid={errorDataTestId}
-                                >{error.message}</span>
-                            ))}
-                        </button>
+                        {type === 'button' ? (
+                            <button 
+                                className="group flex cursor-pointer select-none items-center justify-center px-3 py-1" 
+                                name="placeholder-button" 
+                                type="button" 
+                                onClick={filePicker}
+                            >
+                                {!errors.length && (
+                                    <p className="!font-sans !text-[1.3rem] !font-medium text-grey-900">{desc}</p>
+                                )}
+                                {errors.map(error => (
+                                    <span
+                                        key={error.message}
+                                        className={errorClasses}
+                                        data-testid={errorDataTestId}
+                                    >
+                                        {error.message}
+                                    </span>
+                                ))}
+                            </button>
+                        ) : (
+                            <button 
+                                className={buttonClasses}
+                                name="placeholder-button" 
+                                type="button" 
+                                onClick={filePicker}
+                            >
+                                {!(size === 'xsmall' && errors.length > 0) && (
+                                    <>
+                                        <Icon className={iconClasses} />
+                                        <p className={descriptionClasses}>{desc}</p>
+                                    </>
+                                )}
+                                {errors.map(error => (
+                                    <span
+                                        key={error.message}
+                                        className={errorClasses}
+                                        data-testid={errorDataTestId}
+                                    >
+                                        {error.message}
+                                    </span>
+                                ))}
+                            </button>
+                        )}
                     </>
-                }
+                )}
             </div>
         </div>
     );
@@ -74,6 +148,7 @@ MediaPlaceholder.propTypes = {
     icon: PropTypes.oneOf(['image', 'gallery', 'video', 'audio', 'file', 'product']),
     desc: PropTypes.string,
     size: PropTypes.oneOf(['xsmall', 'small', 'medium', 'large']),
+    type: PropTypes.oneOf(['image', 'button']),
     borderStyle: PropTypes.oneOf(['squared', 'rounded'])
 };
 

--- a/packages/koenig-lexical/src/components/ui/MediaUploader.jsx
+++ b/packages/koenig-lexical/src/components/ui/MediaUploader.jsx
@@ -17,6 +17,7 @@ export function MediaUploader({
     desc,
     icon,
     size,
+    type,
     borderStyle = 'squared',
     backgroundSize = 'cover',
     mimeTypes,
@@ -64,6 +65,7 @@ export function MediaUploader({
                     isDraggedOver={dragHandler?.isDraggedOver}
                     placeholderRef={dragHandler?.setRef}
                     size={size}
+                    type={type}
                 />
                 <ImageUploadForm
                     fileInputRef={onFileInputRef}
@@ -120,6 +122,7 @@ MediaUploader.propTypes = {
     desc: PropTypes.string,
     icon: PropTypes.string,
     size: PropTypes.string,
+    type: PropTypes.oneOf(['image', 'button']),
     borderStyle: PropTypes.string,
     mimeTypes: PropTypes.arrayOf(PropTypes.string),
     onFileChange: PropTypes.func,

--- a/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
+++ b/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import clsx from 'clsx';
 import useSettingsPanelReposition from '../../hooks/useSettingsPanelReposition';
 import {ButtonGroup} from './ButtonGroup';
-import {ColorIndicator, ColorPicker} from './ColorPicker';
+import {ColorIndicator} from './ColorPicker';
 import {ColorOptionButtons} from './ColorOptionButtons';
 import {Dropdown} from './Dropdown';
 import {Input} from './Input';
@@ -243,28 +243,10 @@ export function ColorOptionSetting({label, onClick, selectedName, buttons, layou
     );
 }
 
-export function ColorPickerSetting({label, isExpanded, onSwatchChange, onPickerChange, onTogglePicker, value, swatches, eyedropper, hasTransparentOption, dataTestId}) {
-    const mappedPicker = (event) => {
-        onTogglePicker(true);
-    };
-
+export function ColorPickerSetting({label, isExpanded, onSwatchChange, onPickerChange, onTogglePicker, value, swatches, eyedropper, hasTransparentOption, dataTestId, customToolbarContent, children}) {
     const markClickedInside = (event) => {
         event.stopPropagation();
     };
-
-    // Close on click outside
-    React.useEffect(() => {
-        if (isExpanded) {
-            const closePicker = (event) => {
-                onTogglePicker(false);
-            };
-            document.addEventListener('click', closePicker);
-
-            return () => {
-                document.removeEventListener('click', closePicker);
-            };
-        }
-    }, [isExpanded, onTogglePicker]);
 
     return (
         <div className="flex-col" data-testid={dataTestId} onClick={markClickedInside}>
@@ -273,28 +255,36 @@ export function ColorPickerSetting({label, isExpanded, onSwatchChange, onPickerC
 
                 <div className="shrink-0 pl-2">
                     <ColorIndicator
+                        eyedropper={eyedropper}
+                        hasTransparentOption={hasTransparentOption}
                         isExpanded={isExpanded}
                         swatches={swatches}
                         value={value}
+                        onChange={onPickerChange}
                         onSwatchChange={onSwatchChange}
-                        onTogglePicker={mappedPicker}
-                    />
+                        onTogglePicker={onTogglePicker}
+                    >
+                        {children}
+                    </ColorIndicator>
                 </div>
             </div>
-            {isExpanded && <ColorPicker eyedropper={eyedropper} hasTransparentOption={hasTransparentOption} value={value} onChange={onPickerChange} />}
         </div>
     );
 }
 
-export function MediaUploadSetting({className, label, hideLabel, onFileChange, isDraggedOver, placeholderRef, src, alt, isLoading, errors = [], progress, onRemoveMedia, icon, desc = '', size, stacked, borderStyle, mimeTypes, isPinturaEnabled, openImageEditor, setFileInputRef}) {
+export function MediaUploadSetting({className, label, hideLabel, onFileChange, isDraggedOver, placeholderRef, src, alt, isLoading, errors = [], progress, onRemoveMedia, icon, desc, size, type, stacked, borderStyle, mimeTypes, isPinturaEnabled, openImageEditor, setFileInputRef}) {
     return (
-        <div className={clsx(className, !stacked && 'flex justify-between')} data-testid="media-upload-setting">
-            <div className={hideLabel ? 'sr-only' : 'mb-2 text-sm font-medium tracking-normal text-grey-900 dark:text-grey-400'}>{label}</div>
+        <div className={clsx(className, !stacked && 'flex justify-between gap-3')} data-testid="media-upload-setting">
+            <div className={hideLabel ? 'sr-only' : 'mb-2 shrink-0 text-sm font-medium tracking-normal text-grey-900 dark:text-grey-400'}>{label}</div>
 
             <MediaUploader
                 alt={alt}
                 borderStyle={borderStyle}
-                className={clsx(stacked ? 'h-32' : src ? 'h-[5.2rem]' : 'h-[5.2rem] w-[7.2rem]')}
+                className={clsx(
+                    stacked && 'h-32',
+                    !stacked && src && 'h-[5.2rem]',
+                    !stacked && type !== 'button' && !src && 'h-[5.2rem] w-[7.2rem]'
+                )}
                 desc={desc}
                 dragHandler={{isDraggedOver, setRef: placeholderRef}}
                 errors={errors}
@@ -307,6 +297,7 @@ export function MediaUploadSetting({className, label, hideLabel, onFileChange, i
                 setFileInputRef={setFileInputRef}
                 size={size}
                 src={src}
+                type={type}
                 onFileChange={onFileChange}
                 onRemoveMedia={onRemoveMedia}
             />

--- a/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
@@ -21,7 +21,9 @@ export const CALLTOACTION_COLORS = {
     blue: 'bg-blue/10 border-transparent',
     green: 'bg-green/10 border-transparent',
     yellow: 'bg-yellow/10 border-transparent',
-    red: 'bg-red/10 border-transparent'
+    red: 'bg-red/10 border-transparent',
+    pink: 'bg-pink/10 border-transparent',
+    purple: 'bg-purple/10 border-transparent'
 };
 
 const sponsoredLabelTheme = {
@@ -43,27 +45,37 @@ export const callToActionColorPicker = [
     {
         label: 'Grey',
         name: 'grey',
-        color: 'bg-grey/15 border-black/[.08] dark:border-white/10'
+        color: 'bg-grey/20 border-black/[.08] dark:border-white/10'
     },
     {
         label: 'Blue',
         name: 'blue',
-        color: 'bg-blue/15 border-black/[.08] dark:border-white/10'
+        color: 'bg-blue/20 border-black/[.08] dark:border-white/10'
     },
     {
         label: 'Green',
         name: 'green',
-        color: 'bg-green/15 border-black/[.08] dark:border-white/10'
+        color: 'bg-green/20 border-black/[.08] dark:border-white/10'
     },
     {
         label: 'Yellow',
         name: 'yellow',
-        color: 'bg-yellow/15 border-black/[.08] dark:border-white/10'
+        color: 'bg-yellow/20 border-black/[.08] dark:border-white/10'
     },
     {
         label: 'Red',
         name: 'red',
-        color: 'bg-red/15 border-black/[.08] dark:border-white/10'
+        color: 'bg-red/20 border-black/[.08] dark:border-white/10'
+    },
+    {
+        label: 'Pink',
+        name: 'pink',
+        color: 'bg-pink/20 border-black/[0.08] dark:border-white/10'
+    },
+    {
+        label: 'Purple',
+        name: 'purple',
+        color: 'bg-purple/20 border-black/[0.08] dark:border-white/10'
     }
 ];
 
@@ -123,19 +135,19 @@ export function CallToActionCard({
 
     const designSettings = (
         <>
-            {/* Color picker */}
-            <ColorOptionSetting
-                buttons={callToActionColorPicker}
-                label='Background'
-                selectedName={color}
-                onClick={handleColorChange}
-            />
             {/* Layout settings */}
             <ButtonGroupSetting
                 buttons={layoutOptions}
                 label='Layout'
                 selectedName={layout}
                 onClick={updateLayout}
+            />
+            {/* Color picker */}
+            <ColorOptionSetting
+                buttons={callToActionColorPicker}
+                label='Background'
+                selectedName={color}
+                onClick={handleColorChange}
             />
             {/* Sponsor label setting */}
             <ToggleSetting
@@ -148,12 +160,13 @@ export function CallToActionCard({
             <MediaUploadSetting
                 alt='Image'
                 borderStyle={'rounded'}
+                desc='Upload'
                 icon='file'
                 label='Image'
                 mimeTypes={['image/*']}
                 setFileInputRef={setFileInputRef}
-                size='xsmall'
                 src={imageSrc}
+                type='button'
                 onFileChange={onFileChange}
                 onRemoveMedia={onRemoveMedia}
             />
@@ -237,7 +250,7 @@ export function CallToActionCard({
                             initialTheme={sponsoredLabelTheme}
                             nodes='basic'
                             textClassName={clsx(
-                                'not-kg-prose w-full whitespace-normal font-sans !text-xs font-semibold uppercase leading-8 tracking-normal text-grey-900/40 dark:text-grey-100/40'
+                                'koenig-lexical-cta-label not-kg-prose w-full whitespace-normal font-sans !text-xs font-semibold uppercase leading-8 tracking-normal text-grey-900/40 dark:text-grey-200/40'
                             )}
                             useDefaultClasses={false}
                         >
@@ -280,7 +293,7 @@ export function CallToActionCard({
                             placeholderClassName={`bg-transparent whitespace-normal font-serif text-xl !text-grey-500 !dark:text-grey-800 ` }
                             placeholderText="Write something worth clicking..."
                             textClassName={clsx(
-                                'w-full whitespace-normal text-pretty bg-transparent font-serif text-xl text-grey-900 dark:text-grey-200',
+                                'koenig-lexical-cta-text w-full whitespace-normal text-pretty bg-transparent font-serif text-xl text-grey-900 dark:text-grey-200',
                                 layout === 'immersive' ? 'text-center' : 'text-left'
                             )}
                         >
@@ -332,7 +345,7 @@ CallToActionCard.propTypes = {
     buttonUrl: PropTypes.string,
     buttonColor: PropTypes.string,
     buttonTextColor: PropTypes.string,
-    color: PropTypes.oneOf(['none', 'grey', 'white', 'blue', 'green', 'yellow', 'red']),
+    color: PropTypes.oneOf(['none', 'grey', 'white', 'blue', 'green', 'yellow', 'red', 'pink', 'purple']),
     hasSponsorLabel: PropTypes.bool,
     imageSrc: PropTypes.string,
     isEditing: PropTypes.bool,
@@ -366,7 +379,7 @@ CallToActionCard.defaultProps = {
     imageSrc: '',
     isEditing: false,
     layout: 'immersive',
-    showButton: false,
+    showButton: true,
     updateHasSponsorLabel: () => {},
     updateShowButton: () => {},
     updateLayout: () => {},

--- a/packages/koenig-lexical/src/components/ui/cards/CalloutCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CalloutCard.jsx
@@ -43,37 +43,37 @@ export const calloutColorPicker = [
     {
         label: 'Grey',
         name: 'grey',
-        color: 'bg-grey/15 border-black/[0.08] dark:border-white/10'
+        color: 'bg-grey/20 border-black/[0.08] dark:border-white/10'
     },
     {
         label: 'Blue',
         name: 'blue',
-        color: 'bg-blue/15 border-black/[0.08] dark:border-white/10'
+        color: 'bg-blue/20 border-black/[0.08] dark:border-white/10'
     },
     {
         label: 'Green',
         name: 'green',
-        color: 'bg-green/15 border-black/[0.08] dark:border-white/10'
+        color: 'bg-green/20 border-black/[0.08] dark:border-white/10'
     },
     {
         label: 'Yellow',
         name: 'yellow',
-        color: 'bg-yellow/15 border-black/[0.08] dark:border-white/10'
+        color: 'bg-yellow/20 border-black/[0.08] dark:border-white/10'
     },
     {
         label: 'Red',
         name: 'red',
-        color: 'bg-red/15 border-black/[0.08] dark:border-white/10'
+        color: 'bg-red/20 border-black/[0.08] dark:border-white/10'
     },
     {
         label: 'Pink',
         name: 'pink',
-        color: 'bg-pink/15 border-black/[0.08] dark:border-white/10'
+        color: 'bg-pink/20 border-black/[0.08] dark:border-white/10'
     },
     {
         label: 'Purple',
         name: 'purple',
-        color: 'bg-purple/15 border-black/[0.08] dark:border-white/10'
+        color: 'bg-purple/20 border-black/[0.08] dark:border-white/10'
     },
     {
         label: 'Accent',
@@ -158,7 +158,6 @@ export function CalloutCard({
                             buttons={calloutColorPicker}
                             dataTestId='callout-color-picker'
                             label='Background'
-                            layout='stacked'
                             selectedName={color}
                             onClick={handleColorChange}
                         />

--- a/packages/koenig-lexical/src/components/ui/cards/HeaderCard/v2/HeaderCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/HeaderCard/v2/HeaderCard.jsx
@@ -415,7 +415,7 @@ export function HeaderCard({alignment,
                                         type="button"
                                         onClick={() => {
                                             handleShowBackgroundImage();
-                                            setBackgroundColorPickerExpanded(false);
+                                            setBackgroundColorPickerExpanded(true);
                                             setButtonColorPickerExpanded(false);
                                         }}
                                     >
@@ -434,7 +434,7 @@ export function HeaderCard({alignment,
                             handleBackgroundColor(color, matchingTextColor(color));
                             setBackgroundColorPickerExpanded(false);
                         }}
-                        onTogglePicker={ (isExpanded) => {
+                        onTogglePicker={(isExpanded) => {
                             if (isExpanded) {
                                 if (layout !== 'split') {
                                     handleHideBackgroundImage();
@@ -450,32 +450,34 @@ export function HeaderCard({alignment,
                                 setButtonColorPickerExpanded(!isExpanded);
                             }
                         }}
-                    />
-                    <MediaUploadSetting
-                        alt='Background image'
-                        borderStyle={'rounded'}
-                        className={(!showBackgroundImage || layout === 'split') && 'hidden'}
-                        errors={fileUploader?.errors}
-                        hideLabel={layout !== 'split'}
-                        icon='file'
-                        isDraggedOver={imageDragHandler?.isDraggedOver}
-                        isLoading={isLoading}
-                        isPinturaEnabled={isPinturaEnabled}
-                        label='Image'
-                        mimeTypes={['image/*']}
-                        openImageEditor={openImageEditor}
-                        placeholderRef={imageDragHandler?.setRef}
-                        progress={progress}
-                        setFileInputRef={setFileInputRef}
-                        size='xsmall'
-                        src={backgroundImageSrc}
-                        stacked={true}
-                        onFileChange={onFileChange}
-                        onRemoveMedia={() => {
-                            handleClearBackgroundImage();
-                            handleTextColor(matchingTextColor(backgroundColor));
-                        }}
-                    />
+                    >
+                        {layout !== 'split' && showBackgroundImage && (
+                            <MediaUploadSetting
+                                alt='Background image'
+                                borderStyle={'rounded'}
+                                desc='Click to select image'
+                                errors={fileUploader?.errors}
+                                hideLabel={true}
+                                icon='file'
+                                isDraggedOver={imageDragHandler?.isDraggedOver}
+                                isLoading={isLoading}
+                                isPinturaEnabled={isPinturaEnabled}
+                                mimeTypes={['image/*']}
+                                openImageEditor={openImageEditor}
+                                placeholderRef={imageDragHandler?.setRef}
+                                progress={progress}
+                                setFileInputRef={setFileInputRef}
+                                size='xsmall'
+                                src={backgroundImageSrc}
+                                stacked={true}
+                                onFileChange={onFileChange}
+                                onRemoveMedia={() => {
+                                    handleClearBackgroundImage();
+                                    handleTextColor(matchingTextColor(backgroundColor));
+                                }}
+                            />
+                        )}
+                    </ColorPickerSetting>
 
                     {/* Button settings */}
                     <ToggleSetting

--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
@@ -413,7 +413,7 @@ export function SignupCard({alignment,
                                         type="button"
                                         onClick={() => {
                                             handleShowBackgroundImage();
-                                            setBackgroundColorPickerExpanded(false);
+                                            setBackgroundColorPickerExpanded(true);
                                             setButtonColorPickerExpanded(false);
                                         }}
                                     >
@@ -448,33 +448,34 @@ export function SignupCard({alignment,
                                 setButtonColorPickerExpanded(!isExpanded);
                             }
                         }}
-                    />
-
-                    <MediaUploadSetting
-                        alt='Background image'
-                        borderStyle={'rounded'}
-                        className={(!showBackgroundImage || layout === 'split') && 'hidden'}
-                        errors={fileUploader?.errors}
-                        hideLabel={layout !== 'split'}
-                        icon='file'
-                        isDraggedOver={imageDragHandler?.isDraggedOver}
-                        isLoading={isLoading}
-                        isPinturaEnabled={isPinturaEnabled}
-                        label='Image'
-                        mimeTypes={['image/*']}
-                        openImageEditor={openImageEditor}
-                        placeholderRef={imageDragHandler?.setRef}
-                        progress={progress}
-                        setFileInputRef={setFileInputRef}
-                        size='xsmall'
-                        src={backgroundImageSrc}
-                        stacked={true}
-                        onFileChange={onFileChange}
-                        onRemoveMedia={() => {
-                            handleClearBackgroundImage();
-                            handleTextColor(matchingTextColor(backgroundColor));
-                        }}
-                    />
+                    >
+                        {layout !== 'split' && showBackgroundImage && (
+                            <MediaUploadSetting
+                                alt='Background image'
+                                borderStyle={'rounded'}
+                                desc='Click to select image'
+                                errors={fileUploader?.errors}
+                                hideLabel={true}
+                                icon='file'
+                                isDraggedOver={imageDragHandler?.isDraggedOver}
+                                isLoading={isLoading}
+                                isPinturaEnabled={isPinturaEnabled}
+                                mimeTypes={['image/*']}
+                                openImageEditor={openImageEditor}
+                                placeholderRef={imageDragHandler?.setRef}
+                                progress={progress}
+                                setFileInputRef={setFileInputRef}
+                                size='xsmall'
+                                src={backgroundImageSrc}
+                                stacked={true}
+                                onFileChange={onFileChange}
+                                onRemoveMedia={() => {
+                                    handleClearBackgroundImage();
+                                    handleTextColor(matchingTextColor(backgroundColor));
+                                }}
+                            />
+                        )}
+                    </ColorPickerSetting>
 
                     <ColorPickerSetting
                         dataTestId='signup-button-color'

--- a/packages/koenig-lexical/src/components/ui/cards/VideoCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/VideoCard.jsx
@@ -99,6 +99,7 @@ function PopulatedVideoCard({
                                 alt='Custom thumbnail'
                                 borderStyle={'rounded'}
                                 dataTestId="custom-thumbnail-replace"
+                                desc='Upload'
                                 errors={customThumbnailUploader.errors}
                                 icon='file'
                                 isDraggedOver={thumbnailDragHandler.isDraggedOver}
@@ -107,8 +108,8 @@ function PopulatedVideoCard({
                                 mimeTypes={thumbnailMimeTypes}
                                 placeholderRef={thumbnailDragHandler.setRef}
                                 progress={customThumbnailUploader.progress}
-                                size='xsmall'
                                 src={customThumbnail}
+                                type='button'
                                 onFileChange={onCustomThumbnailChange}
                                 onRemoveMedia={onRemoveCustomThumbnail}
                             />

--- a/packages/koenig-lexical/src/styles/components/kg-prose.css
+++ b/packages/koenig-lexical/src/styles/components/kg-prose.css
@@ -981,6 +981,14 @@
     }
 }
 
+.koenig-lexical-cta-label a {
+    @apply !text-grey-900 dark:!text-grey-200 underline;
+}
+
+.koenig-lexical-cta-text a {
+    @apply !text-grey-900 dark:!text-grey-200;
+}
+
 /* stylelint-enable at-rule-disallowed-list */
 
 

--- a/packages/koenig-lexical/tailwind.config.cjs
+++ b/packages/koenig-lexical/tailwind.config.cjs
@@ -91,6 +91,7 @@ module.exports = {
         },
         boxShadow: {
             DEFAULT: '0 0 1px rgba(0,0,0,.15), 0px 13px 27px -5px rgba(50, 50, 93, 0.08), 0px 8px 16px -8px rgba(0, 0, 0, 0.12)',
+            xs: '0px 1px 2px rgba(0, 0, 0, 0.06)',
             sm: '0px 2px 5px -1px rgba(50, 50, 93, 0.2), 0px 1px 3px -1px rgba(0, 0, 0, 0.25)',
             md: '0px 13px 27px -5px rgba(50, 50, 93, 0.25), 0px 8px 16px -8px rgba(0, 0, 0, 0.3)',
             lg: '0px 50px 100px -25px rgba(50, 50, 93, 0.2), 0px 30px 60px -20px rgba(0, 0, 0, 0.25)',


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PLG-355/improve-cta-card-settings-panel
- Updated ButtonGroup styles.
- Added a button-style image upload placeholder to MediaPlaceholder. Also updated the VideoCard to follow the same style.
- Refactored ColorOptionButtons and ColorPicker to display swatches and colorpicker inside toolbar. This also affects the callout, signup and header cards and the image-background selector.
- Added pink and purple as background colors to the CTA card.
- Changed CTA card link styles to currentColor instead of accent color – both for the label and the body text.