### PR TITLE
Added support for outline button style in emails

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -59,9 +59,31 @@ function ctaCardTemplate(dataset) {
 }
 
 function emailCTATemplate(dataset, options = {}) {
-    const buttonStyle = dataset.buttonColor === 'accent'
+    // accent button color backgrounds are set in main template styles,
+    // for other button colors we need to set the background color explicitly
+    let buttonStyle = dataset.buttonColor === 'accent'
         ? `color: ${dataset.buttonTextColor};`
         : `background-color: ${dataset.buttonColor}; color: ${dataset.buttonTextColor};`;
+    // by default we duplicate style across the <td> and <a> tags, but
+    // we separate the variables to allow <a> tag style overrides for outline buttons
+    let buttonLinkStyle = buttonStyle;
+
+    if (
+        options?.feature?.emailCustomizationAlpha &&
+        options?.design?.buttonStyle === 'outline' &&
+        // accent buttons are fully handled by main template CSS
+        dataset.buttonColor !== 'accent'
+    ) {
+        buttonStyle = `
+            border: 1px solid ${dataset.buttonColor};
+            background-color: transparent;
+            color: ${dataset.buttonColor};
+        `;
+        buttonLinkStyle = `
+            background-color: transparent;
+            color: ${dataset.buttonColor};
+        `;
+    }
 
     let imageDimensions;
 
@@ -114,7 +136,7 @@ function emailCTATemplate(dataset, options = {}) {
                                                             <td class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}" style="${buttonStyle}">
                                                                 <a href="${dataset.buttonUrl}"
                                                                    class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}"
-                                                                   style="${buttonStyle}"
+                                                                   style="${buttonLinkStyle}"
                                                                 >
                                                                     ${dataset.buttonText}
                                                                 </a>
@@ -163,7 +185,7 @@ function emailCTATemplate(dataset, options = {}) {
                                                 <td class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}" style="${buttonStyle}" align="${dataset.alignment}">
                                                     <a href="${dataset.buttonUrl}"
                                                        class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}"
-                                                       style="${buttonStyle}"
+                                                       style="${buttonLinkStyle}"
                                                     >
                                                         ${dataset.buttonText}
                                                     </a>

