### PR TITLE
Added support for buttonCorners design option to card renderers

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/product/product-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/product/product-renderer.js
@@ -10,9 +10,22 @@ export function renderProductNode(node, options = {}) {
         return renderEmptyContainer(document);
     }
 
+    let buttonBorderRadius = '5px';
+
+    // we're switching to 6px by default as part of settings being added
+    // TODO: remove 'rounded' check and switch default above to 6px
+    if (options.design?.buttonCorners === 'rounded') {
+        buttonBorderRadius = '6px';
+    } else if (options.design?.buttonCorners === 'square') {
+        buttonBorderRadius = '0px';
+    } else if (options.design?.buttonCorners === 'pill') {
+        buttonBorderRadius = '9999px';
+    }
+
     const templateData = {
         ...node.getDataset(),
-        starIcon: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"/></svg>`
+        starIcon: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"/></svg>`,
+        buttonBorderRadius
     };
 
     const starActiveClasses = 'kg-product-card-rating-active';
@@ -107,7 +120,7 @@ export function emailCardTemplate({data}) {
                 <tr>
                     <td style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;">
                         <div class="btn btn-accent" style="box-sizing: border-box;display: table;width: 100%;padding-top: 16px;">
-                            <a href="${data.productUrl}" style="overflow-wrap: anywhere;border: solid 1px;border-radius: 5px;box-sizing: border-box;cursor: pointer;display: inline-block;font-size: 14px;font-weight: bold;margin: 0;padding: 0;text-decoration: none;color: #FFFFFF; width: 100%; text-align: center;"><span style="display: block;padding: 12px 25px;">${data.productButton}</span></a>
+                            <a href="${data.productUrl}" style="overflow-wrap: anywhere;border: solid 1px;border-radius: ${data.buttonBorderRadius};box-sizing: border-box;cursor: pointer;display: inline-block;font-size: 14px;font-weight: bold;margin: 0;padding: 0;text-decoration: none;color: #FFFFFF; width: 100%; text-align: center;"><span style="display: block;padding: 12px 25px;">${data.productButton}</span></a>
                         </div>
                     </td>
                 </tr>

--- a/packages/kg-default-nodes/test/nodes/product.test.js
+++ b/packages/kg-default-nodes/test/nodes/product.test.js
@@ -435,6 +435,43 @@ describe('ProductNode', function () {
                 <table cellspacing="0" cellpadding="0" border="0" style="width:100%; padding:20px; border:1px solid #E9E9E9; border-radius: 5px; margin: 0 0 1.5em; width: 100%;"><tbody><tr><td valign="top"><h4 style="font-size: 22px !important; margin-top: 0 !important; margin-bottom: 0 !important; font-weight: 700;">Product title!</h4></td></tr><tr><td style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;"><div style="padding-top: 8px; opacity: 0.7; font-size: 17px; line-height: 1.4; margin-bottom: -24px;">This product is ok</div></td></tr></tbody></table>
             `);
         }));
+
+        function renderButton(design) {
+            const payload = {
+                productButton: 'Click me',
+                productButtonEnabled: true,
+                productDescription: 'This product is ok',
+                productRatingEnabled: false,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
+            };
+
+            const options = {
+                target: 'email',
+                design
+            };
+
+            const productNode = $createProductNode(payload);
+            const {element} = productNode.exportDOM({...exportOptions, ...options});
+
+            return element.outerHTML;
+        }
+
+        it('handles no design option', editorTest(function () {
+            renderButton().should.containEql('border-radius: 5px;');
+        }));
+
+        it('renders rounded button border radius', editorTest(function () {
+            renderButton({buttonCorners: 'rounded'}).should.containEql('border-radius: 6px;');
+        }));
+
+        it('renders square button border radius', editorTest(function () {
+            renderButton({buttonCorners: 'square'}).should.containEql('border-radius: 0px;');
+        }));
+
+        it('renders pill button border radius', editorTest(function () {
+            renderButton({buttonCorners: 'pill'}).should.containEql('border-radius: 9999px;');
+        }));
     });
 
     describe('importDOM', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1688

- updated product card renderer to output different border-radius values dependent on the `design.buttonCorners` option value that will be passed through from Ghost when the `emailCustomizationAlpha` flag is enabled
- switches between a `rounded`, `squared`, and `pill` radius
- this required changes in the card renderer because it currently uses inline styles
