### PR TITLE
Strip `<p>` tags from sponsorLabel in CallToActionNode renderer

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -2,6 +2,7 @@ import {addCreateDocumentOption} from '../../utils/add-create-document-option';
 import {renderWithVisibility} from '../../utils/visibility';
 import {getResizedImageDimensions} from '../../utils/get-resized-image-dimensions';
 import {isLocalContentImage} from '../../utils/is-local-content-image';
+import {buildCleanBasicHtmlForElement} from '../../utils/build-clean-basic-html-for-element';
 
 const showButton = dataset => dataset.showButton && dataset.buttonUrl && dataset.buttonText;
 
@@ -22,6 +23,7 @@ function ctaCardTemplate(dataset) {
     const buttonStyle = dataset.buttonColor === 'accent'
         ? `style="color: ${dataset.buttonTextColor};"`
         : `style="background-color: ${dataset.buttonColor}; color: ${dataset.buttonTextColor};"`;
+
     return `
         <div class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.imageUrl ? 'kg-cta-has-img' : ''}" data-layout="${dataset.layout}">
             ${dataset.hasSponsorLabel ? `
@@ -230,8 +232,15 @@ export function renderCallToActionNode(node, options = {}) {
         return renderWithVisibility({element: emailDiv.firstElementChild}, node.visibility, options);
     }
 
-    const htmlString = ctaCardTemplate(dataset);
     const element = document.createElement('div');
+
+    if (dataset.hasSponsorLabel) {
+        const cleanBasicHtml = buildCleanBasicHtmlForElement(element);
+        const cleanedHtml = cleanBasicHtml(dataset.sponsorLabel, {firstChildInnerContent: true});
+        dataset.sponsorLabel = cleanedHtml;
+    }
+    const htmlString = ctaCardTemplate(dataset);
+
     element.innerHTML = htmlString?.trim();
 
     return renderWithVisibility({element: element.firstElementChild}, node.visibility, options);

--- a/packages/kg-default-nodes/lib/utils/build-clean-basic-html-for-element.js
+++ b/packages/kg-default-nodes/lib/utils/build-clean-basic-html-for-element.js
@@ -1,13 +1,14 @@
 import cleanBasicHtml from '@tryghost/kg-clean-basic-html';
 
 export function buildCleanBasicHtmlForElement(domNode) {
-    return function _cleanBasicHtml(html) {
+    return function _cleanBasicHtml(html, additionalOptions = {}) {
         const cleanedHtml = cleanBasicHtml(html, {
             createDocument: (_html) => {
                 const newDoc = domNode.ownerDocument.implementation.createHTMLDocument();
                 newDoc.body.innerHTML = _html;
                 return newDoc;
-            }
+            },
+            ...additionalOptions
         });
         return cleanedHtml;
     };

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -381,6 +381,15 @@ describe('CallToActionNode', function () {
             });
         }));
 
+        it('removes <p> first child tag from sponsorLabel', editorTest(function () {
+            testRender(({element}) => {
+                const sponsorLabel = element.querySelector('.kg-cta-sponsor-label');
+                sponsorLabel.should.exist;
+                sponsorLabel.firstElementChild.tagName.should.equal('SPAN');
+                sponsorLabel.firstElementChild.outerHTML.should.equal('<span style="white-space: pre-wrap;">SPONSORED</span>');
+            });
+        }));
+
         function testButtonSkipOnMissingData(target, layout, {missing = []} = {}) {
             return editorTest(function () {
                 dataset.layout = layout;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-370/fix-sponsor-label-rendering-on-web

- Modified `renderCallToActionNode` in `calltoaction-renderer.js` to clean `dataset.sponsorLabel` using `buildCleanBasicHtmlForElement` with `firstChildInnerContent: true`, ensuring `<p>` tags are removed before rendering.
- Updated `buildCleanBasicHtmlForElement.js` to accept `additionalOptions`, merging them with the default `createDocument` option to support `firstChildInnerContent` and maintain flexibility.
- Added test in `call-to-action.test.js` to verify `.kg-cta-sponsor-label` has `<span>` as its first child without `<p>` tags, ensuring correct rendering behavior.

Fixes sponsor label rendering issue where `<p>` tags persisted in output.