### PR TITLE
Linked image in CTA card when button is shown

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -5,6 +5,14 @@ import {isLocalContentImage} from '../../utils/is-local-content-image';
 
 const showButton = dataset => dataset.showButton && dataset.buttonUrl && dataset.buttonText;
 
+const wrapWithLink = (dataset, content) => {
+    if (!showButton(dataset)) {
+        return content;
+    }
+
+    return `<a href="${dataset.buttonUrl}">${content}</a>`;
+};
+
 function ctaCardTemplate(dataset) {
     // Add validation for buttonColor
     if (!dataset.buttonColor || !dataset.buttonColor.match(/^[a-zA-Z\d-]+|#([a-fA-F\d]{3}|[a-fA-F\d]{6})$/)) {
@@ -24,7 +32,7 @@ function ctaCardTemplate(dataset) {
             <div class="kg-cta-content">
                 ${dataset.imageUrl ? `
                     <div class="kg-cta-image-container">
-                        <img src="${dataset.imageUrl}" alt="CTA Image">
+                        ${wrapWithLink(dataset, `<img src="${dataset.imageUrl}" alt="CTA Image">`)}
                     </div>
                 ` : ''}
                 ${dataset.textValue || dataset.showButton ? `
@@ -81,7 +89,7 @@ function emailCTATemplate(dataset, options = {}) {
                             <tr>
                                 ${dataset.imageUrl ? `
                                     <td class="kg-cta-image-container" width="64">
-                                        <img src="${dataset.imageUrl}" alt="CTA Image" class="kg-cta-image" width="64" height="64">
+                                        ${wrapWithLink(dataset, `<img src="${dataset.imageUrl}" alt="CTA Image" class="kg-cta-image" width="64" height="64">`)}
                                     </td>
                                 ` : ''}
                                 <td class="kg-cta-content-inner">
@@ -130,7 +138,7 @@ function emailCTATemplate(dataset, options = {}) {
                                     <table border="0" cellpadding="0" cellspacing="0" width="100%">
                                         <tr>
                                             <td>
-                                                <img src="${dataset.imageUrl}" alt="CTA Image" class="kg-cta-image" ${imageDimensions ? `width="${imageDimensions.width}"` : ''} ${imageDimensions ? `height="${imageDimensions.height}"` : ''}>
+                                                ${wrapWithLink(dataset, `<img src="${dataset.imageUrl}" alt="CTA Image" class="kg-cta-image" ${imageDimensions ? `width="${imageDimensions.width}"` : ''} ${imageDimensions ? `height="${imageDimensions.height}"` : ''}>`)}
                                             </td>
                                         </tr>
                                     </table>

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -411,6 +411,40 @@ describe('CallToActionNode', function () {
         it('skips button when buttonUrl is empty (email, immersive)', testButtonSkipOnMissingData('email', 'immersive', {missing: ['buttonUrl']}));
         it('skips button when buttonText is empty (email, minimal)', testButtonSkipOnMissingData('email', 'minimal', {missing: ['buttonText']}));
         it('skips button when buttonText is empty (email, immersive)', testButtonSkipOnMissingData('email', 'immersive', {missing: ['buttonText']}));
+
+        function testImageLink(target, layout) {
+            return editorTest(function () {
+                exportOptions.target = target;
+                dataset.layout = layout;
+                dataset.showButton = true;
+                dataset.buttonUrl = 'http://blog.com/post1';
+
+                testRender(({html}) => {
+                    html.should.containEql('<a href="http://blog.com/post1"><img');
+                });
+            });
+        }
+
+        it('adds link to image when button is present with url (web)', testImageLink('web', 'minimal'));
+        it('adds link to image when button is present with url (email, minimal)', testImageLink('email', 'minimal'));
+        it('adds link to image when button is present with url (email, immersive)', testImageLink('email', 'immersive'));
+
+        function testSkippedImageLink(target, layout) {
+            return editorTest(function () {
+                exportOptions.target = target;
+                dataset.layout = layout;
+                dataset.showButton = false;
+                dataset.buttonUrl = 'http://blog.com/post1';
+
+                testRender(({html}) => {
+                    html.should.not.containEql('<a href="http://blog.com/post1"><img');
+                });
+            });
+        }
+
+        it('skips link to image when button is not shown (web)', testSkippedImageLink('web', 'minimal'));
+        it('skips link to image when button is not shown (email, minimal)', testSkippedImageLink('email', 'minimal'));
+        it('skips link to image when button is not shown (email, immersive)', testSkippedImageLink('email', 'immersive'));
     });
 
     describe('exportJSON', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-366

- wraps `<img>` in an `<a>` when button is displayed so the image is also linked, hopefully increasing click rate / avoiding clicks not doing the expected thing
