### PR TITLE
Disabled `man` reconfiguration for font installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
         run: |
           sudo apt-get update -yq
           sudo sh -c "echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections"
+          echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
+          sudo dpkg-reconfigure man-db
           sudo apt-get install msttcorefonts -qq
 
       - run: yarn --prefer-offline


### PR DESCRIPTION
refs https://github.com/actions/runner-images/issues/10977#issuecomment-2681219742

- this takes up to 1 minute in CI, but we don't even use man and can avoid this step completely