### PR TITLE
Prevented CI from cloning all repository git history

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,6 @@ jobs:
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
-        with:
-          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         env:


### PR DESCRIPTION
- we don't need to clone ALL git history to run this workflow, so we can save up to 35s per CI run by removing the infinite fetch depth