### PR TITLE
Added ability to call custom render function for decorator nodes

### DIFF
--- a/packages/kg-default-nodes/lib/generate-decorator-node.js
+++ b/packages/kg-default-nodes/lib/generate-decorator-node.js
@@ -180,6 +180,20 @@ export function generateDecoratorNode({nodeType, properties = [], defaultRenderF
             // means it's set from the serialized version data at runtime
             const nodeVersion = this.__version || version;
 
+            if (options.feature?.emailCustomizationAlpha && options.renderers?.[nodeType]) {
+                const render = options.renderers[nodeType];
+
+                if (typeof render === 'object') {
+                    const versionRenderer = render[nodeVersion];
+                    if (!versionRenderer) {
+                        throw new Error(`[generateDecoratorNode] ${nodeType}: options.renderers['${nodeType}'] for version ${nodeVersion} is required`);
+                    }
+                    return versionRenderer(this, options);
+                } else {
+                    return render(this, options);
+                }
+            }
+
             if (typeof defaultRenderFn === 'object') {
                 const render = defaultRenderFn[nodeVersion];
                 if (!render) {

--- a/packages/kg-default-nodes/test/generate-decorator-node.test.js
+++ b/packages/kg-default-nodes/test/generate-decorator-node.test.js
@@ -20,6 +20,179 @@ describe('Utils: generateDecoratorNode', function () {
         });
     };
 
+    describe('exportDOM', function () {
+        let NodeWithRender;
+        let $createNodeWithRender;
+
+        before(function () {
+            NodeWithRender = utils.generateDecoratorNode({
+                nodeType: 'render-test',
+                properties: [],
+                defaultRenderFn: () => ({
+                    element: 'div',
+                    type: 'inner',
+                    content: 'default render'
+                })
+            });
+
+            $createNodeWithRender = (dataset) => {
+                return new NodeWithRender(dataset);
+            };
+
+            editor = createHeadlessEditor({nodes: [NodeWithRender]});
+        });
+
+        it('uses default renderer when no custom renderer is provided', editorTest(function () {
+            const node = $createNodeWithRender();
+            const result = node.exportDOM();
+
+            result.should.deepEqual({
+                element: 'div',
+                type: 'inner',
+                content: 'default render'
+            });
+        }));
+
+        it('uses versioned default renderer (static version)', editorTest(function () {
+            const VersionedNode = utils.generateDecoratorNode({
+                nodeType: 'versioned-render-test',
+                properties: [],
+                version: 2,
+                defaultRenderFn: {
+                    1: () => ({
+                        element: 'div',
+                        type: 'inner',
+                        content: 'version 1'
+                    }),
+                    2: () => ({
+                        element: 'div',
+                        type: 'inner',
+                        content: 'version 2'
+                    })
+                }
+            });
+
+            const node = new VersionedNode();
+            const result = node.exportDOM();
+
+            result.should.deepEqual({
+                element: 'div',
+                type: 'inner',
+                content: 'version 2'
+            });
+        }));
+
+        it('uses versioned default renderer (dataset version)', editorTest(function () {
+            const VersionedNode = utils.generateDecoratorNode({
+                nodeType: 'versioned-render-test',
+                properties: [{name: 'version', default: 1}],
+                version: 1,
+                defaultRenderFn: {
+                    1: () => ({
+                        element: 'div',
+                        type: 'inner',
+                        content: 'version 1'
+                    }),
+                    2: () => ({
+                        element: 'div',
+                        type: 'inner',
+                        content: 'version 2'
+                    })
+                }
+            });
+
+            const node = new VersionedNode({version: 2});
+            const result = node.exportDOM();
+
+            result.should.deepEqual({
+                element: 'div',
+                type: 'inner',
+                content: 'version 2'
+            });
+        }));
+
+        it('throws error when defaultRenderFn is not provided', editorTest(function () {
+            const NodeWithoutRender = utils.generateDecoratorNode({
+                nodeType: 'no-render-test',
+                properties: []
+            });
+
+            const node = new NodeWithoutRender();
+            (() => node.exportDOM()).should.throw('[generateDecoratorNode] no-render-test: "defaultRenderFn" is required');
+        }));
+
+        it('throws error when default versioned renderer is missing for node version', editorTest(function () {
+            const VersionedNode = utils.generateDecoratorNode({
+                nodeType: 'versioned-render-test',
+                properties: [],
+                version: 2,
+                defaultRenderFn: {
+                    1: () => ({})
+                }
+            });
+
+            const node = new VersionedNode();
+            (() => node.exportDOM()).should.throw('[generateDecoratorNode] versioned-render-test: "defaultRenderFn" for version 2 is required');
+        }));
+
+        it('uses custom renderer if passed in (emailCustomizationAlpha)', editorTest(function () {
+            const node = $createNodeWithRender();
+            const customRenderer = () => ({
+                element: 'span',
+                type: 'inner',
+                content: 'custom render'
+            });
+
+            const result = node.exportDOM({
+                feature: {
+                    emailCustomizationAlpha: true
+                },
+                renderers: {
+                    'render-test': customRenderer
+                }
+            });
+
+            result.should.deepEqual({
+                element: 'span',
+                type: 'inner',
+                content: 'custom render'
+            });
+        }));
+
+        it('throws error when custom versioned renderer is missing for node version (emailCustomizationAlpha)', editorTest(function () {
+            const VersionedNode = utils.generateDecoratorNode({
+                nodeType: 'versioned-render-test',
+                properties: [{name: 'version', default: 1}],
+                version: 1,
+                defaultRenderFn: {
+                    1: () => ({
+                        element: 'div',
+                        type: 'inner',
+                        content: 'version 1'
+                    }),
+                    2: () => ({
+                        element: 'div',
+                        type: 'inner',
+                        content: 'version 2'
+                    })
+                }
+            });
+
+            const node = new VersionedNode({version: 2});
+
+            (() => node.exportDOM({
+                feature: {
+                    emailCustomizationAlpha: true
+                },
+                renderers: {
+                    'versioned-render-test': {
+                        1: () => ({})
+                    }
+                }
+            })).should.throw('[generateDecoratorNode] versioned-render-test: options.renderers[\'versioned-render-test\'] for version 2 is required');
+        }));
+    });
+
     describe('hasVisibility', function () {
         let NodeWithVisibility;
         let $createNodeWithVisibility;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1784

- updated the `exportDOM` function in our decorator factory to use `options.renderers[node-type]` if passed in
- allows consumers of `@tryghost/kg-lexical-html-renderer` to pass in their own card rendering functions

Example usage:

```
const customRenderers = {
    'embed': renderCustomEmbed,
    'header': {
        1: renderCustomHeaderV1,
        2: renderCustomHeaderV2
    }
}

const lexicalHtmlRenderer = new LexicalHtmlRenderer({nodes});

lexicalHtmlRenderer.render(lexical, {renderers: customRenderers})
```
