### PR TITLE
Replaced `data-testid` with `data-kg-settings-panel`

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -54,7 +54,7 @@ const KoenigCardWrapper = ({nodeKey, width, wrapperStyle, IndicatorIcon, childre
                         const cardNode = $getNodeByKey(nodeKey);
                         const clickedDifferentEditor = !cardNode;
                         const clickedToolbar = event.target.closest('[data-kg-allow-clickthrough="false"]');
-                        const clickedSettingsPanel = event.target.closest('[data-testid="settings-panel"]');
+                        const clickedSettingsPanel = event.target.closest('[data-kg-settings-panel]');
 
                         if (isSelected && (cardNode?.hasEditMode?.() && !isEditing && !clickedToolbar && !clickedSettingsPanel)) {
                             editor.dispatchCommand(EDIT_CARD_COMMAND, {cardKey: nodeKey, focusEditor: !clickedDifferentEditor});

--- a/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
+++ b/packages/koenig-lexical/src/components/ui/SettingsPanel.jsx
@@ -33,6 +33,7 @@ export function SettingsPanel({children, darkMode, cardWidth, tabs, defaultTab})
                 <div ref={ref}
                     className="not-kg-prose fixed left-0 top-0 z-[9999999] m-0 flex w-[320px] flex-col rounded-lg bg-white bg-clip-padding font-sans shadow-lg will-change-transform dark:bg-grey-950 dark:shadow-xl"
                     data-testid="settings-panel"
+                    data-kg-settings-panel
                 >
                     <TabView defaultTab={defaultTab} tabContent={tabContent} tabs={tabs} />
                 </div>
@@ -40,6 +41,7 @@ export function SettingsPanel({children, darkMode, cardWidth, tabs, defaultTab})
                 <div ref={ref}
                     className="not-kg-prose fixed left-0 top-0 z-[9999999] m-0 flex w-[320px] flex-col gap-3 rounded-lg bg-white bg-clip-padding p-6 font-sans shadow-lg will-change-transform dark:bg-grey-950 dark:shadow-xl"
                     data-testid="settings-panel"
+                    data-kg-settings-panel
                 >{children}</div>
             )}
         </div>

--- a/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
@@ -315,7 +315,7 @@ test.describe('Email card', async () => {
                     <hr />
                 </div>
                 <div>
-                    <div draggable="true">
+                    <div data-kg-settings-panel="true" draggable="true">
                         <div>
                             <div>Visibility</div>
                             <div>

--- a/packages/koenig-lexical/test/e2e/cards/product-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/product-card.test.js
@@ -304,7 +304,7 @@ test.describe('Product card', async () => {
                         </div>
                     </div>
                     <div>
-                        <div draggable="true">
+                        <div data-kg-settings-panel="true" draggable="true">
                             <label>
                                 <div><div>Rating</div></div>
                                 <div>
@@ -715,7 +715,7 @@ test.describe('Product card', async () => {
                         </div>
                     </div>
                     <div>
-                        <div draggable="true">
+                        <div data-kg-settings-panel="true" draggable="true">
                             <label>
                                 <div><div>Rating</div></div>
                                 <div>


### PR DESCRIPTION
no issue

Replaced `data-testid="settings-panel"` with `data-kg-settings-panel` in the settings panel click detection logic. This avoids using test-specific identifiers in production code.