### PR TITLE
fix: check if item belongs to the container before removing

### DIFF
--- a/packages/koenig-lexical/src/hooks/useGalleryReorder.js
+++ b/packages/koenig-lexical/src/hooks/useGalleryReorder.js
@@ -83,6 +83,10 @@ export default function useGalleryReorder({images, updateImages, isSelected = fa
             return;
         }
 
+        if (!containerRef || !containerRef.contains(draggableInfo.element)) {
+            return;
+        }
+
         const image = images.find(i => i.src === draggableInfo.dataset.src);
         if (image) {
             const updatedImages = images.filter(i => i !== image);


### PR DESCRIPTION
Fixes https://github.com/TryGhost/Ghost/issues/29221

## Description

It is because `onDropEnd` function runs with the `draggableInfo` which has the same `src` as the one in the other gallery. And since src is the only identifier we use, I added a check if the `draggableInfo.element` belongs to the parent i.e. this gallery component before deleting (because we anyways run delete functions for the elements inside the component). 