### PR TITLE
Removed need for `exportDOM` overrides in each node

### DIFF
--- a/packages/kg-default-nodes/lib/nodes/audio/AudioNode.js
+++ b/packages/kg-default-nodes/lib/nodes/audio/AudioNode.js
@@ -3,21 +3,19 @@ import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseAudioNode} from './audio-parser';
 import {renderAudioNode} from './audio-renderer';
 
-export class AudioNode extends generateDecoratorNode({nodeType: 'audio',
+export class AudioNode extends generateDecoratorNode({
+    nodeType: 'audio',
     properties: [
         {name: 'duration', default: 0},
         {name: 'mimeType', default: ''},
         {name: 'src', default: '', urlType: 'url'},
         {name: 'title', default: ''},
         {name: 'thumbnailSrc', default: ''}
-    ]}
-) {
+    ],
+    defaultRenderFn: renderAudioNode
+}) {
     static importDOM() {
         return parseAudioNode(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderAudioNode(this, options);
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkNode.js
+++ b/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkNode.js
@@ -3,7 +3,8 @@ import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseBookmarkNode} from './bookmark-parser';
 import {renderBookmarkNode} from './bookmark-renderer';
 
-export class BookmarkNode extends generateDecoratorNode({nodeType: 'bookmark',
+export class BookmarkNode extends generateDecoratorNode({
+    nodeType: 'bookmark',
     properties: [
         {name: 'title', default: '', wordCount: true},
         {name: 'description', default: '', wordCount: true},
@@ -13,14 +14,11 @@ export class BookmarkNode extends generateDecoratorNode({nodeType: 'bookmark',
         {name: 'publisher', default: ''},
         {name: 'icon', urlPath: 'metadata.icon', default: '', urlType: 'url'},
         {name: 'thumbnail', urlPath: 'metadata.thumbnail', default: '', urlType: 'url'}
-    ]}
-) {
+    ],
+    defaultRenderFn: renderBookmarkNode
+}) {
     static importDOM() {
         return parseBookmarkNode(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderBookmarkNode(this, options);
     }
 
     /* override */

--- a/packages/kg-default-nodes/lib/nodes/button/ButtonNode.js
+++ b/packages/kg-default-nodes/lib/nodes/button/ButtonNode.js
@@ -3,19 +3,17 @@ import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseButtonNode} from './button-parser';
 import {renderButtonNode} from './button-renderer';
 
-export class ButtonNode extends generateDecoratorNode({nodeType: 'button',
+export class ButtonNode extends generateDecoratorNode({
+    nodeType: 'button',
     properties: [
         {name: 'buttonText', default: ''},
         {name: 'alignment', default: 'center'},
         {name: 'buttonUrl', default: '', urlType: 'url'}
-    ]}
-) {
+    ],
+    defaultRenderFn: renderButtonNode
+}) {
     static importDOM() {
         return parseButtonNode(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderButtonNode(this, options);
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
@@ -23,13 +23,9 @@ export class CallToActionNode extends generateDecoratorNode({
         {name: 'imageUrl', default: ''},
         {name: 'imageWidth', default: null},
         {name: 'imageHeight', default: null}
-    ]
+    ],
+    defaultRenderFn: renderCallToActionNode
 }) {
-    /* overrides */
-    exportDOM(options = {}) {
-        return renderCallToActionNode(this, options);
-    }
-
     static importDOM() {
         return parseCallToActionNode(this);
     }

--- a/packages/kg-default-nodes/lib/nodes/callout/CalloutNode.js
+++ b/packages/kg-default-nodes/lib/nodes/callout/CalloutNode.js
@@ -3,13 +3,15 @@ import {generateDecoratorNode} from '../../generate-decorator-node';
 import {renderCalloutNode} from './callout-renderer';
 import {parseCalloutNode} from './callout-parser';
 
-export class CalloutNode extends generateDecoratorNode({nodeType: 'callout',
+export class CalloutNode extends generateDecoratorNode({
+    nodeType: 'callout',
     properties: [
         {name: 'calloutText', default: '', wordCount: true},
         {name: 'calloutEmoji', default: '💡'},
         {name: 'backgroundColor', default: 'blue'}
-    ]}
-) {
+    ],
+    defaultRenderFn: renderCalloutNode
+}) {
     /* override */
     constructor({calloutText, calloutEmoji, backgroundColor} = {}, key) {
         super(key);
@@ -20,10 +22,6 @@ export class CalloutNode extends generateDecoratorNode({nodeType: 'callout',
 
     static importDOM() {
         return parseCalloutNode(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderCalloutNode(this, options);
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/codeblock/CodeBlockNode.js
+++ b/packages/kg-default-nodes/lib/nodes/codeblock/CodeBlockNode.js
@@ -3,19 +3,17 @@ import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseCodeBlockNode} from './codeblock-parser';
 import {renderCodeBlockNode} from './codeblock-renderer';
 
-export class CodeBlockNode extends generateDecoratorNode({nodeType: 'codeblock',
+export class CodeBlockNode extends generateDecoratorNode({
+    nodeType: 'codeblock',
     properties: [
         {name: 'code', default: '', wordCount: true},
         {name: 'language', default: ''},
         {name: 'caption', default: '', urlType: 'html', wordCount: true}
-    ]}
-) {
+    ],
+    defaultRenderFn: renderCodeBlockNode
+}) {
     static importDOM() {
         return parseCodeBlockNode(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderCodeBlockNode(this, options);
     }
 
     isEmpty() {

--- a/packages/kg-default-nodes/lib/nodes/collection/CollectionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/collection/CollectionNode.js
@@ -3,21 +3,19 @@ import {generateDecoratorNode} from '../../generate-decorator-node';
 import {renderCollectionNode} from './collection-renderer';
 import {collectionParser} from './collection-parser';
 
-export class CollectionNode extends generateDecoratorNode({nodeType: 'collection',
+export class CollectionNode extends generateDecoratorNode({
+    nodeType: 'collection',
     properties: [
         {name: 'collection', default: 'latest'}, // start with empty object; might want to just store the slug
         {name: 'postCount', default: 3},
         {name: 'layout', default: 'grid'},
         {name: 'columns', default: 3},
         {name: 'header', default: '', wordCount: true}
-    ]}
-) {
+    ],
+    defaultRenderFn: renderCollectionNode
+}) {
     static importDOM() {
         return collectionParser(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderCollectionNode(this, options);
     }
 
     hasDynamicData() {
@@ -28,7 +26,7 @@ export class CollectionNode extends generateDecoratorNode({nodeType: 'collection
         const key = this.getKey();
         const collection = this.__collection;
         const postCount = this.__postCount;
-        
+
         if (!options?.getCollectionPosts) {
             return;
         }

--- a/packages/kg-default-nodes/lib/nodes/email-cta/EmailCtaNode.js
+++ b/packages/kg-default-nodes/lib/nodes/email-cta/EmailCtaNode.js
@@ -2,7 +2,8 @@
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {renderEmailCtaNode} from './email-cta-renderer';
 
-export class EmailCtaNode extends generateDecoratorNode({nodeType: 'email-cta',
+export class EmailCtaNode extends generateDecoratorNode({
+    nodeType: 'email-cta',
     properties: [
         {name: 'alignment', default: 'left'},
         {name: 'buttonText', default: ''},
@@ -11,11 +12,9 @@ export class EmailCtaNode extends generateDecoratorNode({nodeType: 'email-cta',
         {name: 'segment', default: 'status:free'},
         {name: 'showButton', default: false},
         {name: 'showDividers', default: true}
-    ]}
-) {
-    exportDOM(options = {}) {
-        return renderEmailCtaNode(this, options);
-    }
+    ],
+    defaultRenderFn: renderEmailCtaNode
+}) {
 }
 
 export const $createEmailCtaNode = (dataset) => {

--- a/packages/kg-default-nodes/lib/nodes/email/EmailNode.js
+++ b/packages/kg-default-nodes/lib/nodes/email/EmailNode.js
@@ -2,14 +2,13 @@
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {renderEmailNode} from './email-renderer';
 
-export class EmailNode extends generateDecoratorNode({nodeType: 'email',
+export class EmailNode extends generateDecoratorNode({
+    nodeType: 'email',
     properties: [
         {name: 'html', default: '', urlType: 'html'}
-    ]}
-) {
-    exportDOM(options = {}) {
-        return renderEmailNode(this, options);
-    }
+    ],
+    defaultRenderFn: renderEmailNode
+}) {
 }
 
 export const $createEmailNode = (dataset) => {

--- a/packages/kg-default-nodes/lib/nodes/embed/EmbedNode.js
+++ b/packages/kg-default-nodes/lib/nodes/embed/EmbedNode.js
@@ -3,21 +3,19 @@ import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseEmbedNode} from './embed-parser';
 import {renderEmbedNode} from './embed-renderer';
 
-export class EmbedNode extends generateDecoratorNode({nodeType: 'embed',
+export class EmbedNode extends generateDecoratorNode({
+    nodeType: 'embed',
     properties: [
         {name: 'url', default: '', urlType: 'url'},
         {name: 'embedType', default: ''},
         {name: 'html', default: ''},
         {name: 'metadata', default: {}},
         {name: 'caption', default: '', wordCount: true}
-    ]}
-) {
+    ],
+    defaultRenderFn: renderEmbedNode
+}) {
     static importDOM() {
         return parseEmbedNode(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderEmbedNode(this, options);
     }
 
     isEmpty() {

--- a/packages/kg-default-nodes/lib/nodes/file/FileNode.js
+++ b/packages/kg-default-nodes/lib/nodes/file/FileNode.js
@@ -4,15 +4,17 @@ import {renderFileNode} from './file-renderer';
 import {parseFileNode} from './file-parser';
 import {bytesToSize} from '../../utils/size-byte-converter';
 
-export class FileNode extends generateDecoratorNode({nodeType: 'file',
+export class FileNode extends generateDecoratorNode({
+    nodeType: 'file',
     properties: [
         {name: 'src', default: '', urlType: 'url'},
         {name: 'fileTitle', default: '', wordCount: true},
         {name: 'fileCaption', default: '', wordCount: true},
         {name: 'fileName', default: ''},
         {name: 'fileSize', default: ''}
-    ]}
-) {
+    ],
+    defaultRenderFn: renderFileNode
+}) {
     /* @override */
     exportJSON() {
         const {src, fileTitle, fileCaption, fileName, fileSize} = this;
@@ -30,10 +32,6 @@ export class FileNode extends generateDecoratorNode({nodeType: 'file',
 
     static importDOM() {
         return parseFileNode(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderFileNode(this, options);
     }
 
     get formattedFileSize() {

--- a/packages/kg-default-nodes/lib/nodes/gallery/GalleryNode.js
+++ b/packages/kg-default-nodes/lib/nodes/gallery/GalleryNode.js
@@ -2,12 +2,14 @@
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseGalleryNode} from './gallery-parser';
 import {renderGalleryNode} from './gallery-renderer';
-export class GalleryNode extends generateDecoratorNode({nodeType: 'gallery',
+export class GalleryNode extends generateDecoratorNode({
+    nodeType: 'gallery',
     properties: [
         {name: 'images', default: []},
         {name: 'caption', default: '', wordCount: true}
-    ]}
-) {
+    ],
+    defaultRenderFn: renderGalleryNode
+}) {
     /* override */
     static get urlTransformMap() {
         return {
@@ -21,10 +23,6 @@ export class GalleryNode extends generateDecoratorNode({nodeType: 'gallery',
 
     static importDOM() {
         return parseGalleryNode(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderGalleryNode(this, options);
     }
 
     hasEditMode() {

--- a/packages/kg-default-nodes/lib/nodes/header/HeaderNode.js
+++ b/packages/kg-default-nodes/lib/nodes/header/HeaderNode.js
@@ -6,7 +6,8 @@ import {parseHeaderNode} from './parsers/header-parser';
 import {renderHeaderNodeV2} from './renderers/v2/header-renderer';
 
 // This is our first node that has a custom version property
-export class HeaderNode extends generateDecoratorNode({nodeType: 'header',
+export class HeaderNode extends generateDecoratorNode({
+    nodeType: 'header',
     properties: [
         {name: 'size', default: 'small'},
         {name: 'style', default: 'dark'},
@@ -32,20 +33,14 @@ export class HeaderNode extends generateDecoratorNode({nodeType: 'header',
         {name: 'buttonTextColor', default: '#000000'},
         {name: 'layout', default: 'full'}, // replaces size
         {name: 'swapped', default: false}
-    ]}
-) {
+    ],
+    defaultRenderFn: {
+        1: renderHeaderNodeV1,
+        2: renderHeaderNodeV2
+    }
+}) {
     static importDOM() {
         return parseHeaderNode(this);
-    }
-
-    exportDOM(options = {}) {
-        if (this.version === 1) {
-            return renderHeaderNodeV1(this, options);
-        }
-
-        if (this.version === 2) {
-            return renderHeaderNodeV2(this, options);
-        }
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleNode.js
+++ b/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleNode.js
@@ -3,13 +3,12 @@ import {generateDecoratorNode} from '../../generate-decorator-node';
 import {renderHorizontalRuleNode} from './horizontalrule-renderer';
 import {parseHorizontalRuleNode} from './horizontalrule-parser';
 
-export class HorizontalRuleNode extends generateDecoratorNode({nodeType: 'horizontalrule'}) {
+export class HorizontalRuleNode extends generateDecoratorNode({
+    nodeType: 'horizontalrule',
+    defaultRenderFn: renderHorizontalRuleNode
+}) {
     static importDOM() {
         return parseHorizontalRuleNode(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderHorizontalRuleNode(this, options);
     }
 
     getTextContent() {

--- a/packages/kg-default-nodes/lib/nodes/html/HtmlNode.js
+++ b/packages/kg-default-nodes/lib/nodes/html/HtmlNode.js
@@ -3,18 +3,16 @@ import {generateDecoratorNode} from '../../generate-decorator-node';
 import {renderHtmlNode} from './html-renderer';
 import {parseHtmlNode} from './html-parser';
 
-export class HtmlNode extends generateDecoratorNode({nodeType: 'html',
+export class HtmlNode extends generateDecoratorNode({
+    nodeType: 'html',
     hasVisibility: true,
     properties: [
         {name: 'html', default: '', urlType: 'html', wordCount: true}
-    ]}
-) {
+    ],
+    defaultRenderFn: renderHtmlNode
+}) {
     static importDOM() {
         return parseHtmlNode(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderHtmlNode(this, options);
     }
 
     isEmpty() {

--- a/packages/kg-default-nodes/lib/nodes/image/ImageNode.js
+++ b/packages/kg-default-nodes/lib/nodes/image/ImageNode.js
@@ -2,7 +2,8 @@
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseImageNode} from './image-parser';
 import {renderImageNode} from './image-renderer';
-export class ImageNode extends generateDecoratorNode({nodeType: 'image',
+export class ImageNode extends generateDecoratorNode({
+    nodeType: 'image',
     properties: [
         {name: 'src', default: '', urlType: 'url'},
         {name: 'caption', default: '', urlType: 'html', wordCount: true},
@@ -12,8 +13,9 @@ export class ImageNode extends generateDecoratorNode({nodeType: 'image',
         {name: 'width', default: null},
         {name: 'height', default: null},
         {name: 'href', default: '', urlType: 'url'}
-    ]}
-) {
+    ],
+    defaultRenderFn: renderImageNode
+}) {
     /* @override */
     exportJSON() {
         // checks if src is a data string
@@ -37,10 +39,6 @@ export class ImageNode extends generateDecoratorNode({nodeType: 'image',
 
     static importDOM() {
         return parseImageNode(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderImageNode(this, options);
     }
 
     hasEditMode() {

--- a/packages/kg-default-nodes/lib/nodes/markdown/MarkdownNode.js
+++ b/packages/kg-default-nodes/lib/nodes/markdown/MarkdownNode.js
@@ -2,15 +2,13 @@
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {renderMarkdownNode} from './markdown-renderer';
 
-export class MarkdownNode extends generateDecoratorNode({nodeType: 'markdown',
+export class MarkdownNode extends generateDecoratorNode({
+    nodeType: 'markdown',
     properties: [
         {name: 'markdown', default: '', urlType: 'markdown', wordCount: true}
-    ]}
-) {
-    exportDOM(options = {}) {
-        return renderMarkdownNode(this, options);
-    }
-
+    ],
+    defaultRenderFn: renderMarkdownNode
+}) {
     isEmpty() {
         return !this.__markdown;
     }

--- a/packages/kg-default-nodes/lib/nodes/paywall/PaywallNode.js
+++ b/packages/kg-default-nodes/lib/nodes/paywall/PaywallNode.js
@@ -3,13 +3,12 @@ import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parsePaywallNode} from './paywall-parser';
 import {renderPaywallNode} from './paywall-renderer';
 
-export class PaywallNode extends generateDecoratorNode({nodeType: 'paywall'}) {
+export class PaywallNode extends generateDecoratorNode({
+    nodeType: 'paywall',
+    defaultRenderFn: renderPaywallNode
+}) {
     static importDOM() {
         return parsePaywallNode(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderPaywallNode(this, options);
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/product/ProductNode.js
+++ b/packages/kg-default-nodes/lib/nodes/product/ProductNode.js
@@ -3,7 +3,8 @@ import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseProductNode} from './product-parser';
 import {renderProductNode} from './product-renderer';
 
-export class ProductNode extends generateDecoratorNode({nodeType: 'product',
+export class ProductNode extends generateDecoratorNode({
+    nodeType: 'product',
     properties: [
         {name: 'productImageSrc', default: '', urlType: 'url'},
         {name: 'productImageWidth', default: null},
@@ -15,8 +16,9 @@ export class ProductNode extends generateDecoratorNode({nodeType: 'product',
         {name: 'productButtonEnabled', default: false},
         {name: 'productButton', default: ''},
         {name: 'productUrl', default: ''}
-    ]}
-) {
+    ],
+    defaultRenderFn: renderProductNode
+}) {
     /* override */
     exportJSON() {
         // checks if src is a data string
@@ -43,10 +45,6 @@ export class ProductNode extends generateDecoratorNode({nodeType: 'product',
 
     static importDOM() {
         return parseProductNode(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderProductNode(this, options);
     }
 
     isEmpty() {

--- a/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
@@ -3,7 +3,8 @@ import {signupParser} from './signup-parser';
 import {renderSignupCardToDOM} from './signup-renderer';
 import {generateDecoratorNode} from '../../generate-decorator-node';
 
-export class SignupNode extends generateDecoratorNode({nodeType: 'signup',
+export class SignupNode extends generateDecoratorNode({
+    nodeType: 'signup',
     properties: [
         {name: 'alignment', default: 'left'},
         {name: 'backgroundColor', default: '#F0F0F0'},
@@ -20,7 +21,9 @@ export class SignupNode extends generateDecoratorNode({nodeType: 'signup',
         {name: 'subheader', default: '', wordCount: true},
         {name: 'successMessage', default: 'Email sent! Check your inbox to complete your signup.'},
         {name: 'swapped', default: false}
-    ]}) {
+    ],
+    defaultRenderFn: renderSignupCardToDOM
+}) {
     /* override */
     constructor({alignment, backgroundColor, backgroundImageSrc, backgroundSize, textColor, buttonColor, buttonTextColor, buttonText, disclaimer, header, labels, layout, subheader, successMessage, swapped} = {}, key) {
         super(key);
@@ -43,10 +46,6 @@ export class SignupNode extends generateDecoratorNode({nodeType: 'signup',
 
     static importDOM() {
         return signupParser(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderSignupCardToDOM(this, options);
     }
 
     // keeping some custom methods for labels as it requires some special handling

--- a/packages/kg-default-nodes/lib/nodes/toggle/ToggleNode.js
+++ b/packages/kg-default-nodes/lib/nodes/toggle/ToggleNode.js
@@ -3,18 +3,16 @@ import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseToggleNode} from './toggle-parser';
 import {renderToggleNode} from './toggle-renderer';
 
-export class ToggleNode extends generateDecoratorNode({nodeType: 'toggle',
+export class ToggleNode extends generateDecoratorNode({
+    nodeType: 'toggle',
     properties: [
         {name: 'heading', default: '', urlType: 'html', wordCount: true},
         {name: 'content', default: '', urlType: 'html', wordCount: true}
-    ]}
-) {
+    ],
+    defaultRenderFn: renderToggleNode
+}) {
     static importDOM() {
         return parseToggleNode(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderToggleNode(this, options);
     }
 }
 

--- a/packages/kg-default-nodes/lib/nodes/video/VideoNode.js
+++ b/packages/kg-default-nodes/lib/nodes/video/VideoNode.js
@@ -2,7 +2,8 @@
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseVideoNode} from './video-parser';
 import {renderVideoNode} from './video-renderer';
-export class VideoNode extends generateDecoratorNode({nodeType: 'video',
+export class VideoNode extends generateDecoratorNode({
+    nodeType: 'video',
     properties: [
         {name: 'src', default: '', urlType: 'url'},
         {name: 'caption', default: '', urlType: 'html', wordCount: true},
@@ -17,8 +18,9 @@ export class VideoNode extends generateDecoratorNode({nodeType: 'video',
         {name: 'thumbnailHeight', default: null},
         {name: 'cardWidth', default: 'regular'},
         {name: 'loop', default: false}
-    ]}
-) {
+    ],
+    defaultRenderFn: renderVideoNode
+}) {
     /* override */
     exportJSON() {
         const {src, caption, fileName, mimeType, width, height, duration, thumbnailSrc, customThumbnailSrc, thumbnailWidth, thumbnailHeight, cardWidth, loop} = this;
@@ -47,10 +49,6 @@ export class VideoNode extends generateDecoratorNode({nodeType: 'video',
 
     static importDOM() {
         return parseVideoNode(this);
-    }
-
-    exportDOM(options = {}) {
-        return renderVideoNode(this, options);
     }
 
     get formattedDuration() {


### PR DESCRIPTION
no issue

First part of a refactor to allow node renderers to be provided by the consumer. This change centralizes our `exportDOM()` definition in our `generateDecoratorNode()` factory which means if needed we can select a different renderer function in one place rather than needing to spread knowledge across every node.

- added a required `defaultRenderFn` option to `generateDecoratorNode()`
  - takes a function or an object, the object version should be keyed by version numbers with the appropriate render function as the value
  - adds default `exportDOM()` method that calls `defaultRenderFn` or the appropriate versioned render function
- removed `exportDOM()` overrides from all of our decorator nodes
- standardized on `nodeType:` property being defined on the first line of the properties list in each node which helps with regex search & replace and AI agents
