### PR TITLE
Removed feature flag gating of custom renderers

### DIFF
--- a/packages/kg-default-nodes/lib/generate-decorator-node.js
+++ b/packages/kg-default-nodes/lib/generate-decorator-node.js
@@ -180,11 +180,7 @@ export function generateDecoratorNode({nodeType, properties = [], defaultRenderF
             // means it's set from the serialized version data at runtime
             const nodeVersion = this.__version || version;
 
-            const hasEmailCustomization =
-                options.feature?.emailCustomizationAlpha ||
-                options.feature?.emailCustomization;
-
-            if (hasEmailCustomization && options.nodeRenderers?.[nodeType]) {
+            if (options.nodeRenderers?.[nodeType]) {
                 const render = options.nodeRenderers[nodeType];
 
                 if (typeof render === 'object') {


### PR DESCRIPTION
no issue

- we've had to revert the full removal of default renderers but we still need Ghost to be able to render using it's own provided custom renderers
- removed `emailCustomization` flag gating of the custom renderer code because Ghost no longer has that flag in place since going GA
