### PR TITLE
Enabled custom thumbnail UI for looped videos

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/VideoCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/VideoCard.jsx
@@ -94,25 +94,23 @@ function PopulatedVideoCard({
                             label='Loop'
                             onChange={onLoopChange}
                         />
-                        {!isLoopChecked && (
-                            <MediaUploadSetting
-                                alt='Custom thumbnail'
-                                borderStyle={'rounded'}
-                                dataTestId="custom-thumbnail-replace"
-                                errors={customThumbnailUploader.errors}
-                                icon='file'
-                                isDraggedOver={thumbnailDragHandler.isDraggedOver}
-                                isLoading={customThumbnailUploader.isLoading}
-                                label='Custom thumbnail'
-                                mimeTypes={thumbnailMimeTypes}
-                                placeholderRef={thumbnailDragHandler.setRef}
-                                progress={customThumbnailUploader.progress}
-                                size='xsmall'
-                                src={customThumbnail}
-                                onFileChange={onCustomThumbnailChange}
-                                onRemoveMedia={onRemoveCustomThumbnail}
-                            />
-                        )}
+                        <MediaUploadSetting
+                            alt='Custom thumbnail'
+                            borderStyle={'rounded'}
+                            dataTestId="custom-thumbnail-replace"
+                            errors={customThumbnailUploader.errors}
+                            icon='file'
+                            isDraggedOver={thumbnailDragHandler.isDraggedOver}
+                            isLoading={customThumbnailUploader.isLoading}
+                            label='Custom thumbnail'
+                            mimeTypes={thumbnailMimeTypes}
+                            placeholderRef={thumbnailDragHandler.setRef}
+                            progress={customThumbnailUploader.progress}
+                            size='xsmall'
+                            src={customThumbnail}
+                            onFileChange={onCustomThumbnailChange}
+                            onRemoveMedia={onRemoveCustomThumbnail}
+                        />
                     </SettingsPanel>
                 )
             }

--- a/packages/koenig-lexical/test/e2e/cards/video-card.firefox.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/video-card.firefox.test.js
@@ -212,24 +212,6 @@ test.describe('Video card', async () => {
         await expect(await page.getByTestId('media-upload-errors')).toBeVisible();
     });
 
-    test('can hide custom thumbnail if loop enabled', async function () {
-        await focusEditor(page);
-        await uploadVideo(page);
-
-        // Loop toggle should be visible and unchecked
-        const loopButton = await page.getByTestId('loop-video');
-        await expect(loopButton).toBeVisible();
-        await expect(await page.locator('[data-testid="loop-video"] input').isChecked()).toBeFalsy();
-
-        // Custom thumbnail should be visible
-        const emptyThumbnail = await page.getByTestId('media-upload-placeholder');
-        await expect(emptyThumbnail).toBeVisible();
-
-        // Custom thumbnail should be hidden after loop enabled
-        await loopButton.check();
-        await expect(page.getByTestId('media-upload-placeholder')).toBeHidden();
-    });
-
     test('can upload dropped video', async function () {
         const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/video.mp4');
         const fileChooserPromise = page.waitForEvent('filechooser');


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/ENG-2062/enable-custom-thumbnail-ui-for-looped-videos
- Stopped the custom thumbnail upload UI from being hidden regardless of video loop setting, as thumbnails remain relevant for email previews