### PR TITLE
Exported taggedTemplateFns utils for easier usage within tests

### DIFF
--- a/packages/kg-default-nodes/lib/kg-default-nodes.js
+++ b/packages/kg-default-nodes/lib/kg-default-nodes.js
@@ -65,12 +65,14 @@ export * from './nodes/zwnj/ZWNJNode';
 
 // export utility functions that are useful in other packages or tests
 import * as visibilityUtils from './utils/visibility';
+import * as taggedTemplateFns from './utils/tagged-template-fns.mjs';
 import {generateDecoratorNode} from './generate-decorator-node.js';
 import {rgbToHex} from './utils/rgb-to-hex.js';
 export const utils = {
     generateDecoratorNode,
     visibility: visibilityUtils,
-    rgbToHex
+    rgbToHex,
+    taggedTemplateFns
 };
 
 export const serializers = {

--- a/packages/kg-default-nodes/lib/utils/tagged-template-fns.mjs
+++ b/packages/kg-default-nodes/lib/utils/tagged-template-fns.mjs
@@ -1,4 +1,10 @@
 const oneline = function (strings, ...values) {
+    // Handle case where a plain string is passed
+    if (typeof strings === 'string') {
+        return strings.replace(/\n\s+/g, '').trim();
+    }
+
+    // Handle tagged template literal case
     const result = strings.reduce((acc, str, i) => {
         return acc + str + (values[i] || '');
     }, '');

--- a/packages/kg-default-nodes/test/utils/tagged-template-fns.test.mjs
+++ b/packages/kg-default-nodes/test/utils/tagged-template-fns.test.mjs
@@ -20,4 +20,14 @@ describe('Internal utils: oneline', function () {
 
         result.should.equal('<div class="btn btn-accent"><table border="0" cellspacing="0" cellpadding="0" align="center"><tr><td align="center"><a href="http://example.com">Click me</a></td></tr></table></div>');
     });
+
+    it('works with plain strings', function () {
+        const result = oneline(`
+            <div class="test">
+                <p>Hello world</p>
+            </div>
+        `);
+
+        result.should.equal('<div class="test"><p>Hello world</p></div>');
+    });
 });


### PR DESCRIPTION
no issue

- exporting the fns allows for tests to easily use them without jumping through lots of commonjs/esmodule hoops
- adapted `oneline` fn to accept a plain string too so we can normalize strings in tests for comparison