--- a/packages/kg-default-nodes/lib/nodes/header/renderers/v2/header-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/header/renderers/v2/header-renderer.js
@@ -65,15 +65,38 @@ function cardTemplate(nodeData, options = {}) {
         `;
 }
 
-function emailTemplate(nodeData, feature) {
+function emailTemplate(nodeData, options) {
     const backgroundAccent = nodeData.backgroundColor === 'accent' ? `background-color: ${nodeData.accentColor};` : '';
-    const buttonAccent = nodeData.buttonColor === 'accent' ? `background-color: ${nodeData.accentColor};` : nodeData.buttonColor;
-    const buttonStyle = nodeData.buttonColor !== 'accent' ? `background-color: ${nodeData.buttonColor};` : '';
+    let buttonAccent = nodeData.buttonColor === 'accent' ? `background-color: ${nodeData.accentColor};` : nodeData.buttonColor;
+    let buttonStyle = nodeData.buttonColor !== 'accent' ? `background-color: ${nodeData.buttonColor};` : '';
+    let buttonTextColor = nodeData.buttonTextColor;
     const alignment = nodeData.alignment === 'center' ? 'text-align: center;' : '';
     const backgroundImageStyle = nodeData.backgroundImageSrc ? (nodeData.layout !== 'split' ? `background-image: url(${nodeData.backgroundImageSrc}); background-size: cover; background-position: center center;` : `background-color: ${nodeData.backgroundColor};`) : `background-color: ${nodeData.backgroundColor};`;
     const splitImageStyle = `background-image: url(${nodeData.backgroundImageSrc}); background-size: ${nodeData.backgroundSize !== 'contain' ? 'cover' : '50%'}; background-position: center`;
 
-    if (feature?.emailCustomizationAlpha) {
+    if (
+        options?.feature?.emailCustomizationAlpha &&
+        options?.design?.buttonStyle === 'outline'
+    ) {
+        if (nodeData.buttonColor === 'accent') {
+            buttonAccent = '';
+            buttonStyle = `
+                border: 1px solid ${nodeData.accentColor};
+                background-color: transparent;
+                color: ${nodeData.accentColor} !important;
+            `;
+            buttonTextColor = nodeData.accentColor;
+        } else {
+            buttonStyle = `
+                border: 1px solid ${nodeData.buttonColor};
+                background-color: transparent;
+                color: ${nodeData.buttonColor} !important;
+            `;
+            buttonTextColor = nodeData.buttonColor;
+        }
+    }
+
+    if (options?.feature?.emailCustomizationAlpha) {
         return (
             `
             <div class="kg-header-card kg-v2" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
@@ -104,7 +127,7 @@ function emailTemplate(nodeData, feature) {
                                             <table class="btn" border="0" cellspacing="0" cellpadding="0" align="${nodeData.alignment}">
                                                 <tr>
                                                     <td align="center" style="${buttonStyle} ${buttonAccent}">
-                                                        <a href="${nodeData.buttonUrl}" style="color: ${nodeData.buttonTextColor};">${nodeData.buttonText}</a>
+                                                        <a href="${nodeData.buttonUrl}" style="color: ${buttonTextColor};">${nodeData.buttonText}</a>
                                                     </td>
                                                 </tr>
                                             </table>
@@ -166,10 +189,9 @@ export function renderHeaderNodeV2(dataset, options = {}) {
         const emailDoc = options.createDocument();
         const emailDiv = emailDoc.createElement('div');
 
-        emailDiv.innerHTML = emailTemplate(node, options.feature)?.trim();
+        emailDiv.innerHTML = emailTemplate(node, options)?.trim();
 
         return {element: emailDiv.firstElementChild};
-        // return {element: document.createElement('div')}; // TODO
     }
 
     const htmlString = cardTemplate(node, options);

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -5,6 +5,8 @@ const {dom, createDocument, html: htmlTemplate} = require('../test-utils');
 const {CallToActionNode, $isCallToActionNode, utils} = require('../../');
 const editorNodes = [CallToActionNode];
 
+const {taggedTemplateFns: {oneline}} = utils;
+
 describe('CallToActionNode', function () {
     let editor;
     let dataset;
@@ -46,7 +48,8 @@ describe('CallToActionNode', function () {
         exportOptions = {
             exportFormat: 'html',
             dom,
-            feature: {}
+            feature: {},
+            design: {}
         };
     });
 
@@ -490,6 +493,40 @@ describe('CallToActionNode', function () {
                 // check for an emailCustomizationAlpha specific change to make
                 // sure we're hitting the right code path
                 should.exist(element.querySelector('table.btn'), 'table.btn element should exist');
+            });
+        }));
+
+        it('can render outline accent buttons (emailCustomizationAlpha)', editorTest(function () {
+            exportOptions.target = 'email';
+            exportOptions.feature.emailCustomizationAlpha = true;
+            exportOptions.design.buttonStyle = 'outline';
+
+            dataset.buttonColor = 'accent';
+
+            testRender(({element}) => {
+                const expectedStyle = 'color: none;';
+                element.querySelector('table.btn td').getAttribute('style').should.equal(expectedStyle);
+                element.querySelector('table.btn a').getAttribute('style').should.equal(expectedStyle);
+            });
+        }));
+
+        it('can render outline custom buttons (emailCustomizationAlpha)', editorTest(function () {
+            exportOptions.target = 'email';
+            exportOptions.feature.emailCustomizationAlpha = true;
+            exportOptions.design.buttonStyle = 'outline';
+
+            dataset.buttonColor = '#F0F0F0';
+
+            testRender(({element}) => {
+                oneline(element.querySelector('table.btn td').getAttribute('style')).should.equal(oneline`
+                    border: 1px solid #F0F0F0;
+                    background-color: transparent;
+                    color: #F0F0F0;
+                `);
+                oneline(element.querySelector('table.btn a').getAttribute('style')).should.equal(oneline`
+                    background-color: transparent;
+                    color: #F0F0F0;
+                `);
             });
         }));
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1717

- updated header and call-to-action cards to support an outline button style option
- these cards needed specific support because they override default button styles to allow for custom button colors
