### PR TITLE
fix: do not allow dragging if gallery has max images

### DIFF
--- a/packages/koenig-lexical/src/hooks/useGalleryReorder.js
+++ b/packages/koenig-lexical/src/hooks/useGalleryReorder.js
@@ -3,7 +3,7 @@ import React from 'react';
 import pick from 'lodash/pick';
 import {getImageFilenameFromSrc} from '../utils/getImageFilenameFromSrc';
 
-export default function useGalleryReorder({images, updateImages, isSelected = false, maxImages = 9, disabled = false}) {
+export default function useGalleryReorder({images, updateImages, maxImages, isSelected = false, disabled = false}) {
     const koenig = React.useContext(KoenigComposerContext);
 
     const [containerRef, setContainerRef] = React.useState(null);
@@ -14,8 +14,14 @@ export default function useGalleryReorder({images, updateImages, isSelected = fa
     const onDragStart = (draggableInfo) => {
         // enable dropping when an image is dragged in from outside of this card
         const isImageDrag = draggableInfo.type === 'image' || draggableInfo.cardName === 'image';
-        if (isImageDrag && draggableInfo.dataset.src && images.length !== maxImages) {
+        if (!isImageDrag || !draggableInfo.dataset.src) {
+            return;
+        }
+        const isInternal = containerRef && containerRef.contains(draggableInfo.element);
+        if (images.length < maxImages || isInternal) {
             dragDropContainer.current.enableDrag();
+        } else {
+            dragDropContainer.current.disableDrag();
         }
     };
 

--- a/packages/koenig-lexical/src/nodes/GalleryNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/GalleryNodeComponent.jsx
@@ -27,7 +27,7 @@ export function GalleryNodeComponent({nodeKey, captionEditor, captionEditorIniti
         return existingImages;
     });
 
-    const galleryReorder = useGalleryReorder({images, updateImages: reorderImages, isSelected});
+    const galleryReorder = useGalleryReorder({images, updateImages: reorderImages, maxImages: MAX_IMAGES, isSelected});
     const imageUploader = fileUploader.useFileUpload('image');
     const imageFilesDropper = useFileDragAndDrop({handleDrop: handleImageFilesDrop});
 
@@ -57,7 +57,7 @@ export function GalleryNodeComponent({nodeKey, captionEditor, captionEditorIniti
 
         const strippedFiles = Array.prototype.slice.call(files, 0, allowedCount);
         if (strippedFiles.length < files.length) {
-            setErrorMessage('Galleries are limited to 9 images');
+            setErrorMessage(`Galleries are limited to ${MAX_IMAGES} images`);
         }
 
         if (strippedFiles.length === 0) {


### PR DESCRIPTION
Fixes https://github.com/TryGhost/Ghost/issues/22054

The problem is that we neither disable dragging nor check for `maxImages` in `onDrop`. I thought of showing an error message as per @9larsons' comment but I noticed that if we populate a gallery from the start with 9 images and then try to drag an image inside, it doesn't even show the green line which imo is good feedback to the user. So I did the same here to not show the green line anymore once gallery hits 9 images (rather than showing the green line first and then showing an error message which feels like a bad UX)

Edit: I first disabled drag for all cases when `images.length === maxImages` but that also stops reordering, fixed it now!