### PR TITLE
Fixed SlashCardMenuPlugin re-building menu on every cursor change

### DIFF
--- a/packages/koenig-lexical/src/plugins/SlashCardMenuPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/SlashCardMenuPlugin.jsx
@@ -68,10 +68,12 @@ function useSlashCardMenu(editor) {
         }
         setIsShowingMenu(false);
         setQuery('');
-        setCommandParams([]);
+        if (commandParams.length > 0) {
+            setCommandParams([]);
+        }
         setScrollToSelectedItem(false);
         cachedRange.current = null;
-    }, [setIsShowingMenu]);
+    }, [setIsShowingMenu, commandParams]);
 
     const insert = React.useCallback((insertCommand, {insertParams = {}, queryParams = {}} = {}) => {
         const dataset = {...insertParams};


### PR DESCRIPTION
no issue

- when debugging I noticed `buildCardMenu` was being called on every cursor change when it should only be called when the contents of the menu are likely to have changed
- the cause was setting a state property to a non-primitive-type value inside a function that is called on every cursor change. React can't diff non-primitive types (`[] === [] === false`) so a state change for them always causes a re-render and any hooks that depend on it to re-run
- adding a guard to the often-called function so we only set the `commentParams` state when we need to eliminated the unexpected menu rebuild calls
