### PR TITLE
Extracted button rendering helper

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/button/button-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/button/button-renderer.js
@@ -1,5 +1,6 @@
 import {addCreateDocumentOption} from '../../utils/add-create-document-option';
 import {renderEmptyContainer} from '../../utils/render-empty-container';
+import {renderEmailButton} from '../../utils/render-helpers/email-button';
 import {html} from '../../utils/tagged-template-fns.mjs';
 
 export function renderButtonNode(node, options = {}) {
@@ -50,8 +51,34 @@ function emailTemplate(node, options, document) {
                     </table>
                 </td>
             </tr>
+        </table>`;
+
+        const element = document.createElement('p');
+        element.innerHTML = cardHtml;
+        return {element};
+    } else if (options.feature?.emailCustomizationAlpha) {
+        const buttonHtml = renderEmailButton({
+            alignment: node.alignment,
+            color: 'accent',
+            url: buttonUrl,
+            text: buttonText
+        });
+
+        cardHtml = html`
+        <table border="0" cellpadding="0" cellspacing="0">
+            <tbody>
+                <tr>
+                    <td>
+                        ${buttonHtml}
+                    </td>
+                </tr>
+            </tbody>
         </table>
         `;
+
+        const element = document.createElement('div');
+        element.innerHTML = cardHtml;
+        return {element, type: 'inner'};
     } else {
         cardHtml = html`
         <div class="btn btn-accent">
@@ -64,11 +91,11 @@ function emailTemplate(node, options, document) {
             </table>
         </div>
         `;
-    }
 
-    const element = document.createElement('p');
-    element.innerHTML = cardHtml;
-    return {element};
+        const element = document.createElement('p');
+        element.innerHTML = cardHtml;
+        return {element};
+    }
 }
 
 function getCardClasses(node) {

--- a/packages/kg-default-nodes/lib/utils/render-helpers/email-button.js
+++ b/packages/kg-default-nodes/lib/utils/render-helpers/email-button.js
@@ -1,0 +1,35 @@
+import clsx from 'clsx';
+import {html} from '../tagged-template-fns.mjs';
+
+/**
+ * @param {Object} options
+ * @param {string} [options.alignment]
+ * @param {string} [options.color='accent']
+ * @param {string} [options.text='']
+ * @param {string} [options.textColor]
+ * @param {string} [options.url='']
+ * @returns {string}
+ */
+export function renderEmailButton({
+    alignment = '',
+    color = 'accent',
+    text = '',
+    url = ''
+} = {}) {
+    const buttonClasses = clsx(
+        'btn',
+        color === 'accent' && 'btn-accent'
+    );
+
+    return html`
+        <table class="${buttonClasses}" border="0" cellspacing="0" cellpadding="0" align="${alignment}">
+            <tbody>
+                <tr>
+                    <td align="center">
+                        <a href="${url}">${text}</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    `;
+}

--- a/packages/kg-default-nodes/package.json
+++ b/packages/kg-default-nodes/package.json
@@ -52,6 +52,7 @@
     "@lexical/utils": "0.13.1",
     "@tryghost/kg-clean-basic-html": "4.2.4",
     "@tryghost/kg-markdown-html-renderer": "7.1.2",
+    "clsx": "2.1.1",
     "html-minifier": "^4.0.0",
     "jsdom": "^24.1.1",
     "lexical": "0.13.1",

--- a/packages/kg-default-nodes/test/nodes/button.test.js
+++ b/packages/kg-default-nodes/test/nodes/button.test.js
@@ -132,6 +132,70 @@ describe('ButtonNode', function () {
             output.should.containEql('<td align="center">');
         }));
 
+        it('renders for email target (emailCustomization)', editorTest(function () {
+            const buttonNode = $createButtonNode(dataset);
+            const options = {
+                target: 'email',
+                feature: {
+                    emailCustomization: true
+                }
+            };
+            const {element} = buttonNode.exportDOM({...exportOptions, ...options});
+            const output = element.innerHTML;
+
+            output.should.prettifyTo(html`
+                <table border="0" cellpadding="0" cellspacing="0">
+                    <tbody>
+                        <tr>
+                            <td>
+                                <table class="btn btn-accent" border="0" cellspacing="0" cellpadding="0" align="center">
+                                    <tbody>
+                                        <tr>
+                                            <td align="center">
+                                                <a href="http://blog.com/post1">click me</a>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
+        }));
+
+        it('renders for email target (emailCustomizationAlpha)', editorTest(function () {
+            const buttonNode = $createButtonNode(dataset);
+            const options = {
+                target: 'email',
+                feature: {
+                    emailCustomizationAlpha: true
+                }
+            };
+            const {element} = buttonNode.exportDOM({...exportOptions, ...options});
+            const output = element.innerHTML;
+
+            output.should.prettifyTo(html`
+                <table border="0" cellpadding="0" cellspacing="0">
+                    <tbody>
+                        <tr>
+                            <td>
+                                <table class="btn btn-accent" border="0" cellspacing="0" cellpadding="0" align="center">
+                                    <tbody>
+                                        <tr>
+                                            <td align="center">
+                                                <a href="http://blog.com/post1">click me</a>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
+        }));
+
         it('renders an empty span with a missing buttonUrl', editorTest(function () {
             const buttonNode = $createButtonNode();
             const {element} = buttonNode.exportDOM(exportOptions);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6577,7 +6577,7 @@ cloneable-readable@^1.0.0:
     process-nextick-args "^2.0.0"
     readable-stream "^2.3.5"
 
-clsx@^2.0.0:
+clsx@2.1.1, clsx@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1717

- extracted central part of button node email renderer as the rendered HTML is duplicated across multiple cards
- added tests to check alpha and beta output is the same
- for the alpha version, the wrapping element was changed to `<div>` and the return type changed to `'inner'` because tables inside paragraphs is not valid HTML and results in an empty paragraph being added after the table in the final HTML output
- added `clsx` dependency to make working with class lists nicer
