### PR TITLE
Fixed toggle card rendering with beta flag

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/toggle/toggle-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/toggle/toggle-renderer.js
@@ -20,7 +20,7 @@ function cardTemplate({node}) {
 }
 
 function emailCardTemplate({node}, options = {}) {
-    if (options.feature?.emailCustomizationAlpha) {
+    if (options.feature?.emailCustomization || options.feature?.emailCustomizationAlpha) {
         return (
             html`
             <table cellspacing="0" cellpadding="0" border="0" width="100%" class="kg-toggle-card">


### PR DESCRIPTION
no issue

- the updated renderer output for the toggle node wasn't being output for the beta flag which meant our CSS changes that depended on the class names weren't working
