### PR TITLE
Fixed duplicate `<p>` and indented HTML output of button

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/button/button-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/button/button-renderer.js
@@ -1,6 +1,6 @@
 import {addCreateDocumentOption} from '../../utils/add-create-document-option';
 import {renderEmptyContainer} from '../../utils/render-empty-container';
-import {oneline} from '../../utils/tagged-template-fns.mjs';
+import {html} from '../../utils/tagged-template-fns.mjs';
 
 export function renderButtonNode(node, options = {}) {
     addCreateDocumentOption(options);
@@ -35,7 +35,7 @@ function frontendTemplate(node, document) {
 function emailTemplate(node, options, document) {
     const {buttonUrl, buttonText} = node;
 
-    const html = oneline`
+    const cardHtml = html`
         <div class="btn btn-accent">
             <table border="0" cellspacing="0" cellpadding="0" align="${node.alignment}">
                 <tr>
@@ -48,7 +48,7 @@ function emailTemplate(node, options, document) {
     `;
 
     const element = document.createElement('p');
-    element.innerHTML = html;
+    element.innerHTML = cardHtml;
     return {element};
 }
 

--- a/packages/kg-default-nodes/lib/nodes/button/button-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/button/button-renderer.js
@@ -1,5 +1,6 @@
 import {addCreateDocumentOption} from '../../utils/add-create-document-option';
 import {renderEmptyContainer} from '../../utils/render-empty-container';
+import {oneline} from '../../utils/tagged-template-fns.mjs';
 
 export function renderButtonNode(node, options = {}) {
     addCreateDocumentOption(options);
@@ -34,18 +35,16 @@ function frontendTemplate(node, document) {
 function emailTemplate(node, options, document) {
     const {buttonUrl, buttonText} = node;
 
-    const html = `
-        <p>
-            <div class="btn btn-accent">
-                <table border="0" cellspacing="0" cellpadding="0" align="${node.alignment}">
-                    <tr>
-                        <td align="center">
-                            <a href="${buttonUrl}">${buttonText}</a>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-        </p>
+    const html = oneline`
+        <div class="btn btn-accent">
+            <table border="0" cellspacing="0" cellpadding="0" align="${node.alignment}">
+                <tr>
+                    <td align="center">
+                        <a href="${buttonUrl}">${buttonText}</a>
+                    </td>
+                </tr>
+            </table>
+        </div>
     `;
 
     const element = document.createElement('p');

--- a/packages/kg-default-nodes/lib/utils/tagged-template-fns.mjs
+++ b/packages/kg-default-nodes/lib/utils/tagged-template-fns.mjs
@@ -1,7 +1,12 @@
-export function oneline(strings, ...values) {
+const oneline = function (strings, ...values) {
     const result = strings.reduce((acc, str, i) => {
         return acc + str + (values[i] || '');
     }, '');
     // Remove newline+indentation patterns while preserving intentional whitespace
     return result.replace(/\n\s+/g, '').trim();
-}
+};
+
+// Using `html` as a synonym for `oneline` in order to get syntax highlighting in editors
+const html = oneline;
+
+export {oneline, html};

--- a/packages/kg-default-nodes/lib/utils/tagged-template-fns.mjs
+++ b/packages/kg-default-nodes/lib/utils/tagged-template-fns.mjs
@@ -1,0 +1,7 @@
+export function oneline(strings, ...values) {
+    const result = strings.reduce((acc, str, i) => {
+        return acc + str + (values[i] || '');
+    }, '');
+    // Remove newline+indentation patterns while preserving intentional whitespace
+    return result.replace(/\n\s+/g, '').trim();
+}

--- a/packages/kg-default-nodes/package.json
+++ b/packages/kg-default-nodes/package.json
@@ -12,12 +12,12 @@
     "build": "rollup -c",
     "prepare": "NODE_ENV=production yarn build",
     "pretest": "yarn build",
-    "test:unit": "NODE_ENV=testing c8 --all --check-coverage --reporter text --reporter cobertura mocha './test/**/*.test.js'",
+    "test:unit": "NODE_ENV=testing c8 --all --check-coverage --reporter text --reporter cobertura mocha './test/**/*.test.*js'",
     "test": "yarn test:unit",
-    "test:no-coverage": "yarn pretest && mocha './test/**/*.test.js'",
-    "lint:code": "eslint *.js lib/ --ext .js --cache",
+    "test:no-coverage": "yarn pretest && mocha './test/**/*.test.*js'",
+    "lint:code": "eslint *.js lib/ --ext .js,.mjs --cache",
     "lint": "yarn lint:code && yarn lint:test",
-    "lint:test": "eslint -c test/.eslintrc.js test/ --ext .js --cache"
+    "lint:test": "eslint -c test/.eslintrc.js test/ --ext .js,.mjs --cache"
   },
   "files": [
     "LICENSE",

--- a/packages/kg-default-nodes/test/utils/tagged-template-fns.test.mjs
+++ b/packages/kg-default-nodes/test/utils/tagged-template-fns.test.mjs
@@ -1,0 +1,23 @@
+import {oneline} from '../../lib/utils/tagged-template-fns.mjs';
+
+describe('Internal utils: oneline', function () {
+    it('removes indentation and normalizes whitespace', function () {
+        const buttonUrl = 'http://example.com';
+        const buttonText = 'Click me';
+        const alignment = 'center';
+
+        const result = oneline`
+            <div class="btn btn-accent">
+                <table border="0" cellspacing="0" cellpadding="0" align="${alignment}">
+                    <tr>
+                        <td align="center">
+                            <a href="${buttonUrl}">${buttonText}</a>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        `;
+
+        result.should.equal('<div class="btn btn-accent"><table border="0" cellspacing="0" cellpadding="0" align="center"><tr><td align="center"><a href="http://example.com">Click me</a></td></tr></table></div>');
+    });
+});


### PR DESCRIPTION
ref https://github.com/TryGhost/Koenig/commit/b2fff6a9a1388c23446def59be2d4f0167f0d88a

- when switching to a string template we accidentally introduced a doubly-nested paragraph as one was included in the string template and in the `document.createElement('p')` that string template was injected into
- added a `oneline` tagged template function so the output matches the previous manual DOM build
  - keeps snapshot changes for email content minimal to make real changes more noticeable
  - avoids unwanted newlines being added to the plaintext email output
  - uses `.mjs` so we can import the file directly in a test file, otherwise we have to expose this utility as part of the package's public interface
