### PR TITLE
Koenig: Fix race condition in Unsplash search that causes incorrect results

### DIFF
--- a/packages/kg-unsplash-selector/src/UnsplashSearchModal.tsx
+++ b/packages/kg-unsplash-selector/src/UnsplashSearchModal.tsx
@@ -106,6 +106,9 @@ export const UnsplashSearchModal : React.FC<UnsplashModalProps> = ({onClose, onI
             setDataset([]);
             UnsplashLib.clearPhotos();
             await UnsplashLib.updateSearch(searchTerm);
+            if (!UnsplashLib.hasUpdatedResults) {
+                return;
+            }
             const columns = UnsplashLib.getColumns();
             if (columns) {
                 setDataset(columns);
@@ -124,7 +127,7 @@ export const UnsplashSearchModal : React.FC<UnsplashModalProps> = ({onClose, onI
             } else {
                 await loadInitPhotos();
             }
-        }, 600);
+        }, 10);
         return () => {
             initLoadRef.current = true;
             clearTimeout(timeoutId);

--- a/packages/kg-unsplash-selector/src/UnsplashSearchModal.tsx
+++ b/packages/kg-unsplash-selector/src/UnsplashSearchModal.tsx
@@ -124,7 +124,7 @@ export const UnsplashSearchModal : React.FC<UnsplashModalProps> = ({onClose, onI
             } else {
                 await loadInitPhotos();
             }
-        }, 300);
+        }, 600);
         return () => {
             initLoadRef.current = true;
             clearTimeout(timeoutId);

--- a/packages/kg-unsplash-selector/src/UnsplashSearchModal.tsx
+++ b/packages/kg-unsplash-selector/src/UnsplashSearchModal.tsx
@@ -127,7 +127,7 @@ export const UnsplashSearchModal : React.FC<UnsplashModalProps> = ({onClose, onI
             } else {
                 await loadInitPhotos();
             }
-        }, 10);
+        }, 600);
         return () => {
             initLoadRef.current = true;
             clearTimeout(timeoutId);

--- a/packages/kg-unsplash-selector/src/api/IUnsplashProvider.ts
+++ b/packages/kg-unsplash-selector/src/api/IUnsplashProvider.ts
@@ -6,4 +6,5 @@ export interface IUnsplashProvider {
     searchPhotos(term: string): Promise<Photo[]>;
     triggerDownload(photo: Photo): Promise<void> | void;
     searchIsRunning(): boolean;
+    getLastSearchTerm(): string;
 }

--- a/packages/kg-unsplash-selector/src/api/InMemoryUnsplashProvider.ts
+++ b/packages/kg-unsplash-selector/src/api/InMemoryUnsplashProvider.ts
@@ -9,6 +9,7 @@ export class InMemoryUnsplashProvider implements IUnsplashProvider {
     REQUEST_IS_RUNNING: boolean = false;
     SEARCH_IS_RUNNING: boolean = false;
     LAST_REQUEST_URL: string = '';
+    LAST_SEARCH_TERM: string = '';
     ERROR: string | null = null;
     IS_LOADING: boolean = false;
     currentPage: number = 1;
@@ -36,6 +37,7 @@ export class InMemoryUnsplashProvider implements IUnsplashProvider {
 
     public async searchPhotos(term: string): Promise<Photo[]> {
         this.SEARCH_IS_RUNNING = true;
+        this.LAST_SEARCH_TERM = term;
         const filteredPhotos = this.photos.filter(photo => (photo.description && photo.description.toLowerCase().includes(term.toLowerCase())) || 
             (photo.alt_description && photo.alt_description.toLowerCase().includes(term.toLowerCase()))
         );
@@ -45,6 +47,10 @@ export class InMemoryUnsplashProvider implements IUnsplashProvider {
 
     searchIsRunning(): boolean {
         return this.SEARCH_IS_RUNNING;
+    }
+
+    getLastSearchTerm(): string {
+        return this.LAST_SEARCH_TERM;
     }
 
     triggerDownload(photo: Photo): void {

--- a/packages/kg-unsplash-selector/src/api/PhotoUseCase.ts
+++ b/packages/kg-unsplash-selector/src/api/PhotoUseCase.ts
@@ -33,4 +33,8 @@ export class PhotoUseCases {
     searchIsRunning(): boolean {
         return this._provider.searchIsRunning();
     }
+
+    getLastSearchTerm(): string {
+        return this._provider.getLastSearchTerm();
+    }
 }

--- a/packages/kg-unsplash-selector/src/api/UnsplashProvider.ts
+++ b/packages/kg-unsplash-selector/src/api/UnsplashProvider.ts
@@ -9,6 +9,7 @@ export class UnsplashProvider implements IUnsplashProvider {
     REQUEST_IS_RUNNING: boolean = false;
     SEARCH_IS_RUNNING: boolean = false;
     LAST_REQUEST_URL: string = '';
+    LAST_SEARCH_TERM: string = '';
     IS_LOADING: boolean = false;
 
     constructor(HEADERS: DefaultHeaderTypes) {
@@ -16,10 +17,6 @@ export class UnsplashProvider implements IUnsplashProvider {
     }
 
     private async makeRequest(url: string): Promise<Photo[] | {results: Photo[]} | null> {
-        if (this.REQUEST_IS_RUNNING) {
-            return null;
-        }
-    
         this.LAST_REQUEST_URL = url;
         const options = {
             method: 'GET',
@@ -35,7 +32,7 @@ export class UnsplashProvider implements IUnsplashProvider {
             this.extractPagination(checkedResponse);
     
             const jsonResponse = await checkedResponse.json();
-            
+
             if ('results' in jsonResponse) {
                 return jsonResponse.results;
             } else {
@@ -106,6 +103,7 @@ export class UnsplashProvider implements IUnsplashProvider {
     }
 
     public async searchPhotos(term: string): Promise<Photo[]> {
+        this.LAST_SEARCH_TERM = term;
         const url = `${this.API_URL}/search/photos?query=${term}&per_page=30`;
 
         const request = await this.makeRequest(url);
@@ -158,5 +156,9 @@ export class UnsplashProvider implements IUnsplashProvider {
 
     searchIsRunning(): boolean {
         return this.SEARCH_IS_RUNNING;
+    }
+
+    getLastSearchTerm(): string {
+        return this.LAST_SEARCH_TERM;
     }
 }

--- a/packages/kg-unsplash-selector/src/api/UnsplashService.ts
+++ b/packages/kg-unsplash-selector/src/api/UnsplashService.ts
@@ -12,12 +12,14 @@ export interface IUnsplashService {
     triggerDownload(photo: Photo): void;
     photos: Photo[];
     searchIsRunning(): boolean;
+    getLastSearchTerm(): string;
 }
 
 export class UnsplashService implements IUnsplashService {
     private photoUseCases: PhotoUseCases;
     private masonryService: MasonryService;
     public photos: Photo[] = [];
+    public hasUpdatedResults: boolean = false;
 
     constructor(photoUseCases: PhotoUseCases, masonryService: MasonryService) {
         this.photoUseCases = photoUseCases;
@@ -47,11 +49,13 @@ export class UnsplashService implements IUnsplashService {
 
     async updateSearch(term: string) {
         let results = await this.photoUseCases.searchPhotos(term);
-        if (this.photoUseCases.getLastSearchTerm() !== term) {
+        if (this.getLastSearchTerm() !== term) {
+            this.hasUpdatedResults = false;
             return;
         }
         this.photos = results;
         this.layoutPhotos();
+        this.hasUpdatedResults = true;
     }
 
     async loadNextPage() {
@@ -70,5 +74,9 @@ export class UnsplashService implements IUnsplashService {
 
     searchIsRunning() {
         return this.photoUseCases.searchIsRunning();
+    }
+
+    getLastSearchTerm(): string {
+        return this.photoUseCases.getLastSearchTerm();
     }
 }

--- a/packages/kg-unsplash-selector/src/api/UnsplashService.ts
+++ b/packages/kg-unsplash-selector/src/api/UnsplashService.ts
@@ -47,6 +47,9 @@ export class UnsplashService implements IUnsplashService {
 
     async updateSearch(term: string) {
         let results = await this.photoUseCases.searchPhotos(term);
+        if (this.photoUseCases.getLastSearchTerm() !== term) {
+            return;
+        }
         this.photos = results;
         this.layoutPhotos();
     }


### PR DESCRIPTION
Fixes https://github.com/TryGhost/Ghost/issues/24640

## Problem
The Unsplash search component (used in the lexical editor and Design Settings) can sometimes fail to request results for the final search term. When typing a term like "Trumpet", the component may only send a request for a partial keyword (e.g. "Trump") and never send the request for the full term "Trumpet". This is caused by logic that prevents a new search from being initiated while a prior request is still in flight.

In the example below, the search for "Trumpet" shows results for "Trump".

https://github.com/user-attachments/assets/cf361c99-89da-4a35-900e-534bc7c59243


## Root cause

* **New search is skipped while a prior request is running**. The search logic contains a guard that prevents starting a new request if [another is still in progress](https://github.com/TryGhost/Koenig/blob/cefb1b9b3e235895302e682ff384bcbe4c83a0eb/packages/kg-unsplash-selector/src/api/UnsplashProvider.ts#L19-L21). This means the final, complete query may never be sent.
For example, when typing "Jupiter" with a brief pause after "Jupi", the [debounced search](https://github.com/TryGhost/Koenig/blob/cefb1b9b3e235895302e682ff384bcbe4c83a0eb/packages/kg-unsplash-selector/src/UnsplashSearchModal.tsx#L123) (300 ms) fires for "Jupi". If the remaining "ter" is typed while the "Jupi" request is still in flight, the "Jupiter" request is never made, because the guard blocks it until the current request completes.

* **Debounce is short**. The debounce is relatively short at 300 ms, which increases the probability that a previous request is still running when a new search is fired (The Ember Unsplash component [uses 600 ms](https://github.com/TryGhost/Ghost/blob/3ab6bdcdd133f9e97cc71b3a21c392597a7a3e11/ghost/admin/app/services/unsplash.js#L11) for reference.)

## Fix

* Remove the guard that blocks starting a new fetch when there is an in-flight request. 
* Only update results if they match the active search term. When a response arrives, verify that its search term matches the current active term before updating the modal. This prevents a flash of response for stale search terms, and instead the loading indicator will be displayed.
For example, in the "Jupiter" scenario above, if the active term is "Jupiter", ignore updating the UI with "Jupi" response and instead continue showing the loading indicator.
* Increase debounce to 600ms, which lowers the chances that an in-flight request is still under process when a new fetch has started.
