### PR TITLE
Fixes for Internal Linking/AtLinkPlugin and Firefox

### DIFF
--- a/packages/koenig-lexical/src/plugins/AtLinkPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/AtLinkPlugin.jsx
@@ -414,15 +414,26 @@ export const KoenigAtLinkPlugin = ({searchLinks, siteUrl}) => {
             });
 
             // consolidate multiple search nodes from previous step into single node
-            const searchNode = atLinkNode.getChildAtIndex(1);
-            const currentText = searchNode.getTextContent();
-            let consolidatedText = currentText;
-            atLinkNode.getChildren().forEach((child, index) => {
-                if (index > 1) {
-                    consolidatedText += child.getTextContent();
-                    child.remove();
-                }
+            // NB: Leave the first non-empty search node in-tact if possible
+
+            let searchNodes = atLinkNode.getChildren().slice(1);
+            const currentText = searchNodes.map(node => node.getTextContent()).join();
+            if (currentText !== '') {
+                searchNodes.forEach((node) => {
+                    if (!node.getTextContent()) {
+                        node.remove();
+                    }
+                });
+                searchNodes = atLinkNode.getChildren().slice(1);
+            }
+
+            const [searchNode, ...restNodes] = searchNodes;
+            let consolidatedText = searchNode.getTextContent();
+            restNodes.forEach((node) => {
+                consolidatedText += node.getTextContent();
+                node.remove();
             });
+
             if (consolidatedText !== currentText) {
                 searchNode.setTextContent(consolidatedText);
             }

--- a/packages/koenig-lexical/test/e2e/internal-linking-firefox-test.js
+++ b/packages/koenig-lexical/test/e2e/internal-linking-firefox-test.js
@@ -352,7 +352,11 @@ test.describe('Internal linking (Firefox)', async () => {
         test('can paste into at-link node', async function () {
             await focusEditor(page);
             await page.keyboard.type('@');
-            await pasteText(page, 'https://ghost.org');
+
+            // script based pasting doesn't work in firefox, trigger via keyboard instead
+            await page.evaluate(() => navigator.clipboard.writeText('https://ghost.org'));
+            await page.keyboard.press("ControlOrMeta+KeyV");
+
             await expect(page.getByTestId('at-link-results')).toBeVisible();
 
             await assertHTML(page, html`

--- a/packages/koenig-lexical/test/e2e/internal-linking-firefox-test.js
+++ b/packages/koenig-lexical/test/e2e/internal-linking-firefox-test.js
@@ -1,0 +1,369 @@
+import {assertHTML, focusEditor, html, initialize, insertCard, pasteText} from '../utils/e2e';
+import {expect, test} from '@playwright/test';
+
+test.describe('Internal linking (Firefox)', async () => {
+    let page;
+
+    test.beforeAll(async ({browser}) => {
+        page = await browser.newPage();
+    });
+
+    test.beforeEach(async () => {
+        await initialize({page, uri: '/#/?content=false&labs=internalLinking'});
+    });
+
+    test.afterAll(async () => {
+        await page.close();
+    });
+
+    test.describe('Bookmark card', function () {
+        test('shows default options when opening', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+            await expect(page.getByTestId('bookmark-url-dropdown')).toBeVisible();
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                  <div
+                    data-kg-card-editing="false"
+                    data-kg-card-selected="true"
+                    data-kg-card="bookmark">
+                    <div>
+                      <div>
+                        <div><input placeholder="Paste URL or search posts and pages..." value="" /></div>
+                        <ul>
+                          <li><div>Latest posts</div></li>
+                          <li aria-selected="true" role="option">
+                            <span><span>Remote Work's Impact on Job Markets and Employment</span></span>
+                            <span>
+                              <span title="Members only"><svg></svg></span>
+                              <span>8 May 2024</span>
+                            </span>
+                          </li>
+                          <li aria-selected="false" role="option">
+                            <span><span>Robotics Renaissance: How Automation is Transforming Industries</span></span>
+                          </li>
+                          <li aria-selected="false" role="option">
+                            <span><span>Biodiversity Conservation in Fragile Ecosystems</span></span>
+                          </li>
+                          <li aria-selected="false" role="option">
+                            <span><span>Unveiling the Crisis of Plastic Pollution: Analyzing Its Profound Impact on the Environment</span></span>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <p><br /></p>
+            `);
+        });
+
+        test('shows metadata on selected items', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+            await expect(page.getByTestId('bookmark-url-dropdown')).toBeVisible();
+
+            await assertHTML(page, html`
+                <span><span>Remote Work's Impact on Job Markets and Employment</span></span>
+                <span>
+                  <span title="Members only"><svg></svg></span>
+                  <span>8 May 2024</span>
+                </span>
+            `, {selector: '[data-testid="bookmark-url-listOption"][aria-selected="true"]'});
+
+            await page.keyboard.press('ArrowDown');
+
+            // first item no longer shows metadata
+
+            await assertHTML(page, html`
+                <span><span>Remote Work's Impact on Job Markets and Employment</span></span>
+            `, {selector: '[data-testid="bookmark-url-listOption"]'});
+
+            // second now-selected item shows metadata
+            await assertHTML(page, html`
+                <span><span>Robotics Renaissance: How Automation is Transforming Industries</span></span>
+                <span>
+                  <span title="Specific tiers only"><svg></svg></span>
+                  <span>2 May 2024</span>
+                </span>
+            `, {selector: '[data-testid="bookmark-url-listOption"][aria-selected="true"]'});
+        });
+
+        test('highlights matches in results', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+            await expect(page.getByTestId('bookmark-url-dropdown')).toBeVisible();
+
+            await page.keyboard.type('Emoji');
+
+            await expect(page.locator('[data-testid="bookmark-url-listOption"]')).toBeVisible();
+            await expect(page.locator('span.font-bold').first()).toHaveText('Emoji');
+        });
+
+        test('does not crash with regexp chars in search', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+            await expect(page.getByTestId('bookmark-url-dropdown')).toBeVisible();
+
+            await page.keyboard.type('[');
+
+            await expect(page.locator('[data-testid="bookmark-url-dropdown"]')).toBeVisible();
+        });
+
+        test('matches URL queries (http)', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+            await expect(page.getByTestId('bookmark-url-dropdown')).toBeVisible();
+
+            await page.keyboard.type('http');
+            await expect(page.getByTestId('input-list-spinner')).not.toBeVisible();
+
+            await assertHTML(page, html`
+                <li><div>Link to web page</div></li>
+                <li aria-selected="true" role="option">
+                  <span>
+                    <svg></svg>
+                    <span>http</span>
+                  </span>
+                </li>
+            `, {selector: '[data-testid="bookmark-url-dropdown"]'});
+        });
+
+        test('matches URL queries (anchor)', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+            await expect(page.getByTestId('bookmark-url-dropdown')).toBeVisible();
+
+            await page.keyboard.type('#test');
+            await expect(page.getByTestId('input-list-spinner')).not.toBeVisible();
+
+            await assertHTML(page, html`
+                <li><div>Link to web page</div></li>
+                <li aria-selected="true" role="option">
+                  <span>
+                    <svg></svg>
+                    <span>#test</span>
+                  </span>
+                </li>
+            `, {selector: '[data-testid="bookmark-url-dropdown"]'});
+        });
+
+        test('matches URL queries (relative)', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+            await expect(page.getByTestId('bookmark-url-dropdown')).toBeVisible();
+
+            await page.keyboard.type('/test');
+            await expect(page.getByTestId('input-list-spinner')).not.toBeVisible();
+
+            await assertHTML(page, html`
+                <li><div>Link to web page</div></li>
+                <li aria-selected="true" role="option">
+                  <span>
+                    <svg></svg>
+                    <span>/test</span>
+                  </span>
+                </li>
+            `, {selector: '[data-testid="bookmark-url-dropdown"]'});
+        });
+
+        test('matches URL queries (mailto)', async function () {
+            await focusEditor(page);
+            await insertCard(page, {cardName: 'bookmark'});
+            await expect(page.getByTestId('bookmark-url-dropdown')).toBeVisible();
+
+            await page.keyboard.type('mailto:test@example.com');
+            await expect(page.getByTestId('input-list-spinner')).not.toBeVisible();
+
+            await assertHTML(page, html`
+                <li><div>Link to web page</div></li>
+                <li aria-selected="true" role="option">
+                  <span>
+                    <svg></svg>
+                    <span>mailto:test@example.com</span>
+                  </span>
+                </li>
+            `, {selector: '[data-testid="bookmark-url-dropdown"]'});
+        });
+    });
+
+    test.describe('Link toolbar', function () {});
+
+    test.describe('At-linking', function () {
+        test('displays default links with no query', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('@');
+
+            await assertHTML(page, html`
+                <p>
+                    <span>
+                        <svg></svg>
+                        <span data-lexical-text="true">‌</span>
+                        <span
+                            data-placeholder="Find a post, tag or author"
+                            data-lexical-text="true"
+                        ></span>
+                    </span>
+                </p>
+            `);
+
+            await assertHTML(page, html`
+                <div>
+                    <div>
+                        <div>
+                            <ul>
+                                <li><div>Latest posts</div></li>
+                                <li aria-selected="true" role="option">
+                                    <span><span>Remote Work's Impact on Job Markets and Employment</span></span>
+                                    <span>
+                                        <span title="Members only"><svg></svg></span>
+                                        <span>8 May 2024</span>
+                                    </span>
+                                </li>
+                                <li aria-selected="false" role="option">
+                                    <span><span>Robotics Renaissance: How Automation is Transforming Industries</span></span>
+                                </li>
+                                <li aria-selected="false" role="option">
+                                    <span><span>Biodiversity Conservation in Fragile Ecosystems</span></span>
+                                </li>
+                                <li aria-selected="false" role="option">
+                                    <span><span>Unveiling the Crisis of Plastic Pollution: Analyzing Its Profound Impact on the Environment</span></span>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            `, {selector: '[data-testid="at-link-popup"]'});
+        });
+
+        test('can search for links', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('@');
+            await page.keyboard.type('Emo');
+
+            await assertHTML(page, html`
+                <p>
+                    <span dir="ltr">
+                        <svg></svg>
+                        <span data-lexical-text="true">‌</span>
+                        <span data-placeholder="" data-lexical-text="true">Emo</span>
+                    </span>
+                </p>
+            `);
+
+            // wait for search to complete
+            await expect(page.locator('[data-testid="at-link-results-listOption-label"]')).toContainText(['✨ Emoji autocomplete ✨']);
+
+            await assertHTML(page, html`
+                <div>
+                    <div>
+                        <div>
+                            <ul>
+                                <li><div>Posts</div></li>
+                                <li aria-selected="true" role="option">
+                                    <span><span>✨ <span>Emo</span>ji autocomplete ✨</span></span>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            `, {selector: '[data-testid="at-link-popup"]'});
+        });
+
+        test('has custom no result options', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('@');
+            await page.keyboard.type('Unknown page');
+
+            await expect(page.locator('[data-testid="at-link-popup"]')).toContainText('No results found');
+
+            await page.keyboard.press('Enter');
+
+            await assertHTML(page, html`
+                <p><span data-lexical-text="true">@Unknown page</span></p>
+            `);
+        });
+
+        test('removes at-linking when backspacing', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('@');
+            await page.keyboard.type('AB');
+
+            await page.keyboard.press('Backspace');
+            await page.keyboard.press('Backspace');
+            // we should now have an empty input field with placeholder text
+            await assertHTML(page, html`
+                <p>
+                    <span>
+                        <svg></svg>
+                        <span data-lexical-text="true">‌</span>
+                        <span
+                            data-placeholder="Find a post, tag or author"
+                            data-lexical-text="true"
+                        ></span>
+                    </span>
+                </p>
+            `);
+
+            await page.keyboard.press('Backspace');
+
+            // it should now remove the at-linking entirely leaving only an @
+            await assertHTML(page, html`
+                <p><span data-lexical-text="true">@</span></p>
+            `);
+        });
+
+        test('creates a bookmark when at-linking from a line', async function () {
+            await focusEditor(page);
+
+            await page.keyboard.type('@');
+            await page.keyboard.type('Emo');
+            await expect(page.locator('[data-testid="at-link-results-listOption-label"]')).toContainText(['✨ Emoji autocomplete ✨']);
+            await page.keyboard.press('Enter');
+            // now wait till data-testid="bookmark-container" appears
+            await page.waitForSelector('[data-testid="bookmark-container"]');
+            await assertHTML(page, html`
+                <div data-lexical-decorator="true" contenteditable="false">
+                    <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="bookmark">
+                        <div>
+                            <div>
+                                <div>
+                                    <div>Ghost: The Creator Economy Platform</div>
+                                    <div>
+                                        The former of the two songs addresses the issue of negative rumors
+                                        in a relationship, while the latter, with a more upbeat pulse, is a
+                                        classic club track; the single is highlighted by a hyped bridge.
+                                    </div>
+                                    <div>
+                                        <img alt="" src="https://www.ghost.org/favicon.ico" />
+                                        <span>Ghost - The Professional Publishing Platform</span>
+                                        <span>Author McAuthory</span>
+                                    </div>
+                                </div>
+                                <div><img alt="" src="https://ghost.org/images/meta/ghost.png" /></div>
+                                <div></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div contenteditable="false" data-lexical-cursor="true"></div>
+            `, {ignoreCardToolbarContents: true, ignoreInnerSVG: true});
+        });
+
+        test('can paste into at-link node', async function () {
+            await focusEditor(page);
+            await page.keyboard.type('@');
+            await pasteText(page, 'https://ghost.org');
+            await expect(page.getByTestId('at-link-results')).toBeVisible();
+
+            await assertHTML(page, html`
+                <p>
+                    <span dir="ltr">
+                        <svg></svg>
+                        <span data-lexical-text="true">‌</span>
+                        <span data-placeholder="" data-lexical-text="true">https://ghost.org</span>
+                    </span>
+                </p>
+            `);
+        });
+    });
+});


