### PR TITLE
Removed redundant `hasImage` prop from `CallToActionNode`

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
@@ -16,7 +16,6 @@ export class CallToActionNode extends generateDecoratorNode({
         {name: 'hasSponsorLabel', default: true},
         {name: 'sponsorLabel', default: '<p><span style="white-space: pre-wrap;">SPONSORED</span></p>'},
         {name: 'backgroundColor', default: 'grey'},
-        {name: 'hasImage', default: false},
         {name: 'imageUrl', default: ''},
         {name: 'imageWidth', default: null},
         {name: 'imageHeight', default: null}

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
@@ -16,7 +16,7 @@ export class CallToActionNode extends generateDecoratorNode({
         {name: 'hasSponsorLabel', default: true},
         {name: 'sponsorLabel', default: '<p><span style="white-space: pre-wrap;">SPONSORED</span></p>'},
         {name: 'backgroundColor', default: 'grey'},
-        {name: 'imageUrl', default: ''},
+        {name: 'imageUrl', default: null},
         {name: 'imageWidth', default: null},
         {name: 'imageHeight', default: null}
     ]

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -19,7 +19,7 @@ function ctaCardTemplate(dataset) {
                 </div>
             ` : ''}
             <div class="kg-cta-content">
-                ${dataset.hasImage ? `
+                ${dataset.imageUrl ? `
                     <div class="kg-cta-image-container">
                         <img src="${dataset.imageUrl}" alt="CTA Image">
                     </div>
@@ -51,7 +51,7 @@ function emailCTATemplate(dataset) {
 
     let imageDimensions;
     
-    if (dataset.imageWidth && dataset.imageHeight) {
+    if (dataset.imageUrl && dataset.imageWidth && dataset.imageHeight) {
         imageDimensions = {
             width: dataset.imageWidth,
             height: dataset.imageHeight
@@ -69,7 +69,7 @@ function emailCTATemplate(dataset) {
                     <td class="kg-cta-content">
                         <table border="0" cellpadding="0" cellspacing="0" width="100%" class="kg-cta-content-wrapper">
                             <tr>
-                                ${dataset.hasImage ? `
+                                ${dataset.imageUrl ? `
                                     <td class="kg-cta-image-container" width="64">
                                         <img src="${dataset.imageUrl}" alt="CTA Image" class="kg-cta-image" width="64" height="64">
                                     </td>
@@ -113,7 +113,7 @@ function emailCTATemplate(dataset) {
             <tr>
                 <td class="kg-cta-content">
                     <table border="0" cellpadding="0" cellspacing="0" width="100%" class="kg-cta-content-wrapper">
-                        ${dataset.hasImage ? `
+                        ${dataset.imageUrl ? `
                             <tr>
                                 <td class="kg-cta-image-container">
                                     <table border="0" cellpadding="0" cellspacing="0" width="100%">
@@ -188,7 +188,6 @@ export function renderCallToActionNode(node, options = {}) {
         hasSponsorLabel: node.hasSponsorLabel,
         backgroundColor: node.backgroundColor,
         sponsorLabel: node.sponsorLabel,
-        hasImage: node.hasImage,
         imageUrl: node.imageUrl,
         imageWidth: node.imageWidth,
         imageHeight: node.imageHeight

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -113,7 +113,7 @@ describe('CallToActionNode', function () {
             callToActionNode.backgroundColor = '#654321';
             callToActionNode.backgroundColor.should.equal('#654321');
 
-            callToActionNode.imageUrl.should.equal('');
+            should(callToActionNode.imageUrl).be.null();
             callToActionNode.imageUrl = 'http://blog.com/image1.jpg';
             callToActionNode.imageUrl.should.equal('http://blog.com/image1.jpg');
 

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -36,7 +36,6 @@ describe('CallToActionNode', function () {
             buttonTextColor: 'none',
             hasSponsorLabel: true,
             backgroundColor: 'none',
-            hasImage: true,
             imageUrl: 'http://blog.com/image1.jpg',
             imageWidth: 200,
             imageHeight: 100
@@ -66,7 +65,6 @@ describe('CallToActionNode', function () {
             callToActionNode.hasSponsorLabel.should.equal(dataset.hasSponsorLabel);
             callToActionNode.sponsorLabel.should.equal(dataset.sponsorLabel);
             callToActionNode.backgroundColor.should.equal(dataset.backgroundColor);
-            callToActionNode.hasImage.should.equal(dataset.hasImage);
             callToActionNode.imageUrl.should.equal(dataset.imageUrl);
             callToActionNode.visibility.should.deepEqual(utils.visibility.buildDefaultVisibility());
             callToActionNode.imageHeight.should.equal(dataset.imageHeight);
@@ -114,10 +112,6 @@ describe('CallToActionNode', function () {
             callToActionNode.backgroundColor.should.equal('grey');
             callToActionNode.backgroundColor = '#654321';
             callToActionNode.backgroundColor.should.equal('#654321');
-
-            callToActionNode.hasImage.should.equal(false);
-            callToActionNode.hasImage = true;
-            callToActionNode.hasImage.should.equal(true);
 
             callToActionNode.imageUrl.should.equal('');
             callToActionNode.imageUrl = 'http://blog.com/image1.jpg';
@@ -199,7 +193,6 @@ describe('CallToActionNode', function () {
                 buttonText: 'Get access now',
                 buttonTextColor: '#000000',
                 buttonUrl: 'http://someblog.com/somepost',
-                hasImage: true,
                 hasSponsorLabel: true,
                 sponsorLabel: '<p>Sponsored by</p>',
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
@@ -217,7 +210,7 @@ describe('CallToActionNode', function () {
             html.should.containEql('background-color: #F0F0F0');
             html.should.containEql('Get access now');
             html.should.containEql('http://someblog.com/somepost');
-            html.should.containEql('/content/images/2022/11/koenig-lexical.jpg');// because hasImage is true
+            html.should.containEql('/content/images/2022/11/koenig-lexical.jpg');
             html.should.containEql('This is a new CTA Card.');
             html.should.containEql('Sponsored by'); // because hasSponsorLabel is true
             html.should.containEql('cta-card');
@@ -231,7 +224,6 @@ describe('CallToActionNode', function () {
                 buttonText: 'Get access now',
                 buttonTextColor: '#000000',
                 buttonUrl: 'http://someblog.com/somepost',
-                hasImage: true,
                 hasSponsorLabel: true,
                 sponsorLabel: '<p><span style="white-space: pre-wrap;">SPONSORED</span></p>',
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
@@ -248,7 +240,7 @@ describe('CallToActionNode', function () {
             html.should.containEql('Get access now');
             html.should.containEql('http://someblog.com/somepost');
             html.should.containEql('<p><span style="white-space: pre-wrap;">SPONSORED</span></p>'); // because hasSponsorLabel is true
-            html.should.containEql('/content/images/2022/11/koenig-lexical.jpg'); // because hasImage is true
+            html.should.containEql('/content/images/2022/11/koenig-lexical.jpg');
             html.should.containEql('This is a new CTA Card via email.');
         }));
 
@@ -260,7 +252,6 @@ describe('CallToActionNode', function () {
                 buttonText: 'Get access now',
                 buttonTextColor: '#000000',
                 buttonUrl: 'http://someblog.com/somepost',
-                hasImage: true,
                 hasSponsorLabel: true,
                 sponsorLabel: '<p><span style="white-space: pre-wrap;">SPONSORED</span></p>',
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
@@ -285,7 +276,7 @@ describe('CallToActionNode', function () {
             html.should.containEql('This is a cool advertisement');
         }));
 
-        it('renders img tag when hasImage is true', editorTest(function () {
+        it('renders img tag when imageUrl is not null', editorTest(function () {
             const callToActionNode = new CallToActionNode(dataset);
             const {element} = callToActionNode.exportDOM(exportOptions);
 
@@ -293,8 +284,8 @@ describe('CallToActionNode', function () {
             html.should.containEql('<img src="http://blog.com/image1.jpg" alt="CTA Image">');
         }));
 
-        it('does not render img tag when hasImage is false', editorTest(function () {
-            dataset.hasImage = false;
+        it('does not render img tag when imageUrl is null', editorTest(function () {
+            dataset.imageUrl = null;
             const callToActionNode = new CallToActionNode(dataset);
             const {element} = callToActionNode.exportDOM(exportOptions);
 
@@ -336,7 +327,6 @@ describe('CallToActionNode', function () {
                 buttonText: 'Get access now',
                 buttonTextColor: '#000000',
                 buttonUrl: 'http://someblog.com/somepost',
-                hasImage: true,
                 hasSponsorLabel: true,
                 sponsorLabel: '<p>This post is brought to you by our sponsors</p>',
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
@@ -357,7 +347,6 @@ describe('CallToActionNode', function () {
                 buttonText: 'Get access now',
                 buttonTextColor: '#000000',
                 buttonUrl: 'http://someblog.com/somepost',
-                hasImage: true,
                 hasSponsorLabel: true,
                 sponsorLabel: '<p>This post is brought to you by our sponsors</p>',
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
@@ -390,7 +379,6 @@ describe('CallToActionNode', function () {
                         buttonText: 'Get access now',
                         buttonTextColor: '#000000',
                         buttonUrl: 'http://someblog.com/somepost',
-                        hasImage: true,
                         hasSponsorLabel: true,
                         sponsorLabel: '<p>This post is brought to you by our sponsors</p>',
                         imageUrl: '/content/images/2022/11/koenig-lexical.jpg',

--- a/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
@@ -101,7 +101,6 @@ export class CallToActionNode extends BaseCallToActionNode {
                     buttonText={this.buttonText}
                     buttonTextColor={this.buttonTextColor}
                     buttonUrl={this.buttonUrl}
-                    hasImage={this.hasImage}
                     hasSponsorLabel={this.hasSponsorLabel}
                     href={this.href}
                     htmlEditor={this.__callToActionHtmlEditor}

--- a/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
@@ -15,7 +15,6 @@ export const CallToActionNodeComponent = ({
     backgroundColor,
     buttonText,
     buttonUrl,
-    hasImage,
     hasSponsorLabel,
     imageUrl,
     layout,
@@ -98,7 +97,6 @@ export const CallToActionNodeComponent = ({
             editor.update(() => {
                 const node = $getNodeByKey(nodeKey);
                 node.imageUrl = result?.[0].url;
-                node.hasImage = true;
                 node.imageWidth = width;
                 node.imageHeight = height;
             });
@@ -114,8 +112,7 @@ export const CallToActionNodeComponent = ({
     const onRemoveMedia = () => {
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
-            node.imageUrl = '';
-            node.hasImage = false;
+            node.imageUrl = null;
             node.imageWidth = null;
             node.imageHeight = null;
         });
@@ -141,7 +138,6 @@ export const CallToActionNodeComponent = ({
                 color={backgroundColor}
                 handleButtonColor={handleButtonColorChange}
                 handleColorChange={handleBackgroundColorChange}
-                hasImage={hasImage}
                 hasSponsorLabel={hasSponsorLabel}
                 htmlEditor={htmlEditor}
                 htmlEditorInitialState={htmlEditorInitialState}


### PR DESCRIPTION
no issue

The `hasImage` property was unnecessary as the presence of an image can be reliably determined by checking if imageUrl is set. This prop was originally carried over from the signup node, which has an explicit image toggle, but serves no purpose in the `CallToActionNode` since there's no other mechanism to enable/disable image usage.

- Removing `hasImage` from the node definition and defaults
- Updating conditional rendering to check `imageUrl` directly instead of hasImage
- Removing `hasImage` related test assertions
- Maintaining identical functionality while reducing code complexity
