### PR TITLE
Wired up upload progress bar to CTA Card

### DIFF
--- a/packages/koenig-lexical/src/components/ui/MediaUploader.jsx
+++ b/packages/koenig-lexical/src/components/ui/MediaUploader.jsx
@@ -76,11 +76,11 @@ export function MediaUploader({
     }
 
     return (
-        <div className={clsx('group/image relative flex items-center justify-center', borderStyle === 'dashed' && 'rounded', className)} data-testid="media-upload-filled">
+        <div className={clsx('group/image relative flex items-center justify-center', borderStyle === 'rounded' && 'rounded', className)} data-testid="media-upload-filled">
             {src && (
                 <>
-                    <img alt={alt} className={clsx('mx-auto h-full w-auto rounded-lg', backgroundSize === 'cover' ? 'object-cover' : 'object-contain', imgClassName)} src={src} />
-                    <div className={clsx('absolute inset-0 rounded-lg bg-gradient-to-t from-black/0 via-black/5 to-black/30 opacity-0 transition-all group-hover/image:opacity-100', borderStyle === 'dashed' && 'rounded-lg')}></div>
+                    <img alt={alt} className={clsx('mx-auto h-full w-auto', borderStyle === 'rounded' && 'rounded-lg', backgroundSize === 'cover' ? 'object-cover' : 'object-contain', imgClassName)} src={src} />
+                    <div className={clsx('absolute inset-0 bg-gradient-to-t from-black/0 via-black/5 to-black/30 opacity-0 transition-all group-hover/image:opacity-100', borderStyle === 'rounded' && 'rounded-lg')}></div>
                 </>
             )}
 

--- a/packages/koenig-lexical/src/components/ui/MediaUploaderBeta.jsx
+++ b/packages/koenig-lexical/src/components/ui/MediaUploaderBeta.jsx
@@ -78,11 +78,16 @@ export function MediaUploaderBeta({
     }
 
     return (
-        <div className={clsx('group/image relative flex items-center justify-center', borderStyle === 'rounded' && 'rounded', className)} data-testid="media-upload-filled">
+        <div className={clsx(
+            'group/image relative flex items-center justify-center', 
+            isLoading ? 'min-w-[6.8rem]' : 'min-w-[5.2rem]',
+            borderStyle === 'rounded' && 'rounded', 
+            className
+        )} data-testid="media-upload-filled">
             {src && (
                 <>
-                    <img alt={alt} className={clsx('mx-auto h-full w-auto rounded-lg', backgroundSize === 'cover' ? 'object-cover' : 'object-contain', imgClassName)} src={src} />
-                    <div className={clsx('absolute inset-0 rounded-lg bg-gradient-to-t from-black/0 via-black/5 to-black/30 opacity-0 transition-all group-hover/image:opacity-100', borderStyle === 'rounded' && 'rounded-lg')}></div>
+                    <img alt={alt} className={clsx('mx-auto h-full w-auto min-w-[5.2rem]', borderStyle === 'rounded' && 'rounded-lg', backgroundSize === 'cover' ? 'object-cover' : 'object-contain', imgClassName)} src={src} />
+                    <div className={clsx('absolute inset-0 bg-gradient-to-t from-black/0 via-black/5 to-black/30 opacity-0 transition-all group-hover/image:opacity-100', borderStyle === 'rounded' && 'rounded-lg')}></div>
                 </>
             )}
 
@@ -105,7 +110,7 @@ export function MediaUploaderBeta({
 
             {isLoading && (
                 <div
-                    className={clsx('absolute inset-0 flex min-w-full items-center justify-center overflow-hidden border border-grey-100 bg-grey-75', borderStyle === 'rounded' && 'rounded-lg')}
+                    className={clsx('absolute inset-0 flex min-w-full items-center justify-center overflow-hidden bg-grey-100', borderStyle === 'rounded' && 'rounded-lg')}
                     data-testid="custom-thumbnail-progress"
                 >
                     <ProgressBar style={progressStyle} />

--- a/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
+++ b/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
@@ -360,6 +360,7 @@ export function MediaUploadSetting({className, label, hideLabel, onFileChange, i
                 dragHandler={{isDraggedOver, setRef: placeholderRef}}
                 errors={errors}
                 icon={icon}
+                imgClassName={clsx(stacked && 'w-full')}
                 isLoading={isLoading}
                 isPinturaEnabled={isPinturaEnabled}
                 mimeTypes={mimeTypes}

--- a/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
@@ -106,9 +106,12 @@ export function CallToActionCard({
     updateLayout = () => {},
     updateShowButton = () => {},
     toggleVisibility = () => {},
-    imageDragHandler = {}
+    imageDragHandler = {},
+    imageUploader = () => {}
 }) {
     const [buttonColorPickerExpanded, setButtonColorPickerExpanded] = useState(false);
+
+    const {isLoading, progress} = imageUploader || {};
 
     const tabs = [
         {id: 'design', label: 'Design'},
@@ -168,10 +171,11 @@ export function CallToActionCard({
                 desc='Upload'
                 icon='file'
                 isDraggedOver={imageDragHandler.isDraggedOver}
-                isLoading={imageDragHandler.isLoading}
+                isLoading={isLoading}
                 label='Image'
                 mimeTypes={['image/*']}
                 placeholderRef={imageDragHandler.setRef}
+                progress={progress}
                 setFileInputRef={setFileInputRef}
                 src={imageSrc}
                 type='button'
@@ -378,5 +382,6 @@ CallToActionCard.propTypes = {
     visibilityOptions: PropTypes.array,
     toggleVisibility: PropTypes.func,
     imageUploadHandler: PropTypes.func,
-    imageDragHandler: PropTypes.object
+    imageDragHandler: PropTypes.object,
+    imageUploader: PropTypes.func
 };

--- a/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
@@ -383,5 +383,5 @@ CallToActionCard.propTypes = {
     toggleVisibility: PropTypes.func,
     imageUploadHandler: PropTypes.func,
     imageDragHandler: PropTypes.object,
-    imageUploader: PropTypes.func
+    imageUploader: PropTypes.object
 };

--- a/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/SignupCard.jsx
@@ -225,6 +225,7 @@ export function SignupCard({alignment,
                             </>}
                             alt='Background image'
                             backgroundSize={backgroundSize}
+                            borderStyle='squared'
                             className={clsx(
                                 'sm:w-1/2',
                                 (correctedBackgroundSize === 'contain') && 'sm:my-10 md:my-14',

--- a/packages/koenig-lexical/test/e2e/cards/call-to-action-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/call-to-action-card.test.js
@@ -372,6 +372,14 @@ test.describe('Call To Action Card', async () => {
         await fileChooser.setFiles([filePath]);
         const progressBar = page.locator('[data-testid="progress-bar"]');
         await expect(progressBar).toBeVisible();
+
+        const imgLocator = page.locator('[data-kg-card="call-to-action"] img[src^="blob:"]');
+        const imgElement = await imgLocator.first();
+        await expect(imgElement).toHaveAttribute('src', /blob:/);
+
+        // check for progress bar to disappear
+
+        await expect(progressBar).not.toBeVisible();
     });
 
     test('can drag and drop image over upload button', async function () {

--- a/packages/koenig-lexical/test/e2e/cards/call-to-action-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/call-to-action-card.test.js
@@ -361,6 +361,19 @@ test.describe('Call To Action Card', async () => {
         await expect(imgLocator).not.toBeVisible();
     });
 
+    test('has a progress bar while uploading', async function () {
+        const filePath = path.relative(process.cwd(), __dirname + `/../fixtures/large-image.jpeg`);
+    
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        const fileChooserPromise = page.waitForEvent('filechooser');
+        await page.click('[data-testid="media-upload-placeholder"]');
+        const fileChooser = await fileChooserPromise;
+        await fileChooser.setFiles([filePath]);
+        const progressBar = page.locator('[data-testid="progress-bar"]');
+        await expect(progressBar).toBeVisible();
+    });
+
     test('can drag and drop image over upload button', async function () {
         const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.png');
         await focusEditor(page);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-367/image-upload-is-missing-progress-indicator


- Wired up progress bar to `MediaUploaderBeta`, displaying upload progress with dynamic min-width adjustments for loading states
- Updated `CallToActionCard` to integrate `imageUploader` with `isLoading` and `progress` props
- Adjusted `MediaUploader.jsx` styles for consistency (borderStyle 'rounded' logic)
- Enhanced e2e tests in `call-to-action-card.test.js` to verify progress bar visibility during upload and disappearance on completion
- Minor tweaks to `SettingsPanel.jsx` and `SignupCard.jsx` for prop alignment