### PR TITLE
Hid Email CTA card when contentVisibility flag is enabled

### DIFF
--- a/packages/koenig-lexical/demo/DemoApp.jsx
+++ b/packages/koenig-lexical/demo/DemoApp.jsx
@@ -32,6 +32,18 @@ const params = new URLSearchParams(url.search);
 const WEBSOCKET_ENDPOINT = params.get('multiplayerEndpoint') || 'ws://localhost:1234';
 const WEBSOCKET_ID = params.get('multiplayerId') || '0';
 
+// show deprecated cards by default so they can be tested, unless explicitly hidden
+// so we can test they are removed from the menu when deprecated/behind a feature flag
+function hideDeprecatedCardInMenu(searchParams) {
+    // allow tests to opt in to hiding deprecated cards
+    if (searchParams.get('hideDeprecatedCards') === 'true') {
+        return true;
+    }
+
+    // otherwise show deprecated cards by default so tests don't need updating
+    return process.env.NODE_ENV === 'test' ? false : true;
+}
+
 const defaultCardConfig = {
     unsplash: defaultUnsplashHeaders,
     fetchEmbed: fetchEmbed,
@@ -52,9 +64,6 @@ const defaultCardConfig = {
         collectionsCard: true,
         contentVisibility: false,
         contentVisibilityAlpha: false
-    },
-    deprecated: {
-        headerV1: process.env.NODE_ENV === 'test' ? false : true // show header v1 only for tests
     },
     // this enables the internal linking feature, can be disabled with `/#/?searchLinks=false`
     searchLinks: async (term) => {
@@ -314,7 +323,11 @@ function DemoComposer({editorType, isMultiplayer, setWordCount, setTKCount}) {
             contentVisibilityAlpha: searchParams.get('labs')?.includes('contentVisibilityAlpha') || defaultCardConfig.feature.contentVisibilityAlpha
         },
         searchLinks: searchParams.get('searchLinks') === 'false' ? undefined : defaultCardConfig.searchLinks,
-        stripeEnabled: searchParams.get('stripe') === 'false' ? false : defaultCardConfig.stripeEnabled
+        stripeEnabled: searchParams.get('stripe') === 'false' ? false : defaultCardConfig.stripeEnabled,
+        deprecated: {
+            headerV1: hideDeprecatedCardInMenu(searchParams),
+            emailCta: hideDeprecatedCardInMenu(searchParams)
+        }
     };
 
     return (

--- a/packages/koenig-lexical/src/nodes/EmailCtaNode.jsx
+++ b/packages/koenig-lexical/src/nodes/EmailCtaNode.jsx
@@ -24,7 +24,10 @@ export class EmailCtaNode extends BaseEmailCtaNode {
         matches: ['email', 'cta', 'email-cta'],
         priority: 8,
         postType: 'post',
-        shortcut: '/email-cta'
+        shortcut: '/email-cta',
+        isHidden: ({config}) => {
+            return config?.feature?.contentVisibility && (config?.deprecated?.emailCta ?? true);
+        }
     };
 
     getIcon() {

--- a/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
@@ -24,6 +24,35 @@ test.describe('Email card', async () => {
         await page.close();
     });
 
+    test('is hidden in the card menu when contentVisibility feature is enabled', async function () {
+        // turn on card deprecations so we can test user-visible behaviour
+        await initialize({page, uri: '/#/?content=false&hideDeprecatedCards=true&labs=contentVisibility'});
+        await focusEditor(page);
+        await page.keyboard.press('/');
+        await page.keyboard.type('cta');
+        await expect(page.locator('[data-kg-card-menu-item="Call to Action"]')).toBeVisible();
+        await expect(page.locator('[data-kg-card-menu-item="Email call to action"]')).not.toBeVisible();
+    });
+
+    test('is visible with contentVisibility enabled for general tests', async function () {
+        // default test behaviour is to show deprecated cards
+        await initialize({page, uri: '/#/?content=false&labs=contentVisibility'});
+        await focusEditor(page);
+        await page.keyboard.press('/');
+        await page.keyboard.type('cta');
+        await expect(page.locator('[data-kg-card-menu-item="Call to Action"]')).toBeVisible();
+        await expect(page.locator('[data-kg-card-menu-item="Email call to action"]')).toBeVisible();
+    });
+
+    test('is visible in the card menu with contentVisibility feature disabled', async function () {
+        await initialize({page, uri: '/#/?content=false&hideDeprecatedCards=true'});
+        await focusEditor(page);
+        await page.keyboard.press('/');
+        await page.keyboard.type('cta');
+        await expect(page.locator('[data-kg-card-menu-item="Email call to action"]')).toBeVisible();
+        await expect(page.locator('[data-kg-card-menu-item="Call to Action"]')).not.toBeVisible();
+    });
+
     test.describe('import JSON', async () => {
         test('can import a email CTA card node', async function () {
             const contentParam = encodeURIComponent(JSON.stringify({


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-371

- updated Demo app behaviour so we can enable hiding of deprecated cards in tests with `?hideDeprecated=true` to confirm the hiding behaviour, especially useful when cards should only be hidden when a labs flag is enabled
- hid "Email CTA" card in card menus when the `contentVisibility` flag is enabled because the card will be replaced with the new "Call to action" card
  - hiding in menus rather than fully removing because we still want the "Email CTA" card to work in older content or in existing snippets
