### PR TITLE
Added alignment setting to Call To Action Card

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
@@ -8,6 +8,7 @@ export class CallToActionNode extends generateDecoratorNode({
     hasVisibility: true,
     properties: [
         {name: 'layout', default: 'minimal'},
+        {name: 'alignment', default: 'left'},
         {name: 'textValue', default: '', wordCount: true},
         {name: 'showButton', default: true},
         {name: 'buttonText', default: 'Learn more'},

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-parser.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-parser.js
@@ -10,6 +10,7 @@ export function parseCallToActionNode(CallToActionNode) {
                     conversion(domNode) {
                         const div = domNode;
                         const layout = div.getAttribute('data-layout') || 'minimal';
+                        const alignment = div.getAttribute('data-alignment') || 'left';
                         const textValueElement = domNode.querySelector('.kg-cta-text');
                         const buttonElement = domNode.querySelector('.kg-cta-button');
                         const buttonStyles = buttonElement?.style || {};
@@ -44,6 +45,7 @@ export function parseCallToActionNode(CallToActionNode) {
 
                         const payload = {
                             layout: layout,
+                            alignment: alignment,
                             textValue: textValueElement.textContent.trim() || '',
                             showButton: buttonElement ? true : false,
                             buttonText: buttonElement?.textContent.trim() || '',

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -25,7 +25,7 @@ function ctaCardTemplate(dataset) {
         : `style="background-color: ${dataset.buttonColor}; color: ${dataset.buttonTextColor};"`;
 
     return `
-        <div class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''}" data-layout="${dataset.layout}">
+        <div class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''} ${dataset.alignment === 'center' ? 'kg-cta-centered' : ''}" data-layout="${dataset.layout}">
             ${dataset.hasSponsorLabel ? `
                 <div class="kg-cta-sponsor-label-wrapper">
                     <div class="kg-cta-sponsor-label">
@@ -157,7 +157,7 @@ function emailCTATemplate(dataset, options = {}) {
                         ${showButton(dataset) ? `
                             <tr>
                                 <td class="kg-cta-button-container">
-                                    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                    <table border="0" cellpadding="0" cellspacing="0">
                                         <tr>
                                             <td class="kg-cta-button-wrapper ${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}" style="${buttonStyle}">
                                                 <a href="${dataset.buttonUrl}"
@@ -179,7 +179,7 @@ function emailCTATemplate(dataset, options = {}) {
     };
 
     return `
-        <table class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.hasSponsorLabel ? '' : 'kg-cta-no-label'} ${dataset.textValue ? '' : 'kg-cta-no-text'} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''}" border="0" cellpadding="0" cellspacing="0" width="100%">
+        <table class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.hasSponsorLabel ? '' : 'kg-cta-no-label'} ${dataset.textValue ? '' : 'kg-cta-no-text'} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''} ${dataset.alignment === 'center' ? 'kg-cta-centered' : ''}" border="0" cellpadding="0" cellspacing="0" width="100%">
             ${dataset.hasSponsorLabel ? `
                 <tr>
                     <td>
@@ -203,6 +203,7 @@ export function renderCallToActionNode(node, options = {}) {
     const document = options.createDocument();
     const dataset = {
         layout: node.layout,
+        alignment: node.alignment,
         textValue: node.textValue,
         showButton: node.showButton,
         buttonText: node.buttonText,

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -159,6 +159,7 @@ describe('CallToActionNode', function () {
 
             callToActionNodeDataset.should.deepEqual({
                 ...dataset,
+                alignment: 'left',
                 ...{visibility: utils.visibility.buildDefaultVisibility()}
             });
         }));
@@ -500,6 +501,7 @@ describe('CallToActionNode', function () {
                 showButton: true,
                 textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card.</span></p>',
                 linkColor: 'text',
+                alignment: 'left',
                 visibility: {
                     web: {
                         nonMember: true,

--- a/packages/koenig-lexical/src/components/ui/TabView.jsx
+++ b/packages/koenig-lexical/src/components/ui/TabView.jsx
@@ -10,7 +10,7 @@ const TabView = ({tabs, defaultTab, tabContent}) => {
 
     return (
         <>
-            <div className={`no-scrollbar flex gap-3 border-b border-grey-300 dark:border-grey-900 ${tabs.length > 1 ? 'w-full px-6' : 'mx-6'}`}>
+            <div className={`no-scrollbar flex gap-4 border-b border-grey-300 dark:border-grey-900 ${tabs.length > 1 ? 'w-full px-6' : 'mx-6'}`}>
                 {tabs.map(tab => (
                     <button
                         key={tab.id}

--- a/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
@@ -382,7 +382,7 @@ export function CallToActionCard({
                             placeholderText="Write something worth clicking..."
                             textClassName={clsx(
                                 'koenig-lexical-cta-text w-full whitespace-normal text-pretty bg-transparent font-serif text-xl text-grey-900 dark:text-grey-200',
-                                alignment === 'center' && layout === 'immersive' ? 'text-center' : 'text-left'
+                                alignment === 'center' && layout === 'immersive' ? 'text-center [&:has(.placeholder)]:w-fit [&:has(.placeholder)]:text-left' : 'text-left'
                             )}
                         >
                             <ReplacementStringsPlugin />

--- a/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
@@ -1,5 +1,7 @@
+import CenterAlignIcon from '../../../assets/icons/kg-align-center.svg?react';
 import ImmersiveLayoutIcon from '../../../assets/icons/kg-layout-immersive.svg?react';
 import KoenigNestedEditor from '../../KoenigNestedEditor.jsx';
+import LeftAlignIcon from '../../../assets/icons/kg-align-left.svg?react';
 import MinimalLayoutIcon from '../../../assets/icons/kg-layout-minimal.svg?react';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
@@ -93,6 +95,7 @@ export const callToActionLinkColorPicker = [
 ];
 
 export function CallToActionCard({
+    alignment = 'left',
     buttonColor = '',
     buttonText = '',
     buttonTextColor = '',
@@ -114,6 +117,7 @@ export function CallToActionCard({
     onFileChange = () => {},
     onRemoveMedia = () => {},
     setFileInputRef = () => {},
+    updateAlignment = () => {},
     updateButtonText = () => {},
     updateButtonUrl = () => {},
     updateHasSponsorLabel = () => {},
@@ -140,14 +144,29 @@ export function CallToActionCard({
             name: 'minimal',
             Icon: MinimalLayoutIcon,
             dataTestId: 'minimal-layout',
-            ariaLabel: 'Left-aligned layout with small, square image'
+            ariaLabel: 'Small, square image'
         },
         {
-            label: 'Immersive',
+            label: 'Full',
             name: 'immersive',
             Icon: ImmersiveLayoutIcon,
             dataTestId: 'immersive-layout',
-            ariaLabel: 'Center-aligned layout with full-width image and button'
+            ariaLabel: 'Full-width image'
+        }
+    ];
+
+    const alignmentOptions = [
+        {
+            label: 'Left',
+            name: 'left',
+            Icon: LeftAlignIcon,
+            dataTestId: 'left-align'
+        },
+        {
+            label: 'Center',
+            name: 'center',
+            Icon: CenterAlignIcon,
+            dataTestId: 'center-align'
         }
     ];
 
@@ -217,11 +236,20 @@ export function CallToActionCard({
             {/* Layout settings */}
             <ButtonGroupSettingBeta
                 buttons={layoutOptions}
-                hasTooltip={false}
                 label='Layout'
                 selectedName={layout}
                 onClick={updateLayout}
             />
+            {layout === 'immersive' &&
+                <>
+                    <ButtonGroupSettingBeta
+                        buttons={alignmentOptions}
+                        label='Alignment'
+                        selectedName={alignment}
+                        onClick={updateAlignment}
+                    />
+                </>
+            }
             {/* Color picker */}
             <ColorOptionSettingBeta
                 buttons={callToActionColorPicker}
@@ -337,7 +365,10 @@ export function CallToActionCard({
                             />
                         </div>
                     )}
-                    <div className="flex flex-col gap-6">
+                    <div className={clsx(
+                        'flex flex-col gap-6', 
+                        layout === 'immersive' && alignment === 'center' ? 'items-center' : ''
+                    )}>
                         {/* HTML content */}
                         <KoenigNestedEditor
                             autoFocus={true}
@@ -349,25 +380,31 @@ export function CallToActionCard({
                             nodes='basic'
                             placeholderClassName={`bg-transparent whitespace-normal font-serif text-xl !text-grey-500 !dark:text-grey-800 `}
                             placeholderText="Write something worth clicking..."
-                            textClassName="koenig-lexical-cta-text w-full whitespace-normal text-pretty bg-transparent font-serif text-xl text-grey-900 dark:text-grey-200"
+                            textClassName={clsx(
+                                'koenig-lexical-cta-text w-full whitespace-normal text-pretty bg-transparent font-serif text-xl text-grey-900 dark:text-grey-200',
+                                alignment === 'center' && layout === 'immersive' ? 'text-center' : 'text-left'
+                            )}
                         >
                             <ReplacementStringsPlugin />
                         </KoenigNestedEditor>
 
                         {/* Button */}
                         { (showButton && (isEditing || (buttonText && buttonUrl))) &&
-                            <div data-test-cta-button-current-url={buttonUrl}>
+                            <div className={clsx(
+                                layout === 'immersive' && imageSrc ? 'w-full' : ''
+                            )} data-test-cta-button-current-url={buttonUrl}>
                                 <Button
                                     color={'accent'}
+                                    data-test-cta-button-current-url={buttonUrl}
                                     dataTestId="cta-button"
                                     placeholder="Add button text"
-                                    size={layout === 'immersive' ? 'medium' : 'small'}
+                                    size={layout === 'immersive' && imageSrc ? 'medium' : 'small'}
                                     style={buttonColor !== 'accent' ? {
                                         backgroundColor: buttonColor,
                                         color: buttonTextColor
                                     } : undefined}
                                     value={buttonText}
-                                    width={layout === 'immersive' ? 'full' : 'regular'}
+                                    width={layout === 'minimal' || !imageSrc ? 'regular' : 'full'}
                                 />
                             </div>
                         }
@@ -396,6 +433,7 @@ export function CallToActionCard({
 }
 
 CallToActionCard.propTypes = {
+    alignment: PropTypes.oneOf(['left', 'center']),
     buttonText: PropTypes.string,
     buttonUrl: PropTypes.string,
     buttonColor: PropTypes.string,
@@ -408,6 +446,7 @@ CallToActionCard.propTypes = {
     showButton: PropTypes.bool,
     htmlEditor: PropTypes.object,
     htmlEditorInitialState: PropTypes.object,
+    updateAlignment: PropTypes.func,
     updateButtonText: PropTypes.func,
     updateButtonUrl: PropTypes.func,
     updateHasSponsorLabel: PropTypes.func,

--- a/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
@@ -96,6 +96,7 @@ export class CallToActionNode extends BaseCallToActionNode {
                 wrapperStyle={this.backgroundColor === 'none' ? 'wide' : 'regular'}
             >
                 <CallToActionNodeComponent
+                    alignment={this.alignment}
                     backgroundColor={this.backgroundColor}
                     buttonColor={this.buttonColor}
                     buttonText={this.buttonText}

--- a/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
@@ -13,6 +13,7 @@ import {useVisibilityToggle} from '../hooks/useVisibilityToggle.js';
 
 export const CallToActionNodeComponent = ({
     nodeKey,
+    alignment,
     backgroundColor,
     buttonText,
     buttonUrl,
@@ -133,6 +134,13 @@ export const CallToActionNodeComponent = ({
         });
     };
 
+    const handleUpdatingAlignment = (val) => {
+        editor.update(() => {
+            const node = $getNodeByKey(nodeKey);
+            node.alignment = val;
+        });
+    };
+
     async function handleImageDrop(files) {
         await handleImageChange(files);
     }
@@ -144,6 +152,7 @@ export const CallToActionNodeComponent = ({
     return (
         <>
             <CallToActionCard
+                alignment={alignment}
                 buttonColor={buttonColor}
                 buttonText={buttonText}
                 buttonTextColor={buttonTextColor}
@@ -168,6 +177,7 @@ export const CallToActionNodeComponent = ({
                 sponsorLabelHtmlEditorInitialState={sponsorLabelHtmlEditorInitialState}
                 text={textValue}
                 toggleVisibility={toggleVisibility}
+                updateAlignment={handleUpdatingAlignment}
                 updateButtonText={handleButtonTextChange}
                 updateButtonUrl={handleButtonUrlChange}
                 updateHasSponsorLabel={handleHasSponsorLabelChange}

--- a/packages/koenig-lexical/test/e2e/cards/call-to-action-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/call-to-action-card.test.js
@@ -363,6 +363,53 @@ test.describe('Call To Action Card', async () => {
         await expect(page.locator(firstChildSelector)).toHaveAttribute('data-cta-layout', 'minimal');
     });
 
+    test('alignment settings are hidden when layout is minimal', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        await page.getByTestId('tab-design').click();
+        
+        // Verify alignment settings are not visible by default (minimal layout)
+        await expect(page.getByTestId('left-align')).not.toBeVisible();
+        await expect(page.getByTestId('center-align')).not.toBeVisible();
+    });
+
+    test('alignment settings are visible when layout is immersive', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        await page.getByTestId('tab-design').click();
+        await page.click('[data-testid="immersive-layout"]');
+        
+        // Verify alignment settings are now visible
+        await expect(page.getByTestId('left-align')).toBeVisible();
+        await expect(page.getByTestId('center-align')).toBeVisible();
+
+        // Switch back to minimal layout and verify alignment settings are hidden
+        await page.click('[data-testid="minimal-layout"]');
+        await expect(page.getByTestId('left-align')).not.toBeVisible();
+        await expect(page.getByTestId('center-align')).not.toBeVisible();
+    });
+
+    test('can change text alignment in immersive layout', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+        await page.click('[data-testid="cta-card-content-editor"]');
+        await page.keyboard.type('Test content for alignment');
+        await page.getByTestId('tab-design').click();
+        await page.click('[data-testid="immersive-layout"]');
+        
+        // Test left alignment (default)
+        const contentEditor = page.locator('[data-testid="cta-card-content-editor"]');
+        await expect(contentEditor).toHaveClass(/text-left/);
+        
+        // Test center alignment
+        await page.click('[data-testid="center-align"]');
+        await expect(contentEditor).toHaveClass(/text-center/);
+        
+        // Test switching back to left alignment
+        await page.click('[data-testid="left-align"]');
+        await expect(contentEditor).toHaveClass(/text-left/);
+    });
+
     test('can change background colors', async function () {
         const colors = [
             {testId: 'color-picker-none', expectedClass: 'bg-transparent border-transparent'},


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PLG-379/add-center-alignment-as-a-setting
- To support generic, center-aligned call-to-actions, we've added an option to center align content when the full-width layout is selected.
- As part of this, the button is now only full-width in the immersive layout when there is an image.