### PR TITLE
Added rgbToHex tests and export

### DIFF
--- a/packages/kg-default-nodes/lib/kg-default-nodes.js
+++ b/packages/kg-default-nodes/lib/kg-default-nodes.js
@@ -66,9 +66,11 @@ export * from './nodes/zwnj/ZWNJNode';
 // export utility functions that are useful in other packages or tests
 import * as visibilityUtils from './utils/visibility';
 import {generateDecoratorNode} from './generate-decorator-node.js';
+import {rgbToHex} from './utils/rgb-to-hex.js';
 export const utils = {
     generateDecoratorNode,
-    visibility: visibilityUtils
+    visibility: visibilityUtils,
+    rgbToHex
 };
 
 export const serializers = {

--- a/packages/kg-default-nodes/lib/utils/rgb-to-hex.js
+++ b/packages/kg-default-nodes/lib/utils/rgb-to-hex.js
@@ -1,4 +1,4 @@
-export function rgbToHex(rgb) {
+export const rgbToHex = (rgb) => {
     if (rgb === 'transparent') {
         return rgb;
     }
@@ -16,4 +16,4 @@ export function rgbToHex(rgb) {
     } catch (e) {
         return null;
     }
-}
+};

--- a/packages/kg-default-nodes/test/utils/rgb-to-hex.test.js
+++ b/packages/kg-default-nodes/test/utils/rgb-to-hex.test.js
@@ -1,0 +1,18 @@
+// // import {rgbToHex} from '../../lib/utils/rgb-to-hex';
+const {utils} = require('../../');
+const rgbToHex = utils.rgbToHex;
+
+describe('rgbToHex', function () {
+    it('should convert RGB to HEX', function () {
+        should(rgbToHex('rgb(0, 0, 0)')).equal('#000000');
+        should(rgbToHex('rgb(255, 255, 255)')).equal('#ffffff');
+        should(rgbToHex('rgb(255, 0, 0)')).equal('#ff0000');
+        should(rgbToHex('rgb(0, 255, 0)')).equal('#00ff00');
+        should(rgbToHex('rgb(0, 0, 255)')).equal('#0000ff');
+        should(rgbToHex('rgb(255, 255, 0)')).equal('#ffff00');
+    });
+
+    it('should handle transparent', function () {
+        should(rgbToHex('transparent')).equal('transparent');
+    });
+});


### PR DESCRIPTION
no issue

- Exported `rgbToHex` in `kg-default-nodes.js`
- Changed `rgbToHex` to arrow function syntax in `rgb-to-hex.js`
- Added `rgb-to-hex.test.js` with tests for RGB to HEX conversion and transparent handling