### PR TITLE
Moved button corners related code to beta flag

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/button/button-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/button/button-renderer.js
@@ -36,7 +36,7 @@ function emailTemplate(node, options, document) {
     const {buttonUrl, buttonText} = node;
 
     let cardHtml;
-    if (options.feature?.emailCustomizationAlpha) {
+    if (options.feature?.emailCustomization) {
         cardHtml = html`
         <table border="0" cellpadding="0" cellspacing="0">
             <tr>

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -106,7 +106,7 @@ function emailCTATemplate(dataset, options = {}) {
         }
     }
 
-    if (options.feature?.emailCustomizationAlpha) {
+    if (options.feature?.emailCustomization || options.feature?.emailCustomizationAlpha) {
         const renderContent = () => {
             if (dataset.layout === 'minimal') {
                 return `

--- a/packages/kg-default-nodes/lib/nodes/header/renderers/v2/header-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/header/renderers/v2/header-renderer.js
@@ -96,7 +96,7 @@ function emailTemplate(nodeData, options) {
         }
     }
 
-    if (options?.feature?.emailCustomizationAlpha) {
+    if (options?.feature?.emailCustomization || options?.feature?.emailCustomizationAlpha) {
         return (
             `
             <div class="kg-header-card kg-v2" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">

--- a/packages/kg-default-nodes/lib/nodes/product/product-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/product/product-renderer.js
@@ -89,7 +89,7 @@ export function emailCardTemplate({data, feature}) {
         }
     }
 
-    if (feature?.emailCustomizationAlpha) {
+    if (feature?.emailCustomization || feature?.emailCustomizationAlpha) {
         return (
             `
             <table class="kg-product-card" cellspacing="0" cellpadding="0" border="0">

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.js
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.js
@@ -482,6 +482,20 @@ describe('CallToActionNode', function () {
         it('skips link to image when button is not shown (email, minimal)', testSkippedImageLink('email', 'minimal'));
         it('skips link to image when button is not shown (email, immersive)', testSkippedImageLink('email', 'immersive'));
 
+        it('can render email with emailCustomization', editorTest(function () {
+            exportOptions.target = 'email';
+            exportOptions.feature.emailCustomization = true;
+
+            testRender(({element}) => {
+                // very basic test to ensure we don't error
+                element.tagName.should.equal('TABLE');
+
+                // check for an emailCustomization specific change to make
+                // sure we're hitting the right code path
+                should.exist(element.querySelector('table.btn'), 'table.btn element should exist');
+            });
+        }));
+
         it('can render email with emailCustomizationAlpha', editorTest(function () {
             exportOptions.target = 'email';
             exportOptions.feature.emailCustomizationAlpha = true;
@@ -490,7 +504,7 @@ describe('CallToActionNode', function () {
                 // very basic test to ensure we don't error
                 element.tagName.should.equal('TABLE');
 
-                // check for an emailCustomizationAlpha specific change to make
+                // check for an emailCustomization specific change to make
                 // sure we're hitting the right code path
                 should.exist(element.querySelector('table.btn'), 'table.btn element should exist');
             });

--- a/packages/kg-default-nodes/test/nodes/product.test.js
+++ b/packages/kg-default-nodes/test/nodes/product.test.js
@@ -342,7 +342,7 @@ describe('ProductNode', function () {
             `);
         }));
 
-        it('renders email (emailCustomizationAlpha)', editorTest(function () {
+        it('renders email (emailCustomization)', editorTest(function () {
             const payload = {
                 productButton: 'Click me',
                 productButtonEnabled: true,
@@ -357,7 +357,7 @@ describe('ProductNode', function () {
             const options = {
                 target: 'email',
                 feature: {
-                    emailCustomizationAlpha: true
+                    emailCustomization: true
                 }
             };
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1691
ref https://linear.app/ghost/issue/PROD-1747

- switched conditionals where appropriate from `emailCustomizationAlpha` to `emailCustomizationBeta`
- for the larger template conditionals uses `emailCustomization || emailCustomizationAlpha` to avoid duplicating code unnecessarily
  - button style code within those same template functions is still behind the alpha flag
