### PR TITLE
Added toggle to Call to Action card to show/hide dividers

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
@@ -11,6 +11,7 @@ export class CallToActionNode extends generateDecoratorNode({
         {name: 'alignment', default: 'left'},
         {name: 'textValue', default: '', wordCount: true},
         {name: 'showButton', default: true},
+        {name: 'showDividers', default: true},
         {name: 'buttonText', default: 'Learn more'},
         {name: 'buttonUrl', default: ''},
         {name: 'buttonColor', default: '#000000'}, // Where colour is customisable, we should use hex values

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-parser.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-parser.js
@@ -20,7 +20,7 @@ export function parseCallToActionNode(CallToActionNode) {
 
                         const bgMatch = div.className.match(/kg-cta-bg-(\w+)/);
                         const backgroundColor = bgMatch ? bgMatch[1] : 'grey';
-
+                        const showDividers = div.classList.contains('kg-cta-has-dividers');
                         const imageContainer = domNode.querySelector('.kg-cta-image-container');
                         const imageElement = imageContainer?.querySelector('img');
                         let imageData = {
@@ -48,6 +48,7 @@ export function parseCallToActionNode(CallToActionNode) {
                             alignment: alignment,
                             textValue: textValueElement.textContent.trim() || '',
                             showButton: buttonElement ? true : false,
+                            showDividers: showDividers,
                             buttonText: buttonElement?.textContent.trim() || '',
                             buttonUrl: buttonElement?.getAttribute('href'),
                             buttonColor: rgbToHex(buttonColor),

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -25,7 +25,7 @@ function ctaCardTemplate(dataset) {
         : `style="background-color: ${dataset.buttonColor}; color: ${dataset.buttonTextColor};"`;
 
     return `
-        <div class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''} ${dataset.alignment === 'center' ? 'kg-cta-centered' : ''}" data-layout="${dataset.layout}">
+        <div class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.showDividers ? 'kg-cta-has-dividers' : ''} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''} ${dataset.alignment === 'center' ? 'kg-cta-centered' : ''}" data-layout="${dataset.layout}">
             ${dataset.hasSponsorLabel ? `
                 <div class="kg-cta-sponsor-label-wrapper">
                     <div class="kg-cta-sponsor-label">
@@ -179,7 +179,7 @@ function emailCTATemplate(dataset, options = {}) {
     };
 
     return `
-        <table class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.hasSponsorLabel ? '' : 'kg-cta-no-label'} ${dataset.textValue ? '' : 'kg-cta-no-text'} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''} ${dataset.alignment === 'center' ? 'kg-cta-centered' : ''}" border="0" cellpadding="0" cellspacing="0" width="100%">
+        <table class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} ${dataset.showDividers ? 'kg-cta-has-dividers' : ''} kg-cta-${dataset.layout} ${dataset.hasSponsorLabel ? '' : 'kg-cta-no-label'} ${dataset.textValue ? '' : 'kg-cta-no-text'} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''} ${dataset.alignment === 'center' ? 'kg-cta-centered' : ''}" border="0" cellpadding="0" cellspacing="0" width="100%">
             ${dataset.hasSponsorLabel ? `
                 <tr>
                     <td>
@@ -206,6 +206,7 @@ export function renderCallToActionNode(node, options = {}) {
         alignment: node.alignment,
         textValue: node.textValue,
         showButton: node.showButton,
+        showDividers: node.showDividers,
         buttonText: node.buttonText,
         buttonUrl: node.buttonUrl,
         buttonColor: node.buttonColor,

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -179,7 +179,7 @@ function emailCTATemplate(dataset, options = {}) {
     };
 
     return `
-        <table class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} ${dataset.showDividers ? 'kg-cta-has-dividers' : ''} kg-cta-${dataset.layout} ${dataset.hasSponsorLabel ? '' : 'kg-cta-no-label'} ${dataset.textValue ? '' : 'kg-cta-no-text'} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''} ${dataset.alignment === 'center' ? 'kg-cta-centered' : ''}" border="0" cellpadding="0" cellspacing="0" width="100%">
+        <table class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} ${dataset.showDividers ? '' : 'kg-cta-no-dividers'} kg-cta-${dataset.layout} ${dataset.hasSponsorLabel ? '' : 'kg-cta-no-label'} ${dataset.textValue ? '' : 'kg-cta-no-text'} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''} ${dataset.alignment === 'center' ? 'kg-cta-centered' : ''}" border="0" cellpadding="0" cellspacing="0" width="100%">
             ${dataset.hasSponsorLabel ? `
                 <tr>
                     <td>

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -25,7 +25,7 @@ function ctaCardTemplate(dataset) {
         : `style="background-color: ${dataset.buttonColor}; color: ${dataset.buttonTextColor};"`;
 
     return `
-        <div class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.showDividers ? 'kg-cta-has-dividers' : ''} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''} ${dataset.alignment === 'center' ? 'kg-cta-centered' : ''}" data-layout="${dataset.layout}">
+        <div class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.showDividers ? '' : 'kg-cta-no-dividers'} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''} ${dataset.alignment === 'center' ? 'kg-cta-centered' : ''}" data-layout="${dataset.layout}">
             ${dataset.hasSponsorLabel ? `
                 <div class="kg-cta-sponsor-label-wrapper">
                     <div class="kg-cta-sponsor-label">

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -31,6 +31,7 @@ describe('CallToActionNode', function () {
             textValue: 'This is a cool advertisement',
             sponsorLabel: '<p><span style="white-space: pre-wrap;">SPONSORED</span></p>',
             showButton: true,
+            showDividers: true,
             buttonText: 'click me',
             buttonUrl: 'http://blog.com/post1',
             buttonColor: 'none',
@@ -60,6 +61,7 @@ describe('CallToActionNode', function () {
             callToActionNode.layout.should.equal(dataset.layout);
             callToActionNode.textValue.should.equal(dataset.textValue);
             callToActionNode.showButton.should.equal(dataset.showButton);
+            callToActionNode.showDividers.should.equal(dataset.showDividers);
             callToActionNode.buttonText.should.equal(dataset.buttonText);
             callToActionNode.buttonUrl.should.equal(dataset.buttonUrl);
             callToActionNode.buttonColor.should.equal(dataset.buttonColor);
@@ -87,6 +89,10 @@ describe('CallToActionNode', function () {
             callToActionNode.showButton.should.equal(true);
             callToActionNode.showButton = false;
             callToActionNode.showButton.should.equal(false);
+
+            callToActionNode.showDividers.should.equal(true);
+            callToActionNode.showDividers = false;
+            callToActionNode.showDividers.should.equal(false);
 
             callToActionNode.buttonText.should.equal('Learn more');
             callToActionNode.buttonText = 'click me';
@@ -214,6 +220,7 @@ describe('CallToActionNode', function () {
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                 layout: 'minimal',
                 showButton: true,
+                showDividers: true,
                 textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card.</span></p>'
             };
 
@@ -244,6 +251,7 @@ describe('CallToActionNode', function () {
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                 layout: 'immersive',
                 showButton: true,
+                showDividers: true,
                 textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card via email.</span></p>'
             };
 
@@ -277,6 +285,7 @@ describe('CallToActionNode', function () {
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                 layout: 'minimal',
                 showButton: true,
+                showDividers: true,
                 textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card via email.</span></p>'
             };
 
@@ -305,6 +314,7 @@ describe('CallToActionNode', function () {
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                 layout: 'minimal',
                 showButton: true,
+                showDividers: true,
                 textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card via email.</span></p>'
             };
 
@@ -326,6 +336,7 @@ describe('CallToActionNode', function () {
                 imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                 layout: 'immersive',
                 showButton: true,
+                showDividers: true,
                 textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card via email.</span></p>',
                 imageWidth: 200,
                 imageHeight: 100
@@ -381,6 +392,7 @@ describe('CallToActionNode', function () {
 
         it('uses default buttonText when created with empty buttonText (web)', editorTest(function () {
             dataset.showButton = true;
+            dataset.showDividers = true;
             dataset.buttonText = '';
 
             testRender(({html}) => {
@@ -402,6 +414,7 @@ describe('CallToActionNode', function () {
             return editorTest(function () {
                 dataset.layout = layout;
                 dataset.showButton = true;
+                dataset.showDividers = true;
                 dataset.buttonUrl = 'http://blog.com/post1';
                 dataset.buttonText = 'Click me';
                 exportOptions.target = target;
@@ -434,6 +447,7 @@ describe('CallToActionNode', function () {
                 exportOptions.target = target;
                 dataset.layout = layout;
                 dataset.showButton = true;
+                dataset.showDividers = true;
                 dataset.buttonUrl = 'http://blog.com/post1';
 
                 testRender(({html}) => {
@@ -451,6 +465,7 @@ describe('CallToActionNode', function () {
                 exportOptions.target = target;
                 dataset.layout = layout;
                 dataset.showButton = false;
+                dataset.showDividers = true;
                 dataset.buttonUrl = 'http://blog.com/post1';
 
                 testRender(({html}) => {
@@ -479,6 +494,7 @@ describe('CallToActionNode', function () {
                 imageHeight: 100,
                 layout: 'minimal',
                 showButton: true,
+                showDividers: true,
                 textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card.</span></p>'
             };
             const callToActionNode = new CallToActionNode(dataset);
@@ -499,6 +515,7 @@ describe('CallToActionNode', function () {
                 imageHeight: 100,
                 layout: 'minimal',
                 showButton: true,
+                showDividers: true,
                 textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card.</span></p>',
                 linkColor: 'text',
                 alignment: 'left',
@@ -531,6 +548,7 @@ describe('CallToActionNode', function () {
                         imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
                         layout: 'minimal',
                         showButton: true,
+                        showDividers: true,
                         textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card.</span></p>'
                     }],
                     direction: null,

--- a/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
@@ -308,7 +308,7 @@ export function CallToActionCard({
                     {
                         'py-3': color === 'none' && !hasSponsorLabel,
                         'pb-3': color === 'none' && hasSponsorLabel,
-                        'pt-1': color === 'none' && !hasSponsorLabel && !showDividers
+                        'pt-1': color === 'none' && !hasSponsorLabel && !showDividers && !imageSrc
                     }
                 )} 
                 data-cta-layout={layout}
@@ -345,11 +345,11 @@ export function CallToActionCard({
 
                 <div className={clsx(
                     'flex gap-6',
-                    hasSponsorLabel && color !== 'none' && (imageSrc && layout === 'immersive') ? '' : (color === 'none' && !showDividers && !hasSponsorLabel) ? '' : 'pt-6',
-                    imageSrc && !showButton ? 'pb-8' : (color === 'none' && !showDividers) ? '' : 'pb-7',
+                    hasSponsorLabel && color !== 'none' && (imageSrc && layout === 'immersive') ? '' : (color === 'none' && !showDividers) ? '' : 'pt-6',
+                    (color === 'none' && !showDividers) ? '' : imageSrc && !showButton ? 'pb-8' : 'pb-7',
                     layout === 'immersive' ? 'flex-col' : 'flex-row',
-                    (color === 'none' && showDividers) || (hasSponsorLabel && !(imageSrc && layout === 'immersive')) ? 'border-t border-grey-900/15 dark:border-grey-100/20' : '',
-                    (color === 'none' && showDividers) ? 'border-b border-grey-900/15 dark:border-grey-100/20' : color !== 'none' ? 'mx-6' : ''
+                    (hasSponsorLabel && !(imageSrc && layout === 'immersive') && !(color === 'none' && !showDividers)) && 'border-t border-grey-900/15 dark:border-grey-100/20',
+                    (color === 'none' && showDividers) ? 'border-y border-grey-900/15 dark:border-grey-100/20' : color !== 'none' ? 'mx-6' : ''
                 )}>
                     {imageSrc && (
                         <div className={clsx(

--- a/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/CallToActionCard.jsx
@@ -99,6 +99,7 @@ export function CallToActionCard({
     isEditing = false,
     layout = 'immersive',
     showButton = false,
+    showDividers = true,
     visibilityOptions = {},
     handleButtonColor = () => {},
     handleColorChange = () => {},
@@ -112,6 +113,7 @@ export function CallToActionCard({
     updateHasSponsorLabel = () => {},
     updateLayout = () => {},
     updateShowButton = () => {},
+    updateShowDividers = () => {},
     toggleVisibility = () => {},
     imageDragHandler = {},
     imageUploader = () => {},
@@ -223,7 +225,7 @@ export function CallToActionCard({
 
     const designSettings = (
         <>
-            {/* Layout settings */}
+            {/* Layout button group */}
             <ButtonGroupSetting
                 buttons={layoutOptions}
                 label='Layout'
@@ -240,7 +242,7 @@ export function CallToActionCard({
                     />
                 </>
             }
-            {/* Color picker */}
+            {/* Background color picker */}
             <ColorOptionSetting
                 buttons={callToActionColorPicker}
                 dataTestId='cta-background-color-picker'
@@ -248,7 +250,16 @@ export function CallToActionCard({
                 selectedName={color}
                 onClick={handleColorChange}
             />
-            {/* Link color setting */}
+            {/* Dividers setting */}
+            {color === 'none' &&
+                <ToggleSetting
+                    dataTestId="button-settings"
+                    isChecked={showDividers}
+                    label='Dividers'
+                    onChange={updateShowDividers}
+                />
+            }
+            {/* Link color picker */}
             <ColorOptionSetting
                 buttons={callToActionLinkColorPicker}
                 dataTestId='cta-link-color-picker'
@@ -296,7 +307,8 @@ export function CallToActionCard({
                     CALLTOACTION_COLORS[color],
                     {
                         'py-3': color === 'none' && !hasSponsorLabel,
-                        'pb-3': color === 'none' && hasSponsorLabel
+                        'pb-3': color === 'none' && hasSponsorLabel,
+                        'pt-1': color === 'none' && !hasSponsorLabel && !showDividers
                     }
                 )} 
                 data-cta-layout={layout}
@@ -333,11 +345,11 @@ export function CallToActionCard({
 
                 <div className={clsx(
                     'flex gap-6',
-                    hasSponsorLabel && color !== 'none' && (imageSrc && layout === 'immersive') ? '' : 'pt-6',
-                    imageSrc && !showButton ? 'pb-8' : 'pb-7',
+                    hasSponsorLabel && color !== 'none' && (imageSrc && layout === 'immersive') ? '' : (color === 'none' && !showDividers && !hasSponsorLabel) ? '' : 'pt-6',
+                    imageSrc && !showButton ? 'pb-8' : (color === 'none' && !showDividers) ? '' : 'pb-7',
                     layout === 'immersive' ? 'flex-col' : 'flex-row',
-                    color === 'none' || (hasSponsorLabel && !(imageSrc && layout === 'immersive')) ? 'border-t border-grey-900/15 dark:border-grey-100/20' : '',
-                    color === 'none' ? 'border-b border-grey-900/15 dark:border-grey-100/20' : 'mx-6'
+                    (color === 'none' && showDividers) || (hasSponsorLabel && !(imageSrc && layout === 'immersive')) ? 'border-t border-grey-900/15 dark:border-grey-100/20' : '',
+                    (color === 'none' && showDividers) ? 'border-b border-grey-900/15 dark:border-grey-100/20' : color !== 'none' ? 'mx-6' : ''
                 )}>
                     {imageSrc && (
                         <div className={clsx(
@@ -434,6 +446,7 @@ CallToActionCard.propTypes = {
     isEditing: PropTypes.bool,
     layout: PropTypes.oneOf(['minimal', 'immersive']),
     showButton: PropTypes.bool,
+    showDividers: PropTypes.bool,
     htmlEditor: PropTypes.object,
     htmlEditorInitialState: PropTypes.object,
     updateAlignment: PropTypes.func,
@@ -441,6 +454,7 @@ CallToActionCard.propTypes = {
     updateButtonUrl: PropTypes.func,
     updateHasSponsorLabel: PropTypes.func,
     updateShowButton: PropTypes.func,
+    updateShowDividers: PropTypes.func,
     updateLayout: PropTypes.func,
     handleColorChange: PropTypes.func,
     handleButtonColor: PropTypes.func,

--- a/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNode.jsx
@@ -111,6 +111,7 @@ export class CallToActionNode extends BaseCallToActionNode {
                     linkColor={this.linkColor}
                     nodeKey={this.getKey()}
                     showButton={this.showButton}
+                    showDividers={this.showDividers}
                     sponsorLabelHtmlEditor={this.__sponsorLabelHtmlEditor}
                     sponsorLabelHtmlEditorInitialState={this.__sponsorLabelHtmlEditorInitialState}
                     textValue={this.textValue}

--- a/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/CallToActionNodeComponent.jsx
@@ -23,6 +23,7 @@ export const CallToActionNodeComponent = ({
     layout,
     linkColor,
     showButton,
+    showDividers,
     textValue,
     buttonColor,
     htmlEditor,
@@ -55,6 +56,13 @@ export const CallToActionNodeComponent = ({
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
             node.showButton = !node.showButton;
+        });
+    };
+
+    const toggleShowDividers = (event) => {
+        editor.update(() => {
+            const node = $getNodeByKey(nodeKey);
+            node.showDividers = !node.showDividers;
         });
     };
 
@@ -176,6 +184,7 @@ export const CallToActionNodeComponent = ({
                 setEditing={setEditing}
                 setFileInputRef={ref => fileInputRef.current = ref}
                 showButton={showButton}
+                showDividers={showDividers}
                 showVisibilitySettings={showVisibilitySettings}
                 sponsorLabelHtmlEditor={sponsorLabelHtmlEditor}
                 sponsorLabelHtmlEditorInitialState={sponsorLabelHtmlEditorInitialState}
@@ -187,6 +196,7 @@ export const CallToActionNodeComponent = ({
                 updateHasSponsorLabel={handleHasSponsorLabelChange}
                 updateLayout={handleUpdatingLayout}
                 updateShowButton={toggleShowButton}
+                updateShowDividers={toggleShowDividers}
                 visibilityOptions={visibilityOptions}
                 onFileChange={onFileChange}
                 onRemoveMedia={onRemoveMedia}

--- a/packages/koenig-lexical/test/e2e/cards/call-to-action-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/call-to-action-card.test.js
@@ -31,6 +31,7 @@ test.describe('Call To Action Card', async () => {
             imageUrl: '/content/images/2022/11/koenig-lexical.jpg',
             layout: 'minimal',
             showButton: true,
+            showDividers: true,
             textValue: '<p><span style="white-space: pre-wrap;">This is a new CTA Card.</span></p>'
         };
     });


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1628/add-setting-to-showhide-dividers
- This supports the use case where the card is used as inline with text, and the dividers are not needed.