### PR TITLE
Reduced codemirror undo/redo test time by 20s

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/CodeBlockCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CodeBlockCard.jsx
@@ -6,10 +6,10 @@ import {CardCaptionEditor} from '../CardCaptionEditor';
 import {EditorView, keymap, lineNumbers} from '@codemirror/view';
 import {HighlightStyle, syntaxHighlighting} from '@codemirror/language';
 import {css} from '@codemirror/lang-css';
+import {history, standardKeymap} from '@codemirror/commands';
 import {html} from '@codemirror/lang-html';
 import {javascript} from '@codemirror/lang-javascript';
 import {minimalSetup} from '@uiw/codemirror-extensions-basic-setup';
-import {standardKeymap} from '@codemirror/commands';
 import {tags as t} from '@lezer/highlight';
 
 export function CodeEditor({code, language, updateCode, updateLanguage}) {
@@ -165,8 +165,12 @@ export function CodeEditor({code, language, updateCode, updateLanguage}) {
         syntaxHighlighting(editorHighlightStyle), // customizes syntax highlighting rules
         editorCSS, // customizes general editor appearance (does not include syntax highlighting)
         lineNumbers(), // adds line numbers to the gutter
-        minimalSetup({defaultKeymap: false}), // disable defaultKeymap to prevent Mod+Enter from inserting new line
-        keymap.of(standardKeymap) // add back in standardKeymap, which doesn't include Mod+Enter
+        minimalSetup({defaultKeymap: false, history: false}), // disable defaultKeymap to prevent Mod+Enter from inserting new line
+        keymap.of(standardKeymap), // add back in standardKeymap, which doesn't include Mod+Enter
+        // adds undo/redo functionality with custom behaviour to make tests faster
+        history({
+            joinToEvent: process.env.NODE_ENV === 'test' ? () => false : undefined
+        })
     ];
 
     // If provided language is supported, add the corresponding extension

--- a/packages/koenig-lexical/src/components/ui/cards/HtmlCard/HtmlEditor.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/HtmlCard/HtmlEditor.jsx
@@ -3,9 +3,9 @@ import React from 'react';
 import {EditorView, keymap, lineNumbers} from '@codemirror/view';
 import {HighlightStyle, syntaxHighlighting} from '@codemirror/language';
 import {closeBrackets, closeBracketsKeymap} from '@codemirror/autocomplete';
+import {history, standardKeymap} from '@codemirror/commands';
 import {html as langHtml} from '@codemirror/lang-html';
 import {minimalSetup} from '@uiw/codemirror-extensions-basic-setup';
-import {standardKeymap} from '@codemirror/commands';
 import {tags as t} from '@lezer/highlight';
 
 export default function HtmlEditor({darkMode, html, updateHtml}) {
@@ -140,11 +140,15 @@ export default function HtmlEditor({darkMode, html, updateHtml}) {
         syntaxHighlighting(editorHighlightStyle), // customizes syntax highlighting rules
         editorCSS,
         lineNumbers(), // adds line numbers to the gutter
-        minimalSetup({defaultKeymap: false}), // disable defaultKeymap to prevent Mod+Enter from inserting new line
+        minimalSetup({defaultKeymap: false, history: false}), // disable defaultKeymap to prevent Mod+Enter from inserting new line
         keymap.of(closeBracketsKeymap), // required for quote completion; needs to be listed before standardKeymap
         keymap.of(standardKeymap), // add back in standardKeymap, which doesn't include Mod+Enter
         langHtml(),
-        closeBrackets()
+        closeBrackets(),
+        // adds undo/redo functionality with custom behaviour to make tests faster
+        history({
+            joinToEvent: process.env.NODE_ENV === 'test' ? () => false : undefined
+        })
     ];
 
     return (

--- a/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
@@ -1,4 +1,4 @@
-import {assertHTML, focusEditor, html, initialize, isMac, test} from '../../utils/e2e';
+import {assertHTML, focusEditor, html, initialize, isMac, pasteText, test} from '../../utils/e2e';
 import {expect} from '@playwright/test';
 
 test.describe('Code Block card', async () => {
@@ -211,8 +211,7 @@ test.describe('Code Block card', async () => {
         await page.keyboard.type('```javascript ');
         await page.waitForSelector('[data-kg-card="codeblock"] .cm-editor');
 
-        // Types slower. Codemirror can be slow and needs some time to place the cursor after entering text.
-        await page.keyboard.type('Here are some words', {delay: 500});
+        await pasteText(page, 'Here are some words');
         await expect(page.getByText('Here are some words')).toBeVisible();
         await page.keyboard.press('Backspace');
         await expect(page.getByText('Here are some word')).toBeVisible();
@@ -259,7 +258,6 @@ test.describe('Code Block card', async () => {
         await page.keyboard.type('```javascript ');
         await page.waitForSelector('[data-kg-card="codeblock"] .cm-editor');
 
-        // Types slower. Codemirror can be slow and needs some time to place the cursor after entering text.
         await page.keyboard.type('Here are some words');
         await page.getByTestId('post-title').click();
         await page.keyboard.type('post title'); // click outside of the editor
@@ -282,7 +280,7 @@ test.describe('Code Block card', async () => {
         await page.keyboard.press('Enter');
         await page.waitForSelector('[data-kg-card="codeblock"] .cm-editor');
 
-        await page.keyboard.type('const test = true;', {delay: 80});
+        await page.keyboard.type('const test = true;');
 
         for (let i = 0; i < 8; i++) {
             await page.keyboard.press('ArrowLeft');
@@ -299,39 +297,11 @@ test.describe('Code Block card', async () => {
         await page.keyboard.press(`${ctrlOrCmd}+x`);
 
         await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card-editing="true" data-kg-card-selected="true" data-kg-card="codeblock">
-                    <div>
-                        <div>
-                            <div>
-                                <div aria-live="polite"></div>
-                                <div tabindex="-1">
-                                    <div aria-hidden="true">
-                                        <div>
-                                            <div>9</div>
-                                            <div>1</div>
-                                        </div>
-                                    </div>
-                                    <div spellcheck="false" autocorrect="off" autocapitalize="off" translate="no"
-                                        contenteditable="true" role="textbox" aria-multiline="true"
-                                        data-language="javascript">
-                                        <div>
-                                            <span>const</span>
-                                            = true;
-                                        </div>
-                                    </div>
-                                    <div aria-hidden="true">
-                                        <div></div>
-                                    </div>
-                                    <div aria-hidden="true"></div>
-                                </div>
-                            </div>
-                        </div>
-                        <input aria-label="Code card language" placeholder="Language..." type="text" value="javascript" />
-                    </div>
-                </div>
+            <div>
+                <span>const</span>
+                = true;
             </div>
-        `, {ignoreCardContents: false});
+        `, {selector: '.cm-content'});
 
         // NOTE: for some reason CodeMirror+Playwright don't work well together and cut/copied content
         // doesn't make it to the clipboard to enable testing that we can re-paste the cut content

--- a/packages/koenig-lexical/test/e2e/cards/html-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/html-card.test.js
@@ -105,7 +105,7 @@ test.describe('Html card', async () => {
         // waiting for html editor
         await expect(page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
         await page.locator('[data-kg-card="html"]').click();
-        await page.keyboard.type('text in html card', {delay: 100});
+        await page.keyboard.type('text in html card');
         await expect(page.getByText('text in html card')).toBeVisible();
         await page.keyboard.press('Escape');
 
@@ -130,8 +130,7 @@ test.describe('Html card', async () => {
         // waiting for html editor
         await expect(page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
 
-        // Types slower. Codemirror can be slow and needs some time to place the cursor after entering text.
-        await page.keyboard.type('Here are some words', {delay: 500});
+        await page.keyboard.type('Here are some words');
         await expect(page.getByText('Here are some words')).toBeVisible();
         await page.keyboard.press('Backspace');
         await expect(page.getByText('Here are some word')).toBeVisible();
@@ -151,7 +150,6 @@ test.describe('Html card', async () => {
         // waiting for html editor
         await expect(page.locator('.cm-content[contenteditable="true"]')).toBeVisible();
 
-        // Types slower. Codemirror can be slow and needs some time to place the cursor after entering text.
         await page.keyboard.type('Here are some words');
         await page.getByTestId('post-title').click();
         await page.keyboard.type('post title'); // click outside of the editor


### PR DESCRIPTION
no issue

- CodeMirror by default groups any history events together if they occur within 500ms which our undo/redo tests were trying to work around (with no prior knowledge of that behaviour) by going _really_ slowly
- adjusted our CodeMirror instances to not group any history events together when testing so we don't need to worry about delays
- adjusted the tests to remove any delays
