### PR TITLE
Fixed alignment issues with header and call to action cards in Outlook

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -157,10 +157,10 @@ function emailCTATemplate(dataset, options = {}) {
                             </tr>
                             ${showButton(dataset) ? `
                                 <tr>
-                                    <td class="kg-cta-button-container">
+                                    <td class="kg-cta-button-container" align="${dataset.alignment}">
                                         <table class="btn" border="0" cellpadding="0" cellspacing="0">
                                             <tr>
-                                                <td class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}" style="${buttonStyle}">
+                                                <td class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}" style="${buttonStyle}" align="${dataset.alignment}">
                                                     <a href="${dataset.buttonUrl}"
                                                        class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}"
                                                        style="${buttonStyle}"

--- a/packages/kg-default-nodes/lib/nodes/header/renderers/v2/header-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/header/renderers/v2/header-renderer.js
@@ -89,12 +89,12 @@ function emailTemplate(nodeData, feature) {
                         <td class="kg-header-card-content" style="${nodeData.layout === 'split' && nodeData.backgroundSize === 'contain' ? 'padding-top: 0;' : ''}">
                             <table border="0" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
-                                    <td>
+                                    <td align="${nodeData.alignment}">
                                         <h2 class="kg-header-card-heading" style="color:${nodeData.textColor};">${nodeData.header}</h2>
                                     </td>
                                 </tr>
                                 <tr>
-                                    <td class="kg-header-card-subheading-wrapper">
+                                    <td class="kg-header-card-subheading-wrapper" align="${nodeData.alignment}">
                                         <p class="kg-header-card-subheading" style="color:${nodeData.textColor};">${nodeData.subheader}</p>
                                     </td>
                                 </tr>


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1688/implement-button-corners-setting
- The button in the CTA card wouldn't center, Outlook needs the align attribute to be set
- The header and subheader in the header card wouldn't center, Outlook needs the align attribute to be set