### PR TITLE
Prevented CTA card button showing with missing data

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -3,6 +3,8 @@ import {renderWithVisibility} from '../../utils/visibility';
 import {getResizedImageDimensions} from '../../utils/get-resized-image-dimensions';
 import {isLocalContentImage} from '../../utils/is-local-content-image';
 
+const showButton = dataset => dataset.showButton && dataset.buttonUrl && dataset.buttonText;
+
 function ctaCardTemplate(dataset) {
     // Add validation for buttonColor
     if (!dataset.buttonColor || !dataset.buttonColor.match(/^[a-zA-Z\d-]+|#([a-fA-F\d]{3}|[a-fA-F\d]{6})$/)) {
@@ -32,7 +34,7 @@ function ctaCardTemplate(dataset) {
                             ${dataset.textValue}
                         </div>
                     ` : ''}
-                    ${dataset.showButton ? `
+                    ${showButton(dataset) ? `
                         <a href="${dataset.buttonUrl}" class="kg-cta-button ${buttonAccent}" ${buttonStyle}>
                             ${dataset.buttonText}
                         </a>
@@ -91,7 +93,7 @@ function emailCTATemplate(dataset, options = {}) {
                                                 </td>
                                             </tr>
                                         ` : ''}
-                                        ${dataset.showButton ? `
+                                        ${showButton(dataset) ? `
                                         <tr>
                                             <td class="kg-cta-button-container">
                                                 <table border="0" cellpadding="0" cellspacing="0" class="kg-cta-button-wrapper">
@@ -140,7 +142,7 @@ function emailCTATemplate(dataset, options = {}) {
                                 ${dataset.textValue}
                             </td>
                         </tr>
-                        ${dataset.showButton ? `
+                        ${showButton(dataset) ? `
                             <tr>
                                 <td class="kg-cta-button-container">
                                     <table border="0" cellpadding="0" cellspacing="0" width="100%">

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -370,6 +370,47 @@ describe('CallToActionNode', function () {
                 element.dataset.ghSegment.should.equal('status:free');
             });
         }));
+
+        it('uses default buttonText when created with empty buttonText (web)', editorTest(function () {
+            dataset.showButton = true;
+            dataset.buttonText = '';
+
+            testRender(({html}) => {
+                html.should.containEql('<a href="http://blog.com/post1"');
+                html.should.containEql('Learn more');
+            });
+        }));
+
+        function testButtonSkipOnMissingData(target, layout, {missing = []} = {}) {
+            return editorTest(function () {
+                dataset.layout = layout;
+                dataset.showButton = true;
+                dataset.buttonUrl = 'http://blog.com/post1';
+                dataset.buttonText = 'Click me';
+                exportOptions.target = target;
+
+                // NOTE: does not use testRender() because we need to set button text later to avoid node defaults
+                const callToActionNode = new CallToActionNode(dataset);
+
+                // clear out the missing data
+                missing.forEach((prop) => {
+                    callToActionNode[prop] = '';
+                });
+
+                const {element} = callToActionNode.exportDOM(exportOptions);
+                const html = element.outerHTML.toString();
+
+                html.should.not.containEql('<a href="http://blog.com/post1"');
+                html.should.not.containEql('Click me');
+            });
+        }
+
+        it('skips button when buttonUrl is empty (web, minimal)', testButtonSkipOnMissingData('web', 'minimal', {missing: ['buttonUrl']}));
+        it('skips button when buttonText is empty (web, minimal)', testButtonSkipOnMissingData('web', 'minimal', {missing: ['buttonText']}));
+        it('skips button when buttonUrl is empty (email, minimal)', testButtonSkipOnMissingData('email', 'minimal', {missing: ['buttonUrl']}));
+        it('skips button when buttonUrl is empty (email, immersive)', testButtonSkipOnMissingData('email', 'immersive', {missing: ['buttonUrl']}));
+        it('skips button when buttonText is empty (email, minimal)', testButtonSkipOnMissingData('email', 'minimal', {missing: ['buttonText']}));
+        it('skips button when buttonText is empty (email, immersive)', testButtonSkipOnMissingData('email', 'immersive', {missing: ['buttonText']}));
     });
 
     describe('exportJSON', function () {


### PR DESCRIPTION
no issue

- the CTA renderer was relying on the client-provided `showButton` property for it's button conditionals but there's no guarantee the data needed to show the button has also been set by the client
- extracted the condition to a function that can be called with the dataset so we can perform a more complete data check
- added tests to ensure the button is not shown when required data is missing
