### PR TITLE
Added setting for link color to CTA card

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
@@ -16,6 +16,7 @@ export class CallToActionNode extends generateDecoratorNode({
         {name: 'hasSponsorLabel', default: true},
         {name: 'sponsorLabel', default: '<p><span style="white-space: pre-wrap;">SPONSORED</span></p>'},
         {name: 'backgroundColor', default: 'grey'}, // Since this is one of a few fixed options, we stick to colour names.
+        {name: 'linkColor', default: 'text'},
         {name: 'imageUrl', default: ''},
         {name: 'imageWidth', default: null},
         {name: 'imageHeight', default: null}

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -23,7 +23,7 @@ function ctaCardTemplate(dataset) {
         ? `style="color: ${dataset.buttonTextColor};"`
         : `style="background-color: ${dataset.buttonColor}; color: ${dataset.buttonTextColor};"`;
     return `
-        <div class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.imageUrl ? 'kg-cta-has-img' : ''}" data-layout="${dataset.layout}">
+        <div class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''}" data-layout="${dataset.layout}">
             ${dataset.hasSponsorLabel ? `
                 <div class="kg-cta-sponsor-label-wrapper">
                     <div class="kg-cta-sponsor-label">
@@ -177,7 +177,7 @@ function emailCTATemplate(dataset, options = {}) {
     };
 
     return `
-        <table class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.hasSponsorLabel ? '' : 'kg-cta-no-label'} ${dataset.textValue ? '' : 'kg-cta-no-text'} ${dataset.imageUrl ? 'kg-cta-has-img' : ''}" border="0" cellpadding="0" cellspacing="0" width="100%">
+        <table class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.hasSponsorLabel ? '' : 'kg-cta-no-label'} ${dataset.textValue ? '' : 'kg-cta-no-text'} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''}" border="0" cellpadding="0" cellspacing="0" width="100%">
             ${dataset.hasSponsorLabel ? `
                 <tr>
                     <td>
@@ -212,7 +212,8 @@ export function renderCallToActionNode(node, options = {}) {
         sponsorLabel: node.sponsorLabel,
         imageUrl: node.imageUrl,
         imageWidth: node.imageWidth,
-        imageHeight: node.imageHeight
+        imageHeight: node.imageHeight,
+        linkColor: node.linkColor
     };
 
     // Add validation for backgroundColor

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -489,6 +489,7 @@ describe('CallToActionNode', function () {
                 layout: 'minimal',
                 showButton: true,
                 textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card.</span></p>',
+                linkColor: 'text',
                 visibility: {
                     web: {
                         nonMember: true,

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -38,7 +38,8 @@ describe('CallToActionNode', function () {
             backgroundColor: 'none',
             imageUrl: 'http://blog.com/image1.jpg',
             imageWidth: 200,
-            imageHeight: 100
+            imageHeight: 100,
+            linkColor: 'text'
         };
         exportOptions = {
             exportFormat: 'html',
@@ -69,6 +70,7 @@ describe('CallToActionNode', function () {
             callToActionNode.visibility.should.deepEqual(utils.visibility.buildDefaultVisibility());
             callToActionNode.imageHeight.should.equal(dataset.imageHeight);
             callToActionNode.imageWidth.should.equal(dataset.imageWidth);
+            callToActionNode.linkColor.should.equal(dataset.linkColor);
         }));
 
         it('has setters for all properties', editorTest(function () {
@@ -144,6 +146,10 @@ describe('CallToActionNode', function () {
                     memberSegment: ''
                 }
             });
+
+            callToActionNode.linkColor.should.equal('text');
+            callToActionNode.linkColor = 'accent';
+            callToActionNode.linkColor.should.equal('accent');
         }));
 
         it('has getDataset() convenience method', editorTest(function () {

--- a/packages/koenig-lexical/src/components/ui/ButtonGroupBeta.jsx
+++ b/packages/koenig-lexical/src/components/ui/ButtonGroupBeta.jsx
@@ -7,7 +7,7 @@ import {usePreviousFocus} from '../../hooks/usePreviousFocus';
 export function ButtonGroupBeta({buttons = [], selectedName, onClick, hasTooltip = true}) {
     return (
         <div className="flex">
-            <ul className="flex items-center justify-evenly rounded-lg bg-grey-100 font-sans text-md font-normal text-white" role="menubar">
+            <ul className="flex items-center justify-evenly rounded-lg bg-grey-100 font-sans text-md font-normal text-white dark:bg-grey-900" role="menubar">
                 {buttons.map(({label, name, Icon, dataTestId, ariaLabel}) => (
                     <ButtonGroupIconButton
                         key={`${name}-${label}`}
@@ -36,7 +36,7 @@ export function ButtonGroupIconButton({dataTestId, onClick, label, ariaLabel, na
             <button
                 aria-checked={isActive}
                 aria-label={ariaLabel || label}
-                className={`group relative flex h-7 w-8 cursor-pointer items-center justify-center rounded-lg text-black dark:text-white dark:hover:bg-grey-900 ${isActive ? 'border border-grey-300 bg-white shadow-xs dark:bg-grey-900' : '' } ${Icon ? '' : 'text-[1.3rem] font-bold'}`}
+                className={`group relative flex h-7 w-8 cursor-pointer items-center justify-center rounded-lg text-black dark:text-white ${isActive ? 'border border-grey-300 bg-white shadow-xs dark:border-grey-800 dark:bg-grey-950' : '' } ${Icon ? '' : 'text-[1.3rem] font-bold'}`}
                 data-testid={dataTestId}
                 role="menuitemradio"
                 type="button"

--- a/packages/koenig-lexical/src/components/ui/ColorOptionButtonsBeta.jsx
+++ b/packages/koenig-lexical/src/components/ui/ColorOptionButtonsBeta.jsx
@@ -31,13 +31,13 @@ export function ColorOptionButtonsBeta({buttons = [], selectedName, onClick}) {
                     }} />
                 )}
                 <span
-                    className={`${selectedButton?.color || ''} block size-full rounded-full border-2 border-white`}
+                    className={`${selectedButton?.color || ''} block size-full rounded-full border-2 border-white dark:border-grey-950`}
                 ></span>
             </button>
 
             {/* Color options popover */}
             {isOpen && (
-                <div className="absolute -right-3 bottom-full z-10 mb-2 rounded-lg bg-white px-3 py-2 shadow" data-testid="color-options-popover">
+                <div className="absolute -right-3 bottom-full z-10 mb-2 rounded-lg bg-white px-3 py-2 shadow dark:bg-grey-900" data-testid="color-options-popover">
                     <div className="flex">
                         <ul className="flex w-full items-center justify-between rounded-md font-sans text-md font-normal text-white">
                             {buttons.map(({label, name, color}) => (

--- a/packages/koenig-lexical/src/components/ui/ColorPickerBeta.jsx
+++ b/packages/koenig-lexical/src/components/ui/ColorPickerBeta.jsx
@@ -202,7 +202,7 @@ export function ColorIndicatorBeta({value, swatches, onSwatchChange, onTogglePic
                     }} />
                 )}
                 <span
-                    className="block size-full rounded-full border-2 border-white"
+                    className="block size-full rounded-full border-2 border-white dark:border-grey-950"
                     style={{backgroundColor}}
                 >
                     {
@@ -218,7 +218,7 @@ export function ColorIndicatorBeta({value, swatches, onSwatchChange, onTogglePic
                 <div
                     ref={popoverRef}
                     className={clsx(
-                        'absolute -right-3 bottom-full z-10 mb-2 flex flex-col gap-3 rounded-lg bg-white p-3 shadow transition-[width] duration-200 ease-in-out dark:bg-grey-950',
+                        'absolute -right-3 bottom-full z-10 mb-2 flex flex-col gap-3 rounded-lg bg-white p-3 shadow transition-[width] duration-200 ease-in-out dark:bg-grey-900',
                         (showColorPicker || showChildren) && 'min-w-[296px]'
                     )}
                     onClick={stopPropagation}
@@ -271,7 +271,7 @@ export function ColorIndicatorBeta({value, swatches, onSwatchChange, onTogglePic
                                         maskComposite: 'exclude'
                                     }} />
                                     <span
-                                        className="block size-full rounded-full border-2 border-white"
+                                        className="block size-full rounded-full border-2 border-white dark:border-grey-950"
                                         style={{backgroundColor: value}}
                                     >
                                         {value === 'transparent' && <div className="absolute left-[3px] top-[3px] z-10 w-[136%] origin-left rotate-45 border-b border-b-red" />}

--- a/packages/koenig-lexical/src/components/ui/TabView.jsx
+++ b/packages/koenig-lexical/src/components/ui/TabView.jsx
@@ -10,7 +10,7 @@ const TabView = ({tabs, defaultTab, tabContent}) => {
 
     return (
         <>
-            <div className={`no-scrollbar flex gap-5 border-b border-grey-300 dark:border-grey-900 ${tabs.length > 1 ? 'w-full px-6' : 'mx-6'}`}>
+            <div className={`no-scrollbar flex gap-3 border-b border-grey-300 dark:border-grey-900 ${tabs.length > 1 ? 'w-full px-6' : 'mx-6'}`}>
                 {tabs.map(tab => (
                     <button
                         key={tab.id}

--- a/packages/koenig-lexical/src/components/ui/TabView.jsx
+++ b/packages/koenig-lexical/src/components/ui/TabView.jsx
@@ -19,7 +19,7 @@ const TabView = ({tabs, defaultTab, tabContent}) => {
                         } ${
                             activeTab === tab.id
                                 ? 'border-black text-black dark:border-white dark:text-white'
-                                : 'border-transparent text-grey-600 hover:border-grey-500 dark:text-white'
+                                : 'border-transparent text-grey-600 hover:border-grey-500 dark:text-grey-500 dark:hover:border-grey-500'
                         }`}
                         data-testid={`tab-${tab.id}`}
                         type="button"

--- a/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
@@ -26,10 +26,10 @@ export const CALLTOACTION_COLORS = {
     purple: 'bg-purple/10 border-transparent'
 };
 
-const sponsoredLabelTheme = {
+const getTheme = linkColor => ({
     ...defaultTheme,
-    link: 'text-accent'
-};
+    link: linkColor === 'accent' ? 'text-accent' : 'text-black dark:text-white'
+});
 
 export const callToActionColorPicker = [
     {
@@ -79,6 +79,19 @@ export const callToActionColorPicker = [
     }
 ];
 
+export const callToActionLinkColorPicker = [
+    {
+        label: 'Text',
+        name: 'text',
+        color: 'bg-black border-black'
+    },
+    {
+        label: 'Accent',
+        name: 'accent',
+        color: 'bg-accent border-accent'
+    }
+];
+
 export function CallToActionCard({
     buttonColor = '',
     buttonText = '',
@@ -97,6 +110,7 @@ export function CallToActionCard({
     visibilityOptions = {},
     handleButtonColor = () => {},
     handleColorChange = () => {},
+    handleLinkColorChange = () => {},
     onFileChange = () => {},
     onRemoveMedia = () => {},
     setFileInputRef = () => {},
@@ -106,11 +120,13 @@ export function CallToActionCard({
     updateLayout = () => {},
     updateShowButton = () => {},
     toggleVisibility = () => {},
-    imageDragHandler = {}
+    imageDragHandler = {},
+    linkColor = 'text'
 }) {
     const [buttonColorPickerExpanded, setButtonColorPickerExpanded] = useState(false);
 
     const tabs = [
+        {id: 'content', label: 'Content'},
         {id: 'design', label: 'Design'},
         {id: 'visibility', label: 'Visibility'}
     ];
@@ -136,24 +152,10 @@ export function CallToActionCard({
         return bgColor === 'transparent' ? '' : textColorForBackgroundColor(bgColor === 'accent' ? getAccentColor() : bgColor).hex();
     };
 
-    const designSettings = (
+    const theme = getTheme(linkColor);
+
+    const contentSettings = (
         <>
-            {/* Layout settings */}
-            <ButtonGroupSettingBeta
-                buttons={layoutOptions}
-                hasTooltip={false}
-                label='Layout'
-                selectedName={layout}
-                onClick={updateLayout}
-            />
-            {/* Color picker */}
-            <ColorOptionSettingBeta
-                buttons={callToActionColorPicker}
-                dataTestId='cta-background-color-picker'
-                label='Background'
-                selectedName={color}
-                onClick={handleColorChange}
-            />
             {/* Sponsor label setting */}
             <ToggleSetting
                 dataTestId="sponsor-label-toggle"
@@ -188,26 +190,6 @@ export function CallToActionCard({
             />
             {showButton && (
                 <>
-                    <ColorPickerSettingBeta
-                        dataTestId='cta-button-color'
-                        eyedropper={true}
-                        isExpanded={buttonColorPickerExpanded}
-                        label='Button Color'
-                        swatches={[
-                            {title: 'Black', hex: '#000000'},
-                            {title: 'Grey', hex: '#F0F0F0'},
-                            {title: 'Brand color', accent: true}
-                        ]}
-                        value={buttonColor}
-                        onPickerChange={bgColor => handleButtonColor(bgColor, matchingTextColor(bgColor))}
-                        onSwatchChange={(bgColor) => {
-                            handleButtonColor(bgColor, matchingTextColor(bgColor));
-                            setButtonColorPickerExpanded(false);
-                        }}
-                        onTogglePicker={(isExpanded) => {
-                            setButtonColorPickerExpanded(isExpanded);
-                        }}
-                    />
                     <InputSetting
                         dataTestId="button-text"
                         label='Button text'
@@ -222,6 +204,57 @@ export function CallToActionCard({
                         onChange={updateButtonUrl}
                     />
                 </>
+            )}
+        </>
+    );
+
+    const designSettings = (
+        <>
+            {/* Layout settings */}
+            <ButtonGroupSettingBeta
+                buttons={layoutOptions}
+                hasTooltip={false}
+                label='Layout'
+                selectedName={layout}
+                onClick={updateLayout}
+            />
+            {/* Color picker */}
+            <ColorOptionSettingBeta
+                buttons={callToActionColorPicker}
+                dataTestId='cta-background-color-picker'
+                label='Background'
+                selectedName={color}
+                onClick={handleColorChange}
+            />
+            {/* Link color setting */}
+            <ColorOptionSettingBeta
+                buttons={callToActionLinkColorPicker}
+                dataTestId='cta-link-color-picker'
+                label='Link color'
+                selectedName={linkColor}
+                onClick={handleLinkColorChange}
+            />
+            {showButton && (
+                <ColorPickerSettingBeta
+                    dataTestId='cta-button-color'
+                    eyedropper={true}
+                    isExpanded={buttonColorPickerExpanded}
+                    label='Button Color'
+                    swatches={[
+                        {title: 'Black', hex: '#000000'},
+                        {title: 'Grey', hex: '#F0F0F0'},
+                        {title: 'Brand color', accent: true}
+                    ]}
+                    value={buttonColor}
+                    onPickerChange={bgColor => handleButtonColor(bgColor, matchingTextColor(bgColor))}
+                    onSwatchChange={(bgColor) => {
+                        handleButtonColor(bgColor, matchingTextColor(bgColor));
+                        setButtonColorPickerExpanded(false);
+                    }}
+                    onTogglePicker={(isExpanded) => {
+                        setButtonColorPickerExpanded(isExpanded);
+                    }}
+                />
             )}
         </>
     );
@@ -256,7 +289,7 @@ export function CallToActionCard({
                             hasSettingsPanel={true}
                             initialEditor={sponsorLabelHtmlEditor}
                             initialEditorState={sponsorLabelHtmlEditorInitialState}
-                            initialTheme={sponsoredLabelTheme}
+                            initialTheme={theme}
                             nodes='basic'
                             textClassName={clsx(
                                 'koenig-lexical-cta-label not-kg-prose w-full whitespace-normal font-sans !text-xs font-semibold uppercase leading-8 tracking-normal text-grey-900/50 dark:text-grey-200/40'
@@ -300,8 +333,9 @@ export function CallToActionCard({
                             hasSettingsPanel={true}
                             initialEditor={htmlEditor}
                             initialEditorState={htmlEditorInitialState}
+                            initialTheme={theme}
                             nodes='basic'
-                            placeholderClassName={`bg-transparent whitespace-normal font-serif text-xl !text-grey-500 !dark:text-grey-800 ` }
+                            placeholderClassName={`bg-transparent whitespace-normal font-serif text-xl !text-grey-500 !dark:text-grey-800 `}
                             placeholderText="Write something worth clicking..."
                             textClassName="koenig-lexical-cta-text w-full whitespace-normal text-pretty bg-transparent font-serif text-xl text-grey-900 dark:text-grey-200"
                         >
@@ -334,11 +368,12 @@ export function CallToActionCard({
 
             {isEditing && (
                 <SettingsPanel
-                    defaultTab="design"
+                    defaultTab="content"
                     tabs={tabs}
                     onMouseDown={e => e.preventDefault()}
                 >
                     {{
+                        content: contentSettings,
                         design: designSettings,
                         visibility: visibilitySettings
                     }}
@@ -376,5 +411,7 @@ CallToActionCard.propTypes = {
     visibilityOptions: PropTypes.array,
     toggleVisibility: PropTypes.func,
     imageUploadHandler: PropTypes.func,
-    imageDragHandler: PropTypes.object
+    imageDragHandler: PropTypes.object,
+    linkColor: PropTypes.oneOf(['text', 'accent']),
+    handleLinkColorChange: PropTypes.func
 };

--- a/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
@@ -26,67 +26,67 @@ export const CALLTOACTION_COLORS = {
     purple: 'bg-purple/10 border-transparent'
 };
 
-const getTheme = linkColor => ({
+const getTheme = () => ({
     ...defaultTheme,
-    link: linkColor === 'accent' ? 'text-accent' : 'text-black dark:text-white'
+    link: 'cta-link-color'
 });
 
 export const callToActionColorPicker = [
     {
         label: 'None',
         name: 'none',
-        color: 'bg-transparent border-black/15 relative after:absolute after:left-1/2 after:top-1/2 after:h-[1px] after:w-[18px] after:-translate-x-1/2 after:-translate-y-1/2 after:-rotate-45 after:bg-red-500'
+        color: 'bg-transparent border-black/15 dark:border-white/15 relative after:absolute after:left-1/2 after:top-1/2 after:h-[1px] after:w-[18px] after:-translate-x-1/2 after:-translate-y-1/2 after:-rotate-45 after:bg-red-500'
     },
     {
         label: 'White',
         name: 'white',
-        color: 'bg-transparent border-black/15 dark:border-white/10'
+        color: 'bg-transparent border-black/15 dark:border-white/15'
     },
     {
         label: 'Grey',
         name: 'grey',
-        color: 'bg-grey/20 border-black/[.08] dark:border-white/10'
+        color: 'bg-grey/20 border-black/[.08] dark:border-white/15'
     },
     {
         label: 'Blue',
         name: 'blue',
-        color: 'bg-blue/20 border-black/[.08] dark:border-white/10'
+        color: 'bg-blue/20 border-black/[.08] dark:border-white/15'
     },
     {
         label: 'Green',
         name: 'green',
-        color: 'bg-green/20 border-black/[.08] dark:border-white/10'
+        color: 'bg-green/20 border-black/[.08] dark:border-white/15'
     },
     {
         label: 'Yellow',
         name: 'yellow',
-        color: 'bg-yellow/20 border-black/[.08] dark:border-white/10'
+        color: 'bg-yellow/20 border-black/[.08] dark:border-white/15'
     },
     {
         label: 'Red',
         name: 'red',
-        color: 'bg-red/20 border-black/[.08] dark:border-white/10'
+        color: 'bg-red/20 border-black/[.08] dark:border-white/15'
     },
     {
         label: 'Pink',
         name: 'pink',
-        color: 'bg-pink/20 border-black/[0.08] dark:border-white/10'
+        color: 'bg-pink/20 border-black/[0.08] dark:border-white/15'
     },
     {
         label: 'Purple',
         name: 'purple',
-        color: 'bg-purple/20 border-black/[0.08] dark:border-white/10'
+        color: 'bg-purple/20 border-black/[0.08] dark:border-white/15'
     }
 ];
 
 export const callToActionLinkColorPicker = [
     {
-        label: 'Text',
+        label: 'Text color',
         name: 'text',
-        color: 'bg-black border-black'
+        color: 'bg-black border-black dark:bg-white dark:border-white'
     },
     {
-        label: 'Accent',
+        label: 'Brand color',
         name: 'accent',
         color: 'bg-accent border-accent'
     }
@@ -152,7 +152,7 @@ export function CallToActionCard({
         return bgColor === 'transparent' ? '' : textColorForBackgroundColor(bgColor === 'accent' ? getAccentColor() : bgColor).hex();
     };
 
-    const theme = getTheme(linkColor);
+    const theme = getTheme();
 
     const contentSettings = (
         <>
@@ -268,14 +268,22 @@ export function CallToActionCard({
 
     return (
         <>
-            <div className={clsx(
-                'w-full rounded-lg border',
-                CALLTOACTION_COLORS[color],
-                {
-                    'py-3': color === 'none' && !hasSponsorLabel,
-                    'pb-3': color === 'none' && hasSponsorLabel
-                }
-            )} data-cta-layout={layout}>
+            <div 
+                className={clsx(
+                    'w-full rounded-lg border',
+                    CALLTOACTION_COLORS[color],
+                    {
+                        'py-3': color === 'none' && !hasSponsorLabel,
+                        'pb-3': color === 'none' && hasSponsorLabel
+                    }
+                )} 
+                data-cta-layout={layout}
+                style={{
+                    '--cta-link-color': linkColor === 'accent' 
+                        ? getAccentColor() 
+                        : 'var(--cta-link-color-text)'
+                }}
+            >
 
                 {/* Sponsor label */}
                 {hasSponsorLabel && (

--- a/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
@@ -107,6 +107,7 @@ export class CallToActionNode extends BaseCallToActionNode {
                     htmlEditorInitialState={this.__callToActionHtmlEditorInitialState}
                     imageUrl={this.imageUrl}
                     layout={this.layout}
+                    linkColor={this.linkColor}
                     nodeKey={this.getKey()}
                     showButton={this.showButton}
                     sponsorLabelHtmlEditor={this.__sponsorLabelHtmlEditor}

--- a/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
@@ -19,6 +19,7 @@ export const CallToActionNodeComponent = ({
     hasSponsorLabel,
     imageUrl,
     layout,
+    linkColor,
     showButton,
     textValue,
     buttonColor,
@@ -89,6 +90,13 @@ export const CallToActionNodeComponent = ({
         });
     };
 
+    const handleLinkColorChange = (val) => {
+        editor.update(() => {
+            const node = $getNodeByKey(nodeKey);
+            node.linkColor = val;
+        });
+    };
+
     const handleImageChange = async (files) => {
         const imgPreviewUrl = URL.createObjectURL(files[0]);
         try {
@@ -143,6 +151,7 @@ export const CallToActionNodeComponent = ({
                 color={backgroundColor}
                 handleButtonColor={handleButtonColorChange}
                 handleColorChange={handleBackgroundColorChange}
+                handleLinkColorChange={handleLinkColorChange}
                 hasSponsorLabel={hasSponsorLabel}
                 htmlEditor={htmlEditor}
                 htmlEditorInitialState={htmlEditorInitialState}
@@ -151,6 +160,7 @@ export const CallToActionNodeComponent = ({
                 imageUploader={imageUploader}
                 isEditing={isEditing}
                 layout={layout}
+                linkColor={linkColor}
                 setEditing={setEditing}
                 setFileInputRef={ref => fileInputRef.current = ref}
                 showButton={showButton}

--- a/packages/koenig-lexical/src/styles/components/kg-prose.css
+++ b/packages/koenig-lexical/src/styles/components/kg-prose.css
@@ -981,14 +981,6 @@
     }
 }
 
-.koenig-lexical-cta-label a {
-    @apply !text-grey-900 dark:!text-grey-200 underline;
-}
-
-.koenig-lexical-cta-text a {
-    @apply !text-grey-900 dark:!text-grey-200;
-}
-
 /* stylelint-enable at-rule-disallowed-list */
 
 

--- a/packages/koenig-lexical/src/styles/components/koenig-lexical.css
+++ b/packages/koenig-lexical/src/styles/components/koenig-lexical.css
@@ -1,5 +1,11 @@
 .koenig-lexical {
     position: relative;
+    --cta-link-color-text: var(--grey-900);
+}
+
+/* Link color */
+.koenig-lexical .cta-link-color {
+    color: var(--cta-link-color) !important;
 }
 
 /* everything is nested here to keep it scoped to our container */
@@ -37,6 +43,8 @@
 
 /* Dark mode */
 .koenig-lexical > .dark, .koenig-lexical.dark, .dark .koenig-lexical {
+    --cta-link-color-text: var(--grey-200);
+    
     &:not(.kg-inherit-styles) {
         /* background-color: var(--black); */
 
@@ -114,6 +122,12 @@ em-emoji-picker {
   .koenig-lexical.dark .js-embed-placeholder {
     background: var(--grey-900);
     border: none;
+  }
+
+  /* CTA card */
+
+  .koenig-lexical-cta-label a {
+    text-decoration: underline;
   }
 
 /* Menu */

--- a/packages/koenig-lexical/test/e2e/cards/call-to-action-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/call-to-action-card.test.js
@@ -119,11 +119,10 @@ test.describe('Call To Action Card', async () => {
         `, {ignoreCardContents: true});
     });
 
-    test('button and button settings is visible by default', async function () {
+    test('button and button settings are visible by default', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
         expect(await page.isVisible('[data-testid="cta-button"]')).toBe(true);
-        expect(await page.isVisible('[data-testid="cta-button-color"]')).toBe(true);
         expect(await page.isVisible('[data-testid="button-text"]')).toBe(true);
         expect(await page.isVisible('[data-testid="button-url"]')).toBe(true);
     });
@@ -205,47 +204,49 @@ test.describe('Call To Action Card', async () => {
         expect(await page.isVisible('[data-testid="cta-button"]')).toBe(true);
     });
 
-    test('default button colour is accent', async function () {
+    test('default button color is accent', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
         expect(await page.getAttribute('[data-testid="cta-button"]', 'class')).toContain('bg-accent');
     });
 
-    test('can change button colour to black', async function () {
+    test('can change button color to black', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
-        // find the parent element cta-button-color and select child button with title=black
-        // await page.click('[data-testid="cta-button-color"] button[title="Black"]');
+        // Switch to Design tab for button color settings
+        await page.getByTestId('tab-design').click();
         await cardBackgroundColorSettings(page, {cardColorPickerTestId: 'cta-button-color', findByColorTitle: 'Black'});
-        // check if the button has style="background-color: rgb(0, 0, 0);"
         expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('background-color: rgb(0, 0, 0);');
     });
 
-    test('can change button colour to grey', async function () {
+    test('can change button color to grey', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
-        // find the parent element cta-button-color and select child button with title=white
+        // Switch to Design tab for button color settings
+        await page.getByTestId('tab-design').click();
         await cardBackgroundColorSettings(page, {cardColorPickerTestId: 'cta-button-color', findByColorTitle: 'Grey'});
-        // check if the button has style="background-color: rgb(255, 255, 255);"
         expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('background-color: rgb(240, 240, 240);');
     });
 
-    test('can use colour picker to change button colour', async function () {
+    test('can use color picker to change button color', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
+        await page.getByTestId('tab-design').click();
         await cardBackgroundColorSettings(page, {cardColorPickerTestId: 'cta-button-color', customColor: 'ff0000'});
         expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('background-color: rgb(255, 0, 0);');
     });
 
-    test('button text colour changes with button colour', async function () {
+    test('button text color changes with button color', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
+        await page.getByTestId('tab-content').click();
         await page.fill('[data-testid="button-text"]', 'Click me');
 
+        await page.getByTestId('tab-design').click();
         await cardBackgroundColorSettings(page, {cardColorPickerTestId: 'cta-button-color', customColor: 'FFFFFF'});
         expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('color: rgb(255, 255, 255);');
 
-        // change button colour to black
+        // change button color to black
         await page.click('[data-testid="cta-button-color"] button[title="Black"]');
         expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('color: rgb(0, 0, 0);');
     });
@@ -304,7 +305,7 @@ test.describe('Call To Action Card', async () => {
         await expect(content).toContainText('This is a new CTA Card.');
     });
 
-    test('can change background colours', async function () {
+    test('can change background colors', async function () {
         const colors = [
             {testId: 'color-picker-none', expectedClass: 'bg-transparent border-transparent'},
             {testId: 'color-picker-white', expectedClass: 'bg-transparent border-grey'},
@@ -319,6 +320,8 @@ test.describe('Call To Action Card', async () => {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
 
+        await page.getByTestId('tab-design').click();
+
         const firstChildSelector = '[data-kg-card="call-to-action"] > :first-child';
         await expect(page.locator(firstChildSelector)).not.toHaveClass(/bg-(green|blue|yellow|red|pink|purple)/); // shouldn't have any of the classes yet
         for (const color of colors) {
@@ -332,14 +335,14 @@ test.describe('Call To Action Card', async () => {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
 
+        await page.getByTestId('tab-design').click();
+
         const colorOptions = page.getByTestId('cta-background-color-picker');
         await colorOptions.getByTestId('color-options-button').click();
 
         await expect(colorOptions.getByTestId('color-options-popover')).toBeVisible();
 
-        const card = page.locator('[data-kg-card="call-to-action"]');
-        const settings = card.getByTestId('settings-panel');
-        await settings.getByTestId('media-upload-setting').click();
+        await page.click('[data-testid="cta-link-color-picker"]');
 
         await expect(colorOptions.getByTestId('color-options-popover')).not.toBeVisible();
     });
@@ -413,8 +416,8 @@ test.describe('Call To Action Card', async () => {
     test('can toggle layout to immersive', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
+        await page.getByTestId('tab-design').click();
         await page.click('[data-testid="immersive-layout"]');
-        // find data-cta-layout and check if it data-cta-layout="immersive"
         const firstChildSelector = '[data-kg-card="call-to-action"] > :first-child';
         await expect(page.locator(firstChildSelector)).toHaveAttribute('data-cta-layout', 'immersive');
     });
@@ -422,13 +425,12 @@ test.describe('Call To Action Card', async () => {
     test('can toggle layout to immersive and then back to minimal', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
+        await page.getByTestId('tab-design').click();
         await page.click('[data-testid="immersive-layout"]');
-        // find data-cta-layout and check if it data-cta-layout="immersive"
         const firstChildSelector = '[data-kg-card="call-to-action"] > :first-child';
         await expect(page.locator(firstChildSelector)).toHaveAttribute('data-cta-layout', 'immersive');
 
         await page.click('[data-testid="minimal-layout"]');
-        // find data-cta-layout and check if it data-cta-layout="minimal"
         await expect(page.locator(firstChildSelector)).toHaveAttribute('data-cta-layout', 'minimal');
     });
 

--- a/packages/koenig-lexical/test/e2e/cards/call-to-action-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/call-to-action-card.test.js
@@ -204,53 +204,6 @@ test.describe('Call To Action Card', async () => {
         expect(await page.isVisible('[data-testid="cta-button"]')).toBe(true);
     });
 
-    test('default button color is accent', async function () {
-        await focusEditor(page);
-        await insertCard(page, {cardName: 'call-to-action'});
-        expect(await page.getAttribute('[data-testid="cta-button"]', 'class')).toContain('bg-accent');
-    });
-
-    test('can change button color to black', async function () {
-        await focusEditor(page);
-        await insertCard(page, {cardName: 'call-to-action'});
-        // Switch to Design tab for button color settings
-        await page.getByTestId('tab-design').click();
-        await cardBackgroundColorSettings(page, {cardColorPickerTestId: 'cta-button-color', findByColorTitle: 'Black'});
-        expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('background-color: rgb(0, 0, 0);');
-    });
-
-    test('can change button color to grey', async function () {
-        await focusEditor(page);
-        await insertCard(page, {cardName: 'call-to-action'});
-        // Switch to Design tab for button color settings
-        await page.getByTestId('tab-design').click();
-        await cardBackgroundColorSettings(page, {cardColorPickerTestId: 'cta-button-color', findByColorTitle: 'Grey'});
-        expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('background-color: rgb(240, 240, 240);');
-    });
-
-    test('can use color picker to change button color', async function () {
-        await focusEditor(page);
-        await insertCard(page, {cardName: 'call-to-action'});
-        await page.getByTestId('tab-design').click();
-        await cardBackgroundColorSettings(page, {cardColorPickerTestId: 'cta-button-color', customColor: 'ff0000'});
-        expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('background-color: rgb(255, 0, 0);');
-    });
-
-    test('button text color changes with button color', async function () {
-        await focusEditor(page);
-        await insertCard(page, {cardName: 'call-to-action'});
-        await page.getByTestId('tab-content').click();
-        await page.fill('[data-testid="button-text"]', 'Click me');
-
-        await page.getByTestId('tab-design').click();
-        await cardBackgroundColorSettings(page, {cardColorPickerTestId: 'cta-button-color', customColor: 'FFFFFF'});
-        expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('color: rgb(255, 255, 255);');
-
-        // change button color to black
-        await page.click('[data-testid="cta-button-color"] button[title="Black"]');
-        expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('color: rgb(0, 0, 0);');
-    });
-
     test('can toggle sponsor label', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
@@ -303,48 +256,6 @@ test.describe('Call To Action Card', async () => {
         await page.keyboard.type('This is a new CTA Card.');
         const content = page.locator('[data-testid="cta-card-content-editor"]');
         await expect(content).toContainText('This is a new CTA Card.');
-    });
-
-    test('can change background colors', async function () {
-        const colors = [
-            {testId: 'color-picker-none', expectedClass: 'bg-transparent border-transparent'},
-            {testId: 'color-picker-white', expectedClass: 'bg-transparent border-grey'},
-            {testId: 'color-picker-grey', expectedClass: 'bg-grey'},
-            {testId: 'color-picker-green', expectedClass: 'bg-green'},
-            {testId: 'color-picker-blue', expectedClass: 'bg-blue'},
-            {testId: 'color-picker-yellow', expectedClass: 'bg-yellow'},
-            {testId: 'color-picker-red', expectedClass: 'bg-red'},
-            {testId: 'color-picker-pink', expectedClass: 'bg-pink'},
-            {testId: 'color-picker-purple', expectedClass: 'bg-purple'}
-        ];
-        await focusEditor(page);
-        await insertCard(page, {cardName: 'call-to-action'});
-
-        await page.getByTestId('tab-design').click();
-
-        const firstChildSelector = '[data-kg-card="call-to-action"] > :first-child';
-        await expect(page.locator(firstChildSelector)).not.toHaveClass(/bg-(green|blue|yellow|red|pink|purple)/); // shouldn't have any of the classes yet
-        for (const color of colors) {
-            await page.locator('[data-testid="cta-background-color-picker"] button').click();
-            await page.locator(`[data-test-id="${color.testId}"]`).click();
-            await expect(page.locator(firstChildSelector)).toHaveClass(new RegExp(color.expectedClass));
-        }
-    });
-
-    test('background color popup closes on outside click', async function () {
-        await focusEditor(page);
-        await insertCard(page, {cardName: 'call-to-action'});
-
-        await page.getByTestId('tab-design').click();
-
-        const colorOptions = page.getByTestId('cta-background-color-picker');
-        await colorOptions.getByTestId('color-options-button').click();
-
-        await expect(colorOptions.getByTestId('color-options-popover')).toBeVisible();
-
-        await page.click('[data-testid="cta-link-color-picker"]');
-
-        await expect(colorOptions.getByTestId('color-options-popover')).not.toBeVisible();
     });
 
     test('can add and remove CTA Card image', async function () {
@@ -405,6 +316,24 @@ test.describe('Call To Action Card', async () => {
         await expect (await page.getByTestId('cta-card-image')).toBeVisible();
     });
 
+    test('has image preview', async function () {
+        const filePath = path.relative(process.cwd(), __dirname + `/../fixtures/large-image.jpeg`);
+
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+
+        const fileChooserPromise = page.waitForEvent('filechooser');
+
+        await page.click('[data-testid="media-upload-placeholder"]');
+
+        const fileChooser = await fileChooserPromise;
+        await fileChooser.setFiles([filePath]);
+
+        await page.waitForSelector('[data-testid="media-upload-filled"]');
+        const previewImage = await page.locator('[data-testid="media-upload-filled"] img');
+        await expect(previewImage).toBeVisible();
+    });
+
     test('default layout is minimal', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
@@ -434,22 +363,116 @@ test.describe('Call To Action Card', async () => {
         await expect(page.locator(firstChildSelector)).toHaveAttribute('data-cta-layout', 'minimal');
     });
 
-    test('has image preview', async function () {
-        const filePath = path.relative(process.cwd(), __dirname + `/../fixtures/large-image.jpeg`);
-
+    test('can change background colors', async function () {
+        const colors = [
+            {testId: 'color-picker-none', expectedClass: 'bg-transparent border-transparent'},
+            {testId: 'color-picker-white', expectedClass: 'bg-transparent border-grey'},
+            {testId: 'color-picker-grey', expectedClass: 'bg-grey'},
+            {testId: 'color-picker-green', expectedClass: 'bg-green'},
+            {testId: 'color-picker-blue', expectedClass: 'bg-blue'},
+            {testId: 'color-picker-yellow', expectedClass: 'bg-yellow'},
+            {testId: 'color-picker-red', expectedClass: 'bg-red'},
+            {testId: 'color-picker-pink', expectedClass: 'bg-pink'},
+            {testId: 'color-picker-purple', expectedClass: 'bg-purple'}
+        ];
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});
 
-        const fileChooserPromise = page.waitForEvent('filechooser');
+        await page.getByTestId('tab-design').click();
 
-        await page.click('[data-testid="media-upload-placeholder"]');
+        const firstChildSelector = '[data-kg-card="call-to-action"] > :first-child';
+        await expect(page.locator(firstChildSelector)).not.toHaveClass(/bg-(green|blue|yellow|red|pink|purple)/); // shouldn't have any of the classes yet
+        for (const color of colors) {
+            await page.locator('[data-testid="cta-background-color-picker"] button').click();
+            await page.locator(`[data-test-id="${color.testId}"]`).click();
+            await expect(page.locator(firstChildSelector)).toHaveClass(new RegExp(color.expectedClass));
+        }
+    });
 
-        const fileChooser = await fileChooserPromise;
-        await fileChooser.setFiles([filePath]);
+    test('background color popup closes on outside click', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
 
-        await page.waitForSelector('[data-testid="media-upload-filled"]');
-        const previewImage = await page.locator('[data-testid="media-upload-filled"] img');
-        await expect(previewImage).toBeVisible();
+        await page.getByTestId('tab-design').click();
+
+        const colorOptions = page.getByTestId('cta-background-color-picker');
+        await colorOptions.getByTestId('color-options-button').click();
+
+        await expect(colorOptions.getByTestId('color-options-popover')).toBeVisible();
+
+        await page.click('[data-testid="cta-link-color-picker"]');
+
+        await expect(colorOptions.getByTestId('color-options-popover')).not.toBeVisible();
+    });
+
+    test('can change link color', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        await page.getByTestId('tab-design').click();
+        
+        // Get the initial link color (should be text color by default)
+        const ctaCard = await page.locator('[data-kg-card="call-to-action"] > :first-child');
+        const initialColor = await ctaCard.evaluate(el => getComputedStyle(el).getPropertyValue('--cta-link-color'));
+        expect(initialColor.trim()).toBe('#394047'); // Default text color
+        
+        // Change to accent color
+        await page.locator('[data-testid="cta-link-color-picker"] button').click();
+        await page.locator('[data-test-id="color-picker-accent"]').click();
+        const accentColor = await ctaCard.evaluate(el => getComputedStyle(el).getPropertyValue('--cta-link-color'));
+        expect(accentColor.trim()).toBe('#ff0095'); // Default accent color
+        
+        // Change back to text color
+        await page.locator('[data-testid="cta-link-color-picker"] button').click();
+        await page.locator('[data-test-id="color-picker-text"]').click();
+        const finalColor = await ctaCard.evaluate(el => getComputedStyle(el).getPropertyValue('--cta-link-color'));
+        expect(finalColor.trim()).toBe('#394047'); // Back to default text color
+    });
+
+    test('default button color is accent', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        expect(await page.getAttribute('[data-testid="cta-button"]', 'class')).toContain('bg-accent');
+    });
+
+    test('can change button color to black', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        // Switch to Design tab for button color settings
+        await page.getByTestId('tab-design').click();
+        await cardBackgroundColorSettings(page, {cardColorPickerTestId: 'cta-button-color', findByColorTitle: 'Black'});
+        expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('background-color: rgb(0, 0, 0);');
+    });
+
+    test('can change button color to grey', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        // Switch to Design tab for button color settings
+        await page.getByTestId('tab-design').click();
+        await cardBackgroundColorSettings(page, {cardColorPickerTestId: 'cta-button-color', findByColorTitle: 'Grey'});
+        expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('background-color: rgb(240, 240, 240);');
+    });
+
+    test('can use color picker to change button color', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        await page.getByTestId('tab-design').click();
+        await cardBackgroundColorSettings(page, {cardColorPickerTestId: 'cta-button-color', customColor: 'ff0000'});
+        expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('background-color: rgb(255, 0, 0);');
+    });
+
+    test('button text color changes with button color', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        await page.getByTestId('tab-content').click();
+        await page.fill('[data-testid="button-text"]', 'Click me');
+
+        await page.getByTestId('tab-design').click();
+        await cardBackgroundColorSettings(page, {cardColorPickerTestId: 'cta-button-color', customColor: 'FFFFFF'});
+        expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('color: rgb(255, 255, 255);');
+
+        // change button color to black
+        await page.click('[data-testid="cta-button-color"] button[title="Black"]');
+        expect(await page.getAttribute('[data-testid="cta-button"]', 'style')).toContain('color: rgb(0, 0, 0);');
     });
 
     test('can change visibility settings', async function () {


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PLG-377/add-link-color-setting
- Switched from two to three tabs in the settings panel, to make the settings easier to digest.
- Added link color setting to the CTA card settings panel that allows switching between the default text color and the site accent color.