### PR TITLE
Koenig: Improve Unsplash Modal Responsiveness 

### DIFF
--- a/packages/kg-unsplash-selector/src/UnsplashSearchModal.tsx
+++ b/packages/kg-unsplash-selector/src/UnsplashSearchModal.tsx
@@ -77,13 +77,11 @@ export const UnsplashSearchModal : React.FC<UnsplashModalProps> = ({onClose, onI
     }, [galleryRef, zoomedImg]);
 
     const calculateColumnCountForViewport = () => {
-        const width = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
-        
-        if (width < ONE_COLUMN_WIDTH) {
+        if (window.matchMedia(`(max-width: ${ONE_COLUMN_WIDTH}px)`).matches) {
             return 1;
         }
 
-        if (width < TWO_COLUMN_WIDTH) {
+        if (window.matchMedia(`(max-width: ${TWO_COLUMN_WIDTH}px)`).matches) {
             return 2;
         }
 
@@ -191,13 +189,14 @@ export const UnsplashSearchModal : React.FC<UnsplashModalProps> = ({onClose, onI
     }, [galleryRef, loadMorePhotos, zoomedImg]);
 
     const selectImg = (payload:Photo) => {
-        // if (UnsplashLib.getColumnCount() < 3) {
-        //     setZoomedImg(null);
-        //     if (galleryRef.current) {
-        //         galleryRef.current.scrollTop = lastScrollPos;
-        //     }
-        //     return;
-        // }
+        const isMobileViewport = window.matchMedia('(max-width: 540px)').matches;
+        const isTouchDevice = window.matchMedia('(pointer: coarse)').matches;
+        const shouldNotZoom = isMobileViewport || isTouchDevice;
+
+        if (shouldNotZoom) {
+            setZoomedImg(null);
+            return;
+        }
         
         if (payload) {
             setZoomedImg(payload);

--- a/packages/kg-unsplash-selector/src/api/UnsplashService.ts
+++ b/packages/kg-unsplash-selector/src/api/UnsplashService.ts
@@ -45,6 +45,10 @@ export class UnsplashService implements IUnsplashService {
         return this.masonryService.getColumns();
     }
 
+    getColumnCount(): number {
+        return this.masonryService.columnCount;
+    }
+
     async updateSearch(term: string) {
         let results = await this.photoUseCases.searchPhotos(term);
         this.photos = results;

--- a/packages/kg-unsplash-selector/src/ui/UnsplashGallery.tsx
+++ b/packages/kg-unsplash-selector/src/ui/UnsplashGallery.tsx
@@ -80,16 +80,17 @@ const UnsplashGalleryColumns: React.FC<UnsplashGalleryColumnsProps> = (props) =>
 };
 
 const GalleryLayout: React.FC<GalleryLayoutProps> = (props) => {
+    const columnCount = props?.columnCount ?? 0;
     const classNames = [
         'flex',
         'size-full',
         'justify-center',
         'overflow-auto',
         props?.zoomed ? 'pb-10' : '',
-        !props?.zoomed && (props?.columnCount ?? 0) < 3 ? 'px-5' : 'px-20'
+        columnCount < 3 ? 'px-5' : 'px-20'
     ].filter(Boolean).join(' ');
     return (
-        <div className="relative h-full overflow-hidden" data-kg-unsplash-gallery>
+        <div className={`relative h-full overflow-hidden ${columnCount === 1 ? 'px-5' : ''}`} data-kg-unsplash-gallery>
             <div ref={props.galleryRef} className={classNames} data-kg-unsplash-gallery-scrollref>
                 {props.children}
                 {props?.isLoading && <UnsplashGalleryLoading />}

--- a/packages/kg-unsplash-selector/src/ui/UnsplashGallery.tsx
+++ b/packages/kg-unsplash-selector/src/ui/UnsplashGallery.tsx
@@ -16,12 +16,14 @@ interface UnsplashGalleryColumnsProps {
 
 interface GalleryLayoutProps {
     children?: ReactNode;
+    columnCount?: number;
     galleryRef: RefObject<HTMLDivElement>;
     isLoading?: boolean;
     zoomed?: Photo | null;
 }
 
 interface UnsplashGalleryProps extends GalleryLayoutProps {
+    columnCount?: number;
     error?: string | null;
     dataset?: Photo[][] | [];
     selectImg?: any;
@@ -78,9 +80,17 @@ const UnsplashGalleryColumns: React.FC<UnsplashGalleryColumnsProps> = (props) =>
 };
 
 const GalleryLayout: React.FC<GalleryLayoutProps> = (props) => {
+    const classNames = [
+        'flex',
+        'size-full',
+        'justify-center',
+        'overflow-auto',
+        props?.zoomed ? 'pb-10' : '',
+        !props?.zoomed && (props?.columnCount ?? 0) < 3 ? 'px-5' : 'px-20'
+    ].filter(Boolean).join(' ');
     return (
         <div className="relative h-full overflow-hidden" data-kg-unsplash-gallery>
-            <div ref={props.galleryRef} className={`flex size-full justify-center overflow-auto px-20 ${props?.zoomed ? 'pb-10' : ''}`} data-kg-unsplash-gallery-scrollref>
+            <div ref={props.galleryRef} className={classNames} data-kg-unsplash-gallery-scrollref>
                 {props.children}
                 {props?.isLoading && <UnsplashGalleryLoading />}
             </div>
@@ -89,6 +99,7 @@ const GalleryLayout: React.FC<GalleryLayoutProps> = (props) => {
 };
 
 const UnsplashGallery: React.FC<UnsplashGalleryProps> = ({zoomed,
+    columnCount,
     error,
     galleryRef,
     isLoading,
@@ -133,6 +144,7 @@ const UnsplashGallery: React.FC<UnsplashGalleryProps> = ({zoomed,
 
     return (
         <GalleryLayout
+            columnCount={columnCount}
             galleryRef={galleryRef}
             isLoading={isLoading}
             zoomed={zoomed}>

--- a/packages/kg-unsplash-selector/src/ui/UnsplashImage.tsx
+++ b/packages/kg-unsplash-selector/src/ui/UnsplashImage.tsx
@@ -27,12 +27,12 @@ export interface UnsplashImageProps {
 const UnsplashImage: FC<UnsplashImageProps> = ({payload, srcUrl, links, likes, user, alt, urls, height, width, zoomed, insertImage, selectImg}) => {
     const handleClick = (e: MouseEvent<HTMLDivElement>) => {
         e.stopPropagation();
-        // selectImg(zoomed ? null : payload);
+        selectImg(zoomed ? null : payload);
     };
 
     return (
         <div
-            className={`relative mb-6 block ${zoomed ? 'h-full w-[max-content] cursor-zoom-out' : 'w-full cursor-zoom-in'}`}
+            className={`relative mb-6 block ${zoomed ? 'h-full w-[max-content] cursor-zoom-out' : 'w-full [@media(min-width:540px)]:cursor-zoom-in'}`}
             style={{backgroundColor: payload.color || 'transparent'}}
             data-kg-unsplash-gallery-item
             onClick={handleClick}>

--- a/packages/kg-unsplash-selector/src/ui/UnsplashImage.tsx
+++ b/packages/kg-unsplash-selector/src/ui/UnsplashImage.tsx
@@ -27,7 +27,7 @@ export interface UnsplashImageProps {
 const UnsplashImage: FC<UnsplashImageProps> = ({payload, srcUrl, links, likes, user, alt, urls, height, width, zoomed, insertImage, selectImg}) => {
     const handleClick = (e: MouseEvent<HTMLDivElement>) => {
         e.stopPropagation();
-        selectImg(zoomed ? null : payload);
+        // selectImg(zoomed ? null : payload);
     };
 
     return (
@@ -61,10 +61,10 @@ const UnsplashImage: FC<UnsplashImageProps> = ({payload, srcUrl, links, likes, u
                         icon="download"
                     />
                 </div>
-                <div className="flex items-center justify-between">
-                    <div className="flex items-center">
-                        <img alt="author" className="mr-2 size-8 rounded-full" src={user.profile_image.medium} />
-                        <div className="mr-2 truncate font-sans text-sm font-medium text-white">{user.name}</div>
+                <div className="flex items-center justify-between truncate">
+                    <div className="flex w-0 flex-1 items-center">
+                        <img alt="author" className="mr-2 size-8 shrink-0 rounded-full" src={user.profile_image.medium} />
+                        <div className="truncate font-sans text-sm font-medium text-white">{user.name}</div>
                     </div>
                     <UnsplashButton label="Insert image" data-kg-unsplash-insert-button onClick={(e) => {
                         e.stopPropagation();

--- a/packages/kg-unsplash-selector/src/ui/UnsplashSelector.tsx
+++ b/packages/kg-unsplash-selector/src/ui/UnsplashSelector.tsx
@@ -5,11 +5,12 @@ import {ChangeEvent, FunctionComponent, ReactNode} from 'react';
 
 interface UnsplashSelectorProps {
     closeModal: () => void;
+    columnCount: number;
     handleSearch: (e: ChangeEvent<HTMLInputElement>) => void;
     children: ReactNode;
 }
 
-const UnsplashSelector: FunctionComponent<UnsplashSelectorProps> = ({closeModal, handleSearch, children}) => {
+const UnsplashSelector: FunctionComponent<UnsplashSelectorProps> = ({closeModal, columnCount, handleSearch, children}) => {
     return (
         <>
             <div className="fixed inset-0 z-40 h-[100vh] bg-black opacity-60"></div>
@@ -22,9 +23,9 @@ const UnsplashSelector: FunctionComponent<UnsplashSelectorProps> = ({closeModal,
                     />
                 </button>
                 <div className="flex h-full flex-col">
-                    <header className="flex shrink-0 items-center justify-between px-20 py-10">
+                    <header className={`flex shrink-0 items-center justify-between px-20 py-10 flex-row ${columnCount < 3 ? 'flex-col gap-3 px-5' : ''}`}>
                         <h1 className="flex items-center gap-2 font-sans text-3xl font-bold text-black">
-                            <UnsplashIcon className="mb-1" />
+                            <UnsplashIcon className="size-6 mb-1" />
                             Unsplash
                         </h1>
                         <div className="relative w-full max-w-sm">

--- a/packages/kg-unsplash-selector/src/ui/UnsplashSelector.tsx
+++ b/packages/kg-unsplash-selector/src/ui/UnsplashSelector.tsx
@@ -28,7 +28,7 @@ const UnsplashSelector: FunctionComponent<UnsplashSelectorProps> = ({closeModal,
                             <UnsplashIcon className="size-6 mb-1" />
                             Unsplash
                         </h1>
-                        <div className="relative w-full max-w-sm">
+                        <div className="relative w-full lg:max-w-sm">
                             <SearchIcon className="text-grey-700 absolute left-4 top-1/2 size-4 -translate-y-2" />
                             <input className="border-grey-300 focus:border-grey-400 h-10 w-full rounded-full border border-solid pl-10 pr-8 font-sans text-md font-normal text-black focus-visible:outline-none" placeholder="Search free high-resolution photos" autoFocus data-kg-unsplash-search onChange={handleSearch} />
                         </div>

--- a/packages/kg-unsplash-selector/src/ui/UnsplashSelector.tsx
+++ b/packages/kg-unsplash-selector/src/ui/UnsplashSelector.tsx
@@ -28,7 +28,7 @@ const UnsplashSelector: FunctionComponent<UnsplashSelectorProps> = ({closeModal,
                             <UnsplashIcon className="size-6 mb-1" />
                             Unsplash
                         </h1>
-                        <div className="relative w-full lg:max-w-sm">
+                        <div className={`relative w-full ${columnCount < 3 ? '' : 'max-w-sm'}`}>
                             <SearchIcon className="text-grey-700 absolute left-4 top-1/2 size-4 -translate-y-2" />
                             <input className="border-grey-300 focus:border-grey-400 h-10 w-full rounded-full border border-solid pl-10 pr-8 font-sans text-md font-normal text-black focus-visible:outline-none" placeholder="Search free high-resolution photos" autoFocus data-kg-unsplash-search onChange={handleSearch} />
                         </div>

--- a/packages/kg-unsplash-selector/src/ui/UnsplashZoomed.tsx
+++ b/packages/kg-unsplash-selector/src/ui/UnsplashZoomed.tsx
@@ -9,7 +9,7 @@ interface UnsplashZoomedProps extends Omit<UnsplashImageProps, 'zoomed'> {
 
 const UnsplashZoomed: FC<UnsplashZoomedProps> = ({payload, insertImage, selectImg, zoomed}) => {
     return (
-        <div className="flex h-full grow basis-0 justify-center" data-kg-unsplash-zoomed onClick={() => selectImg(null)}>
+        <div className="flex size-full grow basis-0 justify-center" data-kg-unsplash-zoomed onClick={() => selectImg(null)}>
             <UnsplashImage 
                 alt={payload.alt_description}
                 height={payload.height}


### PR DESCRIPTION
## Summary

The Unsplash modal is nearly unusable on mobile and tablet devices due to layout issues, small interactive elements, and broken hover/touch behaviours. This PR updates the modal to be fully responsive, fixes interaction bugs on touch devices, and ensures UI elements (such as the Unsplash logo) are visible and accessible. These changes improve the UX in both the lexical editor and the design editor (`/settings/design/edit`),  both of which use the same Unsplash React component.

## Issues Fixed:

Fixes all bugs reported in https://github.com/TryGhost/Ghost/issues/24645.

## Changes:

* Responsive grid:
    * Tablet viewports use a 2-column layout.
    * Mobile viewports use a single-column layout for larger, more visible images.

| MOBILE | TABLET
| ---- | ----
| <img width="294" height="692" alt="Screenshot 2025-08-11 at 8 41 13 AM" src="https://github.com/user-attachments/assets/cb0f62e0-fee9-4d32-a067-f43a3a49b5e1" /> | <img width="513" height="681" alt="Screenshot 2025-08-11 at 8 40 48 AM" src="https://github.com/user-attachments/assets/0cfb8ccf-f964-41af-a4b9-93d49923e7e3" />

-----

* Dynamic resizing:
    * Added a resize event listener to adjust columns and behaviours in real time.
    * For ≤540px: hover reveals action buttons, zoom disabled.
    * For 540–1024px: hover reveals action buttons, click-to-zoom enabled.


https://github.com/user-attachments/assets/96613552-f8a6-4476-b008-d4e25a7a92f7

----

* Touch UX improvements:
    * On touch devices, tapping an image reveals action buttons instead of zooming.
![usresize1](https://github.com/user-attachments/assets/81ec9288-bc75-4c01-b7bd-d0bf825e7abb)

----

* Zoomed view responsiveness:
    * Properly fits images in zoomed state after resizing.

https://github.com/user-attachments/assets/3fb82564-a7b1-4686-9573-5c432148aaaa

---

* Search bar:
    * Aligned below the title, now spans full width.

* Unsplash logo:
    * Fixed visibility issue in header.

<img width="50%" alt="Screenshot 2025-08-11 at 8 57 17 AM" src="https://github.com/user-attachments/assets/16251d85-cea5-45aa-84a7-f616a9e79824" />

## Testing Instructions

1. Checkout Koenig repo and run `yarn build` in `packages/kg-unsplash-selector/`. Next, [follow these steps](https://github.com/TryGhost/Koenig/blob/main/packages/koenig-lexical/README.md) to link Koenig to your local Ghost admin.
2. In Ghost admin, open the lexical editor and type `/unsplash` to open the Unsplash modal.
3. Verify browser resize and in mobile/tablet simulators whether the modal behaves as described above. Also verify that the overlay buttons like insert and like behave in all viewport dimensions.
