### PR TITLE
Removed usage of defaultProps

### DIFF
--- a/packages/koenig-lexical/src/components/ui/Button.jsx
+++ b/packages/koenig-lexical/src/components/ui/Button.jsx
@@ -2,7 +2,21 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import clsx from 'clsx';
 
-export function Button({color, dataTestId, href, size, width, rounded, shrink, value, placeholder, type = 'button', disabled = false, target, ...other}) {
+export function Button({
+    color = 'accent',
+    dataTestId,
+    href,
+    size = 'small',
+    width = 'regular',
+    rounded = true,
+    shrink = false,
+    value = '',
+    placeholder = 'Add button text',
+    type = 'button',
+    disabled = false,
+    target,
+    ...other
+}) {
     const Tag = href ? 'a' : 'button';
     const props = {
         type: href ? null : type,
@@ -54,15 +68,4 @@ Button.propTypes = {
     href: PropTypes.string,
     target: PropTypes.string,
     disabled: PropTypes.bool
-};
-
-Button.defaultProps = {
-    color: 'accent',
-    size: 'small',
-    width: 'regular',
-    rounded: true,
-    shrink: false,
-    value: '',
-    placeholder: 'Add button text',
-    disabled: false
 };

--- a/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
@@ -17,10 +17,10 @@ const DEFAULT_INDICATOR_POSITION = {
 
 export const CardWrapper = React.forwardRef(({
     cardType,
-    cardWidth,
+    cardWidth = 'regular',
     feature,
     IndicatorIcon,
-    indicatorPosition,
+    indicatorPosition = DEFAULT_INDICATOR_POSITION,
     isDragging,
     isEditing,
     isSelected,
@@ -115,9 +115,4 @@ CardWrapper.propTypes = {
         left: PropTypes.string,
         top: PropTypes.string
     })
-};
-
-CardWrapper.defaultProps = {
-    cardWidth: 'regular',
-    indicatorPosition: DEFAULT_INDICATOR_POSITION
 };

--- a/packages/koenig-lexical/src/components/ui/EmojiPickerPortal.jsx
+++ b/packages/koenig-lexical/src/components/ui/EmojiPickerPortal.jsx
@@ -5,7 +5,30 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import defaultData from '@emoji-mart/data';
 
-const EmojiPickerPortal = ({onEmojiClick, positionRef, data = defaultData, ...props}) => {
+const EmojiPickerPortal = ({
+    onEmojiClick,
+    positionRef,
+    data = defaultData,
+    autoFocus = true,
+    dynamicWidth = false,
+    emojiButtonRadius = '100%',
+    emojiButtonSize = 36,
+    emojiSize = 24,
+    icons = 'outline',
+    locale = 'en',
+    maxFrequentRows = 1,
+    navPosition = 'bottom',
+    noCountryFlags = false,
+    noResultsEmoji = 'cry',
+    perLine = 9,
+    previewEmoji = null,
+    previewPosition = 'none',
+    searchPosition = 'sticky',
+    set = 'native',
+    skin = 1,
+    skinTonePosition = 'preview',
+    ...props
+}) => {
     const [position, setPosition] = React.useState(null);
     const {darkMode} = React.useContext(KoenigComposerContext);
 
@@ -52,17 +75,29 @@ const EmojiPickerPortal = ({onEmojiClick, positionRef, data = defaultData, ...pr
     };
 
     // https://github.com/missive/emoji-mart#options--props
-    const defaultProps = {
-        autoFocus: true,
-        icons: 'outline',
-        maxFrequentRows: 1,
-        navPosition: 'bottom',
-        noResultsEmoji: 'cry',
-        previewPosition: 'none',
-        theme: darkMode ? 'dark' : 'light'
+    const defaultPickerProps = {
+        theme: darkMode ? 'dark' : 'light',
+        autoFocus,
+        dynamicWidth,
+        emojiButtonRadius,
+        emojiButtonSize,
+        emojiSize,
+        icons,
+        locale,
+        maxFrequentRows,
+        navPosition,
+        noCountryFlags,
+        noResultsEmoji,
+        perLine,
+        previewEmoji,
+        previewPosition,
+        searchPosition,
+        set,
+        skin,
+        skinTonePosition
     };
 
-    const mergedProps = {...defaultProps, ...props};
+    const pickerProps = {...defaultPickerProps, ...props};
 
     return (
         <Portal>
@@ -71,7 +106,7 @@ const EmojiPickerPortal = ({onEmojiClick, positionRef, data = defaultData, ...pr
                     <Picker // https://github.com/missive/emoji-mart#-picker
                         data={data}
                         onEmojiSelect={onEmojiClick}
-                        {...mergedProps}
+                        {...pickerProps}
                     />
                 </div>
             </div>
@@ -106,28 +141,5 @@ EmojiPickerPortal.propTypes = {
     set: PropTypes.oneOf(['native', 'apple', 'facebook', 'google', 'twitter']),
     setInstanceRef: PropTypes.func,
     skin: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
-    skinTonePosition: PropTypes.oneOf(['preview', 'search', 'none']),
-    theme: PropTypes.oneOf(['auto', 'light', 'dark'])
-};
-
-EmojiPickerPortal.defaultProps = {
-    autoFocus: true,
-    dynamicWidth: false,
-    emojiButtonRadius: '100%',
-    emojiButtonSize: 36,
-    emojiSize: 24,
-    icons: 'outline',
-    locale: 'en',
-    maxFrequentRows: 1,
-    navPosition: 'bottom',
-    noCountryFlags: false,
-    noResultsEmoji: 'cry',
-    perLine: 9,
-    previewEmoji: null,
-    previewPosition: 'none',
-    searchPosition: 'sticky',
-    set: 'native',
-    skin: 1,
-    skinTonePosition: 'preview',
-    theme: 'light'
+    skinTonePosition: PropTypes.oneOf(['preview', 'search', 'none'])
 };

--- a/packages/koenig-lexical/src/components/ui/MediaPlaceholder.jsx
+++ b/packages/koenig-lexical/src/components/ui/MediaPlaceholder.jsx
@@ -27,7 +27,7 @@ export function MediaPlaceholder({
     icon,
     filePicker,
     size,
-    borderStyle,
+    borderStyle = 'squared',
     isDraggedOver,
     errors = [],
     placeholderRef,
@@ -75,8 +75,4 @@ MediaPlaceholder.propTypes = {
     desc: PropTypes.string,
     size: PropTypes.oneOf(['xsmall', 'small', 'medium', 'large']),
     borderStyle: PropTypes.oneOf(['squared', 'rounded'])
-};
-
-MediaPlaceholder.defaultProps = {
-    borderStyle: 'squared'
 };

--- a/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
@@ -355,26 +355,3 @@ CallToActionCard.propTypes = {
     visibilityOptions: PropTypes.object,
     toggleVisibility: PropTypes.func
 };
-
-CallToActionCard.defaultProps = {
-    buttonText: '',
-    buttonUrl: '',
-    buttonColor: '',
-    buttonTextColor: '',
-    color: 'none',
-    hasSponsorLabel: false,
-    imageSrc: '',
-    isEditing: false,
-    layout: 'immersive',
-    showButton: false,
-    updateHasSponsorLabel: () => {},
-    updateShowButton: () => {},
-    updateLayout: () => {},
-    handleColorChange: () => {},
-    handleButtonColor: () => {},
-    onFileChange: () => {},
-    setFileInputRef: () => {},
-    onRemoveMedia: () => {},
-    visibilityOptions: PropTypes.object,
-    toggleVisibility: PropTypes.func
-};

--- a/packages/koenig-lexical/src/components/ui/cards/CalloutCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CalloutCard.jsx
@@ -83,14 +83,14 @@ export const calloutColorPicker = [
 ];
 
 export function CalloutCard({
-    color,
+    color = 'green',
     isEditing,
     setShowEmojiPicker,
     toggleEmoji,
-    hasEmoji,
+    hasEmoji = true,
     handleColorChange,
     changeEmoji,
-    calloutEmoji,
+    calloutEmoji = '💡',
     textEditor,
     textEditorInitialState,
     nodeKey,
@@ -188,10 +188,4 @@ CalloutCard.propTypes = {
     nodeKey: PropTypes.string,
     toggleEmojiPicker: PropTypes.func,
     showEmojiPicker: PropTypes.bool
-};
-
-CalloutCard.defaultProps = {
-    color: 'green',
-    calloutEmoji: '💡',
-    hasEmoji: true
 };

--- a/packages/koenig-lexical/src/components/ui/cards/EmailCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/EmailCard.jsx
@@ -5,7 +5,11 @@ import ReplacementStringsPlugin from '../../../plugins/ReplacementStringsPlugin'
 import {CardVisibilityMessage} from '../CardVisibilityMessage.jsx';
 import {ReadOnlyOverlay} from '../ReadOnlyOverlay';
 
-export function EmailCard({htmlEditor, htmlEditorInitialState, isEditing}) {
+export function EmailCard({
+    htmlEditor,
+    htmlEditorInitialState,
+    isEditing = false
+}) {
     return (
         <>
             <CardVisibilityMessage message="Hidden on website" />
@@ -30,8 +34,4 @@ EmailCard.propTypes = {
     htmlEditor: PropTypes.object,
     isEditing: PropTypes.bool,
     htmlEditorInitialState: PropTypes.object
-};
-
-EmailCard.defaultProps = {
-    isEditing: false
 };

--- a/packages/koenig-lexical/src/components/ui/cards/EmailCtaCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/EmailCtaCard.jsx
@@ -10,16 +10,16 @@ import {CardVisibilityMessage} from '../CardVisibilityMessage.jsx';
 import {ReadOnlyOverlay} from '../ReadOnlyOverlay';
 
 export function EmailCtaCard({
-    alignment,
-    buttonText,
-    buttonUrl,
+    alignment = 'left',
+    buttonText = '',
+    buttonUrl = '',
     handleSegmentChange,
     htmlEditor,
     htmlEditorInitialState,
-    isEditing,
-    segment,
-    showDividers,
-    showButton,
+    isEditing = false,
+    segment = 'status:free',
+    showDividers = true,
+    showButton = true,
     toggleDividers,
     updateAlignment,
     updateShowButton,
@@ -173,15 +173,4 @@ EmailCtaCard.propTypes = {
     handleSegmentChange: PropTypes.func,
     htmlEditor: PropTypes.object,
     htmlEditorInitialState: PropTypes.object
-};
-
-EmailCtaCard.defaultProps = {
-    alignment: 'left',
-    buttonText: '',
-    buttonUrl: '',
-    isEditing: false,
-    segment: 'status:free',
-    showButton: true,
-    showDividers: true,
-    suggestedUrls: []
 };

--- a/packages/koenig-lexical/src/components/ui/cards/ToggleCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/ToggleCard.jsx
@@ -7,11 +7,11 @@ import {ReadOnlyOverlay} from '../ReadOnlyOverlay';
 export function ToggleCard({
     contentEditor,
     contentEditorInitialState,
-    contentPlaceholder,
+    contentPlaceholder = 'Collapsible content',
     headingEditor,
     headingEditorInitialState,
-    headingPlaceholder,
-    isEditing
+    headingPlaceholder = 'Toggle header',
+    isEditing = false
 }) {
     return (
         <>
@@ -57,10 +57,4 @@ ToggleCard.propTypes = {
     isEditing: PropTypes.bool,
     contentEditorInitialState: PropTypes.object,
     headingEditorInitialState: PropTypes.object
-};
-
-ToggleCard.defaultProps = {
-    contentPlaceholder: 'Collapsible content',
-    headingPlaceholder: 'Toggle header',
-    isEditing: false
 };


### PR DESCRIPTION
closes https://linear.app/ghost/issue/PLG-347

- `defaultProps` is deprecated in favor of native destructing assignment defaults in props object
