### PR TITLE
Fixed conversion of early visibility format

### DIFF
--- a/packages/kg-default-nodes/lib/generate-decorator-node.js
+++ b/packages/kg-default-nodes/lib/generate-decorator-node.js
@@ -1,6 +1,6 @@
 import {KoenigDecoratorNode} from './KoenigDecoratorNode';
 import readTextContent from './utils/read-text-content';
-import {ALL_MEMBERS_SEGMENT, buildDefaultVisibility, migrateOldVisibilityFormat, usesOldVisibilityFormat} from './utils/visibility';
+import {buildDefaultVisibility, isVisibilityRestricted, migrateOldVisibilityFormat} from './utils/visibility';
 /**
  * Validates the required arguments passed to `generateDecoratorNode`
 */
@@ -148,10 +148,7 @@ export function generateDecoratorNode({nodeType, properties = [], version = 1, h
             const data = {};
 
             // migrate older nodes that were saved with an earlier version of the visibility format
-            const visibility = serializedNode.visibility;
-            if (visibility && usesOldVisibilityFormat(visibility)) {
-                migrateOldVisibilityFormat(visibility);
-            }
+            serializedNode.visibility = migrateOldVisibilityFormat(serializedNode.visibility);
 
             properties.forEach((prop) => {
                 data[prop.name] = serializedNode[prop.name];
@@ -249,15 +246,7 @@ export function generateDecoratorNode({nodeType, properties = [], version = 1, h
             const self = this.getLatest();
             const visibility = self.__visibility;
 
-            if (usesOldVisibilityFormat(visibility)) {
-                return visibility.showOnEmail === false
-                    || visibility.showOnWeb === false
-                    || visibility.segment !== '';
-            } else {
-                return visibility.web.nonMember === false
-                    || visibility.web.memberSegment !== ALL_MEMBERS_SEGMENT
-                    || visibility.email.memberSegment !== ALL_MEMBERS_SEGMENT;
-            }
+            return isVisibilityRestricted(visibility);
         }
     }
 

--- a/packages/kg-default-nodes/lib/utils/visibility.js
+++ b/packages/kg-default-nodes/lib/utils/visibility.js
@@ -1,49 +1,124 @@
 import {renderEmptyContainer} from './render-empty-container';
 
 export const ALL_MEMBERS_SEGMENT = 'status:free,status:-free';
+export const PAID_MEMBERS_SEGMENT = 'status:-free'; // paid + comped
+export const FREE_MEMBERS_SEGMENT = 'status:free';
 export const NO_MEMBERS_SEGMENT = '';
 
 const DEFAULT_VISIBILITY = {
     web: {
         nonMember: true,
-        memberSegment: 'status:free,status:-free'
+        memberSegment: ALL_MEMBERS_SEGMENT
     },
     email: {
-        memberSegment: 'status:free,status:-free'
+        memberSegment: ALL_MEMBERS_SEGMENT
     }
 };
 
-// ensure we always work with a deep copy to avoid accidental constant mutations
+function isNullish(value) {
+    return value === null || value === undefined;
+}
+
+// ensure we always work with a deep copy to avoid accidental ref mutations
 export function buildDefaultVisibility() {
     return JSON.parse(JSON.stringify(DEFAULT_VISIBILITY));
 }
 
-export function usesOldVisibilityFormat(visibility) {
+export function isOldVisibilityFormat(visibility) {
     return !Object.prototype.hasOwnProperty.call(visibility, 'web')
         || !Object.prototype.hasOwnProperty.call(visibility, 'email')
-        || !Object.prototype.hasOwnProperty.call(visibility.web, 'nonMember');
+        || !Object.prototype.hasOwnProperty.call(visibility.web, 'nonMember')
+        || isNullish(visibility.web.memberSegment)
+        || isNullish(visibility.email.memberSegment);
 }
 
-export function migrateOldVisibilityFormat(visibility) {
-    visibility.web ??= {};
-    visibility.web.nonMember ??= visibility.showOnWeb;
-    visibility.web.memberSegment ??= visibility.showOnWeb ? ALL_MEMBERS_SEGMENT : NO_MEMBERS_SEGMENT;
-
-    visibility.email ??= {};
-    if (visibility.showOnEmail) {
-        visibility.email.memberSegment ??= visibility.segment ? visibility.segment : ALL_MEMBERS_SEGMENT;
+export function isVisibilityRestricted(visibility) {
+    if (isOldVisibilityFormat(visibility)) {
+        return visibility.showOnEmail === false
+            || visibility.showOnWeb === false
+            || visibility.emailOnly === true
+            || visibility.segment !== '';
     } else {
-        visibility.email.memberSegment = NO_MEMBERS_SEGMENT;
+        return visibility.web.nonMember === false
+            || visibility.web.memberSegment !== ALL_MEMBERS_SEGMENT
+            || visibility.email.memberSegment !== ALL_MEMBERS_SEGMENT;
     }
+}
+
+// old formats...
+//
+// "segment" only applies to email visibility
+// {emailOnly: true/false, segment: ''}
+// {showOnWeb: true/false, showOnEmail: true/false, segment: 'status:free,status:-free'}
+//
+// segment: '' = everyone
+// segment: 'status:free' = free members
+// segment: 'status:paid' = paid members (incorrect, misses comped)
+// segment: 'status:-free' = paid members (correct, includes comped)
+// segment: 'status:-free+status:-paid' = no-one (incorrect, misses comped)
+//
+// new format...
+//
+// {
+//     web: {
+//         nonMember: true/false,
+//         memberSegment: 'status:free,status:-free'
+//     },
+//     email: {
+//         memberSegment: 'status:free,status:-free'
+//     }
+// }
+//
+// memberSegment: '' = no-one
+// memberSegment: 'status:free,status:-free' = everyone
+// memberSegment: 'status:free' = free members
+// memberSegment: 'status:-free' = paid + comped members
+export function migrateOldVisibilityFormat(visibility) {
+    if (!visibility || !isOldVisibilityFormat(visibility)) {
+        return visibility;
+    }
+
+    // deep clone to avoid mutating the original object
+    const newVisibility = JSON.parse(JSON.stringify(visibility));
+
+    // ensure we have expected objects ready to populate
+    newVisibility.web ??= {};
+    newVisibility.email ??= {};
+
+    // convert web visibility, old formats only had on/off for web visibility rather than specific segments
+    if (isNullish(visibility.showOnWeb) && isNullish(visibility.emailOnly)) {
+        newVisibility.web = buildDefaultVisibility().web;
+    } else if (!isNullish(visibility.emailOnly)) {
+        newVisibility.web.nonMember = !visibility.emailOnly;
+        newVisibility.web.memberSegment = visibility.emailOnly ? NO_MEMBERS_SEGMENT : ALL_MEMBERS_SEGMENT;
+    } else {
+        newVisibility.web.nonMember = visibility.showOnWeb;
+        newVisibility.web.memberSegment = visibility.showOnWeb ? ALL_MEMBERS_SEGMENT : NO_MEMBERS_SEGMENT;
+    }
+
+    // convert email visibility, taking into account the old (and sometimes incorrect) segment formats
+    if (isNullish(visibility.showOnEmail) && isNullish(visibility.emailOnly)) {
+        newVisibility.email = buildDefaultVisibility().email;
+    } else if (visibility.showOnEmail === false) {
+        newVisibility.email.memberSegment = NO_MEMBERS_SEGMENT;
+    } else if (visibility.segment === 'status:-free+status:-paid') {
+        newVisibility.email.memberSegment = NO_MEMBERS_SEGMENT;
+    } else if (visibility.segment === 'status:free') {
+        newVisibility.email.memberSegment = FREE_MEMBERS_SEGMENT;
+    } else if (visibility.segment === 'status:paid' || visibility.segment === 'status:-free') {
+        newVisibility.email.memberSegment = PAID_MEMBERS_SEGMENT;
+    } else if (!visibility.segment) {
+        newVisibility.email.memberSegment = ALL_MEMBERS_SEGMENT;
+    }
+
+    return newVisibility;
 }
 
 export function renderWithVisibility(originalRenderOutput, visibility, options) {
     const document = originalRenderOutput.element.ownerDocument;
     const content = _getRenderContent(originalRenderOutput);
 
-    if (usesOldVisibilityFormat(visibility)) {
-        migrateOldVisibilityFormat(visibility);
-    }
+    visibility = migrateOldVisibilityFormat(visibility);
 
     if (options.target === 'email') {
         if (visibility.email.memberSegment === NO_MEMBERS_SEGMENT) {

--- a/packages/kg-default-nodes/package.json
+++ b/packages/kg-default-nodes/package.json
@@ -14,6 +14,7 @@
     "pretest": "yarn build",
     "test:unit": "NODE_ENV=testing c8 --all --check-coverage --reporter text --reporter cobertura mocha './test/**/*.test.js'",
     "test": "yarn test:unit",
+    "test:no-coverage": "yarn pretest && mocha './test/**/*.test.js'",
     "lint:code": "eslint *.js lib/ --ext .js --cache",
     "lint": "yarn lint:code && yarn lint:test",
     "lint:test": "eslint -c test/.eslintrc.js test/ --ext .js --cache"

--- a/packages/kg-default-nodes/test/utils/visibility.test.js
+++ b/packages/kg-default-nodes/test/utils/visibility.test.js
@@ -1,123 +1,197 @@
 const {JSDOM} = require('jsdom');
 const {utils} = require('../../');
-const {usesOldVisibilityFormat, migrateOldVisibilityFormat, renderWithVisibility, buildDefaultVisibility} = utils.visibility;
+const {isOldVisibilityFormat, isVisibilityRestricted, migrateOldVisibilityFormat, renderWithVisibility, buildDefaultVisibility} = utils.visibility;
 
 describe('Utils: visibility', function () {
-    describe('usesOldVisibilityFormat', function () {
+    describe('isOldVisibilityFormat', function () {
         it('returns true if visibility object does not have web property', function () {
             const visibility = {showOnWeb: true, email: {memberSegment: 'status:free,status:-free'}};
-            usesOldVisibilityFormat(visibility).should.be.true();
+            isOldVisibilityFormat(visibility).should.be.true();
+        });
+
+        it('returns true if visibility does not have web.nonMember property', function () {
+            const visibility = {web: {memberSegment: 'status:free,status:-free'}, email: {memberSegment: 'status:free,status:-free'}};
+            isOldVisibilityFormat(visibility).should.be.true();
         });
 
         it('returns true if visibility object does not have email property', function () {
             const visibility = {web: {nonMember: true, memberSegment: 'status:free,status:-free'}, showOnEmail: true};
-            usesOldVisibilityFormat(visibility).should.be.true();
+            isOldVisibilityFormat(visibility).should.be.true();
         });
 
-        it('returns true if web object is missing nonMember property', function () {
-            const visibility = {web: {memberSegment: 'status:free,status:-free'}, email: {memberSegment: 'status:free,status:-free'}};
-            usesOldVisibilityFormat(visibility).should.be.true();
+        it('returns true for incorrectly migrated old format', function () {
+            const visibility = {emailOnly: false, segment: '', web: {memberSegment: ''}, email: {memberSegment: ''}};
+            isOldVisibilityFormat(visibility).should.be.true();
+        });
+
+        it('returns false if visibility object has web, web.nonMember, and email properties', function () {
+            const visibility = {web: {nonMember: true, memberSegment: ''}, email: {memberSegment: ''}};
+            isOldVisibilityFormat(visibility).should.be.false();
+        });
+    });
+
+    describe('isVisibilityRestricted', function () {
+        it('returns false if old showOnWeb/showOnEmail visibility format is visible to all', function () {
+            const visibility = {showOnWeb: true, showOnEmail: true, segment: ''};
+            isVisibilityRestricted(visibility).should.be.false();
+        });
+
+        it('returns false if old emailOnly format is visible to all', function () {
+            const visibility = {emailOnly: false, segment: ''};
+            isVisibilityRestricted(visibility).should.be.false();
+        });
+
+        it('returns true if old visibility format has showOnEmail === false', function () {
+            const visibility = {showOnEmail: false};
+            isVisibilityRestricted(visibility).should.be.true();
+        });
+
+        it('returns true if old visibility format has showOnWeb === false', function () {
+            const visibility = {showOnWeb: false};
+            isVisibilityRestricted(visibility).should.be.true();
+        });
+
+        it('returns true if old visibility format has segment !== ""', function () {
+            const visibility = {segment: 'status:free'};
+            isVisibilityRestricted(visibility).should.be.true();
+        });
+
+        it('returns true if old visibility format has emailOnly === true', function () {
+            const visibility = {emailOnly: true, segment: ''};
+            isVisibilityRestricted(visibility).should.be.true();
+        });
+
+        it('returns true if new visibility format has web.nonMember === false', function () {
+            const visibility = {web: {nonMember: false, memberSegment: 'status:free,status:-free'}, email: {memberSegment: 'status:free,status:-free'}};
+            isVisibilityRestricted(visibility).should.be.true();
+        });
+
+        it('returns true if new visibility format has web.memberSegment !== ALL_MEMBERS_SEGMENT', function () {
+            const visibility = {web: {nonMember: true, memberSegment: 'status:free'}, email: {memberSegment: 'status:free,status:-free'}};
+            isVisibilityRestricted(visibility).should.be.true();
+        });
+
+        it('returns true if new visibility format has email.memberSegment !== ALL_MEMBERS_SEGMENT', function () {
+            const visibility = {web: {nonMember: true, memberSegment: 'status:free,status:-free'}, email: {memberSegment: 'status:free'}};
+            isVisibilityRestricted(visibility).should.be.true();
+        });
+
+        it('returns false if new visibility format is visible to all', function () {
+            const visibility = {web: {nonMember: true, memberSegment: 'status:free,status:-free'}, email: {memberSegment: 'status:free,status:-free'}};
+            isVisibilityRestricted(visibility).should.be.false();
         });
     });
 
     describe('migrateOldVisibilityFormat', function () {
-        it('creates new web property from showOnWeb:false', function () {
-            const visibility = {showOnWeb: false};
-            migrateOldVisibilityFormat(visibility);
-            visibility.web.should.eql({nonMember: false, memberSegment: ''});
+        it('returns visibility directly if it matches new format', function () {
+            // old format values do not match new, simulating newer data being set
+            // should return visibility as-is rather than converting anything
+            const before = {emailOnly: true, segment: '', web: {nonMember: true, memberSegment: 'status:free'}, email: {memberSegment: 'status:free'}};
+            const refCheck = JSON.parse(JSON.stringify(before));
+            const after = migrateOldVisibilityFormat(before);
+
+            // we get same reference back
+            Object.is(before, after).should.be.true();
+            // original reference is unchanged
+            before.should.deepEqual(refCheck);
         });
 
-        it('creates new web property from showOnWeb:true', function () {
-            const visibility = {showOnWeb: true};
-            migrateOldVisibilityFormat(visibility);
-            visibility.web.should.eql({nonMember: true, memberSegment: 'status:free,status:-free'});
+        it('keeps original properties when migrating to new format', function () {
+            const after = migrateOldVisibilityFormat({showOnWeb: false});
+            after.showOnWeb.should.be.false();
         });
 
-        it('creates new email property from showOnEmail: false', function () {
-            const visibility = {showOnEmail: false, segment: 'status:free'};
-            migrateOldVisibilityFormat(visibility);
-            visibility.email.should.eql({memberSegment: ''});
+        describe('web', function () {
+            function testWebMigration(before, after) {
+                return function () {
+                    const result = migrateOldVisibilityFormat(before);
+                    result.web.should.deepEqual(after);
+                };
+            }
+
+            it('uses default visibility when showOnWeb and emailOnly are not set', testWebMigration(
+                {},
+                buildDefaultVisibility().web
+            ));
+
+            it('handles {emailOnly: false} as visible to all', testWebMigration(
+                {emailOnly: false},
+                {nonMember: true, memberSegment: 'status:free,status:-free'}
+            ));
+
+            it('handles {emailOnly: true} as visible to none', testWebMigration(
+                {emailOnly: true},
+                {nonMember: false, memberSegment: ''}
+            ));
+
+            it('does not use "segment" for web segments with {emailOnly: false}', testWebMigration(
+                {emailOnly: false, segment: 'status:free'},
+                {nonMember: true, memberSegment: 'status:free,status:-free'}
+            ));
+
+            it('handles {showOnWeb: false} as visible to none', testWebMigration(
+                {showOnWeb: false},
+                {nonMember: false, memberSegment: ''}
+            ));
+
+            it('handles {showOnWeb: true} as visible to all', testWebMigration(
+                {showOnWeb: true},
+                {nonMember: true, memberSegment: 'status:free,status:-free'}
+            ));
+
+            it('does not use "segment" for web segments with {showOnWeb: true}', testWebMigration(
+                {showOnWeb: true, segment: 'status:free'},
+                {nonMember: true, memberSegment: 'status:free,status:-free'}
+            ));
         });
 
-        it('creates new email property from showOnEmail: true, segment:""', function () {
-            const visibility = {showOnEmail: true, segment: ''};
-            migrateOldVisibilityFormat(visibility);
-            visibility.email.should.eql({memberSegment: 'status:free,status:-free'});
-        });
+        describe('email', function () {
+            function testEmailMigration(before, after) {
+                return function () {
+                    const result = migrateOldVisibilityFormat(before);
+                    result.email.should.deepEqual(after);
+                };
+            }
 
-        it('creates new email property from showOnEmail: true, segment:"status:free"', function () {
-            const visibility = {showOnEmail: true, segment: 'status:free'};
-            migrateOldVisibilityFormat(visibility);
-            visibility.email.should.eql({memberSegment: 'status:free'});
-        });
+            it('uses default visibility if showOnEmail and emailOnly are not set', testEmailMigration(
+                {},
+                buildDefaultVisibility().email
+            ));
 
-        it('creates new format from {"emailOnly":false,"segment":""}', function () {
-            const visibility = {emailOnly: false, segment: ''};
-            migrateOldVisibilityFormat(visibility);
-            visibility.web.should.eql({nonMember: true, memberSegment: 'status:free,status:-free'});
-            visibility.email.should.eql({memberSegment: 'status:free,status:-free'});
-        });
+            it('handles {showOnEmail: false} as no visibility', testEmailMigration(
+                {showOnEmail: false},
+                {memberSegment: ''}
+            ));
 
-        // Segment tests
-        it('creates new email property from showOnEmail: true, segment:"status:paid"', function () {
-            const visibility = {showOnEmail: true, segment: 'status:paid'};
-            migrateOldVisibilityFormat(visibility);
-            visibility.email.should.eql({memberSegment: 'status:paid'});
-        });
+            it('handles {showOnEmail: false, segment: "status:free"} as no visibility', testEmailMigration(
+                {showOnEmail: false},
+                {memberSegment: ''}
+            ));
 
-        it('creates new email property from showOnEmail: true, segment:"status:-free+status:-paid"', function () {
-            const visibility = {showOnEmail: true, segment: 'status:-free+status:-paid'};
-            migrateOldVisibilityFormat(visibility);
-            visibility.email.should.eql({memberSegment: 'status:-free,status:-paid'});
-        });
+            it('handles {showOnEmail: true, segment: ""} as visible to all', testEmailMigration(
+                {showOnEmail: true},
+                {memberSegment: 'status:free,status:-free'}
+            ));
 
-        it('creates new format from {"emailOnly":true,"segment":"status:free"}', function () {
-            const visibility = {emailOnly: true, segment: 'status:free'};
-            migrateOldVisibilityFormat(visibility);
-            visibility.web.should.eql({nonMember: false, memberSegment: ''});
-            visibility.email.should.eql({memberSegment: 'status:free'});
-        });
+            it('handles {showOnEmail: true, segment: "status:free"} as visible to free', testEmailMigration(
+                {showOnEmail: true, segment: 'status:free'},
+                {memberSegment: 'status:free'}
+            ));
 
-        it('creates new format from {"emailOnly":true,"segment":"status:paid"}', function () {
-            const visibility = {emailOnly: true, segment: 'status:paid'};
-            migrateOldVisibilityFormat(visibility);
-            visibility.web.should.eql({nonMember: false, memberSegment: ''});
-            visibility.email.should.eql({memberSegment: 'status:paid'});
-        });
+            it('handles {showOnEmail: true, segment: "status:paid"} as visible to paid', testEmailMigration(
+                {showOnEmail: true, segment: 'status:paid'},
+                {memberSegment: 'status:-free'}
+            ));
 
-        it('creates new format from {"emailOnly":true,"segment":"status:-free+status:-paid"}', function () {
-            const visibility = {emailOnly: true, segment: 'status:-free+status:-paid'};
-            migrateOldVisibilityFormat(visibility);
-            visibility.web.should.eql({nonMember: false, memberSegment: ''});
-            visibility.email.should.eql({memberSegment: 'status:-free,status:-paid'});
-        });
+            it('handles {showOnEmail: true, segment: "status:-free+status:-paid"} as no visible', testEmailMigration(
+                {showOnEmail: true, segment: 'status:-free+status:-paid'},
+                {memberSegment: ''}
+            ));
 
-        it('creates new format from {"emailOnly":false,"segment":"status:free"}', function () {
-            const visibility = {emailOnly: false, segment: 'status:free'};
-            migrateOldVisibilityFormat(visibility);
-            visibility.web.should.eql({nonMember: true, memberSegment: 'status:free'});
-            visibility.email.should.eql({memberSegment: 'status:free'});
-        });
-
-        it('creates new format from {"emailOnly":false,"segment":"status:paid"}', function () {
-            const visibility = {emailOnly: false, segment: 'status:paid'};
-            migrateOldVisibilityFormat(visibility);
-            visibility.web.should.eql({nonMember: true, memberSegment: 'status:paid'});
-            visibility.email.should.eql({memberSegment: 'status:paid'});
-        });
-
-        it('creates new format from {"emailOnly":false,"segment":"status:-free+status:-paid"}', function () {
-            const visibility = {emailOnly: false, segment: 'status:-free+status:-paid'};
-            migrateOldVisibilityFormat(visibility);
-            visibility.web.should.eql({nonMember: true, memberSegment: 'status:-free,status:-paid'});
-            visibility.email.should.eql({memberSegment: 'status:-free,status:-paid'});
-        });
-
-        it('leaves existing properties alone', function () {
-            const visibility = {showOnWeb: true, segment: 'status:free'};
-            migrateOldVisibilityFormat(visibility);
-            visibility.showOnWeb.should.be.true();
-            visibility.segment.should.eql('status:free');
+            it('handles {emailOnly: false, segment: ""} as visible to all', testEmailMigration(
+                {emailOnly: false},
+                {memberSegment: 'status:free,status:-free'}
+            ));
         });
     });
 

--- a/packages/kg-default-nodes/test/utils/visibility.test.js
+++ b/packages/kg-default-nodes/test/utils/visibility.test.js
@@ -51,6 +51,20 @@ describe('Utils: visibility', function () {
             visibility.email.should.eql({memberSegment: 'status:free'});
         });
 
+        it('creates new format from {"emailOnly":false,"segment":""}', function () {
+            const visibility = {emailOnly: false, segment: ''};
+            migrateOldVisibilityFormat(visibility);
+            visibility.web.should.eql({nonMember: true, memberSegment: 'status:free,status:-free'});
+            visibility.email.should.eql({memberSegment: 'status:free,status:-free'});
+        });
+
+        it('creates new format from {"emailOnly":true,"segment":""}', function () {
+            const visibility = {emailOnly: false, segment: ''};
+            migrateOldVisibilityFormat(visibility);
+            visibility.web.should.eql({nonMember: false, memberSegment: ''});
+            visibility.email.should.eql({memberSegment: 'status:free,status:-free'});
+        });
+
         it('leaves existing properties alone', function () {
             const visibility = {showOnWeb: true, segment: 'status:free'};
             migrateOldVisibilityFormat(visibility);

--- a/packages/kg-default-nodes/test/utils/visibility.test.js
+++ b/packages/kg-default-nodes/test/utils/visibility.test.js
@@ -58,11 +58,59 @@ describe('Utils: visibility', function () {
             visibility.email.should.eql({memberSegment: 'status:free,status:-free'});
         });
 
-        it('creates new format from {"emailOnly":true,"segment":""}', function () {
-            const visibility = {emailOnly: false, segment: ''};
+        // Segment tests
+        it('creates new email property from showOnEmail: true, segment:"status:paid"', function () {
+            const visibility = {showOnEmail: true, segment: 'status:paid'};
+            migrateOldVisibilityFormat(visibility);
+            visibility.email.should.eql({memberSegment: 'status:paid'});
+        });
+
+        it('creates new email property from showOnEmail: true, segment:"status:-free+status:-paid"', function () {
+            const visibility = {showOnEmail: true, segment: 'status:-free+status:-paid'};
+            migrateOldVisibilityFormat(visibility);
+            visibility.email.should.eql({memberSegment: 'status:-free,status:-paid'});
+        });
+
+        it('creates new format from {"emailOnly":true,"segment":"status:free"}', function () {
+            const visibility = {emailOnly: true, segment: 'status:free'};
             migrateOldVisibilityFormat(visibility);
             visibility.web.should.eql({nonMember: false, memberSegment: ''});
-            visibility.email.should.eql({memberSegment: 'status:free,status:-free'});
+            visibility.email.should.eql({memberSegment: 'status:free'});
+        });
+
+        it('creates new format from {"emailOnly":true,"segment":"status:paid"}', function () {
+            const visibility = {emailOnly: true, segment: 'status:paid'};
+            migrateOldVisibilityFormat(visibility);
+            visibility.web.should.eql({nonMember: false, memberSegment: ''});
+            visibility.email.should.eql({memberSegment: 'status:paid'});
+        });
+
+        it('creates new format from {"emailOnly":true,"segment":"status:-free+status:-paid"}', function () {
+            const visibility = {emailOnly: true, segment: 'status:-free+status:-paid'};
+            migrateOldVisibilityFormat(visibility);
+            visibility.web.should.eql({nonMember: false, memberSegment: ''});
+            visibility.email.should.eql({memberSegment: 'status:-free,status:-paid'});
+        });
+
+        it('creates new format from {"emailOnly":false,"segment":"status:free"}', function () {
+            const visibility = {emailOnly: false, segment: 'status:free'};
+            migrateOldVisibilityFormat(visibility);
+            visibility.web.should.eql({nonMember: true, memberSegment: 'status:free'});
+            visibility.email.should.eql({memberSegment: 'status:free'});
+        });
+
+        it('creates new format from {"emailOnly":false,"segment":"status:paid"}', function () {
+            const visibility = {emailOnly: false, segment: 'status:paid'};
+            migrateOldVisibilityFormat(visibility);
+            visibility.web.should.eql({nonMember: true, memberSegment: 'status:paid'});
+            visibility.email.should.eql({memberSegment: 'status:paid'});
+        });
+
+        it('creates new format from {"emailOnly":false,"segment":"status:-free+status:-paid"}', function () {
+            const visibility = {emailOnly: false, segment: 'status:-free+status:-paid'};
+            migrateOldVisibilityFormat(visibility);
+            visibility.web.should.eql({nonMember: true, memberSegment: 'status:-free,status:-paid'});
+            visibility.email.should.eql({memberSegment: 'status:-free,status:-paid'});
         });
 
         it('leaves existing properties alone', function () {

--- a/packages/kg-lexical-html-renderer/test/cards.test.js
+++ b/packages/kg-lexical-html-renderer/test/cards.test.js
@@ -138,4 +138,25 @@ describe('Cards', function () {
 `;
         renderedInput.should.equal(expected);
     });
+
+    it('renders HTML card in email with old visibility format', async function () {
+        const htmlCard = {
+            type: 'html',
+            html: '<p>Should be visible in email</p>',
+            visibility: {emailOnly: false, segment: ''}
+        };
+        lexicalState.root.children.push(htmlCard);
+
+        options.target = 'email';
+        const renderer = new Renderer({nodes});
+        const renderedInput = await renderer.render(JSON.stringify(lexicalState), options);
+
+        const expected = `
+<!--kg-card-begin: html-->
+<p>Should be visible in email</p>
+<!--kg-card-end: html-->
+`;
+
+        renderedInput.should.equal(expected);
+    });
 });

--- a/packages/kg-lexical-html-renderer/test/cards.test.js
+++ b/packages/kg-lexical-html-renderer/test/cards.test.js
@@ -139,6 +139,10 @@ describe('Cards', function () {
         renderedInput.should.equal(expected);
     });
 
+    // https://linear.app/ghost/issue/ONC-801/
+    // we had an issue with HTML cards in content created during early alpha period
+    // where they would not be rendered in email due to incorrect migration of old
+    // visibility format
     it('renders HTML card in email with old visibility format', async function () {
         const htmlCard = {
             type: 'html',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-801/

Early iterations of convent visibility used a `visibility` format that our format conversion did not support. This could result in HTML cards created from these early iterations not rendering in emails.

- changed visibility util functions to always return new objects rather than modify by ref
- renamed `usesOldVisibilityFormat` to `isOldVisibilityFormat` to better represent fn intent
- updated `isOldVisibilityFormat` to handle missing `web/email.memberSegment` properties in case there have been previous incorrect migrations
- extracted "is visibility active" logic to new `isVisibilityRestricted` util function and expanded to cover all old formats
- updated `migrateOldVisibilityFormat` to handle the older `{emailOnly}` format and to correctly migrate the incorrect NQL filters used in older formats
- expanded tests to cover all old formats and NQL filters
- added test to `kg-lexical-html-renderer` to assert HTML card does now get rendered in email when using the old visibility format
- added `yarn test:no-coverage` to `kg-default-nodes` to get cleaner test output when desired during development