### PR TITLE
Swapped inline styles for classes in product card email template

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/product/product-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/product/product-renderer.js
@@ -37,8 +37,8 @@ export function renderProductNode(node, options = {}) {
     }
 
     const htmlString = options.target === 'email'
-        ? emailCardTemplate({data: templateData})
-        : cardTemplate({data: templateData});
+        ? emailCardTemplate({data: templateData, feature: options.feature})
+        : cardTemplate({data: templateData, feature: options.feature});
 
     const element = document.createElement('div');
     element.innerHTML = htmlString.trim();
@@ -75,7 +75,7 @@ export function cardTemplate({data}) {
     );
 }
 
-export function emailCardTemplate({data}) {
+export function emailCardTemplate({data, feature}) {
     let imageDimensions;
 
     if (data.productImageWidth && data.productImageHeight) {
@@ -87,6 +87,48 @@ export function emailCardTemplate({data}) {
         if (data.productImageWidth >= 560) {
             imageDimensions = getResizedImageDimensions(imageDimensions, {width: 560});
         }
+    }
+
+    if (feature?.emailCustomizationAlpha) {
+        return (
+            `
+             <table class="kg-product-card" cellspacing="0" cellpadding="0" border="0">
+                ${data.productImageSrc ? `
+                    <tr>
+                        <td class="kg-product-image" align="center">
+                            <img src="${data.productImageSrc}" ${imageDimensions ? `width="${imageDimensions.width}"` : ''} ${imageDimensions ? `height="${imageDimensions.height}"` : ''} border="0"/>
+                        </td>
+                    </tr>
+                ` : ''}
+                <tr>
+                    <td valign="top">
+                        <h4 class="kg-product-title">${data.productTitle}</h4>
+                    </td>
+                </tr>
+                ${data.productRatingEnabled ? `
+                    <tr class="kg-product-rating">
+                        <td valign="top">
+                            <img src="${`https://static.ghost.org/v4.0.0/images/star-rating-${data.productStarRating}.png`}" border="0" />
+                        </td>
+                    </tr>
+                ` : ''}
+                <tr>
+                    <td class="kg-product-description-wrapper">
+                        <div class="kg-product-description">${data.productDescription}</div>
+                    </td>
+                </tr>
+                ${data.productButtonEnabled ? `
+                    <tr>
+                        <td class="kg-product-button-wrapper">
+                            <div class="btn btn-accent">
+                                <a href="${data.productUrl}"><span>${data.productButton}</span></a>
+                            </div>
+                        </td>
+                    </tr>
+                ` : ''}
+            </table>
+            `
+        );
     }
 
     return (

--- a/packages/kg-default-nodes/test/nodes/product.test.js
+++ b/packages/kg-default-nodes/test/nodes/product.test.js
@@ -342,6 +342,63 @@ describe('ProductNode', function () {
             `);
         }));
 
+        it('renders email (emailCustomizationAlpha)', editorTest(function () {
+            const payload = {
+                productButton: 'Click me',
+                productButtonEnabled: true,
+                productDescription: 'This product is ok',
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productRatingEnabled: true,
+                productStarRating: 3,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
+            };
+
+            const options = {
+                target: 'email',
+                feature: {
+                    emailCustomizationAlpha: true
+                }
+            };
+
+            const productNode = $createProductNode(payload);
+            const {element} = productNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(`
+                <table class="kg-product-card" cellspacing="0" cellpadding="0" border="0">
+                    <tbody>
+                        <tr>
+                            <td class="kg-product-image" align="center">
+                                <img src="https://example.com/images/ok.jpg" border="0">
+                            </td>
+                        </tr>
+                        <tr>
+                            <td valign="top">
+                                <h4 class="kg-product-title">Product title!</h4>
+                            </td>
+                        </tr>
+                        <tr class="kg-product-rating">
+                            <td valign="top">
+                                <img src="https://static.ghost.org/v4.0.0/images/star-rating-3.png" border="0">
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="kg-product-description-wrapper">
+                                <div class="kg-product-description">This product is ok</div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="kg-product-button-wrapper">
+                                <div class="btn btn-accent">
+                                    <a href="https://example.com/product/ok"><span>Click me</span></a>
+                                </div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
+        }));
+
         it('renders email with img width and height', editorTest(function () {
             const payload = {
                 productButton: 'Click me',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1747

- duplicated email template under the emailCustomizationAlpha flag
- replaced inline styles with classes
  - email template in Ghost has been updated to add the previous styles in it's CSS class definitions
