### PR TITLE
Remove link from toolbar on CTA Card

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
@@ -19,8 +19,7 @@ export class CallToActionNode extends generateDecoratorNode({
         {name: 'hasImage', default: false},
         {name: 'imageUrl', default: ''},
         {name: 'imageWidth', default: null},
-        {name: 'imageHeight', default: null},
-        {name: 'href', default: '', urlType: 'url'}
+        {name: 'imageHeight', default: null}
     ]
 }) {
     /* overrides */

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -39,8 +39,7 @@ describe('CallToActionNode', function () {
             hasImage: true,
             imageUrl: 'http://blog.com/image1.jpg',
             imageWidth: 200,
-            imageHeight: 100,
-            href: ''
+            imageHeight: 100
         };
         exportOptions = {
             exportFormat: 'html',
@@ -70,7 +69,6 @@ describe('CallToActionNode', function () {
             callToActionNode.hasImage.should.equal(dataset.hasImage);
             callToActionNode.imageUrl.should.equal(dataset.imageUrl);
             callToActionNode.visibility.should.deepEqual(utils.visibility.buildDefaultVisibility());
-            callToActionNode.href.should.equal(dataset.href);
             callToActionNode.imageHeight.should.equal(dataset.imageHeight);
             callToActionNode.imageWidth.should.equal(dataset.imageWidth);
         }));
@@ -132,10 +130,6 @@ describe('CallToActionNode', function () {
             should(callToActionNode.imageWidth).be.null();
             callToActionNode.imageWidth = 200;
             callToActionNode.imageWidth.should.equal(200);
-
-            callToActionNode.href.should.equal('');
-            callToActionNode.href = 'http://blog.com/post1';
-            callToActionNode.href.should.equal('http://blog.com/post1');
 
             callToActionNode.visibility.should.deepEqual(utils.visibility.buildDefaultVisibility());
             callToActionNode.visibility = {
@@ -350,8 +344,7 @@ describe('CallToActionNode', function () {
                 imageHeight: 100,
                 layout: 'minimal',
                 showButton: true,
-                textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card.</span></p>',
-                href: ''
+                textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card.</span></p>'
             };
             const callToActionNode = new CallToActionNode(dataset);
             const json = callToActionNode.exportJSON();
@@ -373,7 +366,6 @@ describe('CallToActionNode', function () {
                 layout: 'minimal',
                 showButton: true,
                 textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card.</span></p>',
-                href: '',
                 visibility: {
                     web: {
                         nonMember: true,

--- a/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
@@ -1,7 +1,7 @@
 import CardContext from '../context/CardContext';
 import KoenigComposerContext from '../context/KoenigComposerContext.jsx';
 import React, {useRef} from 'react';
-import {$createNodeSelection, $getNodeByKey, $setSelection} from 'lexical';
+import {$getNodeByKey} from 'lexical';
 import {ActionToolbar} from '../components/ui/ActionToolbar.jsx';
 import {CallToActionCard} from '../components/ui/cards/CallToActionCard.jsx';
 import {SnippetActionToolbar} from '../components/ui/SnippetActionToolbar.jsx';

--- a/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
@@ -4,7 +4,6 @@ import React, {useRef} from 'react';
 import {$createNodeSelection, $getNodeByKey, $setSelection} from 'lexical';
 import {ActionToolbar} from '../components/ui/ActionToolbar.jsx';
 import {CallToActionCard} from '../components/ui/cards/CallToActionCard.jsx';
-import {LinkInput} from '../components/ui/LinkInput';
 import {SnippetActionToolbar} from '../components/ui/SnippetActionToolbar.jsx';
 import {ToolbarMenu, ToolbarMenuItem, ToolbarMenuSeparator} from '../components/ui/ToolbarMenu.jsx';
 import {getImageDimensions} from '../utils/getImageDimensions';
@@ -34,7 +33,6 @@ export const CallToActionNodeComponent = ({
     const {isEditing, isSelected, setEditing} = React.useContext(CardContext);
     const {fileUploader, cardConfig} = React.useContext(KoenigComposerContext);
     const [showSnippetToolbar, setShowSnippetToolbar] = React.useState(false);
-    const [showLink, setShowLink] = React.useState(false);
 
     const {visibilityOptions, toggleVisibility} = useVisibilityToggle(editor, nodeKey, cardConfig);
 
@@ -129,26 +127,6 @@ export const CallToActionNodeComponent = ({
         });
     };
 
-    const reselectCallToActionCard = () => {
-        editor.update(() => {
-            const nodeSelection = $createNodeSelection();
-            nodeSelection.add(nodeKey);
-            $setSelection(nodeSelection);
-        });
-    };
-
-    const cancelLinkAndReselect = () => {
-        setShowLink(false);
-        reselectCallToActionCard();
-    };
-
-    const setHref = (newHref) => {
-        editor.update(() => {
-            const node = $getNodeByKey(nodeKey);
-            node.href = newHref;
-        });
-    };
-
     React.useEffect(() => {
         htmlEditor.setEditable(isEditing);
     }, [isEditing, htmlEditor]);
@@ -196,29 +174,11 @@ export const CallToActionNodeComponent = ({
             </ActionToolbar>
 
             <ActionToolbar
-                data-kg-card-toolbar="link"
-                isVisible={showLink}
-            >
-                <LinkInput
-                    cancel={cancelLinkAndReselect}
-                    href={href}
-                    update={(_href) => {
-                        setHref(_href);
-                        cancelLinkAndReselect();
-                    }}
-                />
-            </ActionToolbar>
-
-            <ActionToolbar
                 data-kg-card-toolbar="button"
-                isVisible={isSelected && !isEditing && !showSnippetToolbar && !showLink}
+                isVisible={isSelected && !isEditing && !showSnippetToolbar}
             >
                 <ToolbarMenu>
                     <ToolbarMenuItem dataTestId="edit-button-card" icon="edit" isActive={false} label="Edit" onClick={handleToolbarEdit} />
-                    <ToolbarMenuSeparator />
-                    <ToolbarMenuItem icon="link" isActive={href || false} label="Link" onClick = {() => {
-                        setShowLink(true);
-                    }} />
                     <ToolbarMenuSeparator hide={!cardConfig.createSnippet} />
                     <ToolbarMenuItem
                         dataTestId="create-snippet"

--- a/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/cta-card.test.js
@@ -485,24 +485,4 @@ test.describe('Call To Action Card', async () => {
         await expect(page.getByTestId('visibility-toggle-email-freeMembers')).toBeChecked();
         await expect(page.getByTestId('visibility-toggle-email-paidMembers')).not.toBeChecked();
     });
-
-    test('CTA card toolbar has Link button and link input', async function () {
-        await focusEditor(page);
-        await insertCard(page, {cardName: 'call-to-action'});
-        await page.keyboard.press('Escape');
-        const toolbarLinkButton = await page.locator('[aria-label="Link"]');
-        await expect(toolbarLinkButton).toBeVisible();
-        await toolbarLinkButton.click();
-        await expect(page.getByTestId('link-input')).toBeVisible();
-    });
-
-    test('Settings panel does not show when using link editor', async function () {
-        await focusEditor(page);
-        await insertCard(page, {cardName: 'call-to-action'});
-        await page.keyboard.press('Escape');
-        const toolbarLinkButton = await page.locator('[aria-label="Link"]');
-        await toolbarLinkButton.click();
-        await expect(page.getByTestId('link-input')).toBeVisible();
-        await expect(page.getByTestId('button-settings')).not.toBeVisible();
-    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-358/remove-link-from-toolbar-on-cta-card

We learnt that having the ability to add a Link from the toolbar might cause confusion in multiple ways.
This commit removes all the code related to it.