### PR TITLE
Improved clickable area of editor in CTA card

### DIFF
--- a/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
@@ -366,7 +366,7 @@ export function CallToActionCard({
                         </div>
                     )}
                     <div className={clsx(
-                        'flex flex-col gap-6', 
+                        'flex w-full flex-col gap-6', 
                         layout === 'immersive' && alignment === 'center' ? 'items-center' : ''
                     )}>
                         {/* HTML content */}


### PR DESCRIPTION
Ref https://ghost.slack.com/archives/C06TQR9SHSM/p1742462486864509
- When you don’t have much text in the content area, the click area for getting a cursor is too small. This fix ensures that the clickable area takes up the full width.