### PR DESCRIPTION
Fixes for https://github.com/TryGhost/Ghost/issues/21721

Hi 👋🏻 this bug turned into a bit of a rabbit hole, I'm happy to split this into smaller PRs or make any other adjustments as needed. I found 3 separate, but connected problems:

- Typing '@' in Firefox doesn't open the internal linking popover. This is because of timing, in Firefox the event is triggering before the editor state has updated. To solve this I've used `editor.registerUpdateListener` to catch the next update, and then immediately deregistered that listener. I explored and considered a few other solutions such as setTimeout, upgrading to  [Lexical 17.0](https://github.com/facebook/lexical/blob/main/CHANGELOG.md#v0170-2024-07-31) or higher and taking advantage of the [`editor.read`](https://lexical.dev/docs/api/classes/lexical.LexicalEditor#read) method to force a state reconciliation, but this seemed like a better compromise with the existing code.
- Crashing/infinite loops (Chrome and Firefox) - these are described in https://github.com/TryGhost/Ghost/issues/22421 and I'm still not fully certain of the cause. Essentially, we have an update listener which tries to guarantee the cursor/selection never sits on the ZWNJNode, but rather in the SearchNode instead, but sometimes something else will move the selection back to the ZWNJNode and so it loops forever. My only solution here was to identify the situation by examining `prevEditorState` and avoid looping.
- For the first character typed in Firefox, the cursor would jump backward. This happened because the AtLink node transform behaves just slightly differently if it finds `[ZWNJNode, SearchNode, ExtendedTextNode]` (Firefox) instead of `[ExtendedTextNode]` (Chrome). In Firefox, the existing node is deleted and text copied to another node - this causes the cursor to move left (before the text entered). I've updated the transform code to preserve any existing non-empty node if possible, fixing this issue.

I've also gratefully added the tests already written in the [spike code](https://github.com/TryGhost/Koenig/commit/e8509cad0ddb9cae6171298b772f80ff7829c585).