### PR TITLE
🐛 Fixes list item link pasting behavior

### DIFF
--- a/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/KoenigBehaviourPlugin.jsx
@@ -1296,10 +1296,26 @@ function useKoenigBehaviour({editor, containerElem, cursorDidExitAtTop, isNested
                     // TODO: replace with better regex to include more protocols like mailto, ftp, etc
                     const linkMatch = text?.match(/^(https?:\/\/[^\s]+)$/);
                     if (linkMatch) {
-                        // avoid any conversion if we're pasting onto a card shortcut
                         const node = $getSelection()?.anchor.getNode();
-                        if (node && node.getTextContent().startsWith('/')) {
+
+                        // avoid any conversion if we're pasting onto a card shortcut
+                        const isNodeCardShortcut = node && node.getTextContent().startsWith('/');
+
+                        if (isNodeCardShortcut) {
                             return false;
+                        }
+
+                        // avoid converting to an embed/bookmark if we're pasting onto a list item
+                        const isNodeListItem = node && $isListItemNode(node);
+
+                        if (isNodeListItem) {
+                            const linkNode = $createLinkNode(text);
+                            const textNode = $createTextNode(text);
+
+                            linkNode.append(textNode);
+                            node.append(linkNode);
+
+                            return true;
                         }
 
                         // we're pasting a URL, convert it to an embed/bookmark/link


### PR DESCRIPTION
## Context 
This PR responds to the issue [Editor Bullet into Link #22822](https://github.com/TryGhost/Ghost/issues/22822) posted on the Ghost repository.

## The Problem
When pasting a link inside a list item, we get an unexpected behavior: 
1. An embed link preview is created outside the list
2. The list item remains empty

![CleanShot 2025-04-15 at 20 01 50](https://github.com/user-attachments/assets/9ce1a145-78b2-482b-babc-9b311103dcb7)

## The Solution
1. Detect when the link pasting is happening inside a list item
2. Avoid embed card creation
3. Create a simple link inside the list item

![CleanShot 2025-04-15 at 20 10 03](https://github.com/user-attachments/assets/e5f598f4-0d6f-4470-b058-b71bb3f97b9e)

