### PR TITLE
Fixed CTA card menu capitalisation and matchers

### DIFF
--- a/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
@@ -17,11 +17,11 @@ export class CallToActionNode extends BaseCallToActionNode {
     __sponsorLabelHtmlEditorInitialState;
 
     static kgMenu = {
-        label: 'Call to Action',
+        label: 'Call to action',
         desc: 'Add a call to action to your post',
         Icon: EmailCtaCardIcon,
         insertCommand: INSERT_CALL_TO_ACTION_COMMAND,
-        matches: ['cta', 'call-to-action'],
+        matches: ['cta', 'call-to-action', 'email', 'email-cta'],
         priority: 10,
         shortcut: '/cta',
         isHidden: ({config}) => {

--- a/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/email-cta-card.test.js
@@ -30,7 +30,7 @@ test.describe('Email card', async () => {
         await focusEditor(page);
         await page.keyboard.press('/');
         await page.keyboard.type('cta');
-        await expect(page.locator('[data-kg-card-menu-item="Call to Action"]')).toBeVisible();
+        await expect(page.locator('[data-kg-card-menu-item="Call to action"]')).toBeVisible();
         await expect(page.locator('[data-kg-card-menu-item="Email call to action"]')).not.toBeVisible();
     });
 
@@ -40,7 +40,7 @@ test.describe('Email card', async () => {
         await focusEditor(page);
         await page.keyboard.press('/');
         await page.keyboard.type('cta');
-        await expect(page.locator('[data-kg-card-menu-item="Call to Action"]')).toBeVisible();
+        await expect(page.locator('[data-kg-card-menu-item="Call to action"]')).toBeVisible();
         await expect(page.locator('[data-kg-card-menu-item="Email call to action"]')).toBeVisible();
     });
 
@@ -50,7 +50,7 @@ test.describe('Email card', async () => {
         await page.keyboard.press('/');
         await page.keyboard.type('cta');
         await expect(page.locator('[data-kg-card-menu-item="Email call to action"]')).toBeVisible();
-        await expect(page.locator('[data-kg-card-menu-item="Call to Action"]')).not.toBeVisible();
+        await expect(page.locator('[data-kg-card-menu-item="Call to action"]')).not.toBeVisible();
     });
 
     test.describe('import JSON', async () => {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLG-371

- removed capitalisation of "Action" to match other cards
- added matchers from "Email CTA" card to "Call to action" card so there's no loss of muscle-memory for users of the replaced card
