### PR TITLE
Improved CTA card rendering based on beta feedback

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -23,10 +23,12 @@ function ctaCardTemplate(dataset) {
         ? `style="color: ${dataset.buttonTextColor};"`
         : `style="background-color: ${dataset.buttonColor}; color: ${dataset.buttonTextColor};"`;
     return `
-        <div class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout}" data-layout="${dataset.layout}">
+        <div class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.imageUrl ? 'kg-cta-has-img' : ''}" data-layout="${dataset.layout}">
             ${dataset.hasSponsorLabel ? `
-                <div class="kg-cta-sponsor-label">
-                    ${dataset.sponsorLabel}
+                <div class="kg-cta-sponsor-label-wrapper">
+                    <div class="kg-cta-sponsor-label">
+                        ${dataset.sponsorLabel}
+                    </div>
                 </div>
             ` : ''}
             <div class="kg-cta-content">
@@ -175,7 +177,7 @@ function emailCTATemplate(dataset, options = {}) {
     };
 
     return `
-        <table class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.hasSponsorLabel ? '' : 'kg-cta-no-label'} ${dataset.textValue ? '' : 'kg-cta-no-text'}" border="0" cellpadding="0" cellspacing="0" width="100%">
+        <table class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.hasSponsorLabel ? '' : 'kg-cta-no-label'} ${dataset.textValue ? '' : 'kg-cta-no-text'} ${dataset.imageUrl ? 'kg-cta-has-img' : ''}" border="0" cellpadding="0" cellspacing="0" width="100%">
             ${dataset.hasSponsorLabel ? `
                 <tr>
                     <td>

--- a/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
@@ -269,10 +269,11 @@ export function CallToActionCard({
                 )}
 
                 <div className={clsx(
-                    'flex gap-6 pt-6',
+                    'flex gap-6',
+                    hasSponsorLabel && color !== 'none' && (imageSrc && layout === 'immersive') ? '' : 'pt-6',
                     imageSrc && !showButton ? 'pb-8' : 'pb-7',
                     layout === 'immersive' ? 'flex-col' : 'flex-row',
-                    color === 'none' || hasSponsorLabel ? 'border-t border-grey-900/15 dark:border-grey-100/20' : '',
+                    color === 'none' || (hasSponsorLabel && !(imageSrc && layout === 'immersive')) ? 'border-t border-grey-900/15 dark:border-grey-100/20' : '',
                     color === 'none' ? 'border-b border-grey-900/15 dark:border-grey-100/20' : 'mx-6'
                 )}>
                     {imageSrc && (
@@ -302,10 +303,7 @@ export function CallToActionCard({
                             nodes='basic'
                             placeholderClassName={`bg-transparent whitespace-normal font-serif text-xl !text-grey-500 !dark:text-grey-800 ` }
                             placeholderText="Write something worth clicking..."
-                            textClassName={clsx(
-                                'koenig-lexical-cta-text w-full whitespace-normal text-pretty bg-transparent font-serif text-xl text-grey-900 dark:text-grey-200',
-                                layout === 'immersive' ? 'text-center' : 'text-left'
-                            )}
+                            textClassName="koenig-lexical-cta-text w-full whitespace-normal text-pretty bg-transparent font-serif text-xl text-grey-900 dark:text-grey-200"
                         >
                             <ReplacementStringsPlugin />
                         </KoenigNestedEditor>

--- a/packages/koenig-lexical/test/e2e/cards/call-to-action-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/call-to-action-card.test.js
@@ -384,7 +384,6 @@ test.describe('Call To Action Card', async () => {
         // find data-cta-layout and check if it data-cta-layout="minimal"
         const firstChildSelector = '[data-kg-card="call-to-action"] > :first-child';
         await expect(page.locator(firstChildSelector)).toHaveAttribute('data-cta-layout', 'minimal');
-        expect(await page.getAttribute('[data-testid="cta-card-content-editor"]', 'class')).toContain('text-left');
     });
 
     test('can toggle layout to immersive', async function () {
@@ -394,7 +393,6 @@ test.describe('Call To Action Card', async () => {
         // find data-cta-layout and check if it data-cta-layout="immersive"
         const firstChildSelector = '[data-kg-card="call-to-action"] > :first-child';
         await expect(page.locator(firstChildSelector)).toHaveAttribute('data-cta-layout', 'immersive');
-        expect(await page.getAttribute('[data-testid="cta-card-content-editor"]', 'class')).toContain('text-center');
     });
 
     test('can toggle layout to immersive and then back to minimal', async function () {
@@ -404,12 +402,10 @@ test.describe('Call To Action Card', async () => {
         // find data-cta-layout and check if it data-cta-layout="immersive"
         const firstChildSelector = '[data-kg-card="call-to-action"] > :first-child';
         await expect(page.locator(firstChildSelector)).toHaveAttribute('data-cta-layout', 'immersive');
-        expect(await page.getAttribute('[data-testid="cta-card-content-editor"]', 'class')).toContain('text-center');
 
         await page.click('[data-testid="minimal-layout"]');
         // find data-cta-layout and check if it data-cta-layout="minimal"
         await expect(page.locator(firstChildSelector)).toHaveAttribute('data-cta-layout', 'minimal');
-        expect(await page.getAttribute('[data-testid="cta-card-content-editor"]', 'class')).toContain('text-left');
     });
 
     test('has image preview', async function () {


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PLG-372/process-beta-feedback
- Removed center alignment entirely
- Removed divider below sponsor label whenever a full-width image is present