### PR TITLE
Revert "Removed default node renderers"

### DIFF
--- a/packages/kg-default-nodes/lib/generate-decorator-node.js
+++ b/packages/kg-default-nodes/lib/generate-decorator-node.js
@@ -180,13 +180,17 @@ export function generateDecoratorNode({nodeType, properties = [], defaultRenderF
             // means it's set from the serialized version data at runtime
             const nodeVersion = this.__version || version;
 
-            if (options.nodeRenderers?.[nodeType]) {
+            const hasEmailCustomization =
+                options.feature?.emailCustomizationAlpha ||
+                options.feature?.emailCustomization;
+
+            if (hasEmailCustomization && options.nodeRenderers?.[nodeType]) {
                 const render = options.nodeRenderers[nodeType];
 
                 if (typeof render === 'object') {
                     const versionRenderer = render[nodeVersion];
                     if (!versionRenderer) {
-                        throw new Error(`[generateDecoratorNode] ${nodeType}: "options.nodeRenderers['${nodeType}']" or "defaultRenderFn" for version ${nodeVersion} is required for exportDOM`);
+                        throw new Error(`[generateDecoratorNode] ${nodeType}: options.nodeRenderers['${nodeType}'] for version ${nodeVersion} is required`);
                     }
                     return versionRenderer(this, options);
                 } else {
@@ -197,13 +201,13 @@ export function generateDecoratorNode({nodeType, properties = [], defaultRenderF
             if (typeof defaultRenderFn === 'object') {
                 const render = defaultRenderFn[nodeVersion];
                 if (!render) {
-                    throw new Error(`[generateDecoratorNode] ${nodeType}: "options.nodeRenderers['${nodeType}']" or "defaultRenderFn" for version ${nodeVersion} is required for exportDOM`);
+                    throw new Error(`[generateDecoratorNode] ${nodeType}: "defaultRenderFn" for version ${nodeVersion} is required`);
                 }
                 return render(this, options);
             }
 
             if (!defaultRenderFn) {
-                throw new Error(`[generateDecoratorNode] ${nodeType}: "options.nodeRenderers['${nodeType}']" or "defaultRenderFn" is required for exportDOM`);
+                throw new Error(`[generateDecoratorNode] ${nodeType}: "defaultRenderFn" is required`);
             }
 
             const render = defaultRenderFn;

--- a/packages/kg-default-nodes/lib/nodes/audio/AudioNode.js
+++ b/packages/kg-default-nodes/lib/nodes/audio/AudioNode.js
@@ -1,6 +1,7 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseAudioNode} from './audio-parser';
+import {renderAudioNode} from './audio-renderer';
 
 export class AudioNode extends generateDecoratorNode({
     nodeType: 'audio',
@@ -10,7 +11,8 @@ export class AudioNode extends generateDecoratorNode({
         {name: 'src', default: '', urlType: 'url'},
         {name: 'title', default: ''},
         {name: 'thumbnailSrc', default: ''}
-    ]
+    ],
+    defaultRenderFn: renderAudioNode
 }) {
     static importDOM() {
         return parseAudioNode(this);

--- a/packages/kg-default-nodes/lib/nodes/audio/audio-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/audio/audio-renderer.js
@@ -1,0 +1,248 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {renderEmptyContainer} from '../../utils/render-empty-container';
+
+export function renderAudioNode(node, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+
+    if (!node.src || node.src.trim() === '') {
+        return renderEmptyContainer(document);
+    }
+
+    const thumbnailCls = getThumbnailCls(node);
+    const emptyThumbnailCls = getEmptyThumbnailCls(node);
+
+    if (options.target === 'email') {
+        return emailTemplate(node, document, options, thumbnailCls, emptyThumbnailCls);
+    } else {
+        return frontendTemplate(node, document, thumbnailCls, emptyThumbnailCls);
+    }
+}
+
+function frontendTemplate(node, document, thumbnailCls, emptyThumbnailCls) {
+    const element = document.createElement('div');
+    element.setAttribute('class', 'kg-card kg-audio-card');
+    const img = document.createElement('img');
+    img.src = node.thumbnailSrc;
+    img.alt = 'audio-thumbnail';
+    img.setAttribute('class', thumbnailCls);
+    element.appendChild(img);
+
+    const emptyThumbnailDiv = document.createElement('div');
+    emptyThumbnailDiv.setAttribute('class', emptyThumbnailCls);
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('width', '24');
+    svg.setAttribute('height', '24');
+    svg.setAttribute('fill', 'none');
+    const path1 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path1.setAttribute('fill-rule', 'evenodd');
+    path1.setAttribute('clip-rule', 'evenodd');
+    path1.setAttribute('d', 'M7.5 15.33a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0ZM15 13.83a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0Z');
+    svg.appendChild(path1);
+    const path2 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path2.setAttribute('fill-rule', 'evenodd');
+    path2.setAttribute('clip-rule', 'evenodd');
+    path2.setAttribute('d', 'M14.486 6.81A2.25 2.25 0 0 1 17.25 9v5.579a.75.75 0 0 1-1.5 0v-5.58a.75.75 0 0 0-.932-.727.755.755 0 0 1-.059.013l-4.465.744a.75.75 0 0 0-.544.72v6.33a.75.75 0 0 1-1.5 0v-6.33a2.25 2.25 0 0 1 1.763-2.194l4.473-.746Z');
+    svg.appendChild(path2);
+    const path3 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path3.setAttribute('fill-rule', 'evenodd');
+    path3.setAttribute('clip-rule', 'evenodd');
+    path3.setAttribute('d', 'M3 1.5a.75.75 0 0 0-.75.75v19.5a.75.75 0 0 0 .75.75h18a.75.75 0 0 0 .75-.75V5.133a.75.75 0 0 0-.225-.535l-.002-.002-3-2.883A.75.75 0 0 0 18 1.5H3ZM1.409.659A2.25 2.25 0 0 1 3 0h15a2.25 2.25 0 0 1 1.568.637l.003.002 3 2.883a2.25 2.25 0 0 1 .679 1.61V21.75A2.25 2.25 0 0 1 21 24H3a2.25 2.25 0 0 1-2.25-2.25V2.25c0-.597.237-1.169.659-1.591Z');
+    svg.appendChild(path3);
+    emptyThumbnailDiv.appendChild(svg);
+
+    element.appendChild(emptyThumbnailDiv);
+
+    const audioPlayerContainer = document.createElement('div');
+    audioPlayerContainer.setAttribute('class', 'kg-audio-player-container');
+
+    const audioElement = document.createElement('audio');
+    audioElement.setAttribute('src', node.src);
+    audioElement.setAttribute('preload', 'metadata');
+    audioPlayerContainer.appendChild(audioElement);
+
+    const audioTitle = document.createElement('div');
+    audioTitle.setAttribute('class', 'kg-audio-title');
+    audioTitle.textContent = node.title;
+    audioPlayerContainer.appendChild(audioTitle);
+
+    const audioPlayer = document.createElement('div');
+    audioPlayer.setAttribute('class', 'kg-audio-player');
+    const audioPlayIcon = document.createElement('button');
+    audioPlayIcon.setAttribute('class', 'kg-audio-play-icon');
+    audioPlayIcon.setAttribute('aria-label', 'Play audio');
+    const audioPlayIconSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    audioPlayIconSvg.setAttribute('viewBox', '0 0 24 24');
+    const playPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    playPath.setAttribute('d', 'M23.14 10.608 2.253.164A1.559 1.559 0 0 0 0 1.557v20.887a1.558 1.558 0 0 0 2.253 1.392L23.14 13.393a1.557 1.557 0 0 0 0-2.785Z');
+    audioPlayIconSvg.appendChild(playPath);
+    audioPlayIcon.appendChild(audioPlayIconSvg);
+    audioPlayer.appendChild(audioPlayIcon);
+
+    const audioPauseIcon = document.createElement('button');
+    audioPauseIcon.setAttribute('class', 'kg-audio-pause-icon kg-audio-hide');
+    audioPauseIcon.setAttribute('aria-label', 'Pause audio');
+    const audioPauseIconSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    audioPauseIconSvg.setAttribute('viewBox', '0 0 24 24');
+    const rectSvg = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    rectSvg.setAttribute('x', '3');
+    rectSvg.setAttribute('y', '1');
+    rectSvg.setAttribute('width', '7');
+    rectSvg.setAttribute('height', '22');
+    rectSvg.setAttribute('rx', '1.5');
+    rectSvg.setAttribute('ry', '1.5');
+    audioPauseIconSvg.appendChild(rectSvg);
+    const rectSvg2 = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    rectSvg2.setAttribute('x', '14');
+    rectSvg2.setAttribute('y', '1');
+    rectSvg2.setAttribute('width', '7');
+    rectSvg2.setAttribute('height', '22');
+    rectSvg2.setAttribute('rx', '1.5');
+    rectSvg2.setAttribute('ry', '1.5');
+    audioPauseIconSvg.appendChild(rectSvg2);
+    audioPauseIcon.appendChild(audioPauseIconSvg);
+    audioPlayer.appendChild(audioPauseIcon);
+
+    const audioDuration = document.createElement('span');
+    audioDuration.setAttribute('class', 'kg-audio-current-time');
+    audioDuration.textContent = '0:00';
+    audioPlayer.appendChild(audioDuration);
+
+    const audioDurationTotal = document.createElement('div');
+    audioDurationTotal.setAttribute('class', 'kg-audio-time');
+    audioDurationTotal.textContent = '/';
+    const audioDUrationNode = document.createElement('span');
+    audioDUrationNode.setAttribute('class', 'kg-audio-duration');
+    audioDUrationNode.textContent = node.duration;
+    audioDurationTotal.appendChild(audioDUrationNode);
+    audioPlayer.appendChild(audioDurationTotal);
+
+    const audioSlider = document.createElement('input');
+    audioSlider.setAttribute('type', 'range');
+    audioSlider.setAttribute('class', 'kg-audio-seek-slider');
+    audioSlider.setAttribute('max', '100');
+    audioSlider.setAttribute('value', '0');
+    audioPlayer.appendChild(audioSlider);
+
+    const playbackRate = document.createElement('button');
+    playbackRate.setAttribute('class', 'kg-audio-playback-rate');
+    playbackRate.setAttribute('aria-label', 'Adjust playback speed');
+    playbackRate.innerHTML = '1&#215;'; // innerHTML not textContent because we need the HTML entity
+    audioPlayer.appendChild(playbackRate);
+
+    const unmuteIcon = document.createElement('button');
+    unmuteIcon.setAttribute('class', 'kg-audio-unmute-icon');
+    unmuteIcon.setAttribute('aria-label', 'Unmute');
+    const unmuteIconSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    unmuteIconSvg.setAttribute('viewBox', '0 0 24 24');
+    const unmutePath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    unmutePath.setAttribute('d', 'M15.189 2.021a9.728 9.728 0 0 0-7.924 4.85.249.249 0 0 1-.221.133H5.25a3 3 0 0 0-3 3v2a3 3 0 0 0 3 3h1.794a.249.249 0 0 1 .221.133 9.73 9.73 0 0 0 7.924 4.85h.06a1 1 0 0 0 1-1V3.02a1 1 0 0 0-1.06-.998Z');
+    unmuteIconSvg.appendChild(unmutePath);
+    unmuteIcon.appendChild(unmuteIconSvg);
+    audioPlayer.appendChild(unmuteIcon);
+
+    const muteIcon = document.createElement('button');
+    muteIcon.setAttribute('class', 'kg-audio-mute-icon kg-audio-hide');
+    muteIcon.setAttribute('aria-label', 'Mute');
+
+    const muteIconSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    muteIconSvg.setAttribute('viewBox', '0 0 24 24');
+    const mutePath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    mutePath.setAttribute('d', 'M16.177 4.3a.248.248 0 0 0 .073-.176v-1.1a1 1 0 0 0-1.061-1 9.728 9.728 0 0 0-7.924 4.85.249.249 0 0 1-.221.133H5.25a3 3 0 0 0-3 3v2a3 3 0 0 0 3 3h.114a.251.251 0 0 0 .177-.073ZM23.707 1.706A1 1 0 0 0 22.293.292l-22 22a1 1 0 0 0 0 1.414l.009.009a1 1 0 0 0 1.405-.009l6.63-6.631A.251.251 0 0 1 8.515 17a.245.245 0 0 1 .177.075 10.081 10.081 0 0 0 6.5 2.92 1 1 0 0 0 1.061-1V9.266a.247.247 0 0 1 .073-.176Z');
+    muteIconSvg.appendChild(mutePath);
+    muteIcon.appendChild(muteIconSvg);
+    audioPlayer.appendChild(muteIcon);
+
+    const volumeSlider = document.createElement('input');
+    volumeSlider.setAttribute('type', 'range');
+    volumeSlider.setAttribute('class', 'kg-audio-volume-slider');
+    volumeSlider.setAttribute('max', '100');
+    volumeSlider.setAttribute('value', '100');
+    audioPlayer.appendChild(volumeSlider);
+
+    audioPlayerContainer.appendChild(audioPlayer);
+    element.appendChild(audioPlayerContainer);
+
+    return {element};
+}
+
+function emailTemplate(node, document, options, thumbnailCls, emptyThumbnailCls) {
+    const html = (`
+        <table cellspacing="0" cellpadding="0" border="0" class="kg-audio-card">
+                <tr>
+                    <td>
+                        <table cellspacing="0" cellpadding="0" border="0" width="100%">
+                            <tr>
+                                <td width="60">
+                                    <a href="${options.postUrl}" style="display: block; width: 60px; height: 60px; padding-top: 4px; padding-right: 16px; padding-bottom: 4px; padding-left: 4px; border-radius: 2px;">
+                                        ${node.thumbnailSrc ? `
+                                        <img src="${node.thumbnailSrc}" class="${thumbnailCls}" style="width: 60px; height: 60px; object-fit: cover; border: 0; border-radius: 2px;">
+                                        ` : `
+                                        <img src="https://static.ghost.org/v4.0.0/images/audio-file-icon.png" class="${emptyThumbnailCls}" style="width: 24px; height: 24px; padding: 18px; border-radius: 2px;">
+                                        `}
+                                    </a>
+                                </td>
+                                <td style="position: relative; vertical-align: center;" valign="middle">
+                                    <a href="${options.postUrl}" style="position: absolute; display: block; top: 0; right: 0; bottom: 0; left: 0;"></a>
+                                    <table cellspacing="0" cellpadding="0" border="0" width="100%">
+                                        <tr>
+                                            <td>
+                                                <a href="${options.postUrl}" class="kg-audio-title">${node.title}</a>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>
+                                                <table cellspacing="0" cellpadding="0" border="0" width="100%">
+                                                    <tr>
+                                                        <td width="24" style="vertical-align: middle;" valign="middle">
+                                                            <a href="${options.postUrl}" class="kg-audio-play-button"></a>
+                                                        </td>
+                                                        <td style="vertical-align: middle;" valign="middle">
+                                                            <a href="${options.postUrl}" class="kg-audio-duration">${getFormattedDuration(node.duration)}<span class="kg-audio-link"> • Click to play audio</span></a>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+            `);
+
+    const container = document.createElement('div');
+    container.innerHTML = html.trim();
+
+    return {element: container.firstElementChild};
+}
+
+function getThumbnailCls(node) {
+    let thumbnailCls = 'kg-audio-thumbnail';
+
+    if (!node.thumbnailSrc) {
+        thumbnailCls += ' kg-audio-hide';
+    }
+
+    return thumbnailCls;
+}
+
+function getEmptyThumbnailCls(node) {
+    let emptyThumbnailCls = 'kg-audio-thumbnail placeholder';
+
+    if (node.thumbnailSrc) {
+        emptyThumbnailCls += ' kg-audio-hide';
+    }
+
+    return emptyThumbnailCls;
+}
+
+function getFormattedDuration(duration = 200) {
+    const minutes = Math.floor(duration / 60);
+    const seconds = Math.floor(duration - (minutes * 60));
+    const paddedSeconds = String(seconds).padStart(2, '0');
+    const formattedDuration = `${minutes}:${paddedSeconds}`;
+    return formattedDuration;
+}

--- a/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkNode.js
+++ b/packages/kg-default-nodes/lib/nodes/bookmark/BookmarkNode.js
@@ -1,6 +1,7 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseBookmarkNode} from './bookmark-parser';
+import {renderBookmarkNode} from './bookmark-renderer';
 
 export class BookmarkNode extends generateDecoratorNode({
     nodeType: 'bookmark',
@@ -13,7 +14,8 @@ export class BookmarkNode extends generateDecoratorNode({
         {name: 'publisher', default: ''},
         {name: 'icon', urlPath: 'metadata.icon', default: '', urlType: 'url'},
         {name: 'thumbnail', urlPath: 'metadata.thumbnail', default: '', urlType: 'url'}
-    ]
+    ],
+    defaultRenderFn: renderBookmarkNode
 }) {
     static importDOM() {
         return parseBookmarkNode(this);

--- a/packages/kg-default-nodes/lib/nodes/bookmark/bookmark-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/bookmark/bookmark-renderer.js
@@ -1,0 +1,186 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {renderEmptyContainer} from '../../utils/render-empty-container';
+import {escapeHtml} from '../../utils/escape-html';
+import {truncateHtml} from '../../utils/truncate';
+
+export function renderBookmarkNode(node, options = {}) {
+    addCreateDocumentOption(options);
+
+    const document = options.createDocument();
+
+    if (!node.url || node.url.trim() === '') {
+        return renderEmptyContainer(document);
+    }
+
+    if (options.target === 'email') {
+        return emailTemplate(node, document);
+    } else {
+        return frontendTemplate(node, document);
+    }
+}
+
+function emailTemplate(node, document) {
+    const title = escapeHtml(node.title);
+    const publisher = escapeHtml(node.publisher);
+    const author = escapeHtml(node.author);
+    const description = escapeHtml(node.description);
+
+    const icon = node.icon;
+    const url = node.url;
+    const thumbnail = node.thumbnail;
+    const caption = node.caption;
+
+    const element = document.createElement('div');
+
+    const html =
+        `
+        <!--[if !mso !vml]-->
+            <figure class="kg-card kg-bookmark-card ${caption ? `kg-card-hascaption` : ''}">
+                <a class="kg-bookmark-container" href="${url}">
+                    <div class="kg-bookmark-content">
+                        <div class="kg-bookmark-title">${title}</div>
+                        <div class="kg-bookmark-description">${truncateHtml(description, 120, 90)}</div>
+                        <div class="kg-bookmark-metadata">
+                            ${icon ? `<img class="kg-bookmark-icon" src="${icon}" alt="">` : ''}
+                            ${publisher ? `<span class="kg-bookmark-author" src="${publisher}">${publisher}</span>` : ''}
+                            ${author ? `<span class="kg-bookmark-publisher" src="${author}">${author}</span>` : ''}
+                        </div>
+                    </div>
+                    ${thumbnail ? `<div class="kg-bookmark-thumbnail" style="background-image: url('${thumbnail}')">
+                        <img src="${thumbnail}" alt="" onerror="this.style.display='none'"></div>` : ''}
+                </a>
+                ${caption ? `<figcaption>${caption}</figcaption>` : ''}
+            </figure>
+        <!--[endif]-->
+        <!--[if vml]>
+            <table class="kg-card kg-bookmark-card--outlook" style="margin: 0; padding: 0; width: 100%; border: 1px solid #e5eff5; background: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif; border-collapse: collapse; border-spacing: 0;" width="100%">
+                <tr>
+                    <td width="100%" style="padding: 20px;">
+                        <table style="margin: 0; padding: 0; border-collapse: collapse; border-spacing: 0;">
+                            <tr>
+                                <td class="kg-bookmark-title--outlook">
+                                    <a href="${url}" style="text-decoration: none; color: #15212A; font-size: 15px; line-height: 1.5em; font-weight: 600;">
+                                        ${title}
+                                    </a>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <div class="kg-bookmark-description--outlook">
+                                        <a href="${url}" style="text-decoration: none; margin-top: 12px; color: #738a94; font-size: 13px; line-height: 1.5em; font-weight: 400;">
+                                            ${truncateHtml(description, 120, 90)}
+                                        </a>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="kg-bookmark-metadata--outlook" style="padding-top: 14px; color: #15212A; font-size: 13px; font-weight: 400; line-height: 1.5em;">
+                                    <table style="margin: 0; padding: 0; border-collapse: collapse; border-spacing: 0;">
+                                        <tr>
+                                            ${icon ? `
+                                                <td valign="middle" class="kg-bookmark-icon--outlook" style="padding-right: 8px; font-size: 0; line-height: 1.5em;">
+                                                    <a href="${url}" style="text-decoration: none; color: #15212A;">
+                                                        <img src="${icon}" width="22" height="22" alt=" ">
+                                                    </a>
+                                                </td>
+                                            ` : ''}
+                                            <td valign="middle" class="kg-bookmark-byline--outlook">
+                                                <a href="${url}" style="text-decoration: none; color: #15212A;">
+                                                    ${publisher}
+                                                    ${author ? `&nbsp;&#x2022;&nbsp;` : ''}
+                                                    ${author}
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+            <div class="kg-bookmark-spacer--outlook" style="height: 1.5em;">&nbsp;</div>
+        <![endif]-->`;
+
+    element.innerHTML = html;
+    return {element};
+}
+
+function frontendTemplate(node, document) {
+    const element = document.createElement('figure');
+    const caption = node.caption;
+    let cardClass = 'kg-card kg-bookmark-card';
+    if (caption) {
+        cardClass += ' kg-card-hascaption';
+    }
+    element.setAttribute('class', cardClass);
+
+    const container = document.createElement('a');
+    container.setAttribute('class','kg-bookmark-container');
+    container.href = node.url;
+    element.appendChild(container);
+
+    const content = document.createElement('div');
+    content.setAttribute('class','kg-bookmark-content');
+    container.appendChild(content);
+
+    const title = document.createElement('div');
+    title.setAttribute('class','kg-bookmark-title');
+    title.textContent = node.title;
+    content.appendChild(title);
+
+    const description = document.createElement('div');
+    description.setAttribute('class','kg-bookmark-description');
+    description.textContent = node.description;
+    content.appendChild(description);
+
+    const metadata = document.createElement('div');
+    metadata.setAttribute('class','kg-bookmark-metadata');
+    content.appendChild(metadata);
+
+    metadata.icon = node.icon;
+    if (metadata.icon) {
+        const icon = document.createElement('img');
+        icon.setAttribute('class','kg-bookmark-icon');
+        icon.src = metadata.icon;
+        icon.alt = '';
+        metadata.appendChild(icon);
+    }
+
+    metadata.publisher = node.publisher;
+    if (metadata.publisher) {
+        const publisher = document.createElement('span');
+        publisher.setAttribute('class','kg-bookmark-author'); // NOTE: This is NOT in error. The classes are reversed for theme backwards-compatibility.
+        publisher.textContent = metadata.publisher;
+        metadata.appendChild(publisher);
+    }
+
+    metadata.author = node.author;
+    if (metadata.author) {
+        const author = document.createElement('span');
+        author.setAttribute('class','kg-bookmark-publisher'); // NOTE: This is NOT in error. The classes are reversed for theme backwards-compatibility.
+        author.textContent = metadata.author;
+        metadata.appendChild(author);
+    }
+
+    metadata.thumbnail = node.thumbnail;
+    if (metadata.thumbnail) {
+        const thumbnailDiv = document.createElement('div');
+        thumbnailDiv.setAttribute('class','kg-bookmark-thumbnail');
+        container.appendChild(thumbnailDiv);
+
+        const thumbnail = document.createElement('img');
+        thumbnail.src = metadata.thumbnail;
+        thumbnail.alt = '';
+        thumbnail.setAttribute('onerror',`this.style.display = 'none'`); // Hide thumbnail div if image fails to load
+        thumbnailDiv.appendChild(thumbnail);
+    }
+
+    if (caption) {
+        const figCaption = document.createElement('figcaption');
+        figCaption.innerHTML = caption;
+        element.appendChild(figCaption);
+    }
+
+    return {element};
+}

--- a/packages/kg-default-nodes/lib/nodes/button/ButtonNode.js
+++ b/packages/kg-default-nodes/lib/nodes/button/ButtonNode.js
@@ -1,6 +1,7 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseButtonNode} from './button-parser';
+import {renderButtonNode} from './button-renderer';
 
 export class ButtonNode extends generateDecoratorNode({
     nodeType: 'button',
@@ -8,7 +9,8 @@ export class ButtonNode extends generateDecoratorNode({
         {name: 'buttonText', default: ''},
         {name: 'alignment', default: 'center'},
         {name: 'buttonUrl', default: '', urlType: 'url'}
-    ]
+    ],
+    defaultRenderFn: renderButtonNode
 }) {
     static importDOM() {
         return parseButtonNode(this);

--- a/packages/kg-default-nodes/lib/nodes/button/button-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/button/button-renderer.js
@@ -1,0 +1,109 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {renderEmptyContainer} from '../../utils/render-empty-container';
+import {renderEmailButton} from '../../utils/render-helpers/email-button';
+import {html} from '../../utils/tagged-template-fns.mjs';
+
+export function renderButtonNode(node, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+
+    if (!node.buttonUrl || node.buttonUrl.trim() === '') {
+        return renderEmptyContainer(document);
+    }
+
+    if (options.target === 'email') {
+        return emailTemplate(node, options, document);
+    } else {
+        return frontendTemplate(node, document);
+    }
+}
+
+function frontendTemplate(node, document) {
+    const cardClasses = getCardClasses(node);
+
+    const cardDiv = document.createElement('div');
+    cardDiv.setAttribute('class', cardClasses);
+
+    const button = document.createElement('a');
+    button.setAttribute('href', node.buttonUrl);
+    button.setAttribute('class', 'kg-btn kg-btn-accent');
+    button.textContent = node.buttonText || 'Button Title';
+
+    cardDiv.appendChild(button);
+    return {element: cardDiv};
+}
+
+function emailTemplate(node, options, document) {
+    const {buttonUrl, buttonText} = node;
+
+    let cardHtml;
+    if (options.feature?.emailCustomization) {
+        cardHtml = html`
+        <table border="0" cellpadding="0" cellspacing="0">
+            <tr>
+                <td>
+                    <table class="btn btn-accent" border="0" cellspacing="0" cellpadding="0" align="${node.alignment}">
+                        <tr>
+                            <td align="center">
+                                <a href="${buttonUrl}">${buttonText}</a>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>`;
+
+        const element = document.createElement('p');
+        element.innerHTML = cardHtml;
+        return {element};
+    } else if (options.feature?.emailCustomizationAlpha) {
+        const buttonHtml = renderEmailButton({
+            alignment: node.alignment,
+            color: 'accent',
+            url: buttonUrl,
+            text: buttonText
+        });
+
+        cardHtml = html`
+        <table border="0" cellpadding="0" cellspacing="0">
+            <tbody>
+                <tr>
+                    <td>
+                        ${buttonHtml}
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        `;
+
+        const element = document.createElement('div');
+        element.innerHTML = cardHtml;
+        return {element, type: 'inner'};
+    } else {
+        cardHtml = html`
+        <div class="btn btn-accent">
+            <table border="0" cellspacing="0" cellpadding="0" align="${node.alignment}">
+                <tr>
+                    <td align="center">
+                        <a href="${buttonUrl}">${buttonText}</a>
+                    </td>
+                </tr>
+            </table>
+        </div>
+        `;
+
+        const element = document.createElement('p');
+        element.innerHTML = cardHtml;
+        return {element};
+    }
+}
+
+function getCardClasses(node) {
+    let cardClasses = ['kg-card kg-button-card'];
+
+    if (node.alignment) {
+        cardClasses.push(`kg-align-${node.alignment}`);
+    }
+
+    return cardClasses.join(' ');
+}

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/CallToActionNode.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line ghost/filenames/match-exported-class
 import {generateDecoratorNode} from '../../generate-decorator-node';
+import {renderCallToActionNode} from './calltoaction-renderer';
 import {parseCallToActionNode} from './calltoaction-parser';
 
 export class CallToActionNode extends generateDecoratorNode({
@@ -22,7 +23,8 @@ export class CallToActionNode extends generateDecoratorNode({
         {name: 'imageUrl', default: ''},
         {name: 'imageWidth', default: null},
         {name: 'imageHeight', default: null}
-    ]
+    ],
+    defaultRenderFn: renderCallToActionNode
 }) {
     static importDOM() {
         return parseCallToActionNode(this);

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-parser.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-parser.js
@@ -46,7 +46,7 @@ export function parseCallToActionNode(CallToActionNode) {
                         const payload = {
                             layout: layout,
                             alignment: alignment,
-                            textValue: textValueElement?.textContent.trim() || '',
+                            textValue: textValueElement.textContent.trim() || '',
                             showButton: buttonElement ? true : false,
                             showDividers: showDividers,
                             buttonText: buttonElement?.textContent.trim() || '',

--- a/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/call-to-action/calltoaction-renderer.js
@@ -1,0 +1,387 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {renderWithVisibility} from '../../utils/visibility';
+import {getResizedImageDimensions} from '../../utils/get-resized-image-dimensions';
+import {isLocalContentImage} from '../../utils/is-local-content-image';
+import {buildCleanBasicHtmlForElement} from '../../utils/build-clean-basic-html-for-element';
+
+const showButton = dataset => dataset.showButton && dataset.buttonUrl && dataset.buttonText;
+
+const wrapWithLink = (dataset, content) => {
+    if (!showButton(dataset)) {
+        return content;
+    }
+
+    return `<a href="${dataset.buttonUrl}">${content}</a>`;
+};
+
+function ctaCardTemplate(dataset) {
+    // Add validation for buttonColor
+    if (!dataset.buttonColor || !dataset.buttonColor.match(/^[a-zA-Z\d-]+|#([a-fA-F\d]{3}|[a-fA-F\d]{6})$/)) {
+        dataset.buttonColor = 'accent';
+    }
+    const buttonAccent = dataset.buttonColor === 'accent' ? 'kg-style-accent' : '';
+    const buttonStyle = dataset.buttonColor === 'accent'
+        ? `style="color: ${dataset.buttonTextColor};"`
+        : `style="background-color: ${dataset.buttonColor}; color: ${dataset.buttonTextColor};"`;
+
+    return `
+        <div class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} kg-cta-${dataset.layout} ${dataset.showDividers ? '' : 'kg-cta-no-dividers'} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''} ${dataset.alignment === 'center' ? 'kg-cta-centered' : ''}" data-layout="${dataset.layout}">
+            ${dataset.hasSponsorLabel ? `
+                <div class="kg-cta-sponsor-label-wrapper">
+                    <div class="kg-cta-sponsor-label">
+                        ${dataset.sponsorLabel}
+                    </div>
+                </div>
+            ` : ''}
+            <div class="kg-cta-content">
+                ${dataset.imageUrl ? `
+                    <div class="kg-cta-image-container">
+                        ${wrapWithLink(dataset, `<img src="${dataset.imageUrl}" alt="CTA Image" ${dataset?.imageWidth && dataset.imageHeight ? `data-image-dimensions="${dataset.imageWidth}x${dataset.imageHeight}"` : '' }>`)}
+                    </div>
+                ` : ''}
+                ${dataset.textValue || dataset.showButton ? `
+                    <div class="kg-cta-content-inner">
+                    ${dataset.textValue ? `
+                        <div class="kg-cta-text">
+                            ${dataset.textValue}
+                        </div>
+                    ` : ''}
+                    ${showButton(dataset) ? `
+                        <a href="${dataset.buttonUrl}" class="kg-cta-button ${buttonAccent}" ${buttonStyle}>
+                            ${dataset.buttonText}
+                        </a>
+                        ` : ''}
+                    </div>
+                ` : ''}
+            </div>
+        </div>
+    `;
+}
+
+function emailCTATemplate(dataset, options = {}) {
+    // accent button color backgrounds are set in main template styles,
+    // for other button colors we need to set the background color explicitly
+    let buttonStyle = dataset.buttonColor === 'accent'
+        ? `color: ${dataset.buttonTextColor};`
+        : `background-color: ${dataset.buttonColor}; color: ${dataset.buttonTextColor};`;
+    // by default we duplicate style across the <td> and <a> tags, but
+    // we separate the variables to allow <a> tag style overrides for outline buttons
+    let buttonLinkStyle = buttonStyle;
+
+    if (
+        (options?.feature?.emailCustomization || options?.feature?.emailCustomizationAlpha) &&
+        options?.design?.buttonStyle === 'outline' &&
+        // accent buttons are fully handled by main template CSS
+        dataset.buttonColor !== 'accent'
+    ) {
+        buttonStyle = `
+            border: 1px solid ${dataset.buttonColor};
+            background-color: transparent;
+            color: ${dataset.buttonColor};
+        `;
+        buttonLinkStyle = `
+            background-color: transparent;
+            color: ${dataset.buttonColor};
+        `;
+    }
+
+    let imageDimensions;
+
+    if (dataset.imageUrl && dataset.imageWidth && dataset.imageHeight) {
+        imageDimensions = {
+            width: dataset.imageWidth,
+            height: dataset.imageHeight
+        };
+
+        if (dataset.imageWidth >= 560) {
+            imageDimensions = getResizedImageDimensions(imageDimensions, {width: 560});
+        }
+    }
+
+    if (dataset.layout === 'minimal' && dataset.imageUrl) {
+        if (isLocalContentImage(dataset.imageUrl, options.siteUrl) && options.canTransformImage?.(dataset.imageUrl)) {
+            const [, imagesPath, filename] = dataset.imageUrl.match(/(.*\/content\/images)\/(.*)/);
+            const iconSize = options?.imageOptimization?.internalImageSizes?.['email-cta-minimal-image'] || {width: 256, height: 256}; // default to 256 since we know the image is a square
+            dataset.imageUrl = `${imagesPath}/size/w${iconSize.width}h${iconSize.height}/${filename}`;
+        }
+    }
+
+    if (options.feature?.emailCustomization || options.feature?.emailCustomizationAlpha) {
+        const renderContent = () => {
+            if (dataset.layout === 'minimal') {
+                return `
+                    <tr>
+                        <td class="kg-cta-content">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%" class="kg-cta-content-wrapper">
+                                <tr>
+                                    ${dataset.imageUrl ? `
+                                        <td class="kg-cta-image-container" width="64">
+                                            ${wrapWithLink(dataset, `<img src="${dataset.imageUrl}" alt="CTA Image" class="kg-cta-image" width="64" height="64">`)}
+                                        </td>
+                                    ` : ''}
+                                    <td class="kg-cta-content-inner">
+                                        <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                            ${dataset.textValue ? `
+                                                <tr>
+                                                    <td class="kg-cta-text">
+                                                        ${dataset.textValue}
+                                                    </td>
+                                                </tr>
+                                            ` : ''}
+                                            ${showButton(dataset) ? `
+                                            <tr>
+                                                <td class="kg-cta-button-container">
+                                                    <table border="0" cellpadding="0" cellspacing="0" class="btn">
+                                                        <tr>
+                                                            <td class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}" style="${buttonStyle}">
+                                                                <a href="${dataset.buttonUrl}"
+                                                                   class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}"
+                                                                   style="${buttonLinkStyle}"
+                                                                >
+                                                                    ${dataset.buttonText}
+                                                                </a>
+                                                            </td>
+                                                        </tr>
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                            ` : ''}
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                `;
+            }
+
+            return `
+                <tr>
+                    <td class="kg-cta-content">
+                        <table border="0" cellpadding="0" cellspacing="0" width="100%" class="kg-cta-content-wrapper">
+                            ${dataset.imageUrl ? `
+                                <tr>
+                                    <td class="kg-cta-image-container">
+                                        <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                            <tr>
+                                                <td>
+                                                    ${wrapWithLink(dataset, `<img src="${dataset.imageUrl}" alt="CTA Image" class="kg-cta-image" ${imageDimensions ? `width="${imageDimensions.width}"` : ''} ${imageDimensions ? `height="${imageDimensions.height}"` : ''}>`)}
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            ` : ''}
+                            <tr>
+                                <td class="kg-cta-text">
+                                    ${dataset.textValue}
+                                </td>
+                            </tr>
+                            ${showButton(dataset) ? `
+                                <tr>
+                                    <td class="kg-cta-button-container" align="${dataset.alignment}">
+                                        <table class="btn" border="0" cellpadding="0" cellspacing="0">
+                                            <tr>
+                                                <td class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}" style="${buttonStyle}" align="${dataset.alignment}">
+                                                    <a href="${dataset.buttonUrl}"
+                                                       class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}"
+                                                       style="${buttonLinkStyle}"
+                                                    >
+                                                        ${dataset.buttonText}
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            ` : ''}
+                        </table>
+                    </td>
+                </tr>
+            `;
+        };
+
+        return `
+            <table class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} ${dataset.showDividers ? '' : 'kg-cta-no-dividers'} kg-cta-${dataset.layout} ${dataset.hasSponsorLabel ? '' : 'kg-cta-no-label'} ${dataset.textValue ? '' : 'kg-cta-no-text'} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''} ${dataset.alignment === 'center' ? 'kg-cta-centered' : ''}" border="0" cellpadding="0" cellspacing="0" width="100%">
+                ${dataset.hasSponsorLabel ? `
+                    <tr>
+                        <td>
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td class="kg-cta-sponsor-label">
+                                        ${dataset.sponsorLabel}
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                ` : ''}
+                ${renderContent()}
+            </table>
+        `;
+    } else {
+        const renderContent = () => {
+            if (dataset.layout === 'minimal') {
+                return `
+                    <tr>
+                        <td class="kg-cta-content">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%" class="kg-cta-content-wrapper">
+                                <tr>
+                                    ${dataset.imageUrl ? `
+                                        <td class="kg-cta-image-container" width="64">
+                                            ${wrapWithLink(dataset, `<img src="${dataset.imageUrl}" alt="CTA Image" class="kg-cta-image" width="64" height="64">`)}
+                                        </td>
+                                    ` : ''}
+                                    <td class="kg-cta-content-inner">
+                                        <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                            ${dataset.textValue ? `
+                                                <tr>
+                                                    <td class="kg-cta-text">
+                                                        ${dataset.textValue}
+                                                    </td>
+                                                </tr>
+                                            ` : ''}
+                                            ${showButton(dataset) ? `
+                                            <tr>
+                                                <td class="kg-cta-button-container">
+                                                    <table border="0" cellpadding="0" cellspacing="0" class="kg-cta-button-wrapper">
+                                                        <tr>
+                                                            <td class="${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}" style="${buttonStyle}">
+                                                                <a href="${dataset.buttonUrl}"
+                                                                   class="kg-cta-button ${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}"
+                                                                   style="${buttonStyle}"
+                                                                >
+                                                                    ${dataset.buttonText}
+                                                                </a>
+                                                            </td>
+                                                        </tr>
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                            ` : ''}
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                `;
+            }
+
+            return `
+                <tr>
+                    <td class="kg-cta-content">
+                        <table border="0" cellpadding="0" cellspacing="0" width="100%" class="kg-cta-content-wrapper">
+                            ${dataset.imageUrl ? `
+                                <tr>
+                                    <td class="kg-cta-image-container">
+                                        <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                            <tr>
+                                                <td>
+                                                    ${wrapWithLink(dataset, `<img src="${dataset.imageUrl}" alt="CTA Image" class="kg-cta-image" ${imageDimensions ? `width="${imageDimensions.width}"` : ''} ${imageDimensions ? `height="${imageDimensions.height}"` : ''}>`)}
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            ` : ''}
+                            <tr>
+                                <td class="kg-cta-text">
+                                    ${dataset.textValue}
+                                </td>
+                            </tr>
+                            ${showButton(dataset) ? `
+                                <tr>
+                                    <td class="kg-cta-button-container">
+                                        <table border="0" cellpadding="0" cellspacing="0">
+                                            <tr>
+                                                <td class="kg-cta-button-wrapper ${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}" style="${buttonStyle}">
+                                                    <a href="${dataset.buttonUrl}"
+                                                       class="kg-cta-button ${dataset.buttonColor === 'accent' ? 'kg-style-accent' : ''}"
+                                                       style="${buttonStyle}"
+                                                    >
+                                                        ${dataset.buttonText}
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            ` : ''}
+                        </table>
+                    </td>
+                </tr>
+            `;
+        };
+
+        return `
+            <table class="kg-card kg-cta-card kg-cta-bg-${dataset.backgroundColor} ${dataset.showDividers ? '' : 'kg-cta-no-dividers'} kg-cta-${dataset.layout} ${dataset.hasSponsorLabel ? '' : 'kg-cta-no-label'} ${dataset.textValue ? '' : 'kg-cta-no-text'} ${dataset.imageUrl ? 'kg-cta-has-img' : ''} ${dataset.linkColor === 'accent' ? 'kg-cta-link-accent' : ''} ${dataset.alignment === 'center' ? 'kg-cta-centered' : ''}" border="0" cellpadding="0" cellspacing="0" width="100%">
+                ${dataset.hasSponsorLabel ? `
+                    <tr>
+                        <td>
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td class="kg-cta-sponsor-label">
+                                        ${dataset.sponsorLabel}
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                ` : ''}
+                ${renderContent()}
+            </table>
+        `;
+    }
+}
+
+export function renderCallToActionNode(node, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+    const dataset = {
+        layout: node.layout,
+        alignment: node.alignment,
+        textValue: node.textValue,
+        showButton: node.showButton,
+        showDividers: node.showDividers,
+        buttonText: node.buttonText,
+        buttonUrl: node.buttonUrl,
+        buttonColor: node.buttonColor,
+        buttonTextColor: node.buttonTextColor,
+        hasSponsorLabel: node.hasSponsorLabel,
+        backgroundColor: node.backgroundColor,
+        sponsorLabel: node.sponsorLabel,
+        imageUrl: node.imageUrl,
+        imageWidth: node.imageWidth,
+        imageHeight: node.imageHeight,
+        linkColor: node.linkColor
+    };
+
+    // Add validation for backgroundColor
+
+    if (!dataset.backgroundColor || !dataset.backgroundColor.match(/^[a-zA-Z\d-]+|#([a-fA-F\d]{3}|[a-fA-F\d]{6})$/)) {
+        dataset.backgroundColor = 'white';
+    }
+
+    if (options.target === 'email') {
+        const emailDoc = options.createDocument();
+        const emailDiv = emailDoc.createElement('div');
+
+        emailDiv.innerHTML = emailCTATemplate(dataset, options);
+
+        return renderWithVisibility({element: emailDiv.firstElementChild}, node.visibility, options);
+    }
+
+    const element = document.createElement('div');
+
+    if (dataset.hasSponsorLabel) {
+        const cleanBasicHtml = buildCleanBasicHtmlForElement(element);
+        const cleanedHtml = cleanBasicHtml(dataset.sponsorLabel, {firstChildInnerContent: true});
+        dataset.sponsorLabel = cleanedHtml;
+    }
+    const htmlString = ctaCardTemplate(dataset);
+
+    element.innerHTML = htmlString?.trim();
+
+    return renderWithVisibility({element: element.firstElementChild}, node.visibility, options);
+}

--- a/packages/kg-default-nodes/lib/nodes/callout/CalloutNode.js
+++ b/packages/kg-default-nodes/lib/nodes/callout/CalloutNode.js
@@ -1,5 +1,6 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
+import {renderCalloutNode} from './callout-renderer';
 import {parseCalloutNode} from './callout-parser';
 
 export class CalloutNode extends generateDecoratorNode({
@@ -8,7 +9,8 @@ export class CalloutNode extends generateDecoratorNode({
         {name: 'calloutText', default: '', wordCount: true},
         {name: 'calloutEmoji', default: '💡'},
         {name: 'backgroundColor', default: 'blue'}
-    ]
+    ],
+    defaultRenderFn: renderCalloutNode
 }) {
     /* override */
     constructor({calloutText, calloutEmoji, backgroundColor} = {}, key) {

--- a/packages/kg-default-nodes/lib/nodes/callout/callout-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/callout/callout-renderer.js
@@ -1,0 +1,38 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {cleanDOM} from '../../utils/clean-dom';
+
+export function renderCalloutNode(node, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+    const element = document.createElement('div');
+
+    // backgroundColor can end up with `rgba(0, 0, 0, 0)` from old mobiledoc copy/paste
+    // that is invalid when used in a class name so fall back to `white` when we don't have
+    // something that looks like a valid class
+    if (!node.backgroundColor || !node.backgroundColor.match(/^[a-zA-Z\d-]+$/)) {
+        node.backgroundColor = 'white';
+    }
+
+    element.classList.add('kg-card', 'kg-callout-card', `kg-callout-card-${node.backgroundColor}`);
+
+    if (node.calloutEmoji) {
+        const emojiElement = document.createElement('div');
+        emojiElement.classList.add('kg-callout-emoji');
+        emojiElement.textContent = node.calloutEmoji;
+        element.appendChild(emojiElement);
+    }
+
+    const textElement = document.createElement('div');
+    textElement.classList.add('kg-callout-text');
+
+    const temporaryContainer = document.createElement('div');
+    temporaryContainer.innerHTML = node.calloutText;
+
+    const allowedTags = ['A', 'STRONG', 'EM', 'B', 'I', 'BR', 'CODE', 'MARK', 'S', 'DEL', 'U', 'SUP', 'SUB'];
+    cleanDOM(temporaryContainer, allowedTags);
+
+    textElement.innerHTML = temporaryContainer.innerHTML;
+    element.appendChild(textElement);
+
+    return {element};
+}

--- a/packages/kg-default-nodes/lib/nodes/codeblock/CodeBlockNode.js
+++ b/packages/kg-default-nodes/lib/nodes/codeblock/CodeBlockNode.js
@@ -1,6 +1,7 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseCodeBlockNode} from './codeblock-parser';
+import {renderCodeBlockNode} from './codeblock-renderer';
 
 export class CodeBlockNode extends generateDecoratorNode({
     nodeType: 'codeblock',
@@ -8,7 +9,8 @@ export class CodeBlockNode extends generateDecoratorNode({
         {name: 'code', default: '', wordCount: true},
         {name: 'language', default: ''},
         {name: 'caption', default: '', urlType: 'html', wordCount: true}
-    ]
+    ],
+    defaultRenderFn: renderCodeBlockNode
 }) {
     static importDOM() {
         return parseCodeBlockNode(this);

--- a/packages/kg-default-nodes/lib/nodes/codeblock/codeblock-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/codeblock/codeblock-renderer.js
@@ -1,0 +1,35 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {renderEmptyContainer} from '../../utils/render-empty-container';
+
+export function renderCodeBlockNode(node, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+
+    if (!node.code || node.code.trim() === '') {
+        return renderEmptyContainer(document);
+    }
+
+    const pre = document.createElement('pre');
+    const code = document.createElement('code');
+
+    if (node.language) {
+        code.setAttribute('class', `language-${node.language}`);
+    }
+
+    code.appendChild(document.createTextNode(node.code));
+    pre.appendChild(code);
+
+    if (node.caption) {
+        let figure = document.createElement('figure');
+        figure.setAttribute('class', 'kg-card kg-code-card');
+        figure.appendChild(pre);
+
+        let figcaption = document.createElement('figcaption');
+        figcaption.innerHTML = node.caption;
+        figure.appendChild(figcaption);
+
+        return {element: figure};
+    } else {
+        return {element: pre};
+    }
+}

--- a/packages/kg-default-nodes/lib/nodes/email-cta/EmailCtaNode.js
+++ b/packages/kg-default-nodes/lib/nodes/email-cta/EmailCtaNode.js
@@ -1,5 +1,6 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
+import {renderEmailCtaNode} from './email-cta-renderer';
 
 export class EmailCtaNode extends generateDecoratorNode({
     nodeType: 'email-cta',
@@ -11,7 +12,8 @@ export class EmailCtaNode extends generateDecoratorNode({
         {name: 'segment', default: 'status:free'},
         {name: 'showButton', default: false},
         {name: 'showDividers', default: true}
-    ]
+    ],
+    defaultRenderFn: renderEmailCtaNode
 }) {
 }
 

--- a/packages/kg-default-nodes/lib/nodes/email-cta/email-cta-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/email-cta/email-cta-renderer.js
@@ -1,0 +1,59 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {removeCodeWrappersFromHelpers, removeSpaces, wrapReplacementStrings} from '../../utils/replacement-strings';
+import {escapeHtml} from '../../utils/escape-html';
+import {renderEmptyContainer} from '../../utils/render-empty-container';
+
+export function renderEmailCtaNode(node, options = {}) {
+    addCreateDocumentOption(options);
+
+    const document = options.createDocument();
+    const {html, buttonText, buttonUrl, showButton, alignment, segment, showDividers} = node;
+    const hasButton = showButton && !!buttonText && !!buttonUrl;
+
+    if ((!html && !hasButton) || options.target !== 'email') {
+        return renderEmptyContainer(document);
+    }
+
+    const element = document.createElement('div');
+
+    if (segment) {
+        element.setAttribute('data-gh-segment', segment);
+    }
+
+    if (alignment === 'center') {
+        element.setAttribute('class', 'align-center');
+    }
+
+    if (showDividers) {
+        element.appendChild(document.createElement('hr'));
+    }
+
+    const cleanedHtml = wrapReplacementStrings(removeCodeWrappersFromHelpers(removeSpaces(html),document));
+    element.innerHTML = element.innerHTML + cleanedHtml;
+
+    if (hasButton) {
+        const buttonTemplate = `
+            <div class="btn btn-accent">
+                <table border="0" cellspacing="0" cellpadding="0" align="${escapeHtml(alignment)}">
+                    <tbody>
+                        <tr>
+                            <td align="center">
+                                <a href="${escapeHtml(buttonUrl)}">${escapeHtml(buttonText)}</a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <p></p>
+        `; // the inline <p> element is so we get a line break if there's no separators/hr used
+
+        const cleanedButton = wrapReplacementStrings(removeCodeWrappersFromHelpers(removeSpaces(buttonTemplate),document));
+        element.innerHTML = element.innerHTML + cleanedButton;
+    }
+
+    if (showDividers) {
+        element.appendChild(document.createElement('hr'));
+    }
+
+    return {element};
+}

--- a/packages/kg-default-nodes/lib/nodes/email/EmailNode.js
+++ b/packages/kg-default-nodes/lib/nodes/email/EmailNode.js
@@ -1,11 +1,13 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
+import {renderEmailNode} from './email-renderer';
 
 export class EmailNode extends generateDecoratorNode({
     nodeType: 'email',
     properties: [
         {name: 'html', default: '', urlType: 'html'}
-    ]
+    ],
+    defaultRenderFn: renderEmailNode
 }) {
 }
 

--- a/packages/kg-default-nodes/lib/nodes/email/email-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/email/email-renderer.js
@@ -1,0 +1,23 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {removeSpaces, removeCodeWrappersFromHelpers, wrapReplacementStrings} from '../../utils/replacement-strings';
+import {renderEmptyContainer} from '../../utils/render-empty-container';
+
+export function renderEmailNode(node, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+
+    const html = node.html;
+
+    if (!html || options.target !== 'email') {
+        return renderEmptyContainer(document);
+    }
+
+    const cleanedHtml = wrapReplacementStrings(removeCodeWrappersFromHelpers(removeSpaces(html),document));
+
+    const element = document.createElement('div');
+    element.innerHTML = cleanedHtml;
+
+    // `type: 'inner'` will render only the innerHTML of the element
+    // @see @tryghost/kg-lexical-html-renderer package
+    return {element, type: 'inner'};
+}

--- a/packages/kg-default-nodes/lib/nodes/embed/EmbedNode.js
+++ b/packages/kg-default-nodes/lib/nodes/embed/EmbedNode.js
@@ -1,6 +1,7 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseEmbedNode} from './embed-parser';
+import {renderEmbedNode} from './embed-renderer';
 
 export class EmbedNode extends generateDecoratorNode({
     nodeType: 'embed',
@@ -10,7 +11,8 @@ export class EmbedNode extends generateDecoratorNode({
         {name: 'html', default: ''},
         {name: 'metadata', default: {}},
         {name: 'caption', default: '', wordCount: true}
-    ]
+    ],
+    defaultRenderFn: renderEmbedNode
 }) {
     static importDOM() {
         return parseEmbedNode(this);

--- a/packages/kg-default-nodes/lib/nodes/embed/embed-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/embed/embed-renderer.js
@@ -1,0 +1,73 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {renderEmptyContainer} from '../../utils/render-empty-container';
+import twitterRenderer from './types/twitter';
+
+export function renderEmbedNode(node, options = {}) {
+    addCreateDocumentOption(options);
+
+    const document = options.createDocument();
+    const embedType = node.embedType;
+
+    if (embedType === 'twitter') {
+        return twitterRenderer(node, document, options);
+    }
+
+    return renderTemplate(node, document, options);
+}
+
+function renderTemplate(node, document, options) {
+    if (node.isEmpty()) {
+        return renderEmptyContainer(document);
+    }
+    const isEmail = options.target === 'email';
+    const metadata = node.metadata;
+    const url = node.url;
+    const isVideoWithThumbnail = node.embedType === 'video' && metadata && metadata.thumbnail_url;
+    const figure = document.createElement('figure');
+    figure.setAttribute('class', 'kg-card kg-embed-card');
+
+    if (isEmail && isVideoWithThumbnail) {
+        const emailTemplateMaxWidth = 600;
+        const thumbnailAspectRatio = metadata.thumbnail_width / metadata.thumbnail_height;
+        const spacerWidth = Math.round(emailTemplateMaxWidth / 4);
+        const spacerHeight = Math.round(emailTemplateMaxWidth / thumbnailAspectRatio);
+        const html = `
+            <!--[if !mso !vml]-->
+            <a class="kg-video-preview" href="${url}" aria-label="Play video" style="mso-hide: all">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" background="${metadata.thumbnail_url}" role="presentation" style="background: url('${metadata.thumbnail_url}') left top / cover; mso-hide: all">
+                    <tr style="mso-hide: all">
+                        <td width="25%" style="visibility: hidden; mso-hide: all">
+                            <img src="https://img.spacergif.org/v1/${spacerWidth}x${spacerHeight}/0a/spacer.png" alt="" width="100%" border="0" style="display:block; height: auto; opacity: 0; visibility: hidden; mso-hide: all;">
+                        </td>
+                        <td width="50%" align="center" valign="middle" style="vertical-align: middle; mso-hide: all;">
+                            <div class="kg-video-play-button" style="mso-hide: all"><div style="mso-hide: all"></div></div>
+                        </td>
+                        <td width="25%" style="mso-hide: all">&nbsp;</td>
+                    </tr>
+                </table>
+            </a>
+            <!--[endif]-->
+
+            <!--[if vml]>
+            <v:group xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" coordsize="${emailTemplateMaxWidth},${spacerHeight}" coordorigin="0,0" href="${url}" style="width:${emailTemplateMaxWidth}px;height:${spacerHeight}px;">
+                <v:rect fill="t" stroked="f" style="position:absolute;width:${emailTemplateMaxWidth};height:${spacerHeight};"><v:fill src="${metadata.thumbnail_url}" type="frame"/></v:rect>
+                <v:oval fill="t" strokecolor="white" strokeweight="4px" style="position:absolute;left:${Math.round((emailTemplateMaxWidth / 2) - 39)};top:${Math.round((spacerHeight / 2) - 39)};width:78;height:78"><v:fill color="black" opacity="30%" /></v:oval>
+                <v:shape coordsize="24,32" path="m,l,32,24,16,xe" fillcolor="white" stroked="f" style="position:absolute;left:${Math.round((emailTemplateMaxWidth / 2) - 11)};top:${Math.round((spacerHeight / 2) - 17)};width:30;height:34;" />
+            </v:group>
+            <![endif]-->
+        `;
+        figure.innerHTML = html.trim();
+    } else {
+        figure.innerHTML = node.html;
+    }
+
+    const caption = node.caption;
+    if (caption) {
+        const figcaption = document.createElement('figcaption');
+        figcaption.innerHTML = caption;
+        figure.appendChild(figcaption);
+        figure.setAttribute('class', `${figure.getAttribute('class')} kg-card-hascaption`);
+    }
+
+    return {element: figure};
+}

--- a/packages/kg-default-nodes/lib/nodes/embed/types/twitter.js
+++ b/packages/kg-default-nodes/lib/nodes/embed/types/twitter.js
@@ -1,0 +1,169 @@
+import {DateTime} from 'luxon';
+import toArray from 'lodash/toArray';
+
+export default function render(node, document, options) {
+    const metadata = node.metadata;
+
+    const figure = document.createElement('figure');
+    figure.setAttribute('class', 'kg-card kg-embed-card');
+
+    let html = node.html;
+
+    const tweetData = metadata && metadata.tweet_data;
+    const isEmail = options.target === 'email';
+
+    if (tweetData && isEmail) {
+        const tweetId = tweetData.id;
+        const numberFormatter = new Intl.NumberFormat('en-US', {
+            style: 'decimal',
+            notation: 'compact',
+            unitDisplay: 'narrow',
+            maximumFractionDigits: 1
+        });
+        const retweetCount = numberFormatter.format(tweetData.public_metrics.retweet_count);
+        const likeCount = numberFormatter.format(tweetData.public_metrics.like_count);
+        const authorUser = tweetData.users && tweetData.users.find(user => user.id === tweetData.author_id);
+        const tweetTime = DateTime.fromISO(tweetData.created_at).toLocaleString(DateTime.TIME_SIMPLE);
+        const tweetDate = DateTime.fromISO(tweetData.created_at).toLocaleString(DateTime.DATE_MED);
+
+        const mentions = tweetData.entities && tweetData.entities.mentions || [];
+        const urls = tweetData.entities && tweetData.entities.urls || [];
+        const hashtags = tweetData.entities && tweetData.entities.hashtags || [];
+        const entities = mentions.concat(urls).concat(hashtags).sort((a, b) => a.start - b.start);
+        let tweetContent = tweetData.text;
+
+        let tweetImageUrl = null;
+        const hasImageOrVideo = tweetData.attachments && tweetData.attachments && tweetData.attachments.media_keys;
+        if (hasImageOrVideo) {
+            tweetImageUrl = tweetData.includes.media[0].preview_image_url || tweetData.includes.media[0].url;
+        }
+        const hasPoll = tweetData.attachments && tweetData.attachments && tweetData.attachments.poll_ids;
+
+        if (mentions) {
+            let last = 0;
+            let parts = [];
+            let content = toArray(tweetContent);
+            for (const entity of entities) {
+                let type = 'text';
+                let data = content.slice(entity.start, entity.end + 1).join('').replace(/\n/g, '<br>');
+                if (entity.url) {
+                    if (!entity.display_url || entity.display_url.startsWith('pic.twitter.com')) {
+                        type = 'img_url';
+                    } else {
+                        type = 'url';
+                        data = data.replace(entity.url, entity.display_url);
+                    }
+                }
+                if (entity.username) {
+                    type = 'mention';
+                }
+                if (entity.tag) {
+                    type = 'hashtag';
+                }
+                parts.push({
+                    type: 'text',
+                    data: content.slice(last, entity.start).join('').replace(/\n/g, '<br>')
+                });
+                parts.push({
+                    type: type,
+                    data: data
+                });
+                last = entity.end + 1;
+            }
+            parts.push({
+                type: 'text',
+                data: content.slice(last, content.length).join('').replace(/\n/g, '<br>')
+            });
+
+            tweetContent = parts.reduce((partContent, part) => {
+                if (part.type === 'text') {
+                    return partContent + part.data;
+                }
+                if (part.type === 'mention') {
+                    return partContent + `<span style="color: #1DA1F2;">${part.data}</span>`;
+                }
+                if (part.type === 'hashtag') {
+                    return partContent + `<span style="color: #1DA1F2;">${part.data}</span>`;
+                }
+                if (part.type === 'url') {
+                    return partContent + `<span style="color: #1DA1F2; word-break: break-all;">${part.data}</span>`;
+                }
+                return partContent;
+            }, '');
+        }
+
+        html = `
+        <table cellspacing="0" cellpadding="0" border="0" class="kg-twitter-card">
+            <tr>
+                <td>
+                    <table cellspacing="0" cellpadding="0" border="0" width="100%">
+                        ${authorUser ? `
+                            <tr>
+                                ${authorUser.profile_image_url ? `<td width="48" style="width: 48px;">
+                                    <a href="https://twitter.com/twitter/status/${tweetId}" class="kg-twitter-link" style="padding-left: 16px; padding-top: 16px;"><img src="${authorUser.profile_image_url}" style="max-width: 512px; border: none; width: 48px; height: 48px; border-radius: 999px;" border="0"></a>
+                                </td>` : ''}
+                                ${authorUser.name ? `
+                                <td style="line-height: 1.3em; width: 100%;">
+                                    <a href="https://twitter.com/twitter/status/${tweetId}" class="kg-twitter-link" style="font-size: 15px !important; font-weight: 600; width: 100%; padding-top: 20px; padding-bottom: 18px;">${authorUser.name} <br> <span style="color: #ABB4BE; font-size: 14px; font-weight: 500;">@${authorUser.username}</span></a>
+                                </td>` : ''}
+                                <td align="right" width="24" style="width: 24px;">
+                                    <a href="https://twitter.com/twitter/status/${tweetId}" class="kg-twitter-link" style="padding-right: 16px; padding-top: 20px; width: 24px; height: 38px;"><img src="https://static.ghost.org/v4.0.0/images/twitter-logo-small.png" width="24" border="0"></a>
+                                </td>
+                            </tr>
+                        ` : ''}
+                        <tr>
+                            <td colspan="3">
+                                <a href="https://twitter.com/twitter/status/${tweetId}" class="kg-twitter-link" style="font-size: 15px; line-height: 1.4em; padding-top: 8px; padding-left: 16px; padding-right: 16px; padding-bottom: 16px;">${tweetContent}
+                                ${hasPoll ? `<br><span style="color: #1DA1F2;">View poll &rarr;</span>` : ''}
+                                </a>
+                            </td>
+                        </tr>
+                        ${hasImageOrVideo ? `<tr>
+                            <td colspan="3" align="center" style="width: 100%;">
+                                <a href="https://twitter.com/twitter/status/${tweetId}" style="display: block; padding-top: 0; padding-left: 16px; padding-right: 16px; padding-bottom: 0;"><img src="${tweetImageUrl}" style="width: 100%; border: 1px solid #E9E9E9; max-width: 528px; border-radius: 10px;" border="0"></a>
+                            </td>
+                        </tr>` : ''}
+                        <tr>
+                            <td colspan="3" style="width: 100%;">
+                                <table cellspacing="0" cellpadding="0" border="0" width="100%">
+                                    <tr>
+                                        <td>
+                                        <a href="https://twitter.com/twitter/status/${tweetId}" class="kg-twitter-link" style="padding-top: 4px; padding-right: 16px; padding-bottom: 12px; padding-left: 16px;"><span style="color: #838383;">${tweetTime} &bull; ${tweetDate}</span></a>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td colspan="3" style="width: 100%;">
+                                <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-top: 1px solid #E9E9E9;">
+                                    <tr>
+                                        <td>
+                                            <a href="https://twitter.com/twitter/status/${tweetId}" class="kg-twitter-link" style="padding-top: 12px; padding-right: 16px; padding-bottom: 12px; padding-left: 16px;">
+                                                <span style="font-weight: 600;">${likeCount}</span> <span style="color: #838383;">likes &bull;</span>
+                                                <span style="font-weight: 600;">${retweetCount}</span> <span style="color: #838383;">retweets</span>
+                                            </a>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+        `;
+    }
+
+    figure.innerHTML = html.trim();
+
+    const caption = node.caption;
+    if (caption) {
+        const figcaption = document.createElement('figcaption');
+        figcaption.innerHTML = caption;
+        figure.appendChild(figcaption);
+        figure.setAttribute('class', `${figure.getAttribute('class')} kg-card-hascaption`);
+    }
+
+    return {element: figure};
+}

--- a/packages/kg-default-nodes/lib/nodes/file/FileNode.js
+++ b/packages/kg-default-nodes/lib/nodes/file/FileNode.js
@@ -1,5 +1,6 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
+import {renderFileNode} from './file-renderer';
 import {parseFileNode} from './file-parser';
 import {bytesToSize} from '../../utils/size-byte-converter';
 
@@ -11,7 +12,8 @@ export class FileNode extends generateDecoratorNode({
         {name: 'fileCaption', default: '', wordCount: true},
         {name: 'fileName', default: ''},
         {name: 'fileSize', default: ''}
-    ]
+    ],
+    defaultRenderFn: renderFileNode
 }) {
     /* @override */
     exportJSON() {

--- a/packages/kg-default-nodes/lib/nodes/file/file-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/file/file-renderer.js
@@ -1,0 +1,153 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {renderEmptyContainer} from '../../utils/render-empty-container';
+import {escapeHtml} from '../../utils/escape-html';
+import {bytesToSize} from '../../utils/size-byte-converter';
+
+export function renderFileNode(node, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+
+    if (!node.src || node.src.trim() === '') {
+        return renderEmptyContainer(document);
+    }
+
+    if (options.target === 'email') {
+        return emailTemplate(node, document, options);
+    } else {
+        return cardTemplate(node, document);
+    }
+}
+
+function emailTemplate(node, document, options) {
+    let iconCls;
+    if (!node.fileTitle && !node.fileCaption) {
+        iconCls = 'margin-top: 6px; height: 20px; width: 20px; max-width: 20px; padding-top: 4px; padding-bottom: 4px;';
+    } else {
+        iconCls = 'margin-top: 6px; height: 24px; width: 24px; max-width: 24px;';
+    }
+
+    const html = (`
+        <table cellspacing="0" cellpadding="4" border="0" class="kg-file-card" width="100%">
+            <tr>
+                <td>
+                    <table cellspacing="0" cellpadding="0" border="0" width="100%">
+                        <tr>
+                            <td valign="middle" style="vertical-align: middle;">
+                                ${node.fileTitle ? `
+                                <table cellspacing="0" cellpadding="0" border="0" width="100%"><tr><td>
+                                    <a href="${escapeHtml(options.postUrl)}" class="kg-file-title">${escapeHtml(node.fileTitle)}</a>
+                                </td></tr></table>
+                                ` : ``}
+                                ${node.fileCaption ? `
+                                <table cellspacing="0" cellpadding="0" border="0" width="100%"><tr><td>
+                                    <a href="${escapeHtml(options.postUrl)}" class="kg-file-description">${escapeHtml(node.fileCaption)}</a>
+                                </td></tr></table>
+                                ` : ``}
+                                <table cellspacing="0" cellpadding="0" border="0" width="100%"><tr><td>
+                                    <a href="${escapeHtml(options.postUrl)}" class="kg-file-meta"><span class="kg-file-name">${escapeHtml(node.fileName)}</span> &bull; ${bytesToSize(node.fileSize)}</a>
+                                </td></tr></table>
+                            </td>
+                            <td width="80" valign="middle" class="kg-file-thumbnail">
+                                <a href="${escapeHtml(options.postUrl)}" style="display: block; top: 0; right: 0; bottom: 0; left: 0;">
+                                    <img src="https://static.ghost.org/v4.0.0/images/download-icon-darkmode.png" style="${escapeHtml(iconCls)}">
+                                </a>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    `);
+
+    const container = document.createElement('div');
+    container.innerHTML = html.trim();
+
+    return {element: container.firstElementChild};
+}
+
+function cardTemplate(node, document) {
+    const card = document.createElement('div');
+    card.setAttribute('class', 'kg-card kg-file-card');
+
+    const container = document.createElement('a');
+    container.setAttribute('class', 'kg-file-card-container');
+    container.setAttribute('href', node.src);
+    container.setAttribute('title', 'Download');
+    container.setAttribute('download', '');
+
+    const contents = document.createElement('div');
+    contents.setAttribute('class', 'kg-file-card-contents');
+
+    const title = document.createElement('div');
+    title.setAttribute('class', 'kg-file-card-title');
+    title.textContent = node.fileTitle || '';
+
+    const caption = document.createElement('div');
+    caption.setAttribute('class', 'kg-file-card-caption');
+    caption.textContent = node.fileCaption || '';
+
+    const metadata = document.createElement('div');
+    metadata.setAttribute('class', 'kg-file-card-metadata');
+
+    const filename = document.createElement('div');
+    filename.setAttribute('class', 'kg-file-card-filename');
+    filename.textContent = node.fileName || '';
+
+    const filesize = document.createElement('div');
+    filesize.setAttribute('class', 'kg-file-card-filesize');
+    filesize.textContent = node.formattedFileSize || '';
+
+    metadata.appendChild(filename);
+    metadata.appendChild(filesize);
+
+    contents.appendChild(title);
+    contents.appendChild(caption);
+    contents.appendChild(metadata);
+
+    container.appendChild(contents);
+
+    const icon = document.createElement('div');
+    icon.setAttribute('class', 'kg-file-card-icon');
+
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 24 24');
+
+    const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+
+    const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
+    style.textContent = '.a{fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5px;}';
+
+    defs.appendChild(style);
+
+    const titleElement = document.createElementNS('http://www.w3.org/2000/svg', 'title');
+    titleElement.textContent = 'download-circle';
+
+    const polyline = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+    polyline.setAttribute('class', 'a');
+    polyline.setAttribute('points', '8.25 14.25 12 18 15.75 14.25');
+
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('class', 'a');
+    line.setAttribute('x1', '12');
+    line.setAttribute('y1', '6.75');
+    line.setAttribute('x2', '12');
+    line.setAttribute('y2', '18');
+
+    const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    circle.setAttribute('class', 'a');
+    circle.setAttribute('cx', '12');
+    circle.setAttribute('cy', '12');
+    circle.setAttribute('r', '11.25');
+
+    svg.appendChild(defs);
+    svg.appendChild(titleElement);
+    svg.appendChild(polyline);
+    svg.appendChild(line);
+    svg.appendChild(circle);
+
+    icon.appendChild(svg);
+    container.appendChild(icon);
+    card.appendChild(container);
+
+    return {element: card};
+}

--- a/packages/kg-default-nodes/lib/nodes/gallery/GalleryNode.js
+++ b/packages/kg-default-nodes/lib/nodes/gallery/GalleryNode.js
@@ -1,13 +1,14 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseGalleryNode} from './gallery-parser';
-
+import {renderGalleryNode} from './gallery-renderer';
 export class GalleryNode extends generateDecoratorNode({
     nodeType: 'gallery',
     properties: [
         {name: 'images', default: []},
         {name: 'caption', default: '', wordCount: true}
-    ]
+    ],
+    defaultRenderFn: renderGalleryNode
 }) {
     /* override */
     static get urlTransformMap() {

--- a/packages/kg-default-nodes/lib/nodes/gallery/gallery-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/gallery/gallery-renderer.js
@@ -1,0 +1,157 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {getAvailableImageWidths} from '../../utils/get-available-image-widths';
+import {isLocalContentImage} from '../../utils/is-local-content-image';
+import {isUnsplashImage} from '../../utils/is-unsplash-image';
+import {getResizedImageDimensions} from '../../utils/get-resized-image-dimensions';
+import {setSrcsetAttribute} from '../../utils/srcset-attribute';
+import {renderEmptyContainer} from '../../utils/render-empty-container';
+
+const MAX_IMG_PER_ROW = 3;
+
+function isValidImage(image) {
+    return image.fileName
+        && image.src
+        && image.width
+        && image.height;
+}
+
+function buildStructure(images) {
+    const rows = [];
+    const noOfImages = images.length;
+
+    images.forEach((image, idx) => {
+        let row = image.row;
+
+        if (noOfImages > 1 && (noOfImages % MAX_IMG_PER_ROW === 1) && (idx === (noOfImages - 2))) {
+            row = row + 1;
+        }
+        if (!rows[row]) {
+            rows[row] = [];
+        }
+
+        rows[row].push(image);
+    });
+
+    return rows;
+}
+
+export function renderGalleryNode(node, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+
+    const validImages = node.images.filter(isValidImage);
+    if (!validImages.length) {
+        return renderEmptyContainer(document);
+    }
+
+    const figure = document.createElement('figure');
+    figure.setAttribute('class', 'kg-card kg-gallery-card kg-width-wide');
+
+    const container = document.createElement('div');
+    container.setAttribute('class', 'kg-gallery-container');
+    figure.appendChild(container);
+
+    const rows = buildStructure(validImages);
+
+    rows.forEach((row) => {
+        const rowDiv = document.createElement('div');
+        rowDiv.setAttribute('class', 'kg-gallery-row');
+
+        row.forEach((image) => {
+            const imgDiv = document.createElement('div');
+            imgDiv.setAttribute('class', 'kg-gallery-image');
+
+            const img = document.createElement('img');
+            img.setAttribute('src', image.src);
+            img.setAttribute('width', image.width);
+            img.setAttribute('height', image.height);
+            img.setAttribute('loading', 'lazy');
+            img.setAttribute('alt', image.alt || '');
+            if (image.title) {
+                img.setAttribute('title', image.title);
+            }
+
+            // images can be resized to max width, if that's the case output
+            // the resized width/height attrs to ensure 3rd party gallery plugins
+            // aren't affected by differing sizes
+            const {canTransformImage} = options;
+            const {defaultMaxWidth} = options.imageOptimization || {};
+            if (
+                defaultMaxWidth &&
+                image.width > defaultMaxWidth &&
+                isLocalContentImage(image.src, options.siteUrl) &&
+                canTransformImage &&
+                canTransformImage(image.src)
+            ) {
+                const {width, height} = getResizedImageDimensions(image, {width: defaultMaxWidth});
+                img.setAttribute('width', width);
+                img.setAttribute('height', height);
+            }
+
+            // add srcset+sizes except for email clients which do not have good support for either
+            if (options.target !== 'email') {
+                setSrcsetAttribute(img, image, options);
+
+                if (img.getAttribute('srcset') && image.width >= 720) {
+                    if (rows.length === 1 && row.length === 1 && image.width >= 1200) {
+                        img.setAttribute('sizes', '(min-width: 1200px) 1200px');
+                    } else {
+                        img.setAttribute('sizes', '(min-width: 720px) 720px');
+                    }
+                }
+            }
+
+            // Outlook is unable to properly resize images without a width/height
+            // so we modify those to fit max width (600px) and use appropriately
+            // resized images if available
+            if (options.target === 'email') {
+                // only resize if needed, width/height always exists for gallery image unline image cards
+                if (image.width > 600) {
+                    const newImageDimensions = getResizedImageDimensions(image, {width: 600});
+                    img.setAttribute('width', newImageDimensions.width);
+                    img.setAttribute('height', newImageDimensions.height);
+                }
+
+                if (isLocalContentImage(image.src, options.siteUrl) && options.canTransformImage && options.canTransformImage(image.src)) {
+                    // find available image size next up from 2x600 so we can use it for the "retina" src
+                    const availableImageWidths = getAvailableImageWidths(image, options.imageOptimization.contentImageSizes);
+                    const srcWidth = availableImageWidths.find(width => width >= 1200);
+
+                    if (!srcWidth || srcWidth === image.width) {
+                        // do nothing, width is smaller than retina or matches the original payload src
+                    } else {
+                        const [, imagesPath, filename] = image.src.match(/(.*\/content\/images)\/(.*)/);
+                        img.setAttribute('src', `${imagesPath}/size/w${srcWidth}/${filename}`);
+                    }
+                }
+
+                if (isUnsplashImage(image.src)) {
+                    const unsplashUrl = new URL(image.src);
+                    unsplashUrl.searchParams.set('w', 1200);
+                    img.setAttribute('src', unsplashUrl.href);
+                }
+            }
+
+            if (image.href) {
+                const a = document.createElement('a');
+                a.setAttribute('href', image.href);
+                a.appendChild(img);
+                imgDiv.appendChild(a);
+            } else {
+                imgDiv.appendChild(img);
+            }
+            rowDiv.appendChild(imgDiv);
+        });
+
+        container.appendChild(rowDiv);
+    });
+
+    if (node.caption) {
+        let figcaption = document.createElement('figcaption');
+        figcaption.innerHTML = node.caption;
+        figure.appendChild(figcaption);
+        figure.setAttribute('class', `${figure.getAttribute('class')} kg-card-hascaption`);
+    }
+
+    return {element: figure};
+}

--- a/packages/kg-default-nodes/lib/nodes/header/HeaderNode.js
+++ b/packages/kg-default-nodes/lib/nodes/header/HeaderNode.js
@@ -1,6 +1,9 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
+import {renderHeaderNodeV1} from './renderers/v1/header-renderer';
 import {parseHeaderNode} from './parsers/header-parser';
+// V2 imports below
+import {renderHeaderNodeV2} from './renderers/v2/header-renderer';
 
 // This is our first node that has a custom version property
 export class HeaderNode extends generateDecoratorNode({
@@ -30,7 +33,11 @@ export class HeaderNode extends generateDecoratorNode({
         {name: 'buttonTextColor', default: '#000000'},
         {name: 'layout', default: 'full'}, // replaces size
         {name: 'swapped', default: false}
-    ]
+    ],
+    defaultRenderFn: {
+        1: renderHeaderNodeV1,
+        2: renderHeaderNodeV2
+    }
 }) {
     static importDOM() {
         return parseHeaderNode(this);

--- a/packages/kg-default-nodes/lib/nodes/header/renderers/v1/header-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/header/renderers/v1/header-renderer.js
@@ -1,0 +1,60 @@
+import {addCreateDocumentOption} from '../../../../utils/add-create-document-option';
+import {renderEmptyContainer} from '../../../../utils/render-empty-container';
+import {slugify} from '../../../../utils/slugify';
+
+export function renderHeaderNodeV1(node, options = {}) {
+    addCreateDocumentOption(options);
+
+    const document = options.createDocument();
+
+    if (!node.header && !node.subheader && (!node.buttonEnabled || (!node.buttonUrl || !node.buttonText))) {
+        return renderEmptyContainer(document);
+    }
+
+    const templateData = {
+        size: node.size,
+        style: node.style,
+        buttonEnabled: node.buttonEnabled && Boolean(node.buttonUrl) && Boolean(node.buttonText),
+        buttonUrl: node.buttonUrl,
+        buttonText: node.buttonText,
+        header: node.header,
+        headerSlug: slugify(node.header),
+        subheader: node.subheader,
+        subheaderSlug: slugify(node.subheader),
+        hasHeader: !!node.header,
+        hasSubheader: !!node.subheader && !!node.subheader.replace(/(<br>)+$/g).trim(),
+        backgroundImageStyle: node.style === 'image' ? `background-image: url(${node.backgroundImageSrc})` : '',
+        backgroundImageSrc: node.backgroundImageSrc
+    };
+
+    const div = document.createElement('div');
+    div.classList.add('kg-card', 'kg-header-card', 'kg-width-full', `kg-size-${templateData.size}`, `kg-style-${templateData.style}`);
+    div.setAttribute('data-kg-background-image', templateData.backgroundImageSrc);
+    div.setAttribute('style', templateData.backgroundImageStyle);
+
+    if (templateData.hasHeader) {
+        const headerElement = document.createElement('h2');
+        headerElement.classList.add('kg-header-card-header');
+        headerElement.setAttribute('id', templateData.headerSlug);
+        headerElement.innerHTML = templateData.header;
+        div.appendChild(headerElement);
+    }
+
+    if (templateData.hasSubheader) {
+        const subheaderElement = document.createElement('h3');
+        subheaderElement.classList.add('kg-header-card-subheader');
+        subheaderElement.setAttribute('id', templateData.subheaderSlug);
+        subheaderElement.innerHTML = templateData.subheader;
+        div.appendChild(subheaderElement);
+    }
+
+    if (templateData.buttonEnabled) {
+        const buttonElement = document.createElement('a');
+        buttonElement.classList.add('kg-header-card-button');
+        buttonElement.setAttribute('href', templateData.buttonUrl);
+        buttonElement.textContent = templateData.buttonText;
+        div.appendChild(buttonElement);
+    }
+
+    return {element: div};
+}

--- a/packages/kg-default-nodes/lib/nodes/header/renderers/v2/header-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/header/renderers/v2/header-renderer.js
@@ -1,0 +1,245 @@
+import {addCreateDocumentOption} from '../../../../utils/add-create-document-option';
+import {slugify} from '../../../../utils/slugify';
+import {getSrcsetAttribute} from '../../../../utils/srcset-attribute';
+
+function cardTemplate(nodeData, options = {}) {
+    const cardClasses = getCardClasses(nodeData).join(' ');
+
+    const backgroundAccent = nodeData.backgroundColor === 'accent' ? 'kg-style-accent' : '';
+    const buttonAccent = nodeData.buttonColor === 'accent' ? 'kg-style-accent' : '';
+    const buttonStyle = nodeData.buttonColor !== 'accent' ? `background-color: ${nodeData.buttonColor};` : ``;
+    const alignment = nodeData.alignment === 'center' ? 'kg-align-center' : '';
+    const backgroundImageStyle = nodeData.backgroundColor !== 'accent' && (!nodeData.backgroundImageSrc || nodeData.layout === 'split') ? `background-color: ${nodeData.backgroundColor}` : '';
+
+    let imgTemplate = '';
+    if (nodeData.backgroundImageSrc) {
+        const bgImage = {
+            src: nodeData.backgroundImageSrc,
+            width: nodeData.backgroundImageWidth,
+            height: nodeData.backgroundImageHeight
+        };
+
+        const srcsetValue = getSrcsetAttribute({...bgImage, options});
+        const srcset = srcsetValue ? `srcset="${srcsetValue}"` : '';
+
+        imgTemplate = `
+            <picture><img class="kg-header-card-image" src="${bgImage.src}" ${srcset} loading="lazy" alt="" /></picture>
+        `;
+    }
+
+    const header = () => {
+        if (nodeData.header) {
+            return `<h2 id="${slugify(nodeData.header)}" class="kg-header-card-heading" style="color: ${nodeData.textColor};" data-text-color="${nodeData.textColor}">${nodeData.header}</h2>`;
+        }
+        return '';
+    };
+
+    const subheader = () => {
+        if (nodeData.subheader) {
+            return `<p id="${slugify(nodeData.subheader)}" class="kg-header-card-subheading" style="color: ${nodeData.textColor};" data-text-color="${nodeData.textColor}">${nodeData.subheader}</p>`;
+        }
+        return '';
+    };
+
+    const button = () => {
+        if (nodeData.buttonEnabled && nodeData.buttonUrl && nodeData.buttonUrl.trim() !== '') {
+            return `<a href="${nodeData.buttonUrl}" class="kg-header-card-button ${buttonAccent}" style="${buttonStyle}color: ${nodeData.buttonTextColor};" data-button-color="${nodeData.buttonColor}" data-button-text-color="${nodeData.buttonTextColor}">${nodeData.buttonText}</a>`;
+        }
+        return '';
+    };
+
+    const wrapperStyle = backgroundImageStyle ? `style="${backgroundImageStyle};"` : '';
+
+    return `
+        <div class="${cardClasses} ${backgroundAccent}" ${wrapperStyle} data-background-color="${nodeData.backgroundColor}">
+            ${nodeData.layout !== 'split' ? imgTemplate : ''}
+            <div class="kg-header-card-content">
+                ${nodeData.layout === 'split' ? imgTemplate : ''}
+                <div class="kg-header-card-text ${alignment}">
+                    ${header()}
+                    ${subheader()}
+                    ${button()}
+                </div>
+            </div>
+        </div>
+        `;
+}
+
+function emailTemplate(nodeData, options) {
+    const backgroundAccent = nodeData.backgroundColor === 'accent' ? `background-color: ${nodeData.accentColor};` : '';
+    let buttonAccent = nodeData.buttonColor === 'accent' ? `background-color: ${nodeData.accentColor};` : nodeData.buttonColor;
+    let buttonStyle = nodeData.buttonColor !== 'accent' ? `background-color: ${nodeData.buttonColor};` : '';
+    let buttonTextColor = nodeData.buttonTextColor;
+    const alignment = nodeData.alignment === 'center' ? 'text-align: center;' : '';
+    const backgroundImageStyle = nodeData.backgroundImageSrc ? (nodeData.layout !== 'split' ? `background-image: url(${nodeData.backgroundImageSrc}); background-size: cover; background-position: center center;` : `background-color: ${nodeData.backgroundColor};`) : `background-color: ${nodeData.backgroundColor};`;
+    const splitImageStyle = `background-image: url(${nodeData.backgroundImageSrc}); background-size: ${nodeData.backgroundSize !== 'contain' ? 'cover' : '50%'}; background-position: center`;
+
+    if (
+        (options?.feature?.emailCustomization || options?.feature?.emailCustomizationAlpha) &&
+        options?.design?.buttonStyle === 'outline'
+    ) {
+        if (nodeData.buttonColor === 'accent') {
+            buttonAccent = '';
+            buttonStyle = `
+                border: 1px solid ${nodeData.accentColor};
+                background-color: transparent;
+                color: ${nodeData.accentColor} !important;
+            `;
+            buttonTextColor = nodeData.accentColor;
+        } else {
+            buttonStyle = `
+                border: 1px solid ${nodeData.buttonColor};
+                background-color: transparent;
+                color: ${nodeData.buttonColor} !important;
+            `;
+            buttonTextColor = nodeData.buttonColor;
+        }
+    }
+
+    if (options?.feature?.emailCustomization || options?.feature?.emailCustomizationAlpha) {
+        return (
+            `
+            <div class="kg-header-card kg-v2" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
+                ${nodeData.layout === 'split' && nodeData.backgroundImageSrc ? `
+                    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                        <tr>
+                            <td background="${nodeData.backgroundImageSrc}" style="${splitImageStyle}" class="kg-header-card-image"></td>
+                        </tr>
+                    </table>
+                ` : ''}
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
+                    <tr>
+                        <td class="kg-header-card-content" style="${nodeData.layout === 'split' && nodeData.backgroundSize === 'contain' ? 'padding-top: 0;' : ''}">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td align="${nodeData.alignment}">
+                                        <h2 class="kg-header-card-heading" style="color:${nodeData.textColor};">${nodeData.header}</h2>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="kg-header-card-subheading-wrapper" align="${nodeData.alignment}">
+                                        <p class="kg-header-card-subheading" style="color:${nodeData.textColor};">${nodeData.subheader}</p>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    ${nodeData.buttonEnabled && nodeData.buttonUrl && nodeData.buttonUrl.trim() !== '' ? `
+                                        <td class="kg-header-button-wrapper">
+                                            <table class="btn" border="0" cellspacing="0" cellpadding="0" align="${nodeData.alignment}">
+                                                <tr>
+                                                    <td align="center" style="${buttonStyle} ${buttonAccent}">
+                                                        <a href="${nodeData.buttonUrl}" style="color: ${buttonTextColor};">${nodeData.buttonText}</a>
+                                                    </td>
+                                                </tr>
+                                            </table>
+                                        </td>
+                                    ` : ''}
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            `
+        );
+    }
+
+    return (
+        `
+        <div class="kg-header-card kg-v2" style="color:${nodeData.textColor}; ${alignment} ${backgroundImageStyle} ${backgroundAccent}">
+            ${nodeData.layout === 'split' && nodeData.backgroundImageSrc ? `
+                <div class="kg-header-card-image" background="${nodeData.backgroundImageSrc}" style="${splitImageStyle}"></div>
+            ` : ''}
+            <div class="kg-header-card-content" style="${nodeData.layout === 'split' && nodeData.backgroundSize === 'contain' ? 'padding-top: 0;' : ''}">
+                <h2 class="kg-header-card-heading" style="color:${nodeData.textColor};">${nodeData.header}</h2>
+                <p class="kg-header-card-subheading" style="color:${nodeData.textColor};">${nodeData.subheader}</p>
+                ${nodeData.buttonEnabled && nodeData.buttonUrl && nodeData.buttonUrl.trim() !== '' ? `
+                    <a class="kg-header-card-button" href="${nodeData.buttonUrl}" style="color: ${nodeData.buttonTextColor}; ${buttonStyle} ${buttonAccent}">${nodeData.buttonText}</a>
+                ` : ''}
+            </div>
+        </div>
+        `
+    );
+}
+
+export function renderHeaderNodeV2(dataset, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+
+    const node = {
+        alignment: dataset.__alignment,
+        buttonText: dataset.__buttonText,
+        buttonEnabled: dataset.__buttonEnabled,
+        buttonUrl: dataset.__buttonUrl,
+        header: dataset.__header,
+        subheader: dataset.__subheader,
+        backgroundImageSrc: dataset.__backgroundImageSrc,
+        backgroundImageWidth: dataset.__backgroundImageWidth,
+        backgroundImageHeight: dataset.__backgroundImageHeight,
+        backgroundSize: dataset.__backgroundSize,
+        backgroundColor: dataset.__backgroundColor,
+        buttonColor: dataset.__buttonColor,
+        layout: dataset.__layout,
+        textColor: dataset.__textColor,
+        buttonTextColor: dataset.__buttonTextColor,
+        swapped: dataset.__swapped,
+        accentColor: dataset.__accentColor
+    };
+
+    if (options.target === 'email') {
+        const emailDoc = options.createDocument();
+        const emailDiv = emailDoc.createElement('div');
+
+        emailDiv.innerHTML = emailTemplate(node, options)?.trim();
+
+        return {element: emailDiv.firstElementChild};
+    }
+
+    const htmlString = cardTemplate(node, options);
+
+    const element = document.createElement('div');
+    element.innerHTML = htmlString?.trim();
+
+    if (node.header === '') {
+        const h2Element = element.querySelector('.kg-header-card-heading');
+        if (h2Element) {
+            h2Element.remove();
+        }
+    }
+
+    if (node.subheader === '') {
+        const pElement = element.querySelector('.kg-header-card-subheading');
+        if (pElement) {
+            pElement.remove();
+        }
+    }
+
+    return {element: element.firstElementChild};
+}
+
+export function getCardClasses(nodeData) {
+    let cardClasses = ['kg-card kg-header-card kg-v2'];
+
+    if (nodeData.layout && nodeData.layout !== 'split') {
+        cardClasses.push(`kg-width-${nodeData.layout}`);
+    }
+
+    if (nodeData.layout === 'split') {
+        cardClasses.push('kg-layout-split kg-width-full');
+    }
+
+    if (nodeData.swapped && nodeData.layout === 'split') {
+        cardClasses.push('kg-swapped');
+    }
+
+    if (nodeData.layout && nodeData.layout === 'full') {
+        cardClasses.push(`kg-content-wide`);
+    }
+
+    if (nodeData.layout === 'split') {
+        if (nodeData.backgroundSize === 'contain') {
+            cardClasses.push('kg-content-wide');
+        }
+    }
+
+    return cardClasses;
+}

--- a/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleNode.js
+++ b/packages/kg-default-nodes/lib/nodes/horizontalrule/HorizontalRuleNode.js
@@ -1,9 +1,11 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
+import {renderHorizontalRuleNode} from './horizontalrule-renderer';
 import {parseHorizontalRuleNode} from './horizontalrule-parser';
 
 export class HorizontalRuleNode extends generateDecoratorNode({
-    nodeType: 'horizontalrule'
+    nodeType: 'horizontalrule',
+    defaultRenderFn: renderHorizontalRuleNode
 }) {
     static importDOM() {
         return parseHorizontalRuleNode(this);

--- a/packages/kg-default-nodes/lib/nodes/horizontalrule/horizontalrule-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/horizontalrule/horizontalrule-renderer.js
@@ -1,0 +1,9 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+
+export function renderHorizontalRuleNode(_, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+
+    const element = document.createElement('hr');
+    return {element};
+}

--- a/packages/kg-default-nodes/lib/nodes/html/HtmlNode.js
+++ b/packages/kg-default-nodes/lib/nodes/html/HtmlNode.js
@@ -1,5 +1,6 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
+import {renderHtmlNode} from './html-renderer';
 import {parseHtmlNode} from './html-parser';
 
 export class HtmlNode extends generateDecoratorNode({
@@ -7,7 +8,8 @@ export class HtmlNode extends generateDecoratorNode({
     hasVisibility: true,
     properties: [
         {name: 'html', default: '', urlType: 'html', wordCount: true}
-    ]
+    ],
+    defaultRenderFn: renderHtmlNode
 }) {
     static importDOM() {
         return parseHtmlNode(this);

--- a/packages/kg-default-nodes/lib/nodes/html/html-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/html/html-renderer.js
@@ -1,0 +1,27 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {renderEmptyContainer} from '../../utils/render-empty-container';
+import {renderWithVisibility} from '../../utils/visibility';
+
+export function renderHtmlNode(node, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+
+    const html = node.html;
+
+    if (!html) {
+        return renderEmptyContainer(document);
+    }
+
+    const wrappedHtml = `\n<!--kg-card-begin: html-->\n${html}\n<!--kg-card-end: html-->\n`;
+
+    const textarea = document.createElement('textarea');
+    textarea.value = wrappedHtml;
+
+    if (options.feature?.contentVisibility || node.visibility) {
+        const renderOutput = {element: textarea, type: 'value'};
+        return renderWithVisibility(renderOutput, node.visibility, options);
+    }
+
+    // `type: 'value'` will render the value of the textarea element
+    return {element: textarea, type: 'value'};
+}

--- a/packages/kg-default-nodes/lib/nodes/image/ImageNode.js
+++ b/packages/kg-default-nodes/lib/nodes/image/ImageNode.js
@@ -1,7 +1,7 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseImageNode} from './image-parser';
-
+import {renderImageNode} from './image-renderer';
 export class ImageNode extends generateDecoratorNode({
     nodeType: 'image',
     properties: [
@@ -13,7 +13,8 @@ export class ImageNode extends generateDecoratorNode({
         {name: 'width', default: null},
         {name: 'height', default: null},
         {name: 'href', default: '', urlType: 'url'}
-    ]
+    ],
+    defaultRenderFn: renderImageNode
 }) {
     /* @override */
     exportJSON() {

--- a/packages/kg-default-nodes/lib/nodes/image/image-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/image/image-renderer.js
@@ -1,0 +1,129 @@
+import {getAvailableImageWidths} from '../../utils/get-available-image-widths';
+import {isLocalContentImage} from '../../utils/is-local-content-image';
+import {setSrcsetAttribute} from '../../utils/srcset-attribute';
+import {getResizedImageDimensions} from '../../utils/get-resized-image-dimensions';
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {renderEmptyContainer} from '../../utils/render-empty-container';
+
+export function renderImageNode(node, options = {}) {
+    addCreateDocumentOption(options);
+
+    const document = options.createDocument();
+
+    if (!node.src || node.src.trim() === '') {
+        return renderEmptyContainer(document);
+    }
+
+    const figure = document.createElement('figure');
+
+    let figureClasses = 'kg-card kg-image-card';
+    if (node.cardWidth !== 'regular') {
+        figureClasses += ` kg-width-${node.cardWidth}`;
+    }
+    if (node.caption) {
+        figureClasses += ' kg-card-hascaption';
+    }
+
+    figure.setAttribute('class', figureClasses);
+
+    const img = document.createElement('img');
+    img.setAttribute('src', node.src);
+    img.setAttribute('class', 'kg-image');
+    img.setAttribute('alt', node.alt);
+    img.setAttribute('loading', 'lazy');
+
+    if (node.title) {
+        img.setAttribute('title', node.title);
+    }
+
+    if (node.width && node.height) {
+        img.setAttribute('width', node.width);
+        img.setAttribute('height', node.height);
+    }
+
+    // images can be resized to max width, if that's the case output
+    // the resized width/height attrs to ensure 3rd party gallery plugins
+    // aren't affected by differing sizes
+    const {canTransformImage} = options;
+    const {defaultMaxWidth} = options.imageOptimization || {};
+    if (
+        defaultMaxWidth &&
+            node.width > defaultMaxWidth &&
+            isLocalContentImage(node.src, options.siteUrl) &&
+            canTransformImage &&
+            canTransformImage(node.src)
+    ) {
+        const imageDimensions = {
+            width: node.width,
+            height: node.height
+        };
+        const {width, height} = getResizedImageDimensions(imageDimensions, {width: defaultMaxWidth});
+        img.setAttribute('width', width);
+        img.setAttribute('height', height);
+    }
+
+    if (options.target !== 'email') {
+        const imgAttributes = {
+            src: node.src,
+            width: node.width,
+            height: node.height
+        };
+        setSrcsetAttribute(img, imgAttributes, options);
+
+        if (img.getAttribute('srcset') && node.width && node.width >= 720) {
+            // standard size
+            if (!node.cardWidth || node.cardWidth === 'regular') {
+                img.setAttribute('sizes', '(min-width: 720px) 720px');
+            }
+
+            if (node.cardWidth === 'wide' && node.width >= 1200) {
+                img.setAttribute('sizes', '(min-width: 1200px) 1200px');
+            }
+        }
+    }
+
+    // Outlook is unable to properly resize images without a width/height
+    // so we add that at the expected size in emails (600px) and use a higher
+    // resolution image to keep images looking good on retina screens
+    if (options.target === 'email' && node.width && node.height) {
+        let imageDimensions = {
+            width: node.width,
+            height: node.height
+        };
+        if (node.width >= 600) {
+            imageDimensions = getResizedImageDimensions(imageDimensions, {width: 600});
+        }
+        img.setAttribute('width', imageDimensions.width);
+        img.setAttribute('height', imageDimensions.height);
+
+        if (isLocalContentImage(node.src, options.siteUrl) && options.canTransformImage?.(node.src)) {
+            // find available image size next up from 2x600 so we can use it for the "retina" src
+            const availableImageWidths = getAvailableImageWidths(node, options.imageOptimization.contentImageSizes);
+            const srcWidth = availableImageWidths.find(width => width >= 1200);
+
+            if (!srcWidth || srcWidth === node.width) {
+                // do nothing, width is smaller than retina or matches the original node src
+            } else {
+                const [, imagesPath, filename] = node.src.match(/(.*\/content\/images)\/(.*)/);
+                img.setAttribute('src', `${imagesPath}/size/w${srcWidth}/${filename}`);
+            }
+        }
+    }
+
+    if (node.href) {
+        const a = document.createElement('a');
+        a.setAttribute('href', node.href);
+        a.appendChild(img);
+        figure.appendChild(a);
+    } else {
+        figure.appendChild(img);
+    }
+
+    if (node.caption) {
+        const caption = document.createElement('figcaption');
+        caption.innerHTML = node.caption;
+        figure.appendChild(caption);
+    }
+
+    return {element: figure};
+}

--- a/packages/kg-default-nodes/lib/nodes/markdown/MarkdownNode.js
+++ b/packages/kg-default-nodes/lib/nodes/markdown/MarkdownNode.js
@@ -1,11 +1,13 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
+import {renderMarkdownNode} from './markdown-renderer';
 
 export class MarkdownNode extends generateDecoratorNode({
     nodeType: 'markdown',
     properties: [
         {name: 'markdown', default: '', urlType: 'markdown', wordCount: true}
-    ]
+    ],
+    defaultRenderFn: renderMarkdownNode
 }) {
     isEmpty() {
         return !this.__markdown;

--- a/packages/kg-default-nodes/lib/nodes/markdown/markdown-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/markdown/markdown-renderer.js
@@ -1,0 +1,16 @@
+import markdownHtmlRenderer from '@tryghost/kg-markdown-html-renderer';
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+
+export function renderMarkdownNode(node, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+
+    const html = markdownHtmlRenderer.render(node.markdown || '', options);
+
+    const element = document.createElement('div');
+    element.innerHTML = html;
+
+    // `type: 'inner'` will render only the innerHTML of the element
+    // @see @tryghost/kg-lexical-html-renderer package
+    return {element, type: 'inner'};
+}

--- a/packages/kg-default-nodes/lib/nodes/paywall/PaywallNode.js
+++ b/packages/kg-default-nodes/lib/nodes/paywall/PaywallNode.js
@@ -1,9 +1,11 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parsePaywallNode} from './paywall-parser';
+import {renderPaywallNode} from './paywall-renderer';
 
 export class PaywallNode extends generateDecoratorNode({
-    nodeType: 'paywall'
+    nodeType: 'paywall',
+    defaultRenderFn: renderPaywallNode
 }) {
     static importDOM() {
         return parsePaywallNode(this);

--- a/packages/kg-default-nodes/lib/nodes/paywall/paywall-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/paywall/paywall-renderer.js
@@ -1,0 +1,13 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+
+export function renderPaywallNode(_, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+    const element = document.createElement('div');
+
+    element.innerHTML = '<!--members-only-->';
+
+    // `type: 'inner'` will render only the innerHTML of the element
+    // @see @tryghost/kg-lexical-html-renderer package
+    return {element, type: 'inner'};
+}

--- a/packages/kg-default-nodes/lib/nodes/product/ProductNode.js
+++ b/packages/kg-default-nodes/lib/nodes/product/ProductNode.js
@@ -1,6 +1,7 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseProductNode} from './product-parser';
+import {renderProductNode} from './product-renderer';
 
 export class ProductNode extends generateDecoratorNode({
     nodeType: 'product',
@@ -15,7 +16,8 @@ export class ProductNode extends generateDecoratorNode({
         {name: 'productButtonEnabled', default: false},
         {name: 'productButton', default: ''},
         {name: 'productUrl', default: ''}
-    ]
+    ],
+    defaultRenderFn: renderProductNode
 }) {
     /* override */
     exportJSON() {

--- a/packages/kg-default-nodes/lib/nodes/product/product-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/product/product-renderer.js
@@ -1,0 +1,181 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {renderEmptyContainer} from '../../utils/render-empty-container';
+import {getResizedImageDimensions} from '../../utils/get-resized-image-dimensions';
+
+export function renderProductNode(node, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+
+    if (node.isEmpty()) {
+        return renderEmptyContainer(document);
+    }
+
+    let buttonBorderRadius = '5px';
+
+    // we're switching to 6px by default as part of settings being added
+    // TODO: remove 'rounded' check and switch default above to 6px
+    if (options.design?.buttonCorners === 'rounded') {
+        buttonBorderRadius = '6px';
+    } else if (options.design?.buttonCorners === 'square') {
+        buttonBorderRadius = '0px';
+    } else if (options.design?.buttonCorners === 'pill') {
+        buttonBorderRadius = '9999px';
+    }
+
+    const templateData = {
+        ...node.getDataset(),
+        starIcon: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"/></svg>`,
+        buttonBorderRadius
+    };
+
+    const starActiveClasses = 'kg-product-card-rating-active';
+    for (let i = 1; i <= 5; i++) {
+        templateData['star' + i] = '';
+        if (node.productStarRating >= i) {
+            templateData['star' + i] = starActiveClasses;
+        }
+    }
+
+    const htmlString = options.target === 'email'
+        ? emailCardTemplate({data: templateData, feature: options.feature})
+        : cardTemplate({data: templateData, feature: options.feature});
+
+    const element = document.createElement('div');
+    element.innerHTML = htmlString.trim();
+
+    return {element: element.firstElementChild};
+}
+
+export function cardTemplate({data}) {
+    return (
+        `
+        <div class="kg-card kg-product-card">
+            <div class="kg-product-card-container">
+                ${data.productImageSrc ? `<img src="${data.productImageSrc}" ${data.productImageWidth ? `width="${data.productImageWidth}"` : ''} ${data.productImageHeight ? `height="${data.productImageHeight}"` : ''} class="kg-product-card-image" loading="lazy" />` : ''}
+                <div class="kg-product-card-title-container">
+                    <h4 class="kg-product-card-title">${data.productTitle}</h4>
+                </div>
+                ${data.productRatingEnabled ? `
+                    <div class="kg-product-card-rating">
+                        <span class="${data.star1} kg-product-card-rating-star">${data.starIcon}</span>
+                        <span class="${data.star2} kg-product-card-rating-star">${data.starIcon}</span>
+                        <span class="${data.star3} kg-product-card-rating-star">${data.starIcon}</span>
+                        <span class="${data.star4} kg-product-card-rating-star">${data.starIcon}</span>
+                        <span class="${data.star5} kg-product-card-rating-star">${data.starIcon}</span>
+                    </div>
+                ` : ''}
+
+                <div class="kg-product-card-description">${data.productDescription}</div>
+                ${data.productButtonEnabled ? `
+                    <a href="${data.productUrl}" class="kg-product-card-button kg-product-card-btn-accent" target="_blank" rel="noopener noreferrer"><span>${data.productButton}</span></a>
+                ` : ''}
+            </div>
+        </div>
+    `
+    );
+}
+
+export function emailCardTemplate({data, feature}) {
+    let imageDimensions;
+
+    if (data.productImageWidth && data.productImageHeight) {
+        imageDimensions = {
+            width: data.productImageWidth,
+            height: data.productImageHeight
+        };
+
+        if (data.productImageWidth >= 560) {
+            imageDimensions = getResizedImageDimensions(imageDimensions, {width: 560});
+        }
+    }
+
+    if (feature?.emailCustomization || feature?.emailCustomizationAlpha) {
+        return (
+            `
+            <table class="kg-product-card" cellspacing="0" cellpadding="0" border="0">
+                <tr>
+                    <td class="kg-product-card-container">
+                        <table cellspacing="0" cellpadding="0" border="0">
+                            ${data.productImageSrc ? `
+                                <tr>
+                                    <td class="kg-product-image" align="center">
+                                        <img src="${data.productImageSrc}" ${imageDimensions ? `width="${imageDimensions.width}"` : ''} ${imageDimensions ? `height="${imageDimensions.height}"` : ''} border="0"/>
+                                    </td>
+                                </tr>
+                            ` : ''}
+                            <tr>
+                                <td valign="top">
+                                    <h4 class="kg-product-title">${data.productTitle}</h4>
+                                </td>
+                            </tr>
+                            ${data.productRatingEnabled ? `
+                                <tr class="kg-product-rating">
+                                    <td valign="top">
+                                        <img src="${`https://static.ghost.org/v4.0.0/images/star-rating-${data.productStarRating}.png`}" border="0" />
+                                    </td>
+                                </tr>
+                            ` : ''}
+                            <tr>
+                                <td class="kg-product-description-wrapper">${data.productDescription}</td>
+                            </tr>
+                            ${data.productButtonEnabled ? `
+                                <tr>
+                                    <td class="kg-product-button-wrapper">
+                                        <table class="btn btn-accent" border="0" cellspacing="0" cellpadding="0">
+                                            <tr>
+                                                <td align="center" width="100%">
+                                                    <a href="${data.productUrl}">${data.productButton}</a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            ` : ''}
+                        </table>
+                    </td>
+                </tr>
+            </table>
+            `
+        );
+    }
+
+    return (
+        `
+         <table cellspacing="0" cellpadding="0" border="0" style="width:100%; padding:20px; border:1px solid #E9E9E9; border-radius: 5px; margin: 0 0 1.5em; width: 100%;">
+            ${data.productImageSrc ? `
+                <tr>
+                    <td align="center" style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;">
+                        <img src="${data.productImageSrc}" ${imageDimensions ? `width="${imageDimensions.width}"` : ''} ${imageDimensions ? `height="${imageDimensions.height}"` : ''} style="display: block; width: 100%; height: auto; max-width: 100%; border: none; padding-bottom: 16px;" border="0"/>
+                    </td>
+                </tr>
+            ` : ''}
+            <tr>
+                <td valign="top">
+                    <h4 style="font-size: 22px !important; margin-top: 0 !important; margin-bottom: 0 !important; font-weight: 700;">${data.productTitle}</h4>
+                </td>
+            </tr>
+            ${data.productRatingEnabled ? `
+                <tr style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;">
+                    <td valign="top">
+                        <img src="${`https://static.ghost.org/v4.0.0/images/star-rating-${data.productStarRating}.png`}" style="border: none; width: 96px;" border="0" />
+                    </td>
+                </tr>
+            ` : ''}
+            <tr>
+                <td style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;">
+                    <div style="padding-top: 8px; opacity: 0.7; font-size: 17px; line-height: 1.4; margin-bottom: -24px;">${data.productDescription}</div>
+                </td>
+            </tr>
+            ${data.productButtonEnabled ? `
+                <tr>
+                    <td style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;">
+                        <div class="btn btn-accent" style="box-sizing: border-box;display: table;width: 100%;padding-top: 16px;">
+                            <a href="${data.productUrl}" style="overflow-wrap: anywhere;border: solid 1px;border-radius: ${data.buttonBorderRadius};box-sizing: border-box;cursor: pointer;display: inline-block;font-size: 14px;font-weight: bold;margin: 0;padding: 0;text-decoration: none;color: #FFFFFF; width: 100%; text-align: center;"><span style="display: block;padding: 12px 25px;">${data.productButton}</span></a>
+                        </div>
+                    </td>
+                </tr>
+            ` : ''}
+        </table>
+        `
+    );
+}

--- a/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/SignupNode.js
@@ -1,5 +1,6 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {signupParser} from './signup-parser';
+import {renderSignupCardToDOM} from './signup-renderer';
 import {generateDecoratorNode} from '../../generate-decorator-node';
 
 export class SignupNode extends generateDecoratorNode({
@@ -20,7 +21,8 @@ export class SignupNode extends generateDecoratorNode({
         {name: 'subheader', default: '', wordCount: true},
         {name: 'successMessage', default: 'Email sent! Check your inbox to complete your signup.'},
         {name: 'swapped', default: false}
-    ]
+    ],
+    defaultRenderFn: renderSignupCardToDOM
 }) {
     /* override */
     constructor({alignment, backgroundColor, backgroundImageSrc, backgroundSize, textColor, buttonColor, buttonTextColor, buttonText, disclaimer, header, labels, layout, subheader, successMessage, swapped} = {}, key) {

--- a/packages/kg-default-nodes/lib/nodes/signup/signup-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/signup/signup-renderer.js
@@ -1,0 +1,163 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+
+// ref https://ghost.org/docs/themes/members#signup-forms
+
+function cardTemplate(nodeData) {
+    const cardClasses = getCardClasses(nodeData).join(' ');
+
+    const backgroundAccent = getAccentClass(nodeData); // don't apply accent style if there's a background image
+    const buttonAccent = nodeData.buttonColor === 'accent' ? 'kg-style-accent' : '';
+    const buttonStyle = nodeData.buttonColor !== 'accent' ? `background-color: ${nodeData.buttonColor};` : ``;
+    const alignment = nodeData.alignment === 'center' ? 'kg-align-center' : '';
+    const backgroundImageStyle = nodeData.backgroundColor !== 'accent' && (!nodeData.backgroundImageSrc || nodeData.layout === 'split') ? `background-color: ${nodeData.backgroundColor}` : '';
+
+    const imgTemplate = nodeData.backgroundImageSrc ? `
+        <picture><img class="kg-signup-card-image" src="${nodeData.backgroundImageSrc}" alt="" /></picture>
+    ` : ``;
+
+    const formTemplate = `
+        <form class="kg-signup-card-form" data-members-form="signup">
+            ${nodeData.labels.map(label => `<input data-members-label type="hidden" value="${label}" />`).join('\n')}
+            <div class="kg-signup-card-fields">
+                <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email" />
+                <button class="kg-signup-card-button ${buttonAccent}" style="${buttonStyle}color: ${nodeData.buttonTextColor};" type="submit">
+                    <span class="kg-signup-card-button-default">${nodeData.buttonText || 'Subscribe'}</span>
+                    <span class="kg-signup-card-button-loading">${loadingIcon()}</span>
+                </button>
+            </div>
+            <div class="kg-signup-card-success" ${nodeData.textColor ? `style="color: ${nodeData.textColor};"` : ''}>
+                ${nodeData.successMessage || 'Thanks! Now check your email to confirm.'}
+            </div>
+            <div class="kg-signup-card-error" ${nodeData.textColor ? `style="color: ${nodeData.textColor};"` : ''} data-members-error></div>
+        </form>
+        `;
+
+    return `
+        <div class="${cardClasses} ${backgroundAccent}" data-lexical-signup-form style="${backgroundImageStyle}; display: none;">
+            ${nodeData.layout !== 'split' ? imgTemplate : ''}
+            <div class="kg-signup-card-content">
+                ${nodeData.layout === 'split' ? imgTemplate : ''}
+                <div class="kg-signup-card-text ${alignment}">
+                    <h2 class="kg-signup-card-heading" ${nodeData.textColor ? `style="color: ${nodeData.textColor};"` : ''}>${nodeData.header}</h2>
+                    <p class="kg-signup-card-subheading" ${nodeData.textColor ? `style="color: ${nodeData.textColor};"` : ''}>${nodeData.subheader}</p>
+                    ${formTemplate}
+                    <p class="kg-signup-card-disclaimer" ${nodeData.textColor ? `style="color: ${nodeData.textColor};"` : ''}>${nodeData.disclaimer}</p>
+                </div>
+            </div>
+        </div>
+        `;
+}
+
+function loadingIcon() {
+    return `<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" viewBox="0 0 24 24">
+        <g stroke-linecap="round" stroke-width="2" fill="currentColor" stroke="none" stroke-linejoin="round" class="nc-icon-wrapper">
+            <g class="nc-loop-dots-4-24-icon-o">
+                <circle cx="4" cy="12" r="3"></circle>
+                <circle cx="12" cy="12" r="3"></circle>
+                <circle cx="20" cy="12" r="3"></circle>
+            </g>
+            <style data-cap="butt">
+                .nc-loop-dots-4-24-icon-o{--animation-duration:0.8s}
+                .nc-loop-dots-4-24-icon-o *{opacity:.4;transform:scale(.75);animation:nc-loop-dots-4-anim var(--animation-duration) infinite}
+                .nc-loop-dots-4-24-icon-o :nth-child(1){transform-origin:4px 12px;animation-delay:-.3s;animation-delay:calc(var(--animation-duration)/-2.666)}
+                .nc-loop-dots-4-24-icon-o :nth-child(2){transform-origin:12px 12px;animation-delay:-.15s;animation-delay:calc(var(--animation-duration)/-5.333)}
+                .nc-loop-dots-4-24-icon-o :nth-child(3){transform-origin:20px 12px}
+                @keyframes nc-loop-dots-4-anim{0%,100%{opacity:.4;transform:scale(.75)}50%{opacity:1;transform:scale(1)}}
+            </style>
+        </g>
+    </svg>`;
+}
+
+export function renderSignupCardToDOM(dataset, options = {}) {
+    addCreateDocumentOption(options);
+    const document = options.createDocument();
+
+    const node = {
+        alignment: dataset.__alignment,
+        buttonText: dataset.__buttonText,
+        header: dataset.__header,
+        subheader: dataset.__subheader,
+        disclaimer: dataset.__disclaimer,
+        backgroundImageSrc: dataset.__backgroundImageSrc,
+        backgroundSize: dataset.__backgroundSize,
+        backgroundColor: dataset.__backgroundColor,
+        buttonColor: dataset.__buttonColor,
+        labels: dataset.__labels,
+        layout: dataset.__layout,
+        textColor: dataset.__textColor,
+        buttonTextColor: dataset.__buttonTextColor,
+        successMessage: dataset.__successMessage,
+        swapped: dataset.__swapped
+    };
+
+    if (options.target === 'email') {
+        return {element: document.createElement('div')}; // Return an empty element since we don't want to render the card in email
+    }
+
+    const htmlString = cardTemplate(node);
+
+    const element = document.createElement('div');
+    element.innerHTML = htmlString?.trim();
+
+    if (node.header === '') {
+        const h2Element = element.querySelector('.kg-signup-card-heading');
+        if (h2Element) {
+            h2Element.remove();
+        }
+    }
+
+    if (node.subheader === '') {
+        const h3Element = element.querySelector('.kg-signup-card-subheading');
+        if (h3Element) {
+            h3Element.remove();
+        }
+    }
+
+    if (node.disclaimer === '') {
+        const pElement = element.querySelector('.kg-signup-card-disclaimer');
+        if (pElement) {
+            pElement.remove();
+        }
+    }
+    return {element: element.firstElementChild};
+}
+
+export function getCardClasses(nodeData) {
+    let cardClasses = ['kg-card kg-signup-card'];
+
+    if (nodeData.layout && nodeData.layout !== 'split') {
+        cardClasses.push(`kg-width-${nodeData.layout}`);
+    }
+
+    if (nodeData.layout === 'split') {
+        cardClasses.push('kg-layout-split kg-width-full');
+    }
+
+    if (nodeData.swapped && nodeData.layout === 'split') {
+        cardClasses.push('kg-swapped');
+    }
+
+    if (nodeData.layout && nodeData.layout === 'full') {
+        cardClasses.push(`kg-content-wide`);
+    }
+
+    if (nodeData.layout === 'split') {
+        if (nodeData.backgroundSize === 'contain') {
+            cardClasses.push('kg-content-wide');
+        }
+    }
+
+    return cardClasses;
+}
+
+// In general, we don't want to apply the accent style if there's a background image
+//  but with the split format we display both an image and a background color
+const getAccentClass = (nodeData) => {
+    if (nodeData.layout === 'split' && nodeData.backgroundColor === 'accent') {
+        return 'kg-style-accent';
+    } else if (nodeData.layout !== 'split' && !nodeData.backgroundImageSrc && nodeData.backgroundColor === 'accent') {
+        return 'kg-style-accent';
+    } else {
+        return '';
+    }
+};

--- a/packages/kg-default-nodes/lib/nodes/toggle/ToggleNode.js
+++ b/packages/kg-default-nodes/lib/nodes/toggle/ToggleNode.js
@@ -1,13 +1,15 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseToggleNode} from './toggle-parser';
+import {renderToggleNode} from './toggle-renderer';
 
 export class ToggleNode extends generateDecoratorNode({
     nodeType: 'toggle',
     properties: [
         {name: 'heading', default: '', urlType: 'html', wordCount: true},
         {name: 'content', default: '', urlType: 'html', wordCount: true}
-    ]
+    ],
+    defaultRenderFn: renderToggleNode
 }) {
     static importDOM() {
         return parseToggleNode(this);

--- a/packages/kg-default-nodes/lib/nodes/toggle/toggle-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/toggle/toggle-renderer.js
@@ -1,0 +1,69 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {html} from '../../utils/tagged-template-fns.mjs';
+
+function cardTemplate({node}) {
+    return (
+        `
+        <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
+            <div class="kg-toggle-heading">
+                <h4 class="kg-toggle-heading-text">${node.heading}</h4>
+                <button class="kg-toggle-card-icon" aria-label="Expand toggle to read content">
+                    <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
+                    </svg>
+                </button>
+            </div>
+            <div class="kg-toggle-content">${node.content}</div>
+        </div>
+        `
+    );
+}
+
+function emailCardTemplate({node}, options = {}) {
+    if (options.feature?.emailCustomization || options.feature?.emailCustomizationAlpha) {
+        return (
+            html`
+            <table cellspacing="0" cellpadding="0" border="0" width="100%" class="kg-toggle-card">
+                <tbody>
+                    <tr>
+                        <td class="kg-toggle-heading">
+                            <h4>${node.heading}</h4>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="kg-toggle-content">
+                            ${node.content}
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            `
+        );
+    }
+
+    return (
+        `
+        <div style="background: transparent;
+        border: 1px solid rgba(124, 139, 154, 0.25); border-radius: 4px; padding: 20px; margin-bottom: 1.5em;">
+            <h4 style="font-size: 1.375rem; font-weight: 600; margin-bottom: 8px; margin-top:0px">${node.heading}</h4>
+            <div style="font-size: 1rem; line-height: 1.5; margin-bottom: -1.5em;">${node.content}</div>
+        </div>
+        `
+    );
+}
+
+export function renderToggleNode(node, options = {}) {
+    addCreateDocumentOption(options);
+
+    const document = options.createDocument();
+
+    const htmlString = options.target === 'email'
+        ? emailCardTemplate({node}, options)
+        : cardTemplate({node});
+
+    const container = document.createElement('div');
+    container.innerHTML = htmlString.trim();
+
+    const element = container.firstElementChild;
+    return {element};
+}

--- a/packages/kg-default-nodes/lib/nodes/video/VideoNode.js
+++ b/packages/kg-default-nodes/lib/nodes/video/VideoNode.js
@@ -1,7 +1,7 @@
 /* eslint-disable ghost/filenames/match-exported-class */
 import {generateDecoratorNode} from '../../generate-decorator-node';
 import {parseVideoNode} from './video-parser';
-
+import {renderVideoNode} from './video-renderer';
 export class VideoNode extends generateDecoratorNode({
     nodeType: 'video',
     properties: [
@@ -18,7 +18,8 @@ export class VideoNode extends generateDecoratorNode({
         {name: 'thumbnailHeight', default: null},
         {name: 'cardWidth', default: 'regular'},
         {name: 'loop', default: false}
-    ]
+    ],
+    defaultRenderFn: renderVideoNode
 }) {
     /* override */
     exportJSON() {

--- a/packages/kg-default-nodes/lib/nodes/video/video-renderer.js
+++ b/packages/kg-default-nodes/lib/nodes/video/video-renderer.js
@@ -1,0 +1,157 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option';
+import {renderEmptyContainer} from '../../utils/render-empty-container';
+
+export function renderVideoNode(node, options = {}) {
+    addCreateDocumentOption(options);
+
+    const document = options.createDocument();
+
+    if (!node.src || node.src.trim() === '') {
+        return renderEmptyContainer(document);
+    }
+
+    const cardClasses = getCardClasses(node).join(' ');
+
+    const htmlString = options.target === 'email'
+        ? emailCardTemplate({node, options, cardClasses})
+        : cardTemplate({node, cardClasses});
+
+    const element = document.createElement('div');
+    element.innerHTML = htmlString.trim();
+
+    return {element: element.firstElementChild};
+}
+
+export function cardTemplate({node, cardClasses}) {
+    const width = node.width;
+    const height = node.height;
+    const posterSpacerSrc = `https://img.spacergif.org/v1/${width}x${height}/0a/spacer.png`;
+    const autoplayAttr = node.loop ? 'loop autoplay muted' : '';
+    const thumbnailSrc = node.customThumbnailSrc || node.thumbnailSrc;
+    const hideControlsClass = node.loop ? ' kg-video-hide' : '';
+
+    return (
+        `
+        <figure class="${cardClasses}" data-kg-thumbnail=${node.thumbnailSrc} data-kg-custom-thumbnail=${node.customThumbnailSrc}>
+            <div class="kg-video-container">
+                <video
+                    src="${node.src}"
+                    poster="${posterSpacerSrc}"
+                    width="${width}"
+                    height="${height}"
+                    ${autoplayAttr}
+                    playsinline
+                    preload="metadata"
+                    style="background: transparent url('${thumbnailSrc}') 50% 50% / cover no-repeat;"
+                ></video>
+                <div class="kg-video-overlay">
+                    <button class="kg-video-large-play-icon" aria-label="Play video">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                            <path d="M23.14 10.608 2.253.164A1.559 1.559 0 0 0 0 1.557v20.887a1.558 1.558 0 0 0 2.253 1.392L23.14 13.393a1.557 1.557 0 0 0 0-2.785Z"/>
+                        </svg>
+                    </button>
+                </div>
+                <div class="kg-video-player-container${hideControlsClass}">
+                    <div class="kg-video-player">
+                        <button class="kg-video-play-icon" aria-label="Play video">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                <path d="M23.14 10.608 2.253.164A1.559 1.559 0 0 0 0 1.557v20.887a1.558 1.558 0 0 0 2.253 1.392L23.14 13.393a1.557 1.557 0 0 0 0-2.785Z"></path>
+                            </svg>
+                        </button>
+                        <button class="kg-video-pause-icon kg-video-hide" aria-label="Pause video">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                <rect x="3" y="1" width="7" height="22" rx="1.5" ry="1.5"></rect>
+                                <rect x="14" y="1" width="7" height="22" rx="1.5" ry="1.5"></rect>
+                            </svg>
+                        </button>
+                        <span class="kg-video-current-time">0:00</span>
+                        <div class="kg-video-time">
+                            /<span class="kg-video-duration">${node.formattedDuration}</span>
+                        </div>
+                        <input type="range" class="kg-video-seek-slider" max="100" value="0">
+                        <button class="kg-video-playback-rate" aria-label="Adjust playback speed">1&#215;</button>
+                        <button class="kg-video-unmute-icon" aria-label="Unmute">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                <path d="M15.189 2.021a9.728 9.728 0 0 0-7.924 4.85.249.249 0 0 1-.221.133H5.25a3 3 0 0 0-3 3v2a3 3 0 0 0 3 3h1.794a.249.249 0 0 1 .221.133 9.73 9.73 0 0 0 7.924 4.85h.06a1 1 0 0 0 1-1V3.02a1 1 0 0 0-1.06-.998Z"></path>
+                            </svg>
+                        </button>
+                        <button class="kg-video-mute-icon kg-video-hide" aria-label="Mute">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                <path d="M16.177 4.3a.248.248 0 0 0 .073-.176v-1.1a1 1 0 0 0-1.061-1 9.728 9.728 0 0 0-7.924 4.85.249.249 0 0 1-.221.133H5.25a3 3 0 0 0-3 3v2a3 3 0 0 0 3 3h.114a.251.251 0 0 0 .177-.073ZM23.707 1.706A1 1 0 0 0 22.293.292l-22 22a1 1 0 0 0 0 1.414l.009.009a1 1 0 0 0 1.405-.009l6.63-6.631A.251.251 0 0 1 8.515 17a.245.245 0 0 1 .177.075 10.081 10.081 0 0 0 6.5 2.92 1 1 0 0 0 1.061-1V9.266a.247.247 0 0 1 .073-.176Z"></path>
+                            </svg>
+                        </button>
+                        <input type="range" class="kg-video-volume-slider" max="100" value="100"/>
+                    </div>
+                </div>
+            </div>
+            ${node.caption ? `<figcaption>${node.caption}</figcaption>` : ''}
+        </figure>
+    `
+    );
+}
+
+export function emailCardTemplate({node, options, cardClasses}) {
+    const thumbnailSrc = node.customThumbnailSrc || node.thumbnailSrc;
+    const emailTemplateMaxWidth = 600;
+    const aspectRatio = node.width / node.height;
+    const emailSpacerWidth = Math.round(emailTemplateMaxWidth / 4);
+    const emailSpacerHeight = Math.round(emailTemplateMaxWidth / aspectRatio);
+    const posterSpacerSrc = `https://img.spacergif.org/v1/${emailSpacerWidth}x${emailSpacerHeight}/0a/spacer.png`;
+    const outlookCircleLeft = Math.round((emailTemplateMaxWidth / 2) - 39);
+    const outlookCircleTop = Math.round((emailSpacerHeight / 2) - 39);
+    const outlookPlayLeft = Math.round((emailTemplateMaxWidth / 2) - 11);
+    const outlookPlayTop = Math.round((emailSpacerHeight / 2) - 17);
+
+    return (
+        `
+         <figure class="${cardClasses}">
+            <!--[if !mso !vml]-->
+            <a class="kg-video-preview" href="${options.postUrl}" aria-label="Play video" style="mso-hide: all">
+                <table
+                    cellpadding="0"
+                    cellspacing="0"
+                    border="0"
+                    width="100%"
+                    background="${thumbnailSrc}"
+                    role="presentation"
+                    style="background: url('${thumbnailSrc}') left top / cover; mso-hide: all"
+                >
+                    <tr style="mso-hide: all">
+                        <td width="25%" style="visibility: hidden; mso-hide: all">
+                            <img src="${posterSpacerSrc}" alt="" width="100%" border="0" style="display:block; height: auto; opacity: 0; visibility: hidden; mso-hide: all;">
+                        </td>
+                        <td width="50%" align="center" valign="middle" style="vertical-align: middle; mso-hide: all;">
+                            <div class="kg-video-play-button" style="mso-hide: all"><div style="mso-hide: all"></div></div>
+                        </td>
+                        <td width="25%" style="mso-hide: all">&nbsp;</td>
+                    </tr>
+                </table>
+            </a>
+            <!--[endif]-->
+
+            <!--[if vml]>
+            <v:group xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" coordsize="${emailTemplateMaxWidth},${emailSpacerHeight}" coordorigin="0,0" href="${options.postUrl}" style="width:${emailTemplateMaxWidth}px;height:${emailSpacerHeight}px;">
+                <v:rect fill="t" stroked="f" style="position:absolute;width:${emailTemplateMaxWidth};height:${emailSpacerHeight};"><v:fill src="${thumbnailSrc}" type="frame"/></v:rect>
+                <v:oval fill="t" strokecolor="white" strokeweight="4px" style="position:absolute;left:${outlookCircleLeft};top:${outlookCircleTop};width:78;height:78"><v:fill color="black" opacity="30%" /></v:oval>
+                <v:shape coordsize="24,32" path="m,l,32,24,16,xe" fillcolor="white" stroked="f" style="position:absolute;left:${outlookPlayLeft};top:${outlookPlayTop};width:30;height:34;" />
+            </v:group>
+            <![endif]-->
+
+            ${node.caption ? `<figcaption>${node.caption}</figcaption>` : ''}
+        </figure>
+        `
+    );
+}
+
+export function getCardClasses(node) {
+    let cardClasses = ['kg-card kg-video-card'];
+
+    if (node.cardWidth) {
+        cardClasses.push(`kg-width-${node.cardWidth}`);
+    }
+    if (node.caption) {
+        cardClasses.push(`kg-card-hascaption`);
+    }
+
+    return cardClasses;
+}

--- a/packages/kg-default-nodes/lib/utils/clean-dom.js
+++ b/packages/kg-default-nodes/lib/utils/clean-dom.js
@@ -1,0 +1,14 @@
+export function cleanDOM(node, allowedTags) {
+    for (let i = 0; i < node.childNodes.length; i++) {
+        let child = node.childNodes[i];
+        if (child.nodeType === 1 && !allowedTags.includes(child.tagName)) {
+            while (child.firstChild) {
+                node.insertBefore(child.firstChild, child);
+            }
+            node.removeChild(child);
+            i -= 1;
+        } else if (child.nodeType === 1) {
+            cleanDOM(child, allowedTags);
+        }
+    }
+}

--- a/packages/kg-default-nodes/lib/utils/escape-html.js
+++ b/packages/kg-default-nodes/lib/utils/escape-html.js
@@ -1,0 +1,13 @@
+/**
+ * Escape HTML special characters
+ * @param {string} unsafe
+ * @returns string
+ */
+export function escapeHtml(unsafe) {
+    return unsafe
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}

--- a/packages/kg-default-nodes/lib/utils/get-available-image-widths.js
+++ b/packages/kg-default-nodes/lib/utils/get-available-image-widths.js
@@ -1,0 +1,20 @@
+export const getAvailableImageWidths = function (image, imageSizes) {
+    // get a sorted list of the available responsive widths
+    const imageWidths = Object.values(imageSizes)
+        .map(({width}) => width)
+        .sort((a, b) => a - b);
+
+    // select responsive widths that are usable based on the image width
+    const availableImageWidths = imageWidths
+        .filter(width => width <= image.width);
+
+    // add the original image size to the responsive list if it's not captured by largest responsive size
+    // - we can't know the width/height of the original `src` image because we don't know if it was resized
+    //   or not. Adding the original image to the responsive list ensures we're not showing smaller sized
+    //   images than we need to be
+    if (image.width > availableImageWidths[availableImageWidths.length - 1] && image.width < imageWidths[imageWidths.length - 1]) {
+        availableImageWidths.push(image.width);
+    }
+
+    return availableImageWidths;
+};

--- a/packages/kg-default-nodes/lib/utils/get-resized-image-dimensions.js
+++ b/packages/kg-default-nodes/lib/utils/get-resized-image-dimensions.js
@@ -1,0 +1,22 @@
+export const getResizedImageDimensions = function (image, {width: desiredWidth, height: desiredHeight} = {}) {
+    const {width, height} = image;
+    const ratio = width / height;
+
+    if (desiredWidth) {
+        const resizedHeight = Math.round(desiredWidth / ratio);
+
+        return {
+            width: desiredWidth,
+            height: resizedHeight
+        };
+    }
+
+    if (desiredHeight) {
+        const resizedWidth = Math.round(desiredHeight * ratio);
+
+        return {
+            width: resizedWidth,
+            height: desiredHeight
+        };
+    }
+};

--- a/packages/kg-default-nodes/lib/utils/is-local-content-image.js
+++ b/packages/kg-default-nodes/lib/utils/is-local-content-image.js
@@ -1,0 +1,5 @@
+export const isLocalContentImage = function (url, siteUrl = '') {
+    const normalizedSiteUrl = siteUrl.replace(/\/$/, '');
+    const imagePath = url.replace(normalizedSiteUrl, '');
+    return /^(\/.*|__GHOST_URL__)\/?content\/images\//.test(imagePath);
+};

--- a/packages/kg-default-nodes/lib/utils/is-unsplash-image.js
+++ b/packages/kg-default-nodes/lib/utils/is-unsplash-image.js
@@ -1,0 +1,3 @@
+export const isUnsplashImage = function (url) {
+    return /images\.unsplash\.com/.test(url);
+};

--- a/packages/kg-default-nodes/lib/utils/render-empty-container.js
+++ b/packages/kg-default-nodes/lib/utils/render-empty-container.js
@@ -1,0 +1,12 @@
+/*
+ * Renders an empty container element
+ * In the returned object, `type: 'inner'` is picked up by the `@tryghost/kg-lexical-html-renderer` package
+ * to render the inner content of the container element (in this case, nothing)
+ *
+ * @see @tryghost/kg-lexical-html-renderer package
+ * @see https://github.com/TryGhost/Koenig/blob/e14c008e176f7a1036fe3f3deb924ed69a69191f/packages/kg-lexical-html-renderer/lib/convert-to-html-string.js#L29
+ */
+export function renderEmptyContainer(document) {
+    const emptyContainer = document.createElement('span');
+    return {element: emptyContainer, type: 'inner'};
+}

--- a/packages/kg-default-nodes/lib/utils/render-helpers/email-button.js
+++ b/packages/kg-default-nodes/lib/utils/render-helpers/email-button.js
@@ -1,0 +1,35 @@
+import clsx from 'clsx';
+import {html} from '../tagged-template-fns.mjs';
+
+/**
+ * @param {Object} options
+ * @param {string} [options.alignment]
+ * @param {string} [options.color='accent']
+ * @param {string} [options.text='']
+ * @param {string} [options.textColor]
+ * @param {string} [options.url='']
+ * @returns {string}
+ */
+export function renderEmailButton({
+    alignment = '',
+    color = 'accent',
+    text = '',
+    url = ''
+} = {}) {
+    const buttonClasses = clsx(
+        'btn',
+        color === 'accent' && 'btn-accent'
+    );
+
+    return html`
+        <table class="${buttonClasses}" border="0" cellspacing="0" cellpadding="0" align="${alignment}">
+            <tbody>
+                <tr>
+                    <td align="center">
+                        <a href="${url}">${text}</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    `;
+}

--- a/packages/kg-default-nodes/lib/utils/replacement-strings.js
+++ b/packages/kg-default-nodes/lib/utils/replacement-strings.js
@@ -1,0 +1,45 @@
+/**
+ * Removes consecutive whitespaces and newlines
+ * @param {string} html
+ * @returns {string}
+ */
+export function removeSpaces(html) {
+    return html.replace(/\n/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Wraps replacement strings with %%
+ * This helps to prevent conflicts between code samples and our replacement strings
+ * Example: {foo} -> %%{foo}%%
+ * @param {string} html
+ * @returns {string}
+ */
+export function wrapReplacementStrings(html) {
+    return html.replace(/\{(\w*?)(?:,? *"(.*?)")?\}/g, '%%$&%%');
+}
+
+/**
+ * Removes any <code> wrappers around replacement strings {foo}
+ * Example input:  <code><span>{foo}</span></code>
+ * Example output:       <span>{foo}</span>
+ * @param {string} html
+ * @returns {string}
+ */
+export function removeCodeWrappersFromHelpers(html,document) {
+    // parse html to make patterns easier to match
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = html;
+
+    const codeElements = tempDiv.querySelectorAll('code');
+    codeElements.forEach((codeElement) => {
+        const codeTextContent = codeElement.textContent;
+        // extract the content of the code element if it follows the helper pattern (e.g. {foo})
+        if (codeTextContent.match(/((.*?){.*?}(.*?))/gi)) {
+            const codeContent = codeElement.innerHTML; 
+            codeElement.parentNode.replaceChild(document.createRange().createContextualFragment(codeContent), codeElement);
+        }
+    });
+
+    const cleanedHtml = tempDiv.innerHTML;
+    return cleanedHtml;
+}

--- a/packages/kg-default-nodes/lib/utils/slugify.js
+++ b/packages/kg-default-nodes/lib/utils/slugify.js
@@ -1,0 +1,15 @@
+export function slugify(str) {
+    // Remove HTML tags
+    str = str.replace(/<[^>]*>?/gm, '');
+
+    // Remove any non-word character with whitespace
+    str = str.replace(/[^\w\s]/gi, '');
+
+    // Replace any whitespace character with a dash
+    str = str.replace(/\s+/g, '-');
+
+    // Convert to lowercase
+    str = str.toLowerCase();
+
+    return str;
+}

--- a/packages/kg-default-nodes/lib/utils/srcset-attribute.js
+++ b/packages/kg-default-nodes/lib/utils/srcset-attribute.js
@@ -1,0 +1,63 @@
+import {isLocalContentImage} from './is-local-content-image';
+import {getAvailableImageWidths} from './get-available-image-widths';
+import {isUnsplashImage} from './is-unsplash-image';
+
+// default content sizes: [600, 1000, 1600, 2400]
+
+export const getSrcsetAttribute = function ({src, width, options}) {
+    if (!options.imageOptimization || options.imageOptimization.srcsets === false || !width || !options.imageOptimization.contentImageSizes) {
+        return;
+    }
+
+    if (isLocalContentImage(src, options.siteUrl) && options.canTransformImage && !options.canTransformImage(src)) {
+        return;
+    }
+
+    const srcsetWidths = getAvailableImageWidths({width}, options.imageOptimization.contentImageSizes);
+
+    // apply srcset if this is a relative image that matches Ghost's image url structure
+    if (isLocalContentImage(src, options.siteUrl)) {
+        const [, imagesPath, filename] = src.match(/(.*\/content\/images)\/(.*)/);
+        const srcs = [];
+
+        srcsetWidths.forEach((srcsetWidth) => {
+            if (srcsetWidth === width) {
+                // use original image path if width matches exactly (avoids 302s from size->original)
+                srcs.push(`${src} ${srcsetWidth}w`);
+            } else if (srcsetWidth <= width) {
+                // avoid creating srcset sizes larger than intrinsic image width
+                srcs.push(`${imagesPath}/size/w${srcsetWidth}/${filename} ${srcsetWidth}w`);
+            }
+        });
+
+        if (srcs.length) {
+            return srcs.join(', ');
+        }
+    }
+
+    // apply srcset if this is an Unsplash image
+    if (isUnsplashImage(src)) {
+        const unsplashUrl = new URL(src);
+        const srcs = [];
+
+        srcsetWidths.forEach((srcsetWidth) => {
+            unsplashUrl.searchParams.set('w', srcsetWidth);
+            srcs.push(`${unsplashUrl.href} ${srcsetWidth}w`);
+        });
+
+        return srcs.join(', ');
+    }
+};
+
+export const setSrcsetAttribute = function (elem, image, options) {
+    if (!elem || !['IMG', 'SOURCE'].includes(elem.tagName) || !elem.getAttribute('src') || !image) {
+        return;
+    }
+
+    const {src, width} = image;
+    const srcset = getSrcsetAttribute({src, width, options});
+
+    if (srcset) {
+        elem.setAttribute('srcset', srcset);
+    }
+};

--- a/packages/kg-default-nodes/lib/utils/truncate.js
+++ b/packages/kg-default-nodes/lib/utils/truncate.js
@@ -1,0 +1,36 @@
+import {escapeHtml} from './escape-html';
+
+export function truncateText(text, maxLength) {
+    if (text && text.length > maxLength) {
+        return text.substring(0, maxLength - 1).trim() + '…';
+    } else {
+        return text ?? '';
+    }
+}
+
+export function truncateHtml(text, maxLength, maxLengthMobile) {
+    // If no mobile length specified or mobile length is larger than desktop,
+    // just do a simple truncate
+    if (!maxLengthMobile || maxLength <= maxLengthMobile) {
+        return escapeHtml(truncateText(text, maxLength));
+    }
+
+    // Handle text shorter than mobile length
+    if (text.length <= maxLengthMobile) {
+        return escapeHtml(text);
+    }
+
+    if (text && text.length > maxLengthMobile) {
+        let ellipsis = '';
+
+        if (text.length > maxLengthMobile && text.length <= maxLength) {
+            ellipsis = '<span class="hide-desktop">…</span>';
+        } else if (text.length > maxLength) {
+            ellipsis = '…';
+        }
+
+        return escapeHtml(text.substring(0, maxLengthMobile - 1)) + '<span class="desktop-only">' + escapeHtml(text.substring(maxLengthMobile - 1, maxLength - 1)) + '</span>' + ellipsis;
+    } else {
+        return escapeHtml(text ?? '');
+    }
+}

--- a/packages/kg-default-nodes/package.json
+++ b/packages/kg-default-nodes/package.json
@@ -51,7 +51,12 @@
     "@lexical/selection": "0.13.1",
     "@lexical/utils": "0.13.1",
     "@tryghost/kg-clean-basic-html": "4.2.7",
+    "@tryghost/kg-markdown-html-renderer": "7.1.2",
+    "clsx": "2.1.1",
+    "html-minifier": "^4.0.0",
     "jsdom": "^24.1.1",
-    "lexical": "0.13.1"
+    "lexical": "0.13.1",
+    "lodash": "^4.17.21",
+    "luxon": "^3.5.0"
   }
 }

--- a/packages/kg-default-nodes/test/generate-decorator-node.test.js
+++ b/packages/kg-default-nodes/test/generate-decorator-node.test.js
@@ -118,7 +118,7 @@ describe('Utils: generateDecoratorNode', function () {
             });
 
             const node = new NodeWithoutRender();
-            (() => node.exportDOM()).should.throw(`[generateDecoratorNode] no-render-test: "options.nodeRenderers['no-render-test']" or "defaultRenderFn" is required for exportDOM`);
+            (() => node.exportDOM()).should.throw('[generateDecoratorNode] no-render-test: "defaultRenderFn" is required');
         }));
 
         it('throws error when default versioned renderer is missing for node version', editorTest(function () {
@@ -132,31 +132,38 @@ describe('Utils: generateDecoratorNode', function () {
             });
 
             const node = new VersionedNode();
-            (() => node.exportDOM()).should.throw(`[generateDecoratorNode] versioned-render-test: "options.nodeRenderers['versioned-render-test']" or "defaultRenderFn" for version 2 is required for exportDOM`);
+            (() => node.exportDOM()).should.throw('[generateDecoratorNode] versioned-render-test: "defaultRenderFn" for version 2 is required');
         }));
 
-        it(`uses custom renderer if passed in`, editorTest(function () {
-            const node = $createNodeWithRender();
-            const customRenderer = () => ({
-                element: 'span',
-                type: 'inner',
-                content: 'custom render'
-            });
+        // eslint-disable-next-line ghost/mocha/no-setup-in-describe
+        ['emailCustomizationAlpha', 'emailCustomization'].forEach((feature) => {
+            it(`uses custom renderer if passed in (${feature})`, editorTest(function () {
+                const node = $createNodeWithRender();
+                const customRenderer = () => ({
+                    element: 'span',
+                    type: 'inner',
+                    content: 'custom render'
+                });
 
-            const result = node.exportDOM({
-                nodeRenderers: {
-                    'render-test': customRenderer
-                }
-            });
+                const featureOption = {};
+                featureOption[feature] = true;
 
-            result.should.deepEqual({
-                element: 'span',
-                type: 'inner',
-                content: 'custom render'
-            });
-        }));
+                const result = node.exportDOM({
+                    feature: featureOption,
+                    nodeRenderers: {
+                        'render-test': customRenderer
+                    }
+                });
 
-        it('throws error when custom versioned renderer is missing for node version', editorTest(function () {
+                result.should.deepEqual({
+                    element: 'span',
+                    type: 'inner',
+                    content: 'custom render'
+                });
+            }));
+        });
+
+        it('throws error when custom versioned renderer is missing for node version (emailCustomizationAlpha)', editorTest(function () {
             const VersionedNode = utils.generateDecoratorNode({
                 nodeType: 'versioned-render-test',
                 properties: [{name: 'version', default: 1}],
@@ -178,12 +185,15 @@ describe('Utils: generateDecoratorNode', function () {
             const node = new VersionedNode({version: 2});
 
             (() => node.exportDOM({
+                feature: {
+                    emailCustomizationAlpha: true
+                },
                 nodeRenderers: {
                     'versioned-render-test': {
                         1: () => ({})
                     }
                 }
-            })).should.throw(`[generateDecoratorNode] versioned-render-test: "options.nodeRenderers['versioned-render-test']" or "defaultRenderFn" for version 2 is required for exportDOM`);
+            })).should.throw('[generateDecoratorNode] versioned-render-test: options.nodeRenderers[\'versioned-render-test\'] for version 2 is required');
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/audio.test.js
+++ b/packages/kg-default-nodes/test/nodes/audio.test.js
@@ -1,4 +1,4 @@
-const {createDocument, html} = require('../test-utils');
+const {dom, createDocument, html} = require('../test-utils');
 const {$getRoot} = require('lexical');
 const {createHeadlessEditor} = require('@lexical/headless');
 const {$generateNodesFromDOM} = require('@lexical/html');
@@ -10,6 +10,7 @@ const editorNodes = [AudioNode];
 describe('AudioNode', function () {
     let editor;
     let dataset;
+    let exportOptions;
 
     // NOTE: all tests should use this function, without it you need manual
     // try/catch and done handling to avoid assertion failures not triggering
@@ -34,6 +35,10 @@ describe('AudioNode', function () {
             duration: 60,
             mimeType: 'audio/mp3',
             thumbnailSrc: '/content/images/2022/11/koenig-audio-lexical.jpg'
+        };
+
+        exportOptions = {
+            dom
         };
     });
 
@@ -171,6 +176,22 @@ describe('AudioNode', function () {
                 }
             });
         });
+    });
+
+    describe('exportDOM', function () {
+        it('creates an audio card', editorTest(function () {
+            const audioNode = $createAudioNode(dataset);
+            const {element} = audioNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(html`<div class="kg-card kg-audio-card"><img src="/content/images/2022/11/koenig-audio-lexical.jpg" alt="audio-thumbnail" class="kg-audio-thumbnail"><div class="kg-audio-thumbnail placeholder kg-audio-hide"><svg width="24" height="24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.5 15.33a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0ZM15 13.83a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0Z"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M14.486 6.81A2.25 2.25 0 0 1 17.25 9v5.579a.75.75 0 0 1-1.5 0v-5.58a.75.75 0 0 0-.932-.727.755.755 0 0 1-.059.013l-4.465.744a.75.75 0 0 0-.544.72v6.33a.75.75 0 0 1-1.5 0v-6.33a2.25 2.25 0 0 1 1.763-2.194l4.473-.746Z"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M3 1.5a.75.75 0 0 0-.75.75v19.5a.75.75 0 0 0 .75.75h18a.75.75 0 0 0 .75-.75V5.133a.75.75 0 0 0-.225-.535l-.002-.002-3-2.883A.75.75 0 0 0 18 1.5H3ZM1.409.659A2.25 2.25 0 0 1 3 0h15a2.25 2.25 0 0 1 1.568.637l.003.002 3 2.883a2.25 2.25 0 0 1 .679 1.61V21.75A2.25 2.25 0 0 1 21 24H3a2.25 2.25 0 0 1-2.25-2.25V2.25c0-.597.237-1.169.659-1.591Z"></path></svg></div><div class="kg-audio-player-container"><audio src="/content/audio/2022/11/koenig-lexical.mp3" preload="metadata"></audio><div class="kg-audio-title">Test Audio</div><div class="kg-audio-player"><button class="kg-audio-play-icon" aria-label="Play audio"><svg viewBox="0 0 24 24"><path d="M23.14 10.608 2.253.164A1.559 1.559 0 0 0 0 1.557v20.887a1.558 1.558 0 0 0 2.253 1.392L23.14 13.393a1.557 1.557 0 0 0 0-2.785Z"></path></svg></button><button class="kg-audio-pause-icon kg-audio-hide" aria-label="Pause audio"><svg viewBox="0 0 24 24"><rect x="3" y="1" width="7" height="22" rx="1.5" ry="1.5"></rect><rect x="14" y="1" width="7" height="22" rx="1.5" ry="1.5"></rect></svg></button><span class="kg-audio-current-time">0:00</span><div class="kg-audio-time">/<span class="kg-audio-duration">60</span></div><input type="range" class="kg-audio-seek-slider" max="100" value="0"><button class="kg-audio-playback-rate" aria-label="Adjust playback speed">1×</button><button class="kg-audio-unmute-icon" aria-label="Unmute"><svg viewBox="0 0 24 24"><path d="M15.189 2.021a9.728 9.728 0 0 0-7.924 4.85.249.249 0 0 1-.221.133H5.25a3 3 0 0 0-3 3v2a3 3 0 0 0 3 3h1.794a.249.249 0 0 1 .221.133 9.73 9.73 0 0 0 7.924 4.85h.06a1 1 0 0 0 1-1V3.02a1 1 0 0 0-1.06-.998Z"></path></svg></button><button class="kg-audio-mute-icon kg-audio-hide" aria-label="Mute"><svg viewBox="0 0 24 24"><path d="M16.177 4.3a.248.248 0 0 0 .073-.176v-1.1a1 1 0 0 0-1.061-1 9.728 9.728 0 0 0-7.924 4.85.249.249 0 0 1-.221.133H5.25a3 3 0 0 0-3 3v2a3 3 0 0 0 3 3h.114a.251.251 0 0 0 .177-.073ZM23.707 1.706A1 1 0 0 0 22.293.292l-22 22a1 1 0 0 0 0 1.414l.009.009a1 1 0 0 0 1.405-.009l6.63-6.631A.251.251 0 0 1 8.515 17a.245.245 0 0 1 .177.075 10.081 10.081 0 0 0 6.5 2.92 1 1 0 0 0 1.061-1V9.266a.247.247 0 0 1 .073-.176Z"></path></svg></button><input type="range" class="kg-audio-volume-slider" max="100" value="100"></div></div></div>`);
+        }));
+
+        it('renders an empty span with a missing src', editorTest(function () {
+            const audioNode = $createAudioNode();
+            const {element} = audioNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.equal('<span></span>');
+        }));
     });
 
     describe('importDOM', function () {

--- a/packages/kg-default-nodes/test/nodes/button.test.js
+++ b/packages/kg-default-nodes/test/nodes/button.test.js
@@ -1,4 +1,4 @@
-const {createDocument, html} = require('../test-utils');
+const {createDocument, dom, html} = require('../test-utils');
 const {$getRoot} = require('lexical');
 const {createHeadlessEditor} = require('@lexical/headless');
 const {$generateNodesFromDOM} = require('@lexical/html');
@@ -10,6 +10,7 @@ const editorNodes = [ButtonNode];
 describe('ButtonNode', function () {
     let editor;
     let dataset;
+    let exportOptions;
 
     // NOTE: all tests should use this function, without it you need manual
     // try/catch and done handling to avoid assertion failures not triggering
@@ -31,6 +32,9 @@ describe('ButtonNode', function () {
             buttonText: 'click me',
             buttonUrl: 'http://blog.com/post1',
             alignment: 'center'
+        };
+        exportOptions = {
+            dom
         };
     });
 
@@ -103,6 +107,100 @@ describe('ButtonNode', function () {
         it('returns true', editorTest(function () {
             const buttonNode = $createButtonNode(dataset);
             buttonNode.hasEditMode().should.be.true();
+        }));
+    });
+
+    describe('exportDOM', function () {
+        it('creates a button card', editorTest(function () {
+            const buttonNode = $createButtonNode(dataset);
+            const {element} = buttonNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(html`<div class="kg-card kg-button-card kg-align-center"><a href="http://blog.com/post1" class="kg-btn kg-btn-accent">click me</a></div>`);
+        }));
+
+        it('renders for email target', editorTest(function () {
+            const buttonNode = $createButtonNode(dataset);
+            const options = {
+                target: 'email'
+            };
+            const {element} = buttonNode.exportDOM({...exportOptions, ...options});
+            const output = element.outerHTML;
+
+            output.should.not.containEql('kg-card');
+            output.should.containEql('<div class="btn btn-accent">');
+            output.should.containEql('<table border="0" cellspacing="0" cellpadding="0"');
+            output.should.containEql('<td align="center">');
+        }));
+
+        it('renders for email target (emailCustomization)', editorTest(function () {
+            const buttonNode = $createButtonNode(dataset);
+            const options = {
+                target: 'email',
+                feature: {
+                    emailCustomization: true
+                }
+            };
+            const {element} = buttonNode.exportDOM({...exportOptions, ...options});
+            const output = element.innerHTML;
+
+            output.should.prettifyTo(html`
+                <table border="0" cellpadding="0" cellspacing="0">
+                    <tbody>
+                        <tr>
+                            <td>
+                                <table class="btn btn-accent" border="0" cellspacing="0" cellpadding="0" align="center">
+                                    <tbody>
+                                        <tr>
+                                            <td align="center">
+                                                <a href="http://blog.com/post1">click me</a>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
+        }));
+
+        it('renders for email target (emailCustomizationAlpha)', editorTest(function () {
+            const buttonNode = $createButtonNode(dataset);
+            const options = {
+                target: 'email',
+                feature: {
+                    emailCustomizationAlpha: true
+                }
+            };
+            const {element} = buttonNode.exportDOM({...exportOptions, ...options});
+            const output = element.innerHTML;
+
+            output.should.prettifyTo(html`
+                <table border="0" cellpadding="0" cellspacing="0">
+                    <tbody>
+                        <tr>
+                            <td>
+                                <table class="btn btn-accent" border="0" cellspacing="0" cellpadding="0" align="center">
+                                    <tbody>
+                                        <tr>
+                                            <td align="center">
+                                                <a href="http://blog.com/post1">click me</a>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
+        }));
+
+        it('renders an empty span with a missing buttonUrl', editorTest(function () {
+            const buttonNode = $createButtonNode();
+            const {element} = buttonNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.equal('<span></span>');
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/email-cta.test.js
+++ b/packages/kg-default-nodes/test/nodes/email-cta.test.js
@@ -1,5 +1,6 @@
 const {createHeadlessEditor} = require('@lexical/headless');
 const {$getRoot} = require('lexical');
+const {dom, html} = require('../test-utils');
 const {EmailCtaNode, $createEmailCtaNode, $isEmailCtaNode} = require('../../');
 
 const editorNodes = [EmailCtaNode];
@@ -7,6 +8,7 @@ const editorNodes = [EmailCtaNode];
 describe('EmailCtaNode', function () {
     let editor;
     let dataset;
+    let exportOptions;
 
     const editorTest = testFn => function (done) {
         editor.update(() => {
@@ -32,6 +34,11 @@ describe('EmailCtaNode', function () {
             segment: 'status:free',
             showButton: false,
             showDividers: true
+        };
+
+        exportOptions = {
+            exportFormat: 'html',
+            dom
         };
     });
 
@@ -183,6 +190,302 @@ describe('EmailCtaNode', function () {
                 }
             });
         });
+    });
+
+    describe('exportDOM', function () {
+        it('renders for email target without button', editorTest(function () {
+            const payload = {
+                alignment: 'left',
+                buttonText: 'Test',
+                buttonUrl: 'https://example.com',
+                html: '<p>Hello World</p>',
+                segment: 'status:free',
+                showButton: false,
+                showDividers: true
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailCtaNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(html`
+                <div data-gh-segment="status:free">
+                    <hr>
+                    <p>Hello World</p>
+                    <hr>
+                </div>
+            `);
+        }));
+
+        it('does not render for web', editorTest(function () {
+            const payload = {
+                alignment: 'left',
+                buttonText: '',
+                buttonUrl: '',
+                html: '<p>Hello World</p>',
+                segment: 'status:free',
+                showButton: false,
+                showDividers: true
+            };
+
+            const options = {
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailCtaNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.equal('<span></span>');
+        }));
+
+        it('does not render if all empty', editorTest(function () {
+            const payload = {
+                alignment: 'left',
+                buttonText: '',
+                buttonUrl: '',
+                html: '',
+                segment: 'status:free',
+                showButton: false,
+                showDividers: true
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailCtaNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.equal('<span></span>');
+        }));
+
+        it('does not render if button text empty', editorTest(function () {
+            const payload = {
+                alignment: 'left',
+                buttonText: '',
+                buttonUrl: '',
+                html: '',
+                segment: 'status:free',
+                showButton: true,
+                showDividers: true
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailCtaNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.equal('<span></span>');
+        }));
+
+        it('does not render button if button text empty', editorTest(function () {
+            const payload = {
+                alignment: 'left',
+                buttonText: '',
+                buttonUrl: '',
+                html: '<p>Hello World</p>',
+                segment: 'status:free',
+                showButton: true,
+                showDividers: true
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailCtaNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(html`
+                <div data-gh-segment="status:free">
+                    <hr>
+                    <p>Hello World</p>
+                    <hr>
+                </div>
+            `);
+        }));
+
+        it('does not render button if button url empty', editorTest(function () {
+            const payload = {
+                alignment: 'left',
+                buttonText: 'Test',
+                buttonUrl: '',
+                html: '<p>Hello World</p>',
+                segment: 'status:free',
+                showButton: true,
+                showDividers: true
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailCtaNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(html`
+                <div data-gh-segment="status:free">
+                    <hr>
+                    <p>Hello World</p>
+                    <hr>
+                </div>
+            `);
+        }));
+
+        it('renders for email target with button', editorTest(function () {
+            const payload = {
+                alignment: 'left',
+                buttonText: 'Test',
+                buttonUrl: 'https://example.com',
+                html: '<p>Hello World</p>',
+                segment: 'status:free',
+                showButton: true,
+                showDividers: true
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailCtaNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(html`
+                <div data-gh-segment="status:free">
+                    <hr>
+                    <p>Hello World</p>
+                    <div class="btn btn-accent">
+                        <table border="0" cellspacing="0" cellpadding="0" align="left">
+                            <tbody>
+                                <tr>
+                                    <td align="center">
+                                        <a href="https://example.com">Test</a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <p></p>
+                    <hr>
+                </div>
+            `);
+        }));
+
+        it('renders text with button and no dividers', editorTest(function () {
+            const payload = {
+                alignment: 'left',
+                buttonText: 'Test',
+                buttonUrl: 'https://example.com',
+                html: '<p>Hello World</p>',
+                segment: 'status:free',
+                showButton: true,
+                showDividers: false
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailCtaNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(html`
+                <div data-gh-segment="status:free">
+                    <p>Hello World</p>
+                    <div class="btn btn-accent">
+                        <table border="0" cellspacing="0" cellpadding="0" align="left">
+                            <tbody>
+                                <tr>
+                                    <td align="center">
+                                        <a href="https://example.com">Test</a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <p></p>
+                </div>
+            `);
+        }));
+
+        it('renders only the button', editorTest(function () {
+            const payload = {
+                alignment: 'left',
+                buttonText: 'Test',
+                buttonUrl: 'https://example.com',
+                html: '',
+                segment: 'status:free',
+                showButton: true,
+                showDividers: false
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailCtaNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(html`
+                <div data-gh-segment="status:free">
+                    <div class="btn btn-accent">
+                        <table border="0" cellspacing="0" cellpadding="0" align="left">
+                            <tbody>
+                                <tr>
+                                    <td align="center">
+                                        <a href="https://example.com">Test</a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <p></p>
+                </div>
+            `);
+        }));
+
+        it('can align center', editorTest(function () {
+            const payload = {
+                alignment: 'center',
+                buttonText: 'Test',
+                buttonUrl: 'https://example.com',
+                html: '<p>Hello World</p>',
+                segment: 'status:free',
+                showButton: true,
+                showDividers: true
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailCtaNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(html`
+                <div data-gh-segment="status:free" class="align-center">
+                    <hr>
+                    <p>Hello World</p>
+                    <div class="btn btn-accent">
+                        <table border="0" cellspacing="0" cellpadding="0" align="center">
+                            <tbody>
+                                <tr>
+                                    <td align="center">
+                                        <a href="https://example.com">Test</a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <p></p>
+                    <hr>
+                </div>
+            `);
+        }));
     });
 
     describe('getTextContent', function () {

--- a/packages/kg-default-nodes/test/nodes/email.test.js
+++ b/packages/kg-default-nodes/test/nodes/email.test.js
@@ -143,6 +143,280 @@ describe('EmailNode', function () {
         });
     });
 
+    describe('exportDOM', function () {
+        it('renders for email target', editorTest(function () {
+            const payload = {
+                html: '<p>Hello World</p>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p>Hello World</p>
+            `);
+        }));
+
+        it('renders nothing if the target is not email', editorTest(function () {
+            const payload = {
+                html: '<p>Hello World</p>'
+            };
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM(exportOptions);
+
+            element.should.be.empty();
+        }));
+
+        it('renders nothing if the `html` payload is empty', editorTest(function () {
+            const payload = {
+                html: ''
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.should.be.empty();
+        }));
+
+        it('removes any extra consecutives whitespaces', editorTest(function () {
+            const payload = {
+                html: '<p><span>Hey    you</span></p>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p><span>Hey you</span></p>
+            `);
+        }));
+
+        it('removes any linebreaks', editorTest(function () {
+            const payload = {
+                html: '<p>\n<span>Hey \nyou</span>\n</p>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p><span>Hey you</span></p>
+            `);
+        }));
+
+        it('wraps {foo} in %%', editorTest(function () {
+            const payload = {
+                html: '<p>Hey {foo}</p>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p>Hey %%{foo}%%</p>
+            `);
+        }));
+
+        it('wraps {foo, "default"} in %%', editorTest(function () {
+            const payload = {
+                html: '<p>Hey {foo, "default"}</p>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p>Hey %%{foo, "default"}%%</p>
+            `);
+        }));
+
+        it('wraps {foo,  "default"} in %% (extra spaces)', editorTest(function () {
+            const payload = {
+                html: '<p>Hey {foo,  "default"}</p>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p>Hey %%{foo,  "default"}%%</p>
+            `);
+        }));
+
+        it('wraps {foo "default"} in %% (missing comma)', editorTest(function () {
+            const payload = {
+                html: '<p>Hey {foo "default"}</p>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p>Hey %%{foo "default"}%%</p>
+            `);
+        }));
+
+        it('wraps {foo  "default"} in %% (extra space, missing comma)', editorTest(function () {
+            const payload = {
+                html: '<p>Hey {foo  "default"}</p>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p>Hey %%{foo  "default"}%%</p>
+            `);
+        }));
+
+        it('does not wrap {invalid } in %% (invalid space at the end)', editorTest(function () {
+            const payload = {
+                html: '<p>Hey {foo}, you are {invalid }</p>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p>Hey %%{foo}%%, you are {invalid }</p>
+            `);
+        }));
+
+        it('does not wrap { invalid} in %% (invalid space at the beginning)', editorTest(function () {
+            const payload = {
+                html: '<p>Hey {foo}, you are { invalid}</p>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p>Hey %%{foo}%%, you are { invalid}</p>
+            `);
+        }));
+
+        it('does not wrap {foo invalid} in %% (two words, missing quotes)', editorTest(function () {
+            const payload = {
+                html: '<p>Hey {foo invalid}</p>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p>Hey {foo invalid}</p>
+            `);
+        }));
+
+        it('renders multiple paragraphs', editorTest(function () {
+            const payload = {
+                html: '<p>First paragraph</p><p>Second paragraph</p><p>Third paragraph</p>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p>First paragraph</p>
+                <p>Second paragraph</p>
+                <p>Third paragraph</p>
+            `);
+        }));
+
+        it('strips out <code> elements with placeholders', editorTest(function () {
+            const payload = {
+                html: '<p>First paragraph</p><code>{placeholder}</code><p>Third paragraph</p>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p>First paragraph</p>
+                %%{placeholder}%%
+                <p>Third paragraph</p>
+            `);
+        }));
+
+        it(`leaves <code> elements when not used with a placeholder`, editorTest(function () {
+            const payload = {
+                html: '<p>First paragraph</p><code>Some code</code><p>Third paragraph</p><code>{helper, "test"}</code>'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+
+            const emailNode = $createEmailNode(payload);
+            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+
+            element.innerHTML.should.prettifyTo(html`
+                <p>First paragraph</p>
+                <code>Some code</code>
+                <p>Third paragraph</p>
+                %%{helper, "test"}%%
+            `);
+        }));
+    });
+
     describe('getTextContent', function () {
         it('returns contents', editorTest(function () {
             const node = $createEmailNode();

--- a/packages/kg-default-nodes/test/nodes/embed.test.js
+++ b/packages/kg-default-nodes/test/nodes/embed.test.js
@@ -1,15 +1,36 @@
-const {createDocument, html} = require('../test-utils');
+const {createDocument, dom, html} = require('../test-utils');
 const {$getRoot} = require('lexical');
 const {createHeadlessEditor} = require('@lexical/headless');
 const {$generateNodesFromDOM} = require('@lexical/html');
+const Prettier = require('@prettier/sync');
 
 const {EmbedNode, $createEmbedNode, $isEmbedNode} = require('../../');
 
 const editorNodes = [EmbedNode];
 
+const youtubeEmbed = {
+    html: '<iframe width="200" height="113" src="https://www.youtube.com/embed/7hCPODjJO7s?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen title="Project Binky - Episode 1  - Austin Mini GT-Four - Turbo Charged 4WD Mini"></iframe>',
+    metadata: {
+        author_name: 'Bad Obsession Motorsport',
+        author_url: 'https://www.youtube.com/@BadObsessionMotorsport',
+        height: 113,
+        provider_name: 'YouTube',
+        provider_url: 'https://www.youtube.com/',
+        thumbnail_height: 360,
+        thumbnail_url: 'https://i.ytimg.com/vi/7hCPODjJO7s/hqdefault.jpg',
+        thumbnail_width: '480',
+        title: 'Project Binky - Episode 1  - Austin Mini GT-Four - Turbo Charged 4WD Mini',
+        version: '1.0',
+        width: 200
+    },
+    embedType: 'video',
+    url: 'https://www.youtube.com/watch?v=7hCPODjJO7s'
+};
+
 describe('EmbedNode', function () {
     let editor;
     let dataset;
+    let exportOptions;
 
     // NOTE: all tests should use this function, without it you need manual
     // try/catch and done handling to avoid assertion failures not triggering
@@ -34,6 +55,10 @@ describe('EmbedNode', function () {
             html: '<p>test</p>',
             metadata: {},
             caption: 'caption text'
+        };
+
+        exportOptions = {
+            dom
         };
     });
 
@@ -129,6 +154,198 @@ describe('EmbedNode', function () {
             embedNode.url = '';
             embedNode.html = '';
             embedNode.isEmpty().should.be.true();
+        }));
+    });
+
+    describe('exportDOM', function () {
+        it('renders embed html with no metadata', editorTest(function () {
+            const embedNode = $createEmbedNode(dataset);
+            const {element} = embedNode.exportDOM(exportOptions);
+
+            const expectedHtml = `
+                <figure class="kg-card kg-embed-card kg-card-hascaption">
+                    ${dataset.html}
+                    <figcaption>caption text</figcaption>
+                </figure>
+            `;
+
+            const prettyExpectedHtml = Prettier.format(expectedHtml, {parser: 'html'});
+
+            element.outerHTML.should.prettifyTo(prettyExpectedHtml);
+        }));
+
+        it('renders a twitter embed without api token', editorTest(function () {
+            const embedNode = $createEmbedNode({
+                url: 'https://twitter.com/ghost/status/1395670367216619520',
+                embedType: 'twitter',
+                html: '<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Ghost 4.0 is out now! 🎉</p>&mdash; Ghost (@ghost) <a href="https://twitter.com/ghost/status/1395670367216619520?ref_src=twsrc%5Etfw">May 21, 2021</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>',
+                metadata: {
+                    height: 500,
+                    provider_name: 'Twitter',
+                    provider_url: 'https://twitter.com',
+                    thumbnail_height: 150,
+                    thumbnail_url: 'https://pbs.twimg.com/media/E1Y1q3bXMAU7m4n?format=jpg&name=small',
+                    thumbnail_width: 150,
+                    title: 'Ghost on Twitter: "Ghost 4.0 is out now! 🎉"',
+                    type: 'rich',
+                    version: '1.0',
+                    width: 550
+                },
+                caption: 'caption text'
+            });
+            const {element} = embedNode.exportDOM(exportOptions);
+
+            const expectedHtml = `
+                <figure class="kg-card kg-embed-card kg-card-hascaption">
+                    <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Ghost 4.0 is out now! 🎉</p>— Ghost (@ghost) <a href="https://twitter.com/ghost/status/1395670367216619520?ref_src=twsrc%5Etfw">May 21, 2021</a></blockquote> <script async="" src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+                    <figcaption>caption text</figcaption>
+                </figure>
+            `;
+
+            const prettyExpectedHtml = Prettier.format(expectedHtml, {parser: 'html'});
+
+            element.outerHTML.should.prettifyTo(prettyExpectedHtml);
+        }));
+
+        it('renders a twitter embed with api token data', editorTest(function () {
+            // tweetdata is ignored unless sent via email
+            const tweetData = {
+                id: '1630581157568839683',
+                created_at: '2023-02-28T14:50:17.000Z',
+                author_id: '767545134',
+                edit_history_tweet_ids: ['1630581157568839683'],
+                public_metrics: {
+                    retweet_count: 10,
+                    reply_count: 2,
+                    like_count: 38,
+                    quote_count: 6,
+                    impression_count: 10770
+                },
+                text: 'With the decline of traditional local news outlets, publishers like @MadisonMinutes, @RANGEMedia4all, and @sfsimplified are leading the charge in creating sustainable, community-driven journalism through websites and newsletters.\n' +
+                    '\n' +
+                    'Check out their impact 👇\n' +
+                    'https://t.co/RdNNyY18Iv',
+                lang: 'en',
+                conversation_id: '1630581157568839683',
+                possibly_sensitive: false,
+                reply_settings: 'everyone'
+            };
+
+            const embedNode = $createEmbedNode({
+                url: 'https://twitter.com/ghost/status/1395670367216619520',
+                embedType: 'twitter',
+                html: '<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Ghost 4.0 is out now! 🎉</p>&mdash; Ghost (@ghost) <a href="https://twitter.com/ghost/status/1395670367216619520?ref_src=twsrc%5Etfw">May 21, 2021</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>',
+                metadata: {
+                    tweet_data: tweetData,
+                    height: 500,
+                    provider_name: 'Twitter',
+                    provider_url: 'https://twitter.com',
+                    thumbnail_height: 150,
+                    thumbnail_url: 'https://pbs.twimg.com/media/E1Y1q3bXMAU7m4n?format=jpg&name=small',
+                    thumbnail_width: 150,
+                    title: 'Ghost on Twitter: "Ghost 4.0 is out now! 🎉"',
+                    type: 'rich',
+                    version: '1.0',
+                    width: 550
+                },
+                caption: 'caption text'
+            });
+            const {element} = embedNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.containEql('<blockquote class="twitter-tweet"');
+        }));
+
+        it('renders a twitter embed with api token data for email', editorTest(function () {
+            const options = {
+                target: 'email'
+            };
+            const tweetData = {
+                id: '1630581157568839683',
+                created_at: '2023-02-28T14:50:17.000Z',
+                author_id: '767545134',
+                edit_history_tweet_ids: ['1630581157568839683'],
+                public_metrics: {
+                    retweet_count: 10,
+                    reply_count: 2,
+                    like_count: 38,
+                    quote_count: 6,
+                    impression_count: 10770
+                },
+                text: 'With the decline of traditional local news outlets, publishers like @MadisonMinutes, @RANGEMedia4all, and @sfsimplified are leading the charge in creating sustainable, community-driven journalism through websites and newsletters.\n' +
+                    '\n' +
+                    'Check out their impact 👇\n' +
+                    'https://t.co/RdNNyY18Iv',
+                lang: 'en',
+                conversation_id: '1630581157568839683',
+                possibly_sensitive: false,
+                reply_settings: 'everyone',
+                entities: {
+                    mentions: [
+                        {
+                            start: 68,
+                            end: 83,
+                            username: 'MadisonMinutes',
+                            id: '1371572739333632001'
+                        },
+                        {
+                            start: 85,
+                            end: 100,
+                            username: 'RANGEMedia4all',
+                            id: '1448389854207770627'
+                        },
+                        {
+                            start: 106,
+                            end: 119,
+                            username: 'sfsimplified',
+                            id: '1351509902548738048'
+                        }
+                    ]
+                }
+            };
+
+            const embedNode = $createEmbedNode({
+                url: 'https://twitter.com/ghost/status/1395670367216619520',
+                embedType: 'twitter',
+                html: '<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Ghost 4.0 is out now! 🎉</p>&mdash; Ghost (@ghost) <a href="https://twitter.com/ghost/status/1395670367216619520?ref_src=twsrc%5Etfw">May 21, 2021</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>',
+                metadata: {
+                    tweet_data: tweetData,
+                    height: 500,
+                    provider_name: 'Twitter',
+                    provider_url: 'https://twitter.com',
+                    thumbnail_height: 150,
+                    thumbnail_url: 'https://pbs.twimg.com/media/E1Y1q3bXMAU7m4n?format=jpg&name=small',
+                    thumbnail_width: 150,
+                    title: 'Ghost on Twitter: "Ghost 4.0 is out now! 🎉"',
+                    type: 'rich',
+                    version: '1.0',
+                    width: 550
+                },
+                caption: 'caption text'
+            });
+            const {element} = embedNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.containEql('<table cellspacing="0" cellpadding="0" border="0" class="kg-twitter-card">');
+            element.outerHTML.should.containEql(`<a href="https://twitter.com/twitter/status/${tweetData.id}"`);
+        }));
+
+        it('renders video in email', editorTest(function () {
+            const options = {
+                target: 'email'
+            };
+            const embedNode = $createEmbedNode(youtubeEmbed);
+            const {element} = embedNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.containEql('<!--[if !mso !vml]-->');
+            element.outerHTML.should.containEql('<a class="kg-video-preview"');
+            element.outerHTML.should.containEql('<!--[if vml]>');
+            element.outerHTML.should.containEql('<v:group xmlns');
+        }));
+
+        it('renders empty span with missing data', editorTest(function () {
+            const embedNode = $createEmbedNode();
+            const {element} = embedNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.equal('<span></span>');
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/file.test.js
+++ b/packages/kg-default-nodes/test/nodes/file.test.js
@@ -79,6 +79,88 @@ describe('FileNode', function () {
         }));
     });
 
+    describe('exportDOM', function () {
+        it('creates a file card', editorTest(function () {
+            const fileNode = $createFileNode(dataset);
+            const {element} = fileNode.exportDOM(exportOptions);
+            element.outerHTML.should.equal(`<div class="kg-card kg-file-card"><a class="kg-file-card-container" href="/content/files/2023/03/IMG_0196.jpeg" title="Download" download=""><div class="kg-file-card-contents"><div class="kg-file-card-title">Cool image to download</div><div class="kg-file-card-caption">This is a description</div><div class="kg-file-card-metadata"><div class="kg-file-card-filename">IMG_0196.jpeg</div><div class="kg-file-card-filesize">121 KB</div></div></div><div class="kg-file-card-icon"><svg viewBox="0 0 24 24"><defs><style>.a{fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5px;}</style></defs><title>download-circle</title><polyline class="a" points="8.25 14.25 12 18 15.75 14.25"></polyline><line class="a" x1="12" y1="6.75" x2="12" y2="18"></line><circle class="a" cx="12" cy="12" r="11.25"></circle></svg></div></a></div>`);
+        }));
+
+        describe('email template', function () {
+            beforeEach(function () {
+                exportOptions.target = 'email';
+                exportOptions.postUrl = 'https://example.com/post';
+            });
+
+            it('renders complete email template with all fields', editorTest(function () {
+                const fileNode = $createFileNode(dataset);
+                const {element} = fileNode.exportDOM(exportOptions);
+
+                // Check basic structure
+                element.tagName.should.equal('TABLE');
+                element.className.should.equal('kg-file-card');
+
+                // Check title is present and linked
+                const titleLink = element.querySelector('.kg-file-title');
+                titleLink.textContent.should.equal('Cool image to download');
+                titleLink.closest('a').href.should.equal('https://example.com/post');
+
+                // Check caption is present and linked
+                const descriptionLink = element.querySelector('.kg-file-description');
+                descriptionLink.textContent.should.equal('This is a description');
+                descriptionLink.closest('a').href.should.equal('https://example.com/post');
+
+                // Check metadata
+                const metaLink = element.querySelector('.kg-file-meta');
+                metaLink.innerHTML.should.containEql('IMG_0196.jpeg');
+                metaLink.innerHTML.should.containEql('121 KB');
+
+                // Check icon
+                const icon = element.querySelector('img');
+                icon.src.should.equal('https://static.ghost.org/v4.0.0/images/download-icon-darkmode.png');
+                icon.style.height.should.equal('24px');
+            }));
+
+            it('renders email template without title and caption', editorTest(function () {
+                const minimalDataset = {
+                    src: '/content/files/2023/03/IMG_0196.jpeg',
+                    fileName: 'IMG_0196.jpeg',
+                    fileSize: 123456
+                };
+                const fileNode = $createFileNode(minimalDataset);
+                const {element} = fileNode.exportDOM(exportOptions);
+
+                // Should not have title
+                should.not.exist(element.querySelector('.kg-file-title'));
+
+                // Should not have caption
+                should.not.exist(element.querySelector('.kg-file-description'));
+
+                // Should have smaller icon
+                const icon = element.querySelector('img');
+                icon.style.height.should.equal('20px');
+            }));
+
+            it('properly escapes HTML in all fields', editorTest(function () {
+                const datasetWithHtml = {
+                    ...dataset,
+                    fileTitle: 'Title with <script>alert("xss")</script>',
+                    fileCaption: 'Caption with <strong>html</strong>',
+                    fileName: 'file<.html'
+                };
+                const fileNode = $createFileNode(datasetWithHtml);
+                const {element} = fileNode.exportDOM(exportOptions);
+
+                const html = element.innerHTML;
+                html.should.not.containEql('<script>');
+                html.should.not.containEql('<strong>');
+                html.should.containEql('file&lt;.html');
+                html.should.containEql('Title with ');
+                html.should.containEql('Caption with ');
+            }));
+        });
+    });
+
     describe('getType', function () {
         it('returns the correct node type', editorTest(function () {
             FileNode.getType().should.equal('file');

--- a/packages/kg-default-nodes/test/nodes/gallery.test.js
+++ b/packages/kg-default-nodes/test/nodes/gallery.test.js
@@ -1,4 +1,4 @@
-const {createDocument, html} = require('../test-utils');
+const {createDocument, dom, html} = require('../test-utils');
 const {$getRoot} = require('lexical');
 const {createHeadlessEditor} = require('@lexical/headless');
 const {$generateNodesFromDOM} = require('@lexical/html');
@@ -12,6 +12,7 @@ const editorNodes = [GalleryNode, ImageNode];
 describe('GalleryNode', function () {
     let editor;
     let dataset;
+    let exportOptions;
 
     // NOTE: all tests should use this function, without it you need manual
     // try/catch and done handling to avoid assertion failures not triggering
@@ -93,6 +94,20 @@ describe('GalleryNode', function () {
                 }
             ],
             caption: 'Test caption'
+        };
+
+        exportOptions = {
+            imageOptimization: {
+                defaultMaxWidth: 2000,
+                contentImageSizes: {
+                    w600: {width: 600},
+                    w1000: {width: 1000},
+                    w1600: {width: 1600},
+                    w2400: {width: 2400}
+                }
+            },
+            canTransformImage: () => true,
+            dom
         };
     });
 
@@ -609,6 +624,587 @@ describe('GalleryNode', function () {
                 const nodes = $generateNodesFromDOM(editor, document);
                 nodes.length.should.not.equal(1);
                 nodes[0].getType().should.not.equal('gallery');
+            }));
+        });
+    });
+
+    describe('exportDOM', function () {
+        it('renders empty span with no images', editorTest(function () {
+            const galleryNode = $createGalleryNode({images: [], caption: null});
+            const {element} = galleryNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.equal('<span></span>');
+        }));
+
+        it('renders empty span no valid images', editorTest(function () {
+            const galleryNode = $createGalleryNode({images: [{src: 'undefined'}], caption: null});
+            const {element} = galleryNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.equal('<span></span>');
+        }));
+
+        it('renders', editorTest(function () {
+            const galleryNode = $createGalleryNode(dataset);
+            const {element} = galleryNode.exportDOM({...exportOptions, canTransformImage: () => false});
+
+            element.outerHTML.should.prettifyTo(html`
+                <figure class="kg-card kg-gallery-card kg-width-wide kg-card-hascaption">
+                    <div class="kg-gallery-container">
+                        <div class="kg-gallery-row">
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-9.jpg" width="3200" height="1600" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo02-10.jpg" width="3200" height="1600" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo03-6.jpg" width="3200" height="1600" loading="lazy" alt="" /></div>
+                        </div>
+                        <div class="kg-gallery-row">
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo04-7.jpg" width="3200" height="1600" loading="lazy" alt="Alt test" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo05-4.jpg" width="3200" height="1600" loading="lazy" alt="" title="Title test" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo06-6.jpg" width="3200" height="1600" loading="lazy" alt="" /></div>
+                        </div>
+                        <div class="kg-gallery-row">
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo07-5.jpg" width="3200" height="1600" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image">
+                                <a href="https://example.com"><img src="/content/images/2018/08/NatGeo09-8.jpg" width="3200" height="1600" loading="lazy" alt="" /></a>
+                            </div>
+                        </div>
+                    </div>
+                    <figcaption>Test caption</figcaption>
+                </figure>
+            `);
+        }));
+
+        it('renders images with alt text', editorTest(function () {
+            const galleryNode = $createGalleryNode({
+                images: [
+                    {
+                        row: 0,
+                        fileName: 'NatGeo01.jpg',
+                        src: '/content/images/2018/08/NatGeo01-9.jpg',
+                        width: 3200,
+                        height: 1600,
+                        alt: 'alt test'
+                    }
+                ],
+                caption: 'Test caption'
+            });
+            const {element} = galleryNode.exportDOM({...exportOptions, canTransformImage: () => false});
+
+            element.outerHTML.should.prettifyTo(html`
+                <figure class="kg-card kg-gallery-card kg-width-wide kg-card-hascaption">
+                    <div class="kg-gallery-container">
+                        <div class="kg-gallery-row">
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-9.jpg" width="3200" height="1600" loading="lazy" alt="alt test" /></div>
+                        </div>
+                    </div>
+                    <figcaption>Test caption</figcaption>
+                </figure>
+            `);
+        }));
+
+        it('renders images with blank alt text', editorTest(function () {
+            const galleryNode = $createGalleryNode({
+                images: [
+                    {
+                        row: 0,
+                        fileName: 'NatGeo01.jpg',
+                        src: '/content/images/2018/08/NatGeo01-9.jpg',
+                        width: 3200,
+                        height: 1600
+                    }
+                ],
+                caption: 'Test caption'
+            });
+            const {element} = galleryNode.exportDOM({...exportOptions, canTransformImage: () => false});
+
+            element.outerHTML.should.prettifyTo(html`
+                <figure class="kg-card kg-gallery-card kg-width-wide kg-card-hascaption">
+                    <div class="kg-gallery-container">
+                        <div class="kg-gallery-row">
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-9.jpg" width="3200" height="1600" loading="lazy" alt="" /></div>
+                        </div>
+                    </div>
+                    <figcaption>Test caption</figcaption>
+                </figure>
+            `);
+        }));
+
+        it('skips invalid images', editorTest(function () {
+            const galleryNode = $createGalleryNode({
+                images: [
+                    {
+                        row: 0,
+                        fileName: 'NatGeo01.jpg',
+                        src: '/content/images/2018/08/NatGeo01-9.jpg',
+                        width: 3200,
+                        height: 1600
+                    },
+                    {
+                        row: 0,
+                        fileName: 'NatGeo02.jpg',
+                        src: '/content/images/2018/08/NatGeo02-10.jpg'
+                    },
+                    {
+                        row: 0,
+                        fileName: 'NatGeo03.jpg',
+                        src: '/content/images/2018/08/NatGeo03-6.jpg',
+                        width: 3200,
+                        height: 1600
+                    }
+                ],
+                caption: 'Test caption'
+            });
+            const {element} = galleryNode.exportDOM({...exportOptions, canTransformImage: () => false});
+
+            element.outerHTML.should.prettifyTo(html`
+                <figure class="kg-card kg-gallery-card kg-width-wide kg-card-hascaption">
+                    <div class="kg-gallery-container">
+                        <div class="kg-gallery-row">
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-9.jpg" width="3200" height="1600" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo03-6.jpg" width="3200" height="1600" loading="lazy" alt="" /></div>
+                        </div>
+                    </div>
+                    <figcaption>Test caption</figcaption>
+                </figure>
+            `);
+        }));
+
+        it('outputs width/height matching default max image width', editorTest(function () {
+            const galleryNode = $createGalleryNode({
+                images: [
+                    {
+                        row: 0,
+                        fileName: 'NatGeo01.jpg',
+                        src: '/content/images/2018/08/NatGeo01-9.jpg',
+                        width: 3200,
+                        height: 1600
+                    },
+                    {
+                        row: 0,
+                        fileName: 'photo-1591672299888-e16a08b6c7ce',
+                        src: 'https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=2000&fit=max&ixid=eyJhcHBfaWQiOjExNzczfQ',
+                        width: 2500,
+                        height: 1800
+                    }
+                ]
+            });
+
+            const {element} = galleryNode.exportDOM(exportOptions);
+
+            const output = element.outerHTML;
+
+            // local is resized
+            output.should.match(/width="2000"/);
+            output.should.match(/height="1000"/);
+            output.should.not.match(/width="3200"/);
+            output.should.not.match(/height="1600"/);
+
+            // unsplash is not
+            output.should.match(/width="2500"/);
+            output.should.match(/height="1800"/);
+        }));
+
+        it('renders all 9 images in a 3x3 grid', editorTest(function () {
+            const galleryNode = $createGalleryNode({
+                type: 'gallery',
+                version: 1,
+                images: [
+                    {
+                        row: 0,
+                        src: '/content/images/2018/08/NatGeo01-1.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-1.jpg'
+                    },
+                    {
+                        row: 0,
+                        src: '/content/images/2018/08/NatGeo01-2.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-2.jpg'
+                    },
+                    {
+                        row: 0,
+                        src: '/content/images/2018/08/NatGeo01-3.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-3.jpg'
+                    },
+                    {
+                        row: 1,
+                        src: '/content/images/2018/08/NatGeo01-4.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-4.jpg'
+                    },
+                    {
+                        row: 1,
+                        src: '/content/images/2018/08/NatGeo01-5.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-5.jpg'
+                    },
+                    {
+                        row: 1,
+                        src: '/content/images/2018/08/NatGeo01-6.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-6.jpg'
+                    },
+                    {
+                        row: 2,
+                        src: '/content/images/2018/08/NatGeo01-7.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-7.jpg'
+                    },
+                    {
+                        row: 2,
+                        src: '/content/images/2018/08/NatGeo01-8.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-8.jpg'
+                    },
+                    {
+                        row: 2,
+                        src: '/content/images/2018/08/NatGeo01-9.jpg',
+                        width: 3200,
+                        height: 1600,
+                        fileName: 'NatGeo01-9.jpg'
+                    }
+                ],
+                caption: ''
+            });
+
+            // skip srcset
+            delete exportOptions.imageOptimization.contentImageSizes;
+            const {element} = galleryNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(html`
+                <figure class="kg-card kg-gallery-card kg-width-wide">
+                    <div class="kg-gallery-container">
+                        <div class="kg-gallery-row">
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-1.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-2.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-3.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                        </div>
+                        <div class="kg-gallery-row">
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-4.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-5.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-6.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                        </div>
+                        <div class="kg-gallery-row">
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-7.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-8.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                            <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-9.jpg" width="2000" height="1000" loading="lazy" alt="" /></div>
+                        </div>
+                    </div>
+                </figure>
+            `);
+        }));
+
+        describe('srcset', function () {
+            it('is included when image src is relative or Unsplash', editorTest(function () {
+                const galleryNode = $createGalleryNode({
+                    images: [{
+                        row: 0,
+                        fileName: 'NatGeo01.jpg',
+                        src: '/content/images/2018/08/NatGeo01-9.jpg',
+                        width: 3200,
+                        height: 1600
+                    }, {
+                        row: 0,
+                        fileName: 'NatGeo02.jpg',
+                        src: '/subdir/support/content/images/2018/08/NatGeo01-9.jpg',
+                        width: 3200,
+                        height: 1600
+                    }, {
+                        row: 0,
+                        fileName: 'photo-1591672299888-e16a08b6c7ce',
+                        src: 'https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=2000&fit=max&ixid=eyJhcHBfaWQiOjExNzczfQ',
+                        width: 2000,
+                        height: 1600
+                    }]
+                });
+
+                delete exportOptions.imageOptimization.defaultMaxWidth;
+                const {element} = galleryNode.exportDOM(exportOptions);
+
+                element.outerHTML.should.prettifyTo(html`
+                    <figure class="kg-card kg-gallery-card kg-width-wide">
+                        <div class="kg-gallery-container">
+                            <div class="kg-gallery-row">
+                                <div class="kg-gallery-image"><img src="/content/images/2018/08/NatGeo01-9.jpg" width="3200" height="1600" loading="lazy" alt="" srcset="/content/images/size/w600/2018/08/NatGeo01-9.jpg 600w, /content/images/size/w1000/2018/08/NatGeo01-9.jpg 1000w, /content/images/size/w1600/2018/08/NatGeo01-9.jpg 1600w, /content/images/size/w2400/2018/08/NatGeo01-9.jpg 2400w" sizes="(min-width: 720px) 720px" /></div>
+                                <div class="kg-gallery-image"><img src="/subdir/support/content/images/2018/08/NatGeo01-9.jpg" width="3200" height="1600" loading="lazy" alt="" srcset="/subdir/support/content/images/size/w600/2018/08/NatGeo01-9.jpg 600w, /subdir/support/content/images/size/w1000/2018/08/NatGeo01-9.jpg 1000w, /subdir/support/content/images/size/w1600/2018/08/NatGeo01-9.jpg 1600w, /subdir/support/content/images/size/w2400/2018/08/NatGeo01-9.jpg 2400w" sizes="(min-width: 720px) 720px" /></div>
+                                <div class="kg-gallery-image"><img src="https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=2000&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ" width="2000" height="1600" loading="lazy" alt="" srcset="https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=600&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 600w, https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=1000&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 1000w, https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=1600&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 1600w, https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=2000&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 2000w" sizes="(min-width: 720px) 720px" /></div>
+                            </div>
+                        </div>
+                    </figure>
+                `);
+            }));
+
+            it('is included when image src is absolute or __GHOST_URL__', editorTest(function () {
+                const galleryNode = $createGalleryNode({
+                    images: [{
+                        row: 0,
+                        fileName: 'NatGeo01.jpg',
+                        src: 'https://localhost:2368/content/images/2018/08/NatGeo01-9.jpg',
+                        width: 3200,
+                        height: 1600
+                    }, {
+                        row: 0,
+                        fileName: 'NatGeo02.jpg',
+                        src: '__GHOST_URL__/content/images/2018/08/NatGeo01-9.jpg',
+                        width: 3200,
+                        height: 1600
+                    }]
+                });
+
+                delete exportOptions.imageOptimization.defaultMaxWidth;
+                exportOptions.siteUrl = 'https://localhost:2368';
+                const {element} = galleryNode.exportDOM(exportOptions);
+
+                element.outerHTML.should.prettifyTo(html`
+                    <figure class="kg-card kg-gallery-card kg-width-wide">
+                        <div class="kg-gallery-container">
+                            <div class="kg-gallery-row">
+                                <div class="kg-gallery-image"><img src="https://localhost:2368/content/images/2018/08/NatGeo01-9.jpg" width="3200" height="1600" loading="lazy" alt="" srcset="https://localhost:2368/content/images/size/w600/2018/08/NatGeo01-9.jpg 600w, https://localhost:2368/content/images/size/w1000/2018/08/NatGeo01-9.jpg 1000w, https://localhost:2368/content/images/size/w1600/2018/08/NatGeo01-9.jpg 1600w, https://localhost:2368/content/images/size/w2400/2018/08/NatGeo01-9.jpg 2400w" sizes="(min-width: 720px) 720px" /></div>
+                                <div class="kg-gallery-image"><img src="__GHOST_URL__/content/images/2018/08/NatGeo01-9.jpg" width="3200" height="1600" loading="lazy" alt="" srcset="__GHOST_URL__/content/images/size/w600/2018/08/NatGeo01-9.jpg 600w, __GHOST_URL__/content/images/size/w1000/2018/08/NatGeo01-9.jpg 1000w, __GHOST_URL__/content/images/size/w1600/2018/08/NatGeo01-9.jpg 1600w, __GHOST_URL__/content/images/size/w2400/2018/08/NatGeo01-9.jpg 2400w" sizes="(min-width: 720px) 720px" /></div>
+                            </div>
+                        </div>
+                    </figure>
+                `);
+            }));
+
+            it('is omitted when target === email', editorTest(function () {
+                const galleryNode = $createGalleryNode({
+                    images: [{
+                        row: 0,
+                        fileName: 'NatGeo01.jpg',
+                        src: '/content/images/2018/08/NatGeo01-9.jpg',
+                        width: 3200,
+                        height: 1600
+                    }]
+                });
+
+                delete exportOptions.imageOptimization.defaultMaxWidth;
+                exportOptions.target = 'email';
+                const {element} = galleryNode.exportDOM(exportOptions);
+
+                element.outerHTML.should.not.containEql('srcset=');
+            }));
+
+            it('is omitted when no contentImageSizes are passed as options', editorTest(function () {
+                const galleryNode = $createGalleryNode({
+                    images: [{
+                        row: 0,
+                        fileName: 'NatGeo01.jpg',
+                        src: '/content/images/2018/08/NatGeo01-9.jpg',
+                        width: 3200,
+                        height: 1600
+                    }]
+                });
+
+                delete exportOptions.imageOptimization.contentImageSizes;
+                const {element} = galleryNode.exportDOM(exportOptions);
+
+                element.outerHTML.should.not.containEql('srcset=');
+            }));
+
+            it('is omitted when `srcsets: false` is passed as an options', editorTest(function () {
+                const galleryNode = $createGalleryNode({
+                    images: [{
+                        row: 0,
+                        fileName: 'NatGeo01.jpg',
+                        src: '/content/images/2018/08/NatGeo01-9.jpg',
+                        width: 3200,
+                        height: 1600
+                    }]
+                });
+
+                exportOptions.imageOptimization.srcsets = false;
+                const {element} = galleryNode.exportDOM(exportOptions);
+
+                element.outerHTML.should.not.containEql('srcset=');
+            }));
+        });
+
+        describe('sizes', function () {
+            it('is included for images over 720px', editorTest(function () {
+                const galleryNode = $createGalleryNode({
+                    images: [{
+                        row: 0,
+                        fileName: 'standard.jpg',
+                        src: '/content/images/2018/08/standard.jpg',
+                        width: 720,
+                        height: 1600
+                    }, {
+                        row: 0,
+                        fileName: 'small.jpg',
+                        src: '/subdir/support/content/images/2018/08/small.jpg',
+                        width: 640,
+                        height: 1600
+                    }, {
+                        row: 0,
+                        fileName: 'photo',
+                        src: 'https://images.unsplash.com/photo?w=2000',
+                        width: 2000,
+                        height: 1600
+                    }]
+                });
+
+                const {element} = galleryNode.exportDOM(exportOptions);
+
+                const output = element.outerHTML;
+                const sizes = output.match(/sizes="(.*?)"/g);
+
+                sizes.length.should.equal(2);
+
+                output.should.match(/standard\.jpg 720w" sizes="\(min-width: 720px\) 720px"/);
+                output.should.match(/photo\?w=2000 2000w" sizes="\(min-width: 720px\) 720px"/);
+            }));
+
+            it('uses "wide" media query for large single-image galleries', editorTest(function () {
+                const galleryNode = $createGalleryNode({
+                    images: [{
+                        row: 0,
+                        fileName: 'standard.jpg',
+                        src: '/content/images/2018/08/standard.jpg',
+                        width: 2000,
+                        height: 1600
+                    }]
+                });
+
+                const {element} = galleryNode.exportDOM(exportOptions);
+
+                element.outerHTML.should.match(/standard\.jpg 2000w" sizes="\(min-width: 1200px\) 1200px"/);
+            }));
+
+            it('uses "standard" media query for medium single-image galleries', editorTest(function () {
+                const galleryNode = $createGalleryNode({
+                    images: [{
+                        row: 0,
+                        fileName: 'standard.jpg',
+                        src: '/content/images/2018/08/standard.jpg',
+                        width: 1000,
+                        height: 1600
+                    }]
+                });
+
+                const {element} = galleryNode.exportDOM(exportOptions);
+
+                element.outerHTML.should.match(/standard\.jpg 1000w" sizes="\(min-width: 720px\) 720px"/);
+            }));
+
+            it('is omitted when srcsets are not available', editorTest(function () {
+                const galleryNode = $createGalleryNode({
+                    images: [{
+                        row: 0,
+                        fileName: 'standard.jpg',
+                        src: '/content/images/2018/08/standard.jpg',
+                        width: 720,
+                        height: 1600
+                    }, {
+                        row: 0,
+                        fileName: 'small.jpg',
+                        src: '/subdir/support/content/images/2018/08/small.jpg',
+                        width: 640,
+                        height: 1600
+                    }, {
+                        row: 0,
+                        fileName: 'photo',
+                        src: 'https://images.unsplash.com/photo?w=2000',
+                        width: 2000,
+                        height: 1600
+                    }]
+                });
+
+                exportOptions.imageOptimization.srcsets = false;
+                const {element} = galleryNode.exportDOM(exportOptions);
+
+                const output = element.outerHTML;
+                const sizes = output.match(/sizes="(.*?)"/g);
+
+                should.not.exist(sizes);
+            }));
+        });
+
+        describe('email target', function () {
+            beforeEach(function () {
+                exportOptions.target = 'email';
+            });
+
+            it('adds width/height and uses resized images', editorTest(function () {
+                const galleryNode = $createGalleryNode({
+                    images: [{
+                        row: 0,
+                        fileName: 'standard.jpg',
+                        src: '/content/images/2018/08/standard.jpg',
+                        width: 720,
+                        height: 1600
+                    }, {
+                        row: 0,
+                        fileName: 'small.jpg',
+                        src: '/subdir/support/content/images/2018/08/small.jpg',
+                        width: 300,
+                        height: 800
+                    }, {
+                        row: 1,
+                        fileName: 'photo.jpg',
+                        src: '/content/images/2018/08/photo.jpg',
+                        width: 2000,
+                        height: 1600
+                    }, {
+                        row: 1,
+                        fileName: 'unsplash.jpg',
+                        src: 'https://images.unsplash.com/unsplash.jpg?w=2000',
+                        width: 2000,
+                        height: 1600
+                    }]
+                });
+
+                const {element} = galleryNode.exportDOM(exportOptions);
+                const output = element.outerHTML;
+
+                // 3 images wider than 600px template width resized to fit
+                output.match(/width="600"/g).length.should.equal(3);
+                // 1 image smaller than template width
+                output.should.match(/width="300"/);
+
+                output.should.match(/height="1333"/);
+                output.should.match(/height="800"/);
+                output.should.match(/height="480"/);
+
+                // original because image is < 1600
+                output.should.match(/\/content\/images\/2018\/08\/standard\.jpg/);
+                // original because image is < 300
+                output.should.match(/\/subdir\/support\/content\/images\/2018\/08\/small\.jpg/);
+                // resized because image is > 1600
+                output.should.match(/\/content\/images\/size\/w1600\/2018\/08\/photo\.jpg/);
+                // resized unsplash image
+                output.should.match(/https:\/\/images\.unsplash\.com\/unsplash\.jpg\?w=1200/);
+            }));
+
+            it('resizes width/height attributes but uses original image when local image can\'t be transformed', editorTest(function () {
+                const galleryNode = $createGalleryNode({
+                    images: [{
+                        row: 0,
+                        fileName: 'image.png',
+                        src: '/content/images/2020/06/image.png',
+                        width: 3000,
+                        height: 2000
+                    }]
+                });
+
+                exportOptions.canTransformImage = () => false;
+
+                const {element} = galleryNode.exportDOM(exportOptions);
+                const output = element.outerHTML;
+
+                output.should.not.match(/width="3000"/);
+                output.should.match(/width="600"/);
+                output.should.not.match(/height="2000"/);
+                output.should.match(/height="400"/);
+                output.should.not.match(/\/content\/images\/size\/w1600\/2020\/06\/image\.png/);
+                output.should.match(/\/content\/images\/2020\/06\/image\.png/);
             }));
         });
     });

--- a/packages/kg-default-nodes/test/nodes/header.test.js
+++ b/packages/kg-default-nodes/test/nodes/header.test.js
@@ -1,7 +1,8 @@
-const {createDocument} = require('../test-utils');
+const {createDocument, dom, html} = require('../test-utils');
 const {createHeadlessEditor} = require('@lexical/headless');
 const {$generateNodesFromDOM} = require('@lexical/html');
 const {HeaderNode, $createHeaderNode, $isHeaderNode} = require('../../');
+const {_} = require('lodash');
 
 const editorNodes = [HeaderNode];
 
@@ -9,6 +10,7 @@ describe('HeaderNode', function () {
     describe('v1', function () {
         let editor;
         let dataset;
+        let exportOptions;
 
         const editorTest = testFn => function (done) {
             editor.update(() => {
@@ -34,6 +36,10 @@ describe('HeaderNode', function () {
                 size: 'small',
                 style: 'image',
                 subheader: 'hello'
+            };
+
+            exportOptions = {
+                dom
             };
         });
 
@@ -126,6 +132,67 @@ describe('HeaderNode', function () {
             }));
         });
 
+        describe('exportDOM', function () {
+            it('can render to HTML', editorTest(function () {
+                const headerNode = $createHeaderNode(dataset);
+                const {element} = headerNode.exportDOM(exportOptions);
+                const expectedElement = html`
+                <div class="kg-card kg-header-card kg-width-full kg-size-small kg-style-image" data-kg-background-image="https://example.com/image.jpg" style="background-image: url(https://example.com/image.jpg)">
+                    <h2 class="kg-header-card-header" id="this-is-the-header-card">This is the header card</h2>
+                    <h3 class="kg-header-card-subheader" id="hello">hello</h3>
+                    <a class="kg-header-card-button" href="https://example.com/">The button</a>
+                </div>
+        `;
+                element.outerHTML.should.prettifyTo(expectedElement);
+            }));
+
+            it('renders nothing when header and subheader is undefined and the button is disabled', editorTest(function () {
+                const node = $createHeaderNode(dataset);
+                node.header = null;
+                node.subheader = null;
+                node.buttonEnabled = false;
+                const {element} = node.exportDOM(exportOptions);
+                element.should.be.null;
+            }));
+
+            it('renders a minimal header card', editorTest(function () {
+                let payload = {
+                    version: 1,
+                    backgroundImageSrc: '',
+                    buttonEnabled: false,
+                    buttonText: 'The button',
+                    buttonUrl: 'https://example.com/',
+                    header: 'hello world',
+                    size: 'small',
+                    style: 'dark',
+                    subheader: 'hello sub world'
+                };
+                const node = $createHeaderNode(payload);
+
+                const {element} = node.exportDOM(exportOptions);
+                const expectedElement = `<div class="kg-card kg-header-card kg-width-full kg-size-small kg-style-dark" data-kg-background-image="" style=""><h2 class="kg-header-card-header" id="hello-world">hello world</h2><h3 class="kg-header-card-subheader" id="hello-sub-world">hello sub world</h3></div>`;
+                element.outerHTML.should.equal(expectedElement);
+            }));
+
+            it('renders without subheader', editorTest(function () {
+                let payload = {
+                    version: 1,
+                    backgroundImageSrc: '',
+                    buttonEnabled: false,
+                    buttonText: 'The button',
+                    buttonUrl: 'https://example.com/',
+                    header: 'hello world',
+                    size: 'small',
+                    style: 'dark',
+                    subheader: ''
+                };
+                const node = $createHeaderNode(payload);
+
+                const {element} = node.exportDOM(exportOptions);
+                const expectedElement = `<div class="kg-card kg-header-card kg-width-full kg-size-small kg-style-dark" data-kg-background-image="" style=""><h2 class="kg-header-card-header" id="hello-world">hello world</h2></div>`;
+                element.outerHTML.should.equal(expectedElement);
+            }));
+        });
         describe('importDOM', function () {
             it('parses a header card', editorTest(function () {
                 const htmlstring = `
@@ -181,6 +248,7 @@ describe('HeaderNode', function () {
     describe('v2', function () {
         let editor;
         let dataset;
+        let exportOptions;
 
         const editorTest = testFn => function (done) {
             editor.update(() => {
@@ -212,6 +280,19 @@ describe('HeaderNode', function () {
                 buttonTextColor: '#FFFFFF',
                 layout: 'full',
                 swapped: false
+            };
+
+            exportOptions = {
+                imageOptimization: {
+                    contentImageSizes: {
+                        w600: {width: 600},
+                        w1000: {width: 1000},
+                        w1600: {width: 1600},
+                        w2400: {width: 2400}
+                    }
+                },
+                canTransformImage: () => true,
+                dom
             };
         });
 
@@ -353,6 +434,102 @@ describe('HeaderNode', function () {
             it('returns true', editorTest(function () {
                 const headerNode = $createHeaderNode(dataset);
                 headerNode.hasEditMode().should.be.true();
+            }));
+        });
+
+        describe('exportDOM', function () {
+            it('renders version 2 html', editorTest(function () {
+                const headerNode = $createHeaderNode(dataset);
+                const {element} = headerNode.exportDOM(exportOptions);
+
+                // Assuming outerHTML gets the full HTML string of the element
+                const renderedHtml = _.replace(element.outerHTML, /\s/g, '');
+                const expectedHtml = `
+                <div class="kg-card kg-header-card kg-v2 kg-width-full kg-content-wide " data-background-color="#F0F0F0">
+                <picture><img class="kg-header-card-image" src="https://example.com/image.jpg" loading="lazy" alt=""></picture>
+                    <div class="kg-header-card-content">
+                        <div class="kg-header-card-text kg-align-center">
+                            <h2 id="this-is-the-header-card" class="kg-header-card-heading" style="color: #000000;" data-text-color="#000000">This is the header card</h2>
+                            <p id="hello" class="kg-header-card-subheading" style="color: #000000;" data-text-color="#000000">hello</p>
+                            <a href="https://example.com/" class="kg-header-card-button " style="background-color: #000000;color: #FFFFFF;" data-button-color="#000000" data-button-text-color="#FFFFFF">The button</a>
+                        </div>
+                    </div>
+                </div>
+                `;
+                const cleanedExpectedHtml = _.replace(expectedHtml, /\s/g, '');
+                renderedHtml.should.equal(cleanedExpectedHtml);
+            }));
+
+            it('renders nothing when header and subheader is undefined and the button is disabled', editorTest(function () {
+                const node = $createHeaderNode(dataset);
+                node.header = null;
+                node.subheader = null;
+                node.buttonEnabled = false;
+                const {element} = node.exportDOM(exportOptions);
+                element.should.be.null;
+            }));
+
+            it('renders without subheader', editorTest(function () {
+                let payload = {
+                    version: 2,
+                    backgroundImageSrc: '',
+                    buttonEnabled: false,
+                    buttonText: 'The button',
+                    buttonUrl: 'https://example.com/',
+                    header: 'hello world',
+                    size: 'small',
+                    style: 'dark',
+                    subheader: ''
+                };
+                const node = $createHeaderNode(payload);
+
+                const {element} = node.exportDOM(exportOptions);
+                const renderedHtml = _.replace(element.outerHTML, /\s/g, '');
+                const expectedHtml = `
+                <div class="kg-card kg-header-card kg-v2 kg-width-full kg-content-wide " style="background-color: #000000;" data-background-color="#000000">
+                    <div class="kg-header-card-content">
+                        <div class="kg-header-card-text kg-align-center">
+                        <h2 id="hello-world" class="kg-header-card-heading" style="color: #FFFFFF;" data-text-color="#FFFFFF">hello world</h2>
+                        </div>
+                    </div>
+                </div>
+                `;
+
+                const cleanedExpectedHtml = _.replace(expectedHtml, /\s/g, '');
+                renderedHtml.should.equal(cleanedExpectedHtml);
+            }));
+
+            it('renders with srcset', editorTest(function () {
+                let payload = {
+                    version: 2,
+                    backgroundImageSrc: '/content/images/2022/11/koenig-lexical.jpg',
+                    backgroundImageWidth: 3840,
+                    backgroundImageHeight: 2160,
+                    buttonEnabled: false,
+                    buttonText: 'The button',
+                    buttonUrl: 'https://example.com/',
+                    header: 'hello world',
+                    size: 'small',
+                    style: 'dark',
+                    subheader: ''
+                };
+                const node = $createHeaderNode(payload);
+
+                const {element} = node.exportDOM(exportOptions);
+                const renderedHtml = _.replace(element.outerHTML, /\s/g, '');
+                const expectedHtml = `
+                <div class="kg-card kg-header-card kg-v2 kg-width-full kg-content-wide " data-background-color="#000000">
+                    <picture><img class="kg-header-card-image" src="/content/images/2022/11/koenig-lexical.jpg" srcset="/content/images/size/w600/2022/11/koenig-lexical.jpg 600w, /content/images/size/w1000/2022/11/koenig-lexical.jpg 1000w, /content/images/size/w1600/2022/11/koenig-lexical.jpg 1600w, /content/images/size/w2400/2022/11/koenig-lexical.jpg 2400w" loading="lazy" alt=""></picture>
+                    <div class="kg-header-card-content">
+                        <div class="kg-header-card-text kg-align-center">
+                        <h2 id="hello-world" class="kg-header-card-heading" style="color: #FFFFFF;" data-text-color="#FFFFFF">hello world</h2>
+                        </div>
+                    </div>
+                </div>
+                `;
+
+                const cleanedExpectedHtml = _.replace(expectedHtml, /\s/g, '');
+                renderedHtml.should.equal(cleanedExpectedHtml);
             }));
         });
     });

--- a/packages/kg-default-nodes/test/nodes/horizontalrule.test.js
+++ b/packages/kg-default-nodes/test/nodes/horizontalrule.test.js
@@ -1,4 +1,4 @@
-const {createDocument, html} = require('../test-utils');
+const {createDocument, dom, html} = require('../test-utils');
 const {$getRoot} = require('lexical');
 const {createHeadlessEditor} = require('@lexical/headless');
 const {$generateNodesFromDOM} = require('@lexical/html');
@@ -9,6 +9,7 @@ const editorNodes = [HorizontalRuleNode];
 describe('HorizontalNode', function () {
     let editor;
     let dataset;
+    let exportOptions;
 
     // NOTE: all tests should use this function, without it you need manual
     // try/catch and done handling to avoid assertion failures not triggering
@@ -28,12 +29,27 @@ describe('HorizontalNode', function () {
         editor = createHeadlessEditor({nodes: editorNodes});
 
         dataset = {};
+
+        exportOptions = {
+            dom
+        };
     });
 
     it('matches node with $isHorizontalRuleNode', editorTest(function () {
         const hrNode = $createHorizontalRuleNode();
         $isHorizontalRuleNode(hrNode).should.be.true();
     }));
+
+    describe('exportDOM', function () {
+        it('creates hr element', editorTest(function () {
+            const hrNode = $createHorizontalRuleNode();
+            const {element} = hrNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(html`
+                <hr />
+            `);
+        }));
+    });
 
     describe('importDOM', function () {
         it('parses an hr element', editorTest(function () {

--- a/packages/kg-default-nodes/test/nodes/html.test.js
+++ b/packages/kg-default-nodes/test/nodes/html.test.js
@@ -1,15 +1,16 @@
-const {createDocument, html} = require('../test-utils');
+const {createDocument, dom, html} = require('../test-utils');
 const {createHeadlessEditor} = require('@lexical/headless');
 const {$getRoot} = require('lexical');
 const {HtmlNode, $createHtmlNode, $isHtmlNode, utils} = require('../../');
 const {$generateNodesFromDOM} = require('@lexical/html');
 
 const editorNodes = [HtmlNode];
-const {ALL_MEMBERS_SEGMENT} = utils.visibility;
+const {ALL_MEMBERS_SEGMENT, NO_MEMBERS_SEGMENT} = utils.visibility;
 
 describe('HtmlNode', function () {
     let editor;
     let dataset;
+    let exportOptions;
 
     // NOTE: all tests should use this function, without it you need manual
     // try/catch and done handling to avoid assertion failures not triggering
@@ -32,6 +33,10 @@ describe('HtmlNode', function () {
 
         dataset = {
             html: '<p>Paragraph with:</p><ul><li>list</li><li>items</li></ul>'
+        };
+
+        exportOptions = {
+            dom
         };
     });
 
@@ -141,6 +146,198 @@ describe('HtmlNode', function () {
             const htmlNode = $createHtmlNode(dataset);
             htmlNode.hasEditMode().should.be.true();
         }));
+    });
+
+    describe('exportDOM', function () {
+        it('creates a html card', editorTest(function () {
+            const htmlNode = $createHtmlNode(dataset);
+            const {element, type} = htmlNode.exportDOM(exportOptions);
+            type.should.equal('value');
+            element.value.should.prettifyTo(html`
+                <!--kg-card-begin: html-->
+                <p>Paragraph with:</p>
+                <ul>
+                    <li>list</li>
+                    <li>items</li>
+                </ul>
+                <!--kg-card-end: html-->
+            `);
+        }));
+
+        it('renders an empty span with missing html', editorTest(function () {
+            const htmlNode = $createHtmlNode();
+            const {element, type} = htmlNode.exportDOM(exportOptions);
+            type.should.equal('inner');
+
+            element.outerHTML.should.equal('<span></span>');
+        }));
+
+        it('renders unclosed tags', editorTest(function () {
+            const htmlNode = $createHtmlNode({html: '<div style="color:red">'});
+            const {element, type} = htmlNode.exportDOM(exportOptions);
+            type.should.equal('value');
+
+            // do not prettify, it will add a closing tag to the compared string causing a false pass
+            element.value.should.equal('\n<!--kg-card-begin: html-->\n<div style="color:red">\n<!--kg-card-end: html-->\n');
+        }));
+
+        it('renders html entities', editorTest(function () {
+            const htmlNode = $createHtmlNode({html: '<p>&lt;pre&gt;Test&lt;/pre&gt;</p>'});
+            const {element, type} = htmlNode.exportDOM(exportOptions);
+            type.should.equal('value');
+
+            element.value.should.equal('\n<!--kg-card-begin: html-->\n<p>&lt;pre&gt;Test&lt;/pre&gt;</p>\n<!--kg-card-end: html-->\n');
+        }));
+
+        it('handles single-quote attributes', editorTest(function () {
+            const htmlNode = $createHtmlNode({html: '<div data-graph-name=\'The "all-in" cost of a grant\'>Test</div>'});
+            const {element, type} = htmlNode.exportDOM(exportOptions);
+            type.should.equal('value');
+
+            element.value.should.equal('\n<!--kg-card-begin: html-->\n<div data-graph-name=\'The "all-in" cost of a grant\'>Test</div>\n<!--kg-card-end: html-->\n');
+        }));
+
+        describe('feature.contentVisibility', function () {
+            beforeEach(function () {
+                exportOptions.feature = {
+                    contentVisibility: true
+                };
+            });
+
+            describe('with old visibility settings', function () {
+                function testWebRender(visibility) {
+                    const htmlNode = $createHtmlNode({html: '<div>Test</div>', visibility});
+                    const {element, type} = htmlNode.exportDOM(exportOptions);
+                    type.should.equal('value');
+                    element.value.should.equal('\n<!--kg-card-begin: html-->\n<div>Test</div>\n<!--kg-card-end: html-->\n');
+                }
+
+                function testEmailRender(visibility) {
+                    const htmlNode = $createHtmlNode({html: '<div>Test</div>', visibility});
+                    const {element, type} = htmlNode.exportDOM({...exportOptions, target: 'email'});
+                    const expectedContents = '<!--kg-card-begin: html-->\n<div>Test</div>\n<!--kg-card-end: html-->';
+
+                    if (visibility.segment) {
+                        type.should.equal('html');
+                        element.outerHTML.should.equal(`<div data-gh-segment="${visibility.segment}">\n${expectedContents}\n</div>`);
+                    } else {
+                        type.should.equal('value');
+                        element.value.should.equal(`\n${expectedContents}\n`);
+                    }
+                }
+
+                function testBlankRender(visibility, target) {
+                    const htmlNode = $createHtmlNode({html: '<div>Test</div>', visibility});
+                    const {element, type} = htmlNode.exportDOM({...exportOptions, target});
+                    type.should.equal('inner');
+                    element.innerHTML.should.equal('');
+                }
+
+                it('renders on web but not email if showOnWeb is true and showOnEmail is false', editorTest(function () {
+                    const visibility = {showOnEmail: false, showOnWeb: true, segment: ''};
+                    testWebRender(visibility);
+                    testBlankRender(visibility, 'email');
+                }));
+
+                it('renders on email and not web if showOnEmail is true and showOnWeb is false', editorTest(function () {
+                    const visibility = {showOnEmail: true, showOnWeb: false, segment: ''};
+                    testEmailRender(visibility);
+                    testBlankRender(visibility, 'web');
+                }));
+
+                it('renders both on web and email if showOnEmail and showOnWeb are true', editorTest(function () {
+                    const visibility = {showOnEmail: true, showOnWeb: true, segment: ''};
+                    testWebRender(visibility);
+                    testEmailRender(visibility);
+                }));
+            });
+
+            describe('with new visibility settings', function () {
+                function testWebRender(visibility, expectedGateParams) {
+                    const htmlNode = $createHtmlNode({html: '<div>Test</div>', visibility});
+                    const {element, type} = htmlNode.exportDOM(exportOptions);
+                    type.should.equal('value');
+                    const baseExpectedContents = '\n<!--kg-card-begin: html-->\n<div>Test</div>\n<!--kg-card-end: html-->\n';
+                    element.value.should.equal(expectedGateParams ? `\n<!--kg-gated-block:begin ${expectedGateParams} -->${baseExpectedContents}<!--kg-gated-block:end-->\n` : baseExpectedContents);
+                }
+
+                function testEmailRender(visibility, expectedSegment) {
+                    const htmlNode = $createHtmlNode({html: '<div>Test</div>', visibility});
+                    const {element, type} = htmlNode.exportDOM({...exportOptions, target: 'email'});
+                    const expectedContents = '<!--kg-card-begin: html-->\n<div>Test</div>\n<!--kg-card-end: html-->';
+
+                    if (!expectedSegment) {
+                        type.should.equal('value');
+                        element.value.should.equal(`\n${expectedContents}\n`);
+                    } else {
+                        type.should.equal('html');
+                        element.outerHTML.should.equal(`<div data-gh-segment="${expectedSegment}" class="kg-visibility-wrapper">\n${expectedContents}\n</div>`);
+                    }
+                }
+
+                function testBlankRender(visibility, target) {
+                    const htmlNode = $createHtmlNode({html: '<div>Test</div>', visibility});
+                    const {element, type} = htmlNode.exportDOM({...exportOptions, target});
+                    type.should.equal('inner');
+                    element.innerHTML.should.equal('');
+                }
+
+                it('web: excludes gated wrapper when shown to everyone', editorTest(function () {
+                    const visibility = {web: {nonMember: true, memberSegment: ALL_MEMBERS_SEGMENT}, email: {memberSegment: ALL_MEMBERS_SEGMENT}};
+                    testWebRender(visibility, null);
+                }));
+
+                it('web: includes gated wrapper with member-only params', editorTest(function () {
+                    const visibility = {web: {nonMember: false, memberSegment: ALL_MEMBERS_SEGMENT}, email: {memberSegment: ALL_MEMBERS_SEGMENT}};
+                    testWebRender(visibility, 'nonMember:false memberSegment:"status:free,status:-free"');
+                }));
+
+                it('web: includes gated wrapper with anonymous-only params', editorTest(function () {
+                    const visibility = {web: {nonMember: true, memberSegment: ''}, email: {memberSegment: ALL_MEMBERS_SEGMENT}};
+                    testWebRender(visibility, 'nonMember:true memberSegment:""');
+                }));
+
+                it('email: excludes content when hidden from all members', editorTest(function () {
+                    const visibility = {web: {nonMember: true, memberSegment: NO_MEMBERS_SEGMENT}, email: {memberSegment: ''}};
+                    testBlankRender(visibility, 'email');
+                }));
+
+                it('email: skips segment wrapper when sent to all members', editorTest(function () {
+                    const visibility = {web: {nonMember: true, memberSegment: ALL_MEMBERS_SEGMENT}, email: {memberSegment: ALL_MEMBERS_SEGMENT}};
+                    testWebRender(visibility);
+                    testEmailRender(visibility, '');
+                }));
+
+                it('email: includes content with member segment wrapper', editorTest(function () {
+                    const visibility = {web: {nonMember: true, memberSegment: ALL_MEMBERS_SEGMENT}, email: {memberSegment: 'status:free'}};
+                    testEmailRender(visibility, 'status:free');
+                }));
+
+                it('handles web-only (everyone)', editorTest(function () {
+                    const visibility = {web: {nonMember: true, memberSegment: ALL_MEMBERS_SEGMENT}, email: {memberSegment: NO_MEMBERS_SEGMENT}};
+                    testWebRender(visibility);
+                    testBlankRender(visibility, 'email');
+                }));
+
+                it('handles web-only (members-only)', editorTest(function () {
+                    const visibility = {web: {nonMember: false, memberSegment: ALL_MEMBERS_SEGMENT}, email: {memberSegment: NO_MEMBERS_SEGMENT}};
+                    testWebRender(visibility, 'nonMember:false memberSegment:"status:free,status:-free"');
+                    testBlankRender(visibility, 'email');
+                }));
+
+                it('handles email-only (free members)', editorTest(function () {
+                    const visibility = {web: {nonMember: false, memberSegment: NO_MEMBERS_SEGMENT}, email: {memberSegment: 'status:free'}};
+                    testBlankRender(visibility, 'web');
+                    testEmailRender(visibility, 'status:free');
+                }));
+
+                it('handles visibility for no-one', editorTest(function () {
+                    const visibility = {web: {nonMember: false, memberSegment: NO_MEMBERS_SEGMENT}, email: {memberSegment: NO_MEMBERS_SEGMENT}};
+                    testBlankRender(visibility, 'web');
+                    testBlankRender(visibility, 'email');
+                }));
+            });
+        });
     });
 
     describe('importDOM', function () {

--- a/packages/kg-default-nodes/test/nodes/image.test.js
+++ b/packages/kg-default-nodes/test/nodes/image.test.js
@@ -1,4 +1,4 @@
-const {createDocument, html} = require('../test-utils');
+const {createDocument, dom, html} = require('../test-utils');
 const {$getRoot} = require('lexical');
 const {createHeadlessEditor} = require('@lexical/headless');
 const {$generateNodesFromDOM} = require('@lexical/html');
@@ -9,6 +9,7 @@ const editorNodes = [ImageNode];
 describe('ImageNode', function () {
     let editor;
     let dataset;
+    let exportOptions;
 
     // NOTE: all tests should use this function, without it you need manual
     // try/catch and done handling to avoid assertion failures not triggering
@@ -35,6 +36,19 @@ describe('ImageNode', function () {
             title: 'This is a title',
             alt: 'This is some alt text',
             caption: 'This is a <b>caption</b>'
+        };
+
+        exportOptions = {
+            imageOptimization: {
+                contentImageSizes: {
+                    w600: {width: 600},
+                    w1000: {width: 1000},
+                    w1600: {width: 1600},
+                    w2400: {width: 2400}
+                }
+            },
+            canTransformImage: () => true,
+            dom
         };
     });
 
@@ -102,6 +116,192 @@ describe('ImageNode', function () {
                 cardWidth: 'regular'
             });
         }));
+    });
+
+    describe('exportDOM', function () {
+        it('creates a full-featured image card', editorTest(function () {
+            const imageNode = $createImageNode(dataset);
+            const {element} = imageNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(html`
+                <figure class="kg-card kg-image-card kg-card-hascaption">
+                    <img
+                        src="/content/images/2022/11/koenig-lexical.jpg"
+                        class="kg-image"
+                        alt="This is some alt text"
+                        loading="lazy"
+                        title="This is a title"
+                        width="3840"
+                        height="2160"
+                        srcset="/content/images/size/w600/2022/11/koenig-lexical.jpg 600w, /content/images/size/w1000/2022/11/koenig-lexical.jpg 1000w, /content/images/size/w1600/2022/11/koenig-lexical.jpg 1600w, /content/images/size/w2400/2022/11/koenig-lexical.jpg 2400w" sizes="(min-width: 720px) 720px"
+                    >
+                    <figcaption>This is a <b>caption</b></figcaption>
+                </figure>
+            `);
+        }));
+
+        it('creates a full-featured image card with link', editorTest(function () {
+            const imageNode = $createImageNode({
+                ...dataset,
+                href: 'https://example.com'
+            });
+            const {element} = imageNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(html`
+                <figure class="kg-card kg-image-card kg-card-hascaption">
+                    <a href="https://example.com"
+                        ><img
+                        src="/content/images/2022/11/koenig-lexical.jpg"
+                        class="kg-image"
+                        alt="This is some alt text"
+                        loading="lazy"
+                        title="This is a title"
+                        width="3840"
+                        height="2160"
+                        srcset="
+                            /content/images/size/w600/2022/11/koenig-lexical.jpg   600w,
+                            /content/images/size/w1000/2022/11/koenig-lexical.jpg 1000w,
+                            /content/images/size/w1600/2022/11/koenig-lexical.jpg 1600w,
+                            /content/images/size/w2400/2022/11/koenig-lexical.jpg 2400w
+                        "
+                        sizes="(min-width: 720px) 720px"
+                    /></a>
+                    <figcaption>This is a <b>caption</b></figcaption>
+                </figure>
+            `);
+        }));
+
+        it('creates a minimal image card', editorTest(function () {
+            const imageNode = $createImageNode({src: '/image.png'});
+            const {element} = imageNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(html`
+                <figure class="kg-card kg-image-card">
+                    <img src="/image.png" class="kg-image" alt="" loading="lazy">
+                </figure>
+            `);
+        }));
+
+        it('renders an empty span with a missing src', editorTest(function () {
+            const imageNode = $createImageNode();
+            const {element} = imageNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.equal('<span></span>');
+        }));
+
+        it('renders a wide image', editorTest(function () {
+            dataset.cardWidth = 'wide';
+            const imageNode = $createImageNode(dataset);
+            const {element} = imageNode.exportDOM(exportOptions);
+
+            element.classList.contains('kg-width-wide').should.be.true();
+        }));
+
+        it('uses resized width and height when there\'s a max width', editorTest(function () {
+            dataset.width = 3000;
+            dataset.height = 6000;
+            // add defaultMaxWidth property to options
+            exportOptions.imageOptimization.defaultMaxWidth = 2000;
+            exportOptions.canTransformImage = () => true;
+
+            const imageNode = $createImageNode(dataset);
+            const {element} = imageNode.exportDOM(exportOptions);
+            const output = element.outerHTML;
+
+            output.should.containEql('width="2000"');
+            output.should.containEql('height="4000"');
+        }));
+
+        it('uses original width and height when transform is not available', editorTest(function () {
+            dataset.width = 3000;
+            dataset.height = 6000;
+            exportOptions.canTransformImage = () => false;
+
+            const imageNode = $createImageNode(dataset);
+            const {element} = imageNode.exportDOM(exportOptions);
+            const output = element.outerHTML;
+
+            output.should.containEql('width="3000" height="6000"');
+        }));
+
+        describe('srcset attribute', function () {
+            it('is included when src is an unsplash image', editorTest(function () {
+                dataset.width = 3000;
+                dataset.height = 6000;
+                dataset.src = 'https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=2000&fit=max&ixid=eyJhcHBfaWQiOjExNzczfQ';
+
+                const imageNode = $createImageNode(dataset);
+                const {element} = imageNode.exportDOM(exportOptions);
+                const output = element.outerHTML;
+
+                output.should.containEql('https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=600&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 600w, https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=1000&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 1000w, https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=1600&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 1600w, https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=2400&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 2400w');
+            }));
+
+            it('is ommitted when target is email', editorTest(function () {
+                exportOptions.target = 'email';
+
+                const imageNode = $createImageNode(dataset);
+                const {element} = imageNode.exportDOM(exportOptions);
+                const output = element.outerHTML;
+
+                output.should.not.containEql('srcset');
+            }));
+
+            it('is included for absolute images when siteUrl has trailing slash');
+            it('is omitted when no contentImageSizes are passed as options');
+            it('is omitted when `srcsets: false` is passed in as an option');
+            it('is omitted when canTransformImages is provided and returns false');
+            it('is omitted when no width is provided');
+            it('is omitted when image is smaller than minimum responsive width');
+            it('omits sizes larger than image width and includes origin image width if smaller than largest responsive width');
+            it('works correctly with subdirectories');
+            it('works correctly with absolute subdirectories');
+            it('is included when src is an Unsplash image');
+            it('has same size omission behaviour for Unsplash as local files');
+        });
+
+        describe('sizes attribute', function () {
+            it('is added for standard images', editorTest(function () {
+                dataset.width = 3000;
+                dataset.height = 6000;
+
+                const imageNode = $createImageNode(dataset);
+                const {element} = imageNode.exportDOM(exportOptions);
+                const output = element.outerHTML;
+
+                output.should.containEql('sizes="(min-width: 720px) 720px"');
+            }));
+
+            it('is added for wide images', editorTest(function () {
+                dataset.width = 3000;
+                dataset.height = 2000;
+                dataset.cardWidth = 'wide';
+
+                const imageNode = $createImageNode(dataset);
+                const {element} = imageNode.exportDOM(exportOptions);
+                const output = element.outerHTML;
+
+                output.should.containEql('sizes="(min-width: 1200px) 1200px"');
+            }));
+
+            it('is omitted when srcset is not added');
+            it('is omitted when width is missing');
+            it('is included when only height is missing');
+            it('is omitted for standard images when width is less than 720');
+            it('is omitted for wide images when width is less than 1200');
+            it('is omitted for full images');
+        });
+
+        describe('email target', function () {
+            it('adds width/height and uses resized local image');
+            it('adds width/height and uses resized unsplash image');
+            it('adds width/height and uses original src when local image can\'t be transformed');
+            it('uses original image if size is smaller than "retina" size');
+            it('uses original image width/height if image is smaller than 600px wide');
+            it('skips width/height and resize if payload is missing dimensions');
+            it('resizes Unsplash images even if width/height data is missing');
+            it('omits srcset attribute');
+        });
     });
 
     describe('importDOM', function () {

--- a/packages/kg-default-nodes/test/nodes/markdown.test.js
+++ b/packages/kg-default-nodes/test/nodes/markdown.test.js
@@ -1,3 +1,4 @@
+const {dom, html} = require('../test-utils');
 const {createHeadlessEditor} = require('@lexical/headless');
 const {$getRoot} = require('lexical');
 const {MarkdownNode, $createMarkdownNode, $isMarkdownNode} = require('../../');
@@ -7,6 +8,7 @@ const editorNodes = [MarkdownNode];
 describe('MarkdownNode', function () {
     let editor;
     let dataset;
+    let exportOptions;
 
     // NOTE: all tests should use this function, without it you need manual
     // try/catch and done handling to avoid assertion failures not triggering
@@ -27,6 +29,10 @@ describe('MarkdownNode', function () {
 
         dataset = {
             markdown: '#HEADING\r\n- list\r\n- items'
+        };
+
+        exportOptions = {
+            dom
         };
     });
 
@@ -99,6 +105,28 @@ describe('MarkdownNode', function () {
         it('returns true', editorTest(function () {
             const markdownNode = $createMarkdownNode(dataset);
             markdownNode.hasEditMode().should.be.true();
+        }));
+    });
+
+    describe('exportDOM', function () {
+        it('creates a markdown card', editorTest(function () {
+            const markdownNode = $createMarkdownNode(dataset);
+            const {element, type} = markdownNode.exportDOM(exportOptions);
+            type.should.equal('inner');
+            element.innerHTML.should.prettifyTo(html`
+                <h1 id="heading">HEADING</h1>
+                <ul>
+                <li>list</li>
+                <li>items</li>
+                </ul>
+            `);
+        }));
+
+        it('renders an empty div with a missing src', editorTest(function () {
+            const markdownNode = $createMarkdownNode();
+            const {element} = markdownNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.equal('<div></div>');
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/paywall.test.js
+++ b/packages/kg-default-nodes/test/nodes/paywall.test.js
@@ -1,6 +1,6 @@
 const {createHeadlessEditor} = require('@lexical/headless');
 const {$getRoot} = require('lexical');
-const {createDocument, html} = require('../test-utils');
+const {createDocument, dom, html} = require('../test-utils');
 const {PaywallNode, $createPaywallNode, $isPaywallNode} = require('../../');
 const {$generateNodesFromDOM} = require('@lexical/html');
 
@@ -9,6 +9,7 @@ const editorNodes = [PaywallNode];
 describe('PaywallNode', function () {
     let editor;
     let dataset;
+    let exportOptions;
 
     // NOTE: all tests should use this function, without it you need manual
     // try/catch and done handling to avoid assertion failures not triggering
@@ -30,6 +31,11 @@ describe('PaywallNode', function () {
         });
 
         dataset = {};
+
+        exportOptions = {
+            exportFormat: 'html',
+            dom
+        };
     });
 
     it('matches node with $isPaywallNode', editorTest(function () {
@@ -76,6 +82,15 @@ describe('PaywallNode', function () {
                 }
             });
         });
+    });
+
+    describe('exportDOM', function () {
+        it('renders a paywall node', editorTest(function () {
+            const paywallNode = $createPaywallNode();
+            const {element} = paywallNode.exportDOM(exportOptions);
+
+            element.innerHTML.should.equal('<!--members-only-->');
+        }));
     });
 
     describe('importDOM', function () {

--- a/packages/kg-default-nodes/test/nodes/product.test.js
+++ b/packages/kg-default-nodes/test/nodes/product.test.js
@@ -1,4 +1,4 @@
-const {createDocument, html} = require('../test-utils');
+const {createDocument, dom, html} = require('../test-utils');
 const {$getRoot} = require('lexical');
 const {createHeadlessEditor} = require('@lexical/headless');
 const {ProductNode, $createProductNode, $isProductNode} = require('../../');
@@ -9,6 +9,7 @@ const editorNodes = [ProductNode];
 describe('ProductNode', function () {
     let editor;
     let dataset;
+    let exportOptions;
 
     // NOTE: all tests should use this function, without it you need manual
     // try/catch and done handling to avoid assertion failures not triggering
@@ -51,6 +52,10 @@ describe('ProductNode', function () {
             productButton: 'Button text',
             productUrl: 'https://google.com/'
         };
+
+        exportOptions = new Object({
+            dom
+        });
     });
 
     it('matches node with $isProductNode', editorTest(function () {
@@ -221,6 +226,329 @@ describe('ProductNode', function () {
                 }
             });
         });
+    });
+
+    describe('exportDOM', function () {
+        it('renders', editorTest(function () {
+            const payload = {
+                productButton: 'Click me',
+                productButtonEnabled: true,
+                productDescription: 'This product is ok',
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productRatingEnabled: true,
+                productStarRating: 3,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
+            };
+            const productNode = $createProductNode(payload);
+            const {element} = productNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(`
+                <div class="kg-card kg-product-card"><div class="kg-product-card-container"><img src="https://example.com/images/ok.jpg" class="kg-product-card-image" loading="lazy" /><div class="kg-product-card-title-container"><h4 class="kg-product-card-title">Product title!</h4></div><div class="kg-product-card-rating"><span class="kg-product-card-rating-active kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class="kg-product-card-rating-active kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class="kg-product-card-rating-active kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class=" kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class=" kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span></div><div class="kg-product-card-description">This product is ok</div><a href="https://example.com/product/ok" class="kg-product-card-button kg-product-card-btn-accent" target="_blank" rel="noopener noreferrer"><span>Click me</span></a></div></div>
+            `);
+        }));
+
+        it('renders with img width and height', editorTest(function () {
+            const payload = {
+                productButton: 'Click me',
+                productButtonEnabled: true,
+                productDescription: 'This product is ok',
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productImageWidth: 200,
+                productImageHeight: 100,
+                productRatingEnabled: true,
+                productStarRating: 3,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
+            };
+            const productNode = $createProductNode(payload);
+            const {element} = productNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(`
+                <div class="kg-card kg-product-card"><div class="kg-product-card-container"><img src="https://example.com/images/ok.jpg" width="200" height="100" class="kg-product-card-image" loading="lazy" /><div class="kg-product-card-title-container"><h4 class="kg-product-card-title">Product title!</h4></div><div class="kg-product-card-rating"><span class="kg-product-card-rating-active kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class="kg-product-card-rating-active kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class="kg-product-card-rating-active kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class=" kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span><span class=" kg-product-card-rating-star"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12.729,1.2l3.346,6.629,6.44.638a.805.805,0,0,1,.5,1.374l-5.3,5.253,1.965,7.138a.813.813,0,0,1-1.151.935L12,19.934,5.48,23.163a.813.813,0,0,1-1.151-.935L6.294,15.09.99,9.837a.805.805,0,0,1,.5-1.374l6.44-.638L11.271,1.2A.819.819,0,0,1,12.729,1.2Z"></path></svg></span></div><div class="kg-product-card-description">This product is ok</div><a href="https://example.com/product/ok" class="kg-product-card-button kg-product-card-btn-accent" target="_blank" rel="noopener noreferrer"><span>Click me</span></a></div></div>
+            `);
+        }));
+
+        it('renders empty span if title, description, button and image are missing', editorTest(function () {
+            const payload = {
+                productTitle: '',
+                productDescription: ''
+            };
+            const productNode = $createProductNode(payload);
+            const {element} = productNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.equal('<span></span>');
+        }));
+
+        it('renders if only title is present', editorTest(function () {
+            const payload = {
+                productTitle: 'Just a title'
+            };
+            const productNode = $createProductNode(payload);
+            const {element} = productNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(`
+                <div class="kg-card kg-product-card"><div class="kg-product-card-container"><div class="kg-product-card-title-container"><h4 class="kg-product-card-title">Just a title</h4></div><div class="kg-product-card-description"></div></div></div>
+            `);
+        }));
+
+        it('renders if only description is present', editorTest(function () {
+            const payload = {
+                productDescription: 'Just a description'
+            };
+            const productNode = $createProductNode(payload);
+            const {element} = productNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(`
+                <div class="kg-card kg-product-card"><div class="kg-product-card-container"><div class="kg-product-card-title-container"><h4 class="kg-product-card-title"></h4></div><div class="kg-product-card-description">Just a description</div></div></div>
+            `);
+        }));
+
+        it('renders if only button is present', editorTest(function () {
+            const payload = {
+                productButtonEnabled: true,
+                productButton: 'Button text',
+                productUrl: 'https://example.com/product/ok'
+            };
+            const productNode = $createProductNode(payload);
+            const {element} = productNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(`
+                <div class="kg-card kg-product-card"><div class="kg-product-card-container"><div class="kg-product-card-title-container"><h4 class="kg-product-card-title"></h4></div><div class="kg-product-card-description"></div><a href="https://example.com/product/ok" class="kg-product-card-button kg-product-card-btn-accent" target="_blank" rel="noopener noreferrer"><span>Button text</span></a></div></div>
+            `);
+        }));
+
+        it('renders email', editorTest(function () {
+            const payload = {
+                productButton: 'Click me',
+                productButtonEnabled: true,
+                productDescription: 'This product is ok',
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productRatingEnabled: true,
+                productStarRating: 3,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
+            };
+
+            const options = {
+                target: 'email'
+            };
+
+            const productNode = $createProductNode(payload);
+            const {element} = productNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(`
+                <table cellspacing="0" cellpadding="0" border="0" style="width:100%; padding:20px; border:1px solid #E9E9E9; border-radius: 5px; margin: 0 0 1.5em; width: 100%;"><tbody><tr><td align="center" style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;"><img src="https://example.com/images/ok.jpg" style="display: block; width: 100%; height: auto; max-width: 100%; border: none; padding-bottom: 16px;" border="0"></td></tr><tr><td valign="top"><h4 style="font-size: 22px !important; margin-top: 0 !important; margin-bottom: 0 !important; font-weight: 700;">Product title!</h4></td></tr><tr style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;"><td valign="top"><img src="https://static.ghost.org/v4.0.0/images/star-rating-3.png" style="border: none; width: 96px;" border="0"></td></tr><tr><td style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;"><div style="padding-top: 8px; opacity: 0.7; font-size: 17px; line-height: 1.4; margin-bottom: -24px;">This product is ok</div></td></tr><tr><td style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;"><div class="btn btn-accent" style="box-sizing: border-box;display: table;width: 100%;padding-top: 16px;"><a href="https://example.com/product/ok" style="overflow-wrap: anywhere;border: solid 1px;border-radius: 5px;box-sizing: border-box;cursor: pointer;display: inline-block;font-size: 14px;font-weight: bold;margin: 0;padding: 0;text-decoration: none;color: #FFFFFF; width: 100%; text-align: center;"><span style="display: block;padding: 12px 25px;">Click me</span></a></div></td></tr></tbody></table>
+            `);
+        }));
+
+        it('renders email (emailCustomization)', editorTest(function () {
+            const payload = {
+                productButton: 'Click me',
+                productButtonEnabled: true,
+                productDescription: 'This product is ok',
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productRatingEnabled: true,
+                productStarRating: 3,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
+            };
+
+            const options = {
+                target: 'email',
+                feature: {
+                    emailCustomization: true
+                }
+            };
+
+            const productNode = $createProductNode(payload);
+            const {element} = productNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(`
+                <table class="kg-product-card" cellspacing="0" cellpadding="0" border="0">
+                  <tbody>
+                    <tr>
+                      <td class="kg-product-card-container">
+                        <table cellspacing="0" cellpadding="0" border="0">
+                          <tbody>
+                            <tr>
+                              <td class="kg-product-image" align="center">
+                                <img src="https://example.com/images/ok.jpg" border="0" />
+                              </td>
+                            </tr>
+                            <tr>
+                              <td valign="top">
+                                <h4 class="kg-product-title">Product title!</h4>
+                              </td>
+                            </tr>
+                            <tr class="kg-product-rating">
+                              <td valign="top">
+                                <img
+                                  src="https://static.ghost.org/v4.0.0/images/star-rating-3.png"
+                                  border="0"
+                                />
+                              </td>
+                            </tr>
+                            <tr>
+                              <td class="kg-product-description-wrapper">This product is ok</td>
+                            </tr>
+                            <tr>
+                              <td class="kg-product-button-wrapper">
+                                <table
+                                  class="btn btn-accent"
+                                  border="0"
+                                  cellspacing="0"
+                                  cellpadding="0"
+                                >
+                                  <tbody>
+                                    <tr>
+                                      <td align="center" width="100%">
+                                        <a href="https://example.com/product/ok">Click me</a>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+            `);
+        }));
+
+        it('renders email with img width and height', editorTest(function () {
+            const payload = {
+                productButton: 'Click me',
+                productButtonEnabled: true,
+                productDescription: 'This product is ok',
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productImageWidth: 200,
+                productImageHeight: 100,
+                productRatingEnabled: true,
+                productStarRating: 3,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
+            };
+
+            const options = {
+                target: 'email'
+            };
+
+            const productNode = $createProductNode(payload);
+            const {element} = productNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(`
+                <table cellspacing="0" cellpadding="0" border="0" style="width:100%; padding:20px; border:1px solid #E9E9E9; border-radius: 5px; margin: 0 0 1.5em; width: 100%;"><tbody><tr><td align="center" style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;"><img src="https://example.com/images/ok.jpg" width="200" height="100" style="display: block; width: 100%; height: auto; max-width: 100%; border: none; padding-bottom: 16px;" border="0"></td></tr><tr><td valign="top"><h4 style="font-size: 22px !important; margin-top: 0 !important; margin-bottom: 0 !important; font-weight: 700;">Product title!</h4></td></tr><tr style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;"><td valign="top"><img src="https://static.ghost.org/v4.0.0/images/star-rating-3.png" style="border: none; width: 96px;" border="0"></td></tr><tr><td style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;"><div style="padding-top: 8px; opacity: 0.7; font-size: 17px; line-height: 1.4; margin-bottom: -24px;">This product is ok</div></td></tr><tr><td style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;"><div class="btn btn-accent" style="box-sizing: border-box;display: table;width: 100%;padding-top: 16px;"><a href="https://example.com/product/ok" style="overflow-wrap: anywhere;border: solid 1px;border-radius: 5px;box-sizing: border-box;cursor: pointer;display: inline-block;font-size: 14px;font-weight: bold;margin: 0;padding: 0;text-decoration: none;color: #FFFFFF; width: 100%; text-align: center;"><span style="display: block;padding: 12px 25px;">Click me</span></a></div></td></tr></tbody></table>
+            `);
+        }));
+
+        it('renders email when the star-rating is disabled', editorTest(function () {
+            const payload = {
+                productButton: 'Click me',
+                productButtonEnabled: true,
+                productDescription: 'This product is ok',
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productRatingEnabled: false,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
+            };
+
+            const options = {
+                target: 'email'
+            };
+
+            const productNode = $createProductNode(payload);
+            const {element} = productNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(`
+                <table cellspacing="0" cellpadding="0" border="0" style="width:100%; padding:20px; border:1px solid #E9E9E9; border-radius: 5px; margin: 0 0 1.5em; width: 100%;"><tbody><tr><td align="center" style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;"><img src="https://example.com/images/ok.jpg" style="display: block; width: 100%; height: auto; max-width: 100%; border: none; padding-bottom: 16px;" border="0"></td></tr><tr><td valign="top"><h4 style="font-size: 22px !important; margin-top: 0 !important; margin-bottom: 0 !important; font-weight: 700;">Product title!</h4></td></tr><tr><td style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;"><div style="padding-top: 8px; opacity: 0.7; font-size: 17px; line-height: 1.4; margin-bottom: -24px;">This product is ok</div></td></tr><tr><td style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;"><div class="btn btn-accent" style="box-sizing: border-box;display: table;width: 100%;padding-top: 16px;"><a href="https://example.com/product/ok" style="overflow-wrap: anywhere;border: solid 1px;border-radius: 5px;box-sizing: border-box;cursor: pointer;display: inline-block;font-size: 14px;font-weight: bold;margin: 0;padding: 0;text-decoration: none;color: #FFFFFF; width: 100%; text-align: center;"><span style="display: block;padding: 12px 25px;">Click me</span></a></div></td></tr></tbody></table>
+            `);
+        }));
+
+        it('renders email when the button is disabled', editorTest(function () {
+            const payload = {
+                productButton: 'Click me',
+                productButtonEnabled: false,
+                productDescription: 'This product is ok',
+                productImageSrc: 'https://example.com/images/ok.jpg',
+                productRatingEnabled: false,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
+            };
+
+            const options = {
+                target: 'email'
+            };
+
+            const productNode = $createProductNode(payload);
+            const {element} = productNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(`
+                <table cellspacing="0" cellpadding="0" border="0" style="width:100%; padding:20px; border:1px solid #E9E9E9; border-radius: 5px; margin: 0 0 1.5em; width: 100%;"><tbody><tr><td align="center" style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;"><img src="https://example.com/images/ok.jpg" style="display: block; width: 100%; height: auto; max-width: 100%; border: none; padding-bottom: 16px;" border="0"></td></tr><tr><td valign="top"><h4 style="font-size: 22px !important; margin-top: 0 !important; margin-bottom: 0 !important; font-weight: 700;">Product title!</h4></td></tr><tr><td style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;"><div style="padding-top: 8px; opacity: 0.7; font-size: 17px; line-height: 1.4; margin-bottom: -24px;">This product is ok</div></td></tr></tbody></table>
+            `);
+        }));
+
+        it('renders email without an image if the attribute isn\'t there', editorTest(function () {
+            const payload = {
+                productButton: 'Click me',
+                productButtonEnabled: false,
+                productDescription: 'This product is ok',
+                productRatingEnabled: false,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
+            };
+
+            const options = {
+                target: 'email'
+            };
+
+            const productNode = $createProductNode(payload);
+            const {element} = productNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(`
+                <table cellspacing="0" cellpadding="0" border="0" style="width:100%; padding:20px; border:1px solid #E9E9E9; border-radius: 5px; margin: 0 0 1.5em; width: 100%;"><tbody><tr><td valign="top"><h4 style="font-size: 22px !important; margin-top: 0 !important; margin-bottom: 0 !important; font-weight: 700;">Product title!</h4></td></tr><tr><td style="padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;"><div style="padding-top: 8px; opacity: 0.7; font-size: 17px; line-height: 1.4; margin-bottom: -24px;">This product is ok</div></td></tr></tbody></table>
+            `);
+        }));
+
+        function renderButton(design) {
+            const payload = {
+                productButton: 'Click me',
+                productButtonEnabled: true,
+                productDescription: 'This product is ok',
+                productRatingEnabled: false,
+                productTitle: 'Product title!',
+                productUrl: 'https://example.com/product/ok'
+            };
+
+            const options = {
+                target: 'email',
+                design
+            };
+
+            const productNode = $createProductNode(payload);
+            const {element} = productNode.exportDOM({...exportOptions, ...options});
+
+            return element.outerHTML;
+        }
+
+        it('handles no design option', editorTest(function () {
+            renderButton().should.containEql('border-radius: 5px;');
+        }));
+
+        it('renders rounded button border radius', editorTest(function () {
+            renderButton({buttonCorners: 'rounded'}).should.containEql('border-radius: 6px;');
+        }));
+
+        it('renders square button border radius', editorTest(function () {
+            renderButton({buttonCorners: 'square'}).should.containEql('border-radius: 0px;');
+        }));
+
+        it('renders pill button border radius', editorTest(function () {
+            renderButton({buttonCorners: 'pill'}).should.containEql('border-radius: 9999px;');
+        }));
     });
 
     describe('importDOM', function () {

--- a/packages/kg-default-nodes/test/nodes/signup.test.js
+++ b/packages/kg-default-nodes/test/nodes/signup.test.js
@@ -145,141 +145,482 @@ describe('SignupNode', function () {
         }));
     });
 
-    describe('importDOM', function () {
-        const generateSignupNodes = (contents) => {
-            const document = createDocument(contents);
-            return $generateNodesFromDOM(editor, document);
-        };
+    describe('exportDOM', function () {
+        const loadingIcon = `<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" viewBox="0 0 24 24">
+            <g stroke-linecap="round" stroke-width="2" fill="currentColor" stroke="none" stroke-linejoin="round" class="nc-icon-wrapper">
+                <g class="nc-loop-dots-4-24-icon-o">
+                    <circle cx="4" cy="12" r="3"></circle>
+                    <circle cx="12" cy="12" r="3"></circle>
+                    <circle cx="20" cy="12" r="3"></circle>
+                </g>
+                <style data-cap="butt">
+                    .nc-loop-dots-4-24-icon-o{--animation-duration:0.8s}
+                    .nc-loop-dots-4-24-icon-o *{opacity:.4;transform:scale(.75);animation:nc-loop-dots-4-anim var(--animation-duration) infinite}
+                    .nc-loop-dots-4-24-icon-o :nth-child(1){transform-origin:4px 12px;animation-delay:-.3s;animation-delay:calc(var(--animation-duration)/-2.666)}
+                    .nc-loop-dots-4-24-icon-o :nth-child(2){transform-origin:12px 12px;animation-delay:-.15s;animation-delay:calc(var(--animation-duration)/-5.333)}
+                    .nc-loop-dots-4-24-icon-o :nth-child(3){transform-origin:20px 12px}
+                    @keyframes nc-loop-dots-4-anim{0%,100%{opacity:.4;transform:scale(.75)}50%{opacity:1;transform:scale(1)}}
+                </style>
+            </g>
+        </svg>`;
 
-        it('parses a signup card', editorTest(function () {
-            const nodes = generateSignupNodes(html`
-                <div data-lexical-signup-form="">
-                    <h2>Header</h2>
-                    <h3>Subheader</h3>
-                    <p>Disclaimer</p>
-                    <div class="kg-signup-card-text">
-                        <div class="kg-signup-card-button" style="background-color: #000000; color: #ffffff;">
-                            <span class="kg-signup-card-button-default">Button</span>
+        it('creates signup element', editorTest(function () {
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-signup-card kg-width-regular" data-lexical-signup-form=""  style="display: none;">
+                    <picture><img class="kg-signup-card-image" src="https://example.com/image.jpg" alt=""/></picture>
+                    <div class="kg-signup-card-content">
+                        <div class="kg-signup-card-text kg-align-center">
+                            <h2 class="kg-signup-card-heading" style="color: #000000">Header</h2>
+                            <p class="kg-signup-card-subheading" style="color: #000000">Subheader</p>
+                            <form class="kg-signup-card-form" data-members-form="signup">
+                                <input data-members-label="" type="hidden" value="label 1">
+                                <input data-members-label="" type="hidden" value="label 2">
+                                <div class="kg-signup-card-fields">
+                                    <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email">
+                                    <button class="kg-signup-card-button" style="background-color:#000000;color:#ffffff" type="submit">
+                                        <span class="kg-signup-card-button-default">Button</span>
+                                        <span class="kg-signup-card-button-loading">${loadingIcon}</span>
+                                    </button>
+                                </div>
+                                <div class="kg-signup-card-success" style="color: #000000">Success!</div>
+                                <div class="kg-signup-card-error" style="color: #000000" data-members-error=""></div>
+                            </form>
+                            <p class="kg-signup-card-disclaimer" style="color: #000000">Disclaimer</p>
                         </div>
-                        <div class="kg-signup-card-success" style="color: #000000;">Success!</div>
                     </div>
-                    <input data-members-label value="label 1" />
-                    <input data-members-label value="label 2" />
                 </div>
             `);
+        }));
+
+        it('removes empty elements', editorTest(function () {
+            dataset.header = '';
+            dataset.subheader = '';
+            dataset.disclaimer = '';
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-signup-card kg-width-regular" data-lexical-signup-form="" style="display:none">
+                    <picture><img class="kg-signup-card-image" src="https://example.com/image.jpg" alt=""/></picture>
+                    <div class="kg-signup-card-content">
+                        <div class="kg-signup-card-text kg-align-center">
+                            <form class="kg-signup-card-form" data-members-form="signup">
+                                <input data-members-label="" type="hidden" value="label 1">
+                                <input data-members-label="" type="hidden" value="label 2">
+                                <div class="kg-signup-card-fields">
+                                    <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email">
+                                    <button class="kg-signup-card-button" style="background-color:#000000;color:#ffffff" type="submit">
+                                        <span class="kg-signup-card-button-default">Button</span>
+                                        <span class="kg-signup-card-button-loading">${loadingIcon}</span>
+                                    </button>
+                                </div>
+                                <div class="kg-signup-card-success" style="color: #000000">Success!</div>
+                                <div class="kg-signup-card-error" style="color: #000000" data-members-error=""></div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            `);
+        }));
+
+        it('renders accent classes', editorTest(function () {
+            dataset.backgroundColor = 'accent';
+            dataset.buttonColor = 'accent';
+            dataset.backgroundImageSrc = '';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-signup-card kg-width-regular kg-style-accent" data-lexical-signup-form="" style="display:none">
+                    <div class="kg-signup-card-content">
+                        <div class="kg-signup-card-text kg-align-center">
+                            <h2 class="kg-signup-card-heading" style="color: #000000">Header</h2>
+                            <p class="kg-signup-card-subheading" style="color: #000000">Subheader</p>
+                            <form class="kg-signup-card-form" data-members-form="signup">
+                                <input data-members-label="" type="hidden" value="label 1">
+                                <input data-members-label="" type="hidden" value="label 2">
+                                <div class="kg-signup-card-fields">
+                                    <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email">
+                                    <button class="kg-signup-card-button kg-style-accent" style="color:#ffffff" type="submit">
+                                        <span class="kg-signup-card-button-default">Button</span>
+                                        <span class="kg-signup-card-button-loading">${loadingIcon}</span>
+                                    </button>
+                                </div>
+                                <div class="kg-signup-card-success" style="color: #000000">Success!</div>
+                                <div class="kg-signup-card-error" style="color: #000000" data-members-error=""></div>
+                            </form>
+                            <p class="kg-signup-card-disclaimer" style="color: #000000">Disclaimer</p>
+                        </div>
+                    </div>
+                </div>
+            `);
+        }));
+
+        it('renders split classes', editorTest(function () {
+            dataset.layout = 'split';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-signup-card kg-layout-split kg-width-full" data-lexical-signup-form="" style="background-color: transparent; display:none">
+                    <div class="kg-signup-card-content">
+                        <picture><img class="kg-signup-card-image" src="https://example.com/image.jpg" alt=""></picture>
+                        <div class="kg-signup-card-text kg-align-center">
+                            <h2 class="kg-signup-card-heading">Header</h2>
+                            <p class="kg-signup-card-subheading">Subheader</p>
+                            <form class="kg-signup-card-form" data-members-form="signup">
+                                <input data-members-label="" type="hidden" value="label 1">
+                                <input data-members-label="" type="hidden" value="label 2">
+                                <div class="kg-signup-card-fields">
+                                    <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email">
+                                    <button class="kg-signup-card-button" style="background-color:#000000;color:#ffffff" type="submit">
+                                        <span class="kg-signup-card-button-default">Button</span>
+                                        <span class="kg-signup-card-button-loading">${loadingIcon}</span>
+                                    </button>
+                                </div>
+                                <div class="kg-signup-card-success">Success!</div>
+                                <div class="kg-signup-card-error" data-members-error=""></div>
+                            </form>
+                            <p class="kg-signup-card-disclaimer">Disclaimer</p>
+                        </div>
+                    </div>
+                </div>
+            `);
+        }));
+
+        it('renders split card swapped', editorTest(function () {
+            dataset.layout = 'split';
+            dataset.swapped = true;
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-signup-card kg-layout-split kg-width-full kg-swapped" data-lexical-signup-form="" style="background-color: transparent; display:none">
+                    <div class="kg-signup-card-content">
+                        <picture><img class="kg-signup-card-image" src="https://example.com/image.jpg" alt=""></picture>
+                        <div class="kg-signup-card-text kg-align-center">
+                            <h2 class="kg-signup-card-heading">Header</h2>
+                            <p class="kg-signup-card-subheading">Subheader</p>
+                            <form class="kg-signup-card-form" data-members-form="signup">
+                                <input data-members-label="" type="hidden" value="label 1">
+                                <input data-members-label="" type="hidden" value="label 2">
+                                <div class="kg-signup-card-fields">
+                                    <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email">
+                                    <button class="kg-signup-card-button" style="background-color:#000000;color:#ffffff" type="submit">
+                                        <span class="kg-signup-card-button-default">Button</span>
+                                        <span class="kg-signup-card-button-loading">${loadingIcon}</span>
+                                    </button>
+                                </div>
+                                <div class="kg-signup-card-success">Success!</div>
+                                <div class="kg-signup-card-error" data-members-error=""></div>
+                            </form>
+                            <p class="kg-signup-card-disclaimer">Disclaimer</p>
+                        </div>
+                    </div>
+                </div>
+            `);
+        }));
+
+        it('renders background size', editorTest(function () {
+            dataset.layout = 'split';
+            dataset.backgroundSize = 'contain';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-signup-card kg-layout-split kg-width-full kg-content-wide" data-lexical-signup-form="" style="background-color: transparent; display:none">
+                    <div class="kg-signup-card-content">
+                        <picture><img class="kg-signup-card-image" src="https://example.com/image.jpg" alt=""></picture>
+                        <div class="kg-signup-card-text kg-align-center">
+                            <h2 class="kg-signup-card-heading">Header</h2>
+                            <p class="kg-signup-card-subheading">Subheader</p>
+                            <form class="kg-signup-card-form" data-members-form="signup">
+                                <input data-members-label="" type="hidden" value="label 1">
+                                <input data-members-label="" type="hidden" value="label 2">
+                                <div class="kg-signup-card-fields">
+                                    <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email">
+                                    <button class="kg-signup-card-button" style="background-color:#000000;color:#ffffff" type="submit">
+                                        <span class="kg-signup-card-button-default">Button</span>
+                                        <span class="kg-signup-card-button-loading">${loadingIcon}</span>
+                                    </button>
+                                </div>
+                                <div class="kg-signup-card-success">Success!</div>
+                                <div class="kg-signup-card-error" data-members-error=""></div>
+                            </form>
+                            <p class="kg-signup-card-disclaimer">Disclaimer</p>
+                        </div>
+                    </div>
+                </div>
+            `);
+        }));
+
+        it('renders text color styles with non-transparent background', editorTest(function () {
+            dataset.backgroundColor = '#ffffff';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-signup-card kg-width-regular" data-lexical-signup-form="" style="display:none">
+                <picture><img class="kg-signup-card-image" src="https://example.com/image.jpg" alt=""></picture>
+                    <div class="kg-signup-card-content">
+                        <div class="kg-signup-card-text kg-align-center">
+                            <h2 class="kg-signup-card-heading" style="color: #000000">Header</h2>
+                            <p class="kg-signup-card-subheading" style="color: #000000">Subheader</p>
+                            <form class="kg-signup-card-form" data-members-form="signup">
+                                <input data-members-label="" type="hidden" value="label 1">
+                                <input data-members-label="" type="hidden" value="label 2">
+                                <div class="kg-signup-card-fields">
+                                    <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email">
+                                    <button class="kg-signup-card-button" style="background-color:#000000;color:#ffffff" type="submit">
+                                        <span class="kg-signup-card-button-default">Button</span>
+                                        <span class="kg-signup-card-button-loading">${loadingIcon}</span>
+                                    </button>
+                                </div>
+                                <div class="kg-signup-card-success" style="color: #000000">Success!</div>
+                                <div class="kg-signup-card-error" style="color: #000000" data-members-error=""></div>
+                            </form>
+                            <p class="kg-signup-card-disclaimer" style="color: #000000">Disclaimer</p>
+                        </div>
+                    </div>
+                </div>
+            `);
+        }));
+
+        it('does not render text colors with a transparent background', editorTest(function () {
+            dataset.backgroundColor = 'transparent';
+            dataset.backgroundImageSrc = '';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-signup-card kg-width-regular" data-lexical-signup-form="" style="background-color: transparent; display:none">
+                <div class="kg-signup-card-content">
+                    <div class="kg-signup-card-text kg-align-center">
+                        <h2 class="kg-signup-card-heading">Header</h2>
+                        <p class="kg-signup-card-subheading">Subheader</p>
+                        <form class="kg-signup-card-form" data-members-form="signup">
+                            <input data-members-label="" type="hidden" value="label 1">
+                            <input data-members-label="" type="hidden" value="label 2">
+                            <div class="kg-signup-card-fields">
+                                <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email">
+                                <button class="kg-signup-card-button" style="background-color:#000000;color:#ffffff" type="submit">
+                                    <span class="kg-signup-card-button-default">Button</span>
+                                    <span class="kg-signup-card-button-loading">${loadingIcon}</span>
+                                </button>
+                            </div>
+                            <div class="kg-signup-card-success">Success!</div>
+                            <div class="kg-signup-card-error" data-members-error=""></div>
+                        </form>
+                        <p class="kg-signup-card-disclaimer">Disclaimer</p>
+                    </div>
+                </div>
+            </div>
+            `);
+        }));
+
+        it('applies the accent color class if there is no background image', editorTest(function () {
+            dataset.backgroundColor = 'accent';
+            dataset.backgroundImageSrc = '';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-signup-card kg-width-regular kg-style-accent" data-lexical-signup-form="" style="display:none">
+                    <div class="kg-signup-card-content">
+                        <div class="kg-signup-card-text kg-align-center">
+                            <h2 class="kg-signup-card-heading" style="color: #000000">Header</h2>
+                            <p class="kg-signup-card-subheading" style="color: #000000">Subheader</p>
+                            <form class="kg-signup-card-form" data-members-form="signup">
+                                <input data-members-label="" type="hidden" value="label 1">
+                                <input data-members-label="" type="hidden" value="label 2">
+                                <div class="kg-signup-card-fields">
+                                    <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email">
+                                    <button class="kg-signup-card-button" style="background-color: #000000; color:#ffffff" type="submit">
+                                        <span class="kg-signup-card-button-default">Button</span>
+                                        <span class="kg-signup-card-button-loading">${loadingIcon}</span>
+                                    </button>
+                                </div>
+                                <div class="kg-signup-card-success" style="color: #000000">Success!</div>
+                                <div class="kg-signup-card-error" style="color: #000000" data-members-error=""></div>
+                            </form>
+                            <p class="kg-signup-card-disclaimer" style="color: #000000">Disclaimer</p>
+                        </div>
+                    </div>
+                </div>
+            `);
+        }));
+
+        it('applies the accent color class with a split layout', editorTest(function () {
+            dataset.backgroundColor = 'accent';
+            dataset.layout = 'split';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-signup-card kg-layout-split kg-width-full kg-style-accent" data-lexical-signup-form="" style="display:none">
+                    <div class="kg-signup-card-content">
+                        <picture><img class="kg-signup-card-image" src="https://example.com/image.jpg" alt=""></picture>
+                        <div class="kg-signup-card-text kg-align-center">
+                            <h2 class="kg-signup-card-heading" style="color: #000000">Header</h2>
+                            <p class="kg-signup-card-subheading" style="color: #000000">Subheader</p>
+                            <form class="kg-signup-card-form" data-members-form="signup">
+                                <input data-members-label="" type="hidden" value="label 1">
+                                <input data-members-label="" type="hidden" value="label 2">
+                                <div class="kg-signup-card-fields">
+                                    <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email">
+                                    <button class="kg-signup-card-button" style="background-color:#000000;color:#ffffff" type="submit">
+                                        <span class="kg-signup-card-button-default">Button</span>
+                                        <span class="kg-signup-card-button-loading">${loadingIcon}</span>
+                                    </button>
+                                </div>
+                                <div class="kg-signup-card-success" style="color: #000000">Success!</div>
+                                <div class="kg-signup-card-error" style="color: #000000" data-members-error=""></div>
+                            </form>
+                            <p class="kg-signup-card-disclaimer" style="color: #000000">Disclaimer</p>
+                        </div>
+                    </div>
+                </div>
+            `);
+        }));
+
+        it(`doesn't apply the accent color class if there is a background image`, editorTest(function () {
+            dataset.backgroundColor = 'accent';
+            dataset.backgroundImageSrc = 'https://example.com/image.jpg';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.prettifyTo(html`
+                <div class="kg-card kg-signup-card kg-width-regular" data-lexical-signup-form="" style="display:none">
+                    <picture>
+                        <img
+                            class="kg-signup-card-image"
+                            src="https://example.com/image.jpg"
+                            alt=""
+                        />
+                    </picture>
+                    <div class="kg-signup-card-content">
+                        <div class="kg-signup-card-text kg-align-center">
+                            <h2 class="kg-signup-card-heading" style="color: #000000">Header</h2>
+                            <p class="kg-signup-card-subheading" style="color: #000000">Subheader</p>
+                            <form class="kg-signup-card-form" data-members-form="signup">
+                                <input data-members-label="" type="hidden" value="label 1">
+                                <input data-members-label="" type="hidden" value="label 2">
+                                <div class="kg-signup-card-fields">
+                                    <input class="kg-signup-card-input" id="email" data-members-email="" type="email" required="true" placeholder="Your email">
+                                    <button class="kg-signup-card-button" style="background-color: #000000; color:#ffffff" type="submit">
+                                        <span class="kg-signup-card-button-default">Button</span>
+                                        <span class="kg-signup-card-button-loading">${loadingIcon}</span>
+                                    </button>
+                                </div>
+                                <div class="kg-signup-card-success" style="color: #000000">Success!</div>
+                                <div class="kg-signup-card-error" style="color: #000000" data-members-error=""></div>
+                            </form>
+                            <p class="kg-signup-card-disclaimer" style="color: #000000">Disclaimer</p>
+                        </div>
+                    </div>
+                </div>
+            `);
+        }));
+
+        it('returns empty element if target is email', editorTest(function () {
+            exportOptions.target = 'email';
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            element.outerHTML.should.equal('<div></div>');
+        }));
+    });
+    describe('importDOM', function () {
+        it('parses a signup card', editorTest(function () {
+            dataset.backgroundColor = '#ffffff';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+
+            const document = createDocument(element.outerHTML);
+            const nodes = $generateNodesFromDOM(editor, document);
             nodes.length.should.equal(1);
-            nodes[0].header.should.equal('Header');
-            nodes[0].subheader.should.equal('Subheader');
-            nodes[0].disclaimer.should.equal('Disclaimer');
-            nodes[0].buttonText.should.equal('Button');
-            nodes[0].successMessage.should.equal('Success!');
-            nodes[0].labels.should.deepEqual(['label 1', 'label 2']);
         }));
 
         it('parses split layout correctly', editorTest(function () {
-            const nodes = generateSignupNodes(html`
-                <div data-lexical-signup-form="" class="kg-layout-split">
-                    <h2>Header</h2>
-                </div>
-            `);
+            dataset.layout = 'split';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+
+            const document = createDocument(element.outerHTML);
+            const nodes = $generateNodesFromDOM(editor, document);
             nodes.length.should.equal(1);
-            nodes[0].layout.should.equal('split');
         }));
 
         it('parses split and swapped correctly', editorTest(function () {
-            const nodes = generateSignupNodes(html`
-                <div data-lexical-signup-form="" class="kg-layout-split kg-swapped">
-                    <h2>Header</h2>
-                </div>
-            `);
+            dataset.layout = 'split';
+            dataset.swapped = true;
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            const document = createDocument(element.outerHTML);
+            const nodes = $generateNodesFromDOM(editor, document);
             nodes.length.should.equal(1);
-            nodes[0].layout.should.equal('split');
-            nodes[0].swapped.should.equal(true);
         }));
 
         it('parses background size contain correctly', editorTest(function () {
-            const nodes = generateSignupNodes(html`
-                <div data-lexical-signup-form="" class="kg-layout-split kg-content-wide">
-                    <h2>Header</h2>
-                </div>
-            `);
+            dataset.layout = 'split';
+            dataset.backgroundSize = 'contain';
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            const document = createDocument(element.outerHTML);
+            const nodes = $generateNodesFromDOM(editor, document);
             nodes.length.should.equal(1);
-            nodes[0].layout.should.equal('split');
-            nodes[0].backgroundSize.should.equal('contain');
         }));
 
         it('parses background size cover correctly', editorTest(function () {
-            const nodes = generateSignupNodes(html`
-                <div data-lexical-signup-form="" class="kg-layout-split">
-                    <h2>Header</h2>
-                </div>
-            `);
+            dataset.layout = 'split';
+            dataset.backgroundSize = 'cover';
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+            const document = createDocument(element.outerHTML);
+            const nodes = $generateNodesFromDOM(editor, document);
             nodes.length.should.equal(1);
-            nodes[0].layout.should.equal('split');
-            nodes[0].backgroundSize.should.equal('cover');
         }));
 
         it('parses with empty elements removed', editorTest(function () {
-            const nodes = generateSignupNodes(html`
-                <div data-lexical-signup-form="">
-                </div>
-            `);
+            dataset.header = '';
+            dataset.subheader = '';
+            dataset.disclaimer = '';
+            dataset.backgroundColor = '#ffffff';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+
+            const document = createDocument(element.outerHTML);
+            const nodes = $generateNodesFromDOM(editor, document);
             nodes.length.should.equal(1);
-            nodes[0].header.should.equal('');
-            nodes[0].subheader.should.equal('');
-            nodes[0].disclaimer.should.equal('');
         }));
 
         it('parses without image', editorTest(function () {
-            const nodes = generateSignupNodes(html`
-                <div data-lexical-signup-form="" style="background-color: rgb(255, 0, 0);">
-                    <h2>Header</h2>
-                </div>
-            `);
+            // red background
+            dataset.backgroundColor = '#ff0000';
+            dataset.backgroundImageSrc = '';
+
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
+
+            const document = createDocument(element.outerHTML);
+            const nodes = $generateNodesFromDOM(editor, document);
             nodes.length.should.equal(1);
-            nodes[0].backgroundColor.should.equal('#ff0000');
-            (nodes[0].backgroundImageSrc === undefined || nodes[0].backgroundImageSrc === '').should.be.true();
         }));
 
         it('parses with accent button and background', editorTest(function () {
-            const nodes = generateSignupNodes(html`
-                <div data-lexical-signup-form="" class="kg-style-accent">
-                    <h2>Header</h2>
-                    <div class="kg-signup-card-button kg-style-accent" style="color: #ffffff;">
-                        <span class="kg-signup-card-button-default">Button</span>
-                    </div>
-                </div>
-            `);
-            nodes.length.should.equal(1);
-            nodes[0].backgroundColor.should.equal('accent');
-            nodes[0].buttonColor.should.equal('accent');
-            nodes[0].buttonTextColor.should.equal('#ffffff');
-        }));
+            dataset.backgroundColor = 'accent';
+            dataset.buttonColor = 'accent';
+            dataset.buttonTextColor = '#ffffff';
 
-        it('parses with background image', editorTest(function () {
-            const nodes = generateSignupNodes(html`
-                <div data-lexical-signup-form="">
-                    <h2>Header</h2>
-                    <img class="kg-signup-card-image" src="https://example.com/image.jpg" />
-                </div>
-            `);
-            nodes.length.should.equal(1);
-            nodes[0].backgroundImageSrc.should.equal('https://example.com/image.jpg');
-        }));
+            const signupNode = $createSignupNode(dataset);
+            const {element} = signupNode.exportDOM(exportOptions);
 
-        it('parses text alignment', editorTest(function () {
-            const nodes = generateSignupNodes(html`
-                <div data-lexical-signup-form="">
-                    <h2>Header</h2>
-                    <div class="kg-signup-card-text kg-align-center">
-                        <div class="kg-signup-card-button">
-                            <span class="kg-signup-card-button-default">Button</span>
-                        </div>
-                    </div>
-                </div>
-            `);
+            const document = createDocument(element.outerHTML);
+            const nodes = $generateNodesFromDOM(editor, document);
             nodes.length.should.equal(1);
-            nodes[0].alignment.should.equal('center');
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/toggle.test.js
+++ b/packages/kg-default-nodes/test/nodes/toggle.test.js
@@ -1,6 +1,6 @@
 const {createHeadlessEditor} = require('@lexical/headless');
 const {$getRoot} = require('lexical');
-const {createDocument, html} = require('../test-utils');
+const {createDocument, dom, html} = require('../test-utils');
 const {ToggleNode, $createToggleNode, $isToggleNode} = require('../../');
 const {$generateNodesFromDOM} = require('@lexical/html');
 
@@ -9,6 +9,7 @@ const editorNodes = [ToggleNode];
 describe('ToggleNode', function () {
     let editor;
     let dataset;
+    let exportOptions;
 
     // NOTE: all tests should use this function, without it you need manual
     // try/catch and done handling to avoid assertion failures not triggering
@@ -32,6 +33,11 @@ describe('ToggleNode', function () {
         dataset = {
             heading: 'Toggle Heading',
             content: 'Collapsible content'
+        };
+
+        exportOptions = {
+            exportFormat: 'html',
+            dom
         };
     });
 
@@ -149,6 +155,109 @@ describe('ToggleNode', function () {
                 }
             });
         });
+    });
+
+    describe('exportDOM', function () {
+        it('renders', editorTest(function () {
+            const payload = {
+                heading: 'Heading',
+                content: 'Content'
+            };
+            const toggleNode = $createToggleNode(payload);
+            const {element} = toggleNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(html`
+            <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
+                <div class="kg-toggle-heading">
+                    <h4 class="kg-toggle-heading-text">Heading</h4>
+                    <button class="kg-toggle-card-icon" aria-label="Expand toggle to read content">
+                        <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                            <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
+                        </svg>
+                    </button>
+                </div>
+                <div class="kg-toggle-content">Content</div>
+            </div>
+            `);
+        }));
+
+        it('renders for email target', editorTest(function () {
+            const payload = {
+                heading: 'Heading',
+                content: 'Content'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const toggleNode = $createToggleNode(payload);
+            const {element} = toggleNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(html`
+                <div style="background: transparent;
+                border: 1px solid rgba(124, 139, 154, 0.25); border-radius: 4px; padding: 20px; margin-bottom: 1.5em;">
+                    <h4 style="font-size: 1.375rem; font-weight: 600; margin-bottom: 8px; margin-top:0px">Heading</h4>
+                    <div style="font-size: 1rem; line-height: 1.5; margin-bottom: -1.5em;">Content</div>
+                </div>
+            `);
+        }));
+
+        it('renders for email target (emailCustomizationAlpha)', editorTest(function () {
+            const payload = {
+                heading: 'Heading',
+                content: 'Content'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post',
+                feature: {
+                    emailCustomizationAlpha: true
+                }
+            };
+            const toggleNode = $createToggleNode(payload);
+            const {element} = toggleNode.exportDOM({...exportOptions, ...options});
+
+            element.outerHTML.should.prettifyTo(html`
+                <table cellspacing="0" cellpadding="0" border="0" width="100%" class="kg-toggle-card">
+                    <tbody>
+                        <tr>
+                            <td class="kg-toggle-heading">
+                                <h4>Heading</h4>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="kg-toggle-content">
+                                Content
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
+        }));
+
+        it('renders heading', editorTest(function () {
+            const payload = {
+                heading: 'Heading',
+                content: 'Content'
+            };
+
+            const toggleNode = $createToggleNode(payload);
+            const {element} = toggleNode.exportDOM(exportOptions);
+            element.outerHTML.should.containEql('<h4 class="kg-toggle-heading-text">Heading</h4>');
+        }));
+
+        it('renders content', editorTest(function () {
+            const payload = {
+                heading: 'Heading',
+                content: 'Content'
+            };
+
+            const toggleNode = $createToggleNode(payload);
+            const {element} = toggleNode.exportDOM(exportOptions);
+            element.outerHTML.should.containEql('<div class="kg-toggle-content">Content</div>');
+        }));
     });
 
     describe('importDOM', function () {

--- a/packages/kg-default-nodes/test/nodes/video.test.js
+++ b/packages/kg-default-nodes/test/nodes/video.test.js
@@ -1,4 +1,4 @@
-const {createDocument, html} = require('../test-utils');
+const {createDocument, dom, html} = require('../test-utils');
 const {$getRoot} = require('lexical');
 const {createHeadlessEditor} = require('@lexical/headless');
 const {VideoNode, $createVideoNode, $isVideoNode} = require('../../');
@@ -9,6 +9,7 @@ const editorNodes = [VideoNode];
 describe('VideoNode', function () {
     let editor;
     let dataset;
+    let exportOptions;
 
     // NOTE: all tests should use this function, without it you need manual
     // try/catch and done handling to avoid assertion failures not triggering
@@ -40,6 +41,10 @@ describe('VideoNode', function () {
             thumbnailWidth: 100,
             thumbnailHeight: 50
         };
+
+        exportOptions = new Object({
+            dom
+        });
     });
 
     it('matches node with $isVideoNode', editorTest(function () {
@@ -222,6 +227,147 @@ describe('VideoNode', function () {
                 }
             });
         });
+    });
+
+    describe('exportDOM', function () {
+        it('renders', editorTest(function () {
+            const payload = {
+                src: '/content/images/2022/11/koenig-lexical.mp4',
+                width: 200,
+                height: 100,
+                duration: 60,
+                thumbnailSrc: '/content/images/2022/11/koenig-lexical.jpg'
+            };
+            const videoNode = $createVideoNode(payload);
+            const {element} = videoNode.exportDOM(exportOptions);
+
+            element.outerHTML.should.prettifyTo(html`
+                <figure class="kg-card kg-video-card kg-width-regular" data-kg-thumbnail="/content/images/2022/11/koenig-lexical.jpg" data-kg-custom-thumbnail="">
+                    <div class="kg-video-container">
+                        <video
+                            src="/content/images/2022/11/koenig-lexical.mp4"
+                            poster="https://img.spacergif.org/v1/200x100/0a/spacer.png"
+                            width="200"
+                            height="100"
+                            playsinline=""
+                            preload="metadata"
+                            style="background: transparent url('/content/images/2022/11/koenig-lexical.jpg') 50% 50% / cover no-repeat;"
+                        ></video>
+                        <div class="kg-video-overlay">
+                            <button class="kg-video-large-play-icon" aria-label="Play video">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                    <path d="M23.14 10.608 2.253.164A1.559 1.559 0 0 0 0 1.557v20.887a1.558 1.558 0 0 0 2.253 1.392L23.14 13.393a1.557 1.557 0 0 0 0-2.785Z"></path>
+                                </svg>
+                            </button>
+                        </div>
+                        <div class="kg-video-player-container">
+                            <div class="kg-video-player">
+                                <button class="kg-video-play-icon" aria-label="Play video">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                        <path d="M23.14 10.608 2.253.164A1.559 1.559 0 0 0 0 1.557v20.887a1.558 1.558 0 0 0 2.253 1.392L23.14 13.393a1.557 1.557 0 0 0 0-2.785Z"></path>
+                                    </svg>
+                                </button>
+                                <button class="kg-video-pause-icon kg-video-hide" aria-label="Pause video">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                        <rect x="3" y="1" width="7" height="22" rx="1.5" ry="1.5"></rect>
+                                        <rect x="14" y="1" width="7" height="22" rx="1.5" ry="1.5"></rect>
+                                    </svg>
+                                </button>
+                                <span class="kg-video-current-time">0:00</span>
+                                <div class="kg-video-time">
+                                    /<span class="kg-video-duration">1:00</span>
+                                </div>
+                                <input type="range" class="kg-video-seek-slider" max="100" value="0">
+                                <button class="kg-video-playback-rate" aria-label="Adjust playback speed">1×</button>
+                                <button class="kg-video-unmute-icon" aria-label="Unmute">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                        <path d="M15.189 2.021a9.728 9.728 0 0 0-7.924 4.85.249.249 0 0 1-.221.133H5.25a3 3 0 0 0-3 3v2a3 3 0 0 0 3 3h1.794a.249.249 0 0 1 .221.133 9.73 9.73 0 0 0 7.924 4.85h.06a1 1 0 0 0 1-1V3.02a1 1 0 0 0-1.06-.998Z"></path>
+                                    </svg>
+                                </button>
+                                <button class="kg-video-mute-icon kg-video-hide" aria-label="Mute">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                        <path d="M16.177 4.3a.248.248 0 0 0 .073-.176v-1.1a1 1 0 0 0-1.061-1 9.728 9.728 0 0 0-7.924 4.85.249.249 0 0 1-.221.133H5.25a3 3 0 0 0-3 3v2a3 3 0 0 0 3 3h.114a.251.251 0 0 0 .177-.073ZM23.707 1.706A1 1 0 0 0 22.293.292l-22 22a1 1 0 0 0 0 1.414l.009.009a1 1 0 0 0 1.405-.009l6.63-6.631A.251.251 0 0 1 8.515 17a.245.245 0 0 1 .177.075 10.081 10.081 0 0 0 6.5 2.92 1 1 0 0 0 1.061-1V9.266a.247.247 0 0 1 .073-.176Z"></path>
+                                    </svg>
+                                </button>
+                                <input type="range" class="kg-video-volume-slider" max="100" value="100">
+                            </div>
+                        </div>
+                    </div>
+                </figure>
+            `);
+        }));
+
+        it('renders for email target', editorTest(function () {
+            const payload = {
+                src: '/content/images/2022/11/koenig-lexical.mp4',
+                width: 200,
+                height: 100,
+                duration: 60,
+                thumbnailSrc: '/content/images/2022/11/koenig-lexical.jpg'
+            };
+
+            const options = {
+                target: 'email',
+                postUrl: 'https://example.com/my-post'
+            };
+            const videoNode = $createVideoNode(payload);
+            const {element} = videoNode.exportDOM({...exportOptions, ...options});
+            const output = element.outerHTML;
+
+            output.should.not.containEql('<video');
+            output.should.containEql('<figure class="kg-card kg-video-card kg-width-regular"');
+            output.should.containEql('<a class="kg-video-preview" href="https://example.com/my-post"');
+            output.should.containEql('background="/content/images/2022/11/koenig-lexical.jpg"');
+        }));
+
+        it('renders card width', editorTest(function () {
+            const payload = {
+                src: '/content/images/2022/11/koenig-lexical.mp4',
+                width: 200,
+                height: 100,
+                duration: 60,
+                thumbnailSrc: '/content/images/2022/11/koenig-lexical.jpg',
+                cardWidth: 'wide'
+            };
+
+            const videoNode = $createVideoNode(payload);
+            const {element} = videoNode.exportDOM(exportOptions);
+            const output = element.outerHTML;
+            output.should.containEql('kg-card kg-video-card kg-width-wide');
+        }));
+
+        it('renders loop attribute', editorTest(function () {
+            const payload = {
+                src: '/content/images/2022/11/koenig-lexical.mp4',
+                width: 200,
+                height: 100,
+                duration: 60,
+                thumbnailSrc: '/content/images/2022/11/koenig-lexical.jpg',
+                loop: true
+            };
+
+            const videoNode = $createVideoNode(payload);
+            const {element} = videoNode.exportDOM(exportOptions);
+            const output = element.outerHTML;
+            output.should.containEql('loop');
+        }));
+
+        it('renders caption when provided', editorTest(function () {
+            const payload = {
+                src: '/content/images/2022/11/koenig-lexical.mp4',
+                width: 200,
+                height: 100,
+                duration: 60,
+                thumbnailSrc: '/content/images/2022/11/koenig-lexical.jpg',
+                caption: '<strong>Caption</strong>'
+            };
+
+            const videoNode = $createVideoNode(payload);
+            const {element} = videoNode.exportDOM(exportOptions);
+            const output = element.outerHTML;
+            output.should.containEql('<figure class="kg-card kg-video-card kg-width-regular kg-card-hascaption"');
+            output.should.containEql('<figcaption><strong>Caption</strong></figcaption>');
+        }));
     });
 
     describe('hasEditMode', function () {

--- a/packages/kg-default-nodes/test/utils/visibility.test.js
+++ b/packages/kg-default-nodes/test/utils/visibility.test.js
@@ -1,6 +1,6 @@
 const {JSDOM} = require('jsdom');
 const {utils} = require('../../');
-const {isOldVisibilityFormat, isVisibilityRestricted, migrateOldVisibilityFormat, buildDefaultVisibility} = utils.visibility;
+const {isOldVisibilityFormat, isVisibilityRestricted, migrateOldVisibilityFormat, renderWithVisibility, buildDefaultVisibility} = utils.visibility;
 
 describe('Utils: visibility', function () {
     describe('isOldVisibilityFormat', function () {
@@ -192,6 +192,146 @@ describe('Utils: visibility', function () {
                 {emailOnly: false},
                 {memberSegment: 'status:free,status:-free'}
             ));
+        });
+    });
+
+    describe('renderWithVisibility', function () {
+        let document;
+
+        before(function () {
+            document = (new JSDOM()).window.document;
+        });
+
+        function buildVisibility(visibility) {
+            return {...buildDefaultVisibility(), ...visibility};
+        }
+
+        function runRender(html, visibility, target) {
+            const visibilityWithDefaults = buildVisibility(visibility);
+
+            const p = document.createElement('p');
+            p.innerHTML = html;
+
+            const originalOutput = {
+                element: p,
+                type: 'html'
+            };
+            return renderWithVisibility(originalOutput, visibilityWithDefaults, {target});
+        }
+
+        describe('email target', function () {
+            it('returns empty container when membersSegment === no members', function () {
+                const visibility = {email: {memberSegment: ''}};
+                const result = runRender('testing', visibility, 'email');
+
+                result.element.tagName.should.equal('SPAN');
+                result.element.innerHTML.should.equal('');
+                result.type.should.equal('inner');
+            });
+
+            it('returns original output when membersSegment === all members', function () {
+                const visibility = {email: {memberSegment: 'status:free,status:-free'}};
+                const result = runRender('testing', visibility, 'email');
+
+                result.element.tagName.should.eql('P');
+                result.element.innerHTML.should.equal('testing');
+                result.type.should.equal('html');
+            });
+
+            it('wraps original output when emailing a specific segment', function () {
+                const visibility = {email: {memberSegment: 'status:free'}};
+                const result = runRender('testing', visibility, 'email');
+
+                result.element.tagName.should.eql('DIV');
+                result.element.dataset.ghSegment.should.equal('status:free');
+                result.element.innerHTML.should.equal('<p>testing</p>');
+                result.type.should.equal('html');
+            });
+        });
+
+        describe('web target', function () {
+            it('returns original output when no restrictions placed on web visibility', function () {
+                const visibility = {web: {nonMember: true, memberSegment: 'status:free,status:-free'}};
+                const result = runRender('testing', visibility, 'web');
+
+                result.element.tagName.should.eql('P');
+                result.element.innerHTML.should.equal('testing');
+                result.type.should.equal('html');
+            });
+
+            it('adds wrapping comments when anonymous is gated', function () {
+                const visibility = {web: {nonMember: false, memberSegment: 'status:free,status:-free'}};
+                const result = runRender('testing', visibility, 'web');
+
+                result.element.tagName.should.equal('TEXTAREA');
+                result.element.value.should.equal('\n<!--kg-gated-block:begin nonMember:false memberSegment:"status:free,status:-free" --><p>testing</p><!--kg-gated-block:end-->\n');
+            });
+
+            it('adds wrapping comments when member segment is gated', function () {
+                const visibility = {web: {nonMember: true, memberSegment: 'status:free'}};
+                const result = runRender('testing', visibility, 'web');
+
+                result.element.tagName.should.equal('TEXTAREA');
+                result.element.value.should.equal('\n<!--kg-gated-block:begin nonMember:true memberSegment:"status:free" --><p>testing</p><!--kg-gated-block:end-->\n');
+            });
+        });
+
+        it('handles no render type', function () {
+            const visibility = buildVisibility({web: {nonMember: true, memberSegment: 'status:free'}});
+            const p = document.createElement('p');
+            p.innerHTML = 'testing';
+            const originalOutput = {element: p};
+
+            const result = renderWithVisibility(originalOutput, buildVisibility(visibility), {target: 'web'});
+
+            result.element.tagName.should.equal('TEXTAREA');
+            result.element.value.should.equal('\n<!--kg-gated-block:begin nonMember:true memberSegment:"status:free" --><p>testing</p><!--kg-gated-block:end-->\n');
+        });
+
+        it('handles inner render type', function () {
+            const visibility = buildVisibility({web: {nonMember: true, memberSegment: 'status:free'}});
+            const div = document.createElement('div');
+            div.innerHTML = '<!--comment test--><span>testing</span>';
+            const originalOutput = {element: div, type: 'inner'};
+
+            const result = renderWithVisibility(originalOutput, buildVisibility(visibility), {target: 'web'});
+
+            result.element.tagName.should.equal('TEXTAREA');
+            result.element.value.should.equal('\n<!--kg-gated-block:begin nonMember:true memberSegment:"status:free" --><!--comment test--><span>testing</span><!--kg-gated-block:end-->\n');
+        });
+
+        it('handles value render type', function () {
+            const visibility = buildVisibility({web: {nonMember: true, memberSegment: 'status:free'}});
+            const input = document.createElement('input');
+            input.value = '<!--comment test--><span>testing</span>';
+            const originalOutput = {element: input, type: 'value'};
+
+            const result = renderWithVisibility(originalOutput, buildVisibility(visibility), {target: 'web'});
+
+            result.element.tagName.should.equal('TEXTAREA');
+            result.element.value.should.equal('\n<!--kg-gated-block:begin nonMember:true memberSegment:"status:free" --><!--comment test--><span>testing</span><!--kg-gated-block:end-->\n');
+        });
+
+        it('handles old beta visibility format', function () {
+            const visibility = {
+                showOnWeb: true,
+                showOnEmail: true,
+                segment: 'status:free'
+            };
+
+            const p = document.createElement('p');
+            p.innerHTML = 'testing';
+
+            const originalOutput = {
+                element: p,
+                type: 'html'
+            };
+            const result = renderWithVisibility(originalOutput, visibility, {target: 'email'});
+
+            result.element.tagName.should.eql('DIV');
+            result.element.dataset.ghSegment.should.equal('status:free');
+            result.element.innerHTML.should.equal('<p>testing</p>');
+            result.type.should.equal('html');
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3741,6 +3741,28 @@
   dependencies:
     lodash-es "^4.17.11"
 
+"@tryghost/kg-markdown-html-renderer@7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/kg-markdown-html-renderer/-/kg-markdown-html-renderer-7.1.2.tgz#f896c70acdc8ab9e25174343dd68646d631a06f3"
+  integrity sha512-7/im5iBkBcGvTy+ju5CKChsix+RBsjimLLnHC6agnhr5NzWhSPNzhV57J0msqihbwboDEFr5UPXb6XfiKJvBHw==
+  dependencies:
+    "@tryghost/kg-utils" "1.0.31"
+    markdown-it "^14.0.0"
+    markdown-it-footnote "^4.0.0"
+    markdown-it-image-lazy-loading "^2.0.0"
+    markdown-it-lazy-headers "^0.1.3"
+    markdown-it-mark "^4.0.0"
+    markdown-it-sub "^2.0.0"
+    markdown-it-sup "^2.0.0"
+    semver "^7.7.0"
+
+"@tryghost/kg-utils@1.0.31":
+  version "1.0.31"
+  resolved "https://registry.yarnpkg.com/@tryghost/kg-utils/-/kg-utils-1.0.31.tgz#00e29cec01a16c53bc12e9d0d7f2153e58fde5d4"
+  integrity sha512-TJRTu3XCxfqclueDjs8cVi3p9o5lYrIIkA6abNl4EAHvT9FtR6nY0FQgEgDwtDDjpaWq+VKcDyo48abvAG456g==
+  dependencies:
+    semver "^7.7.0"
+
 "@tryghost/mobiledoc-kit@0.11.2-ghost.4":
   version "0.11.2-ghost.4"
   resolved "https://registry.yarnpkg.com/@tryghost/mobiledoc-kit/-/mobiledoc-kit-0.11.2-ghost.4.tgz#144189e7e62748b3c56e7b723fa18a5e8c807ccf"
@@ -6537,7 +6559,7 @@ cloneable-readable@^1.0.0:
     process-nextick-args "^2.0.0"
     readable-stream "^2.3.5"
 
-clsx@^2.0.0:
+clsx@2.1.1, clsx@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==


### PR DESCRIPTION
This reverts commit bdeec0948b29301c71aa03ec3f4b3ac505b342bd.

- Lexical calls `exportDOM` on nodes when performing cut/copy operations in order to place a HTML representation on the clipboard. Without the default node renderers being present this errors which completely breaks copy/paste
- reverting for now to get back to a working version whilst we look into a solution that still allows renderers to exist in the consuming app
