### PR TITLE
🐛 Fixed snippets displaying for users without permissions

### DIFF
--- a/packages/koenig-lexical/src/components/ui/FormatToolbar.jsx
+++ b/packages/koenig-lexical/src/components/ui/FormatToolbar.jsx
@@ -1,3 +1,4 @@
+import KoenigComposerContext from '../../context/KoenigComposerContext';
 import React from 'react';
 import {$createAsideNode} from '../../nodes/AsideNode';
 import {
@@ -61,6 +62,7 @@ export default function FormatToolbar({
     const [isBold, setIsBold] = React.useState(false);
     const [isItalic, setIsItalic] = React.useState(false);
     const [blockType, setBlockType] = React.useState('paragraph');
+    const {cardConfig: {createSnippet}} = React.useContext(KoenigComposerContext);
 
     let hideHeading = false;
     if (!editor.hasNodes([HeadingNode])){
@@ -71,8 +73,8 @@ export default function FormatToolbar({
     if (!editor.hasNodes([QuoteNode])){
         hideQuotes = true;
     }
-
-    let hideSnippets = !isSnippetsEnabled;
+    
+    let hideSnippets = !isSnippetsEnabled || !createSnippet; // don't show snippet toolbar if we can't create them
     if (editor._parentEditor) {
         hideSnippets = true;
     }

--- a/packages/koenig-lexical/src/utils/buildCardMenu.js
+++ b/packages/koenig-lexical/src/utils/buildCardMenu.js
@@ -92,7 +92,7 @@ function buildSnippetMenuItem(data, config) {
         matches: query => name.indexOf(query) > -1 || 'snippets'.indexOf(query) > -1,
         insertCommand: INSERT_SNIPPET_COMMAND,
         insertParams: data,
-        onRemove: () => config.deleteSnippet(data)
+        ...(config.deleteSnippet && {onRemove: () => config.deleteSnippet(data)})
     };
 
     return snippet;

--- a/packages/koenig-lexical/test/unit/buildCardMenu.test.js
+++ b/packages/koenig-lexical/test/unit/buildCardMenu.test.js
@@ -372,7 +372,7 @@ describe('buildCardMenu', function () {
 
         it('can filter snippets', async function () {
             const snippets = [{name: 'One snippet'}, {name: 'Two snippet'}];
-            const cardMenu = buildCardMenu([], {query: 'snip', config: {snippets}});
+            const cardMenu = buildCardMenu([], {query: 'snip', config: {snippets, deleteSnippet: () => {}}});
 
             expect(cardMenu.menu).toEqual(new Map([
                 ['Snippets', [
@@ -404,6 +404,37 @@ describe('buildCardMenu', function () {
             ]));
         });
 
+        it(`doesn't show delete option if createSnippet is not defined`, async function () {
+            const snippets = [{name: 'One snippet'}, {name: 'Two snippet'}];
+            const cardMenu = buildCardMenu([], {query: 'snippets', config: {snippets}});
+            expect(cardMenu.menu).toEqual(new Map([
+                ['Snippets', [
+                    {
+                        Icon: expect.any(Function),
+                        insertCommand: {},
+                        insertParams: {
+                            name: 'One snippet'
+                        },
+                        label: 'One snippet',
+                        matches: expect.any(Function),
+                        section: 'Snippets',
+                        type: 'snippet'
+                    },
+                    {
+                        Icon: expect.any(Function),
+                        insertCommand: {},
+                        insertParams: {
+                            name: 'Two snippet'
+                        },
+                        label: 'Two snippet',
+                        matches: expect.any(Function),
+                        section: 'Snippets',
+                        type: 'snippet'
+                    }
+                ]]
+            ]));
+        });
+
         it('returns empty value if no snippet matches ', async function () {
             const snippets = [{name: 'One snippet'}, {name: 'Two snippet'}];
             const cardMenu = buildCardMenu([], {query: 'sniptr', config: {snippets}});
@@ -412,7 +443,7 @@ describe('buildCardMenu', function () {
 
         it('shows all snippets when typing /snippets', async function () {
             const snippets = [{name: 'Test1'}, {name: 'Test2'}];
-            const cardMenu = buildCardMenu([], {query: 'snippets', config: {snippets}});
+            const cardMenu = buildCardMenu([], {query: 'snippets', config: {snippets, deleteSnippet: () => {}}});
 
             expect(cardMenu.menu).toEqual(new Map([
                 ['Snippets', [


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-815

We were always displaying the snippet buttons (toolbar + delete button) despite the underlying functions not always being present, resulting in broken buttons. We control the ability to create/delete snippets via passing the fns, so if the fns don't exist we simply shouldn't display the buttons.

This does not include tests for the floating toolbar button as we don't currently have support for custom cardConfig in those tests (with the demo app) and adding this was not cooperative.