### PR TITLE
Adjusted CTA card visibility indicator position

### DIFF
--- a/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/ui/CardWrapper.jsx
@@ -53,7 +53,8 @@ export const CardWrapper = React.forwardRef(({
 
     const position = {
         ...DEFAULT_INDICATOR_POSITION,
-        ...(indicatorPosition || {})
+        ...(indicatorPosition || {}),
+        ...(cardType === 'call-to-action' && {top: '1.4rem'})
     };
 
     let indicatorIcon;


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PLG-331/update-other-cards-with-visibility-indicator
- Aligned the indicator with the sponsor label, as this is most frequently turned on.