### PR TITLE
Refactored toggle card to use table for email

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/toggle/toggle-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/toggle/toggle-renderer.js
@@ -1,4 +1,5 @@
 import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {html} from '../../utils/tagged-template-fns.mjs';
 
 function cardTemplate({node}) {
     return (
@@ -21,18 +22,20 @@ function cardTemplate({node}) {
 function emailCardTemplate({node}, options = {}) {
     if (options.feature?.emailCustomizationAlpha) {
         return (
-            `
+            html`
             <table cellspacing="0" cellpadding="0" border="0" width="100%" class="kg-toggle-card">
-                <tr>
-                    <td class="kg-toggle-heading">
-                        <h4>${node.heading}</h4>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="kg-toggle-content">
-                        ${node.content}
-                    </td>
-                </tr>
+                <tbody>
+                    <tr>
+                        <td class="kg-toggle-heading">
+                            <h4>${node.heading}</h4>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="kg-toggle-content">
+                            ${node.content}
+                        </td>
+                    </tr>
+                </tbody>
             </table>
             `
         );

--- a/packages/kg-default-nodes/lib/nodes/toggle/toggle-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/toggle/toggle-renderer.js
@@ -18,7 +18,26 @@ function cardTemplate({node}) {
     );
 }
 
-function emailCardTemplate({node}) {
+function emailCardTemplate({node}, options = {}) {
+    if (options.feature?.emailCustomizationAlpha) {
+        return (
+            `
+            <table cellspacing="0" cellpadding="0" border="0" width="100%" class="kg-toggle-card">
+                <tr>
+                    <td class="kg-toggle-heading">
+                        <h4>${node.heading}</h4>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="kg-toggle-content">
+                        ${node.content}
+                    </td>
+                </tr>
+            </table>
+            `
+        );
+    }
+
     return (
         `
         <div style="background: transparent;
@@ -36,7 +55,7 @@ export function renderToggleNode(node, options = {}) {
     const document = options.createDocument();
 
     const htmlString = options.target === 'email'
-        ? emailCardTemplate({node})
+        ? emailCardTemplate({node}, options)
         : cardTemplate({node});
 
     const container = document.createElement('div');

--- a/packages/kg-default-nodes/test/nodes/toggle.test.js
+++ b/packages/kg-default-nodes/test/nodes/toggle.test.js
@@ -203,6 +203,40 @@ describe('ToggleNode', function () {
             `);
         }));
 
+        it('renders for email target (emailCustomizationAlpha)', editorTest(function () {
+            const payload = {
+                heading: 'Heading',
+                content: 'Content'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post',
+                feature: {
+                    emailCustomizationAlpha: true
+                }
+            };
+            const toggleNode = $createToggleNode(payload);
+            const {element} = toggleNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(html`
+                <table cellspacing="0" cellpadding="0" border="0" width="100%" class="kg-toggle-card">
+                    <tbody>
+                        <tr>
+                            <td class="kg-toggle-heading">
+                                <h4>Heading</h4>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="kg-toggle-content">
+                                Content
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
+        }));
+
         it('renders heading', editorTest(function () {
             const payload = {
                 heading: 'Heading',


### PR DESCRIPTION
Ref https://linear.app/ghost/issue/PROD-1684/imlement-heading-weight-setting
- This markup is more email safe and ensures spacing is applied in Outlook
- Inline styles have been removed in favour of custom css in `styles.hbs` 