### PR TITLE
  feat(TKPlugin): implemented list-item-level TK detection and positioning

### DIFF
--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -12,6 +12,15 @@ import {useTKContext} from '../context/TKContext';
 const REGEX = new RegExp(/(^|.)([^\p{L}\p{N}\s]*(TK|Tk|tk)+[^\p{L}\p{N}\s]*)(.)?/u);
 const WORD_CHAR_REGEX = new RegExp(/\p{L}|\p{N}/u);
 
+// TK Indicator positioning constants
+const INDICATOR_OFFSET_RIGHT = -56;
+const INDICATOR_OFFSET_TOP = 4;
+
+// Node type constants
+const NODE_TYPES = {
+    LIST_ITEM: 'LI'
+};
+
 // Helper function to get effective top-level element, treating list items as containers
 function getEffectiveTopLevelElement(node) {
     const topLevel = node.getTopLevelElement();
@@ -43,7 +52,7 @@ function TKIndicator({editor, rootElement, parentKey, nodeKeys}) {
     // position element relative to the TK Node containing element
     const calculatePosition = useCallback(() => {
         let top = 0;
-        let right = -56;
+        let right = INDICATOR_OFFSET_RIGHT;
 
         const rootElementRect = rootElement.getBoundingClientRect();
 
@@ -56,7 +65,7 @@ function TKIndicator({editor, rootElement, parentKey, nodeKeys}) {
 
         const positioningElementRect = positioningElement.getBoundingClientRect();
 
-        top = positioningElementRect.top - rootElementRect.top + 4;
+        top = positioningElementRect.top - rootElementRect.top + INDICATOR_OFFSET_TOP;
 
         if (positioningElementRect.right > rootElementRect.right) {
             right = right - (positioningElementRect.right - rootElementRect.right);

--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -53,11 +53,6 @@ function TKIndicator({editor, rootElement, parentKey, nodeKeys}) {
 
     const containingElement = editor.getElementByKey(parentKey);
 
-    // Early return if containing element is not available
-    if (!containingElement) {
-        return null;
-    }
-
     // position element relative to the TK Node containing element
     const calculatePosition = useCallback(() => {
         let top = 0;
@@ -129,7 +124,9 @@ function TKIndicator({editor, rootElement, parentKey, nodeKeys}) {
 
         nodeKeys.forEach((key) => {
             const element = editor.getElementByKey(key);
-            if (!element) return;
+            if (!element) {
+                return;
+            }
 
             if (isHighlighted) {
                 element.classList.remove(...tkClasses);
@@ -162,6 +159,11 @@ function TKIndicator({editor, rootElement, parentKey, nodeKeys}) {
             observer.disconnect();
         };
     }, [rootElement, containingElement, calculatePosition]);
+
+    // Early return if containing element is not available (after all hooks)
+    if (!containingElement) {
+        return null;
+    }
 
     const style = {
         top: `${position.top}px`,

--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -53,6 +53,11 @@ function TKIndicator({editor, rootElement, parentKey, nodeKeys}) {
 
     const containingElement = editor.getElementByKey(parentKey);
 
+    // Early return if containing element is not available
+    if (!containingElement) {
+        return null;
+    }
+
     // position element relative to the TK Node containing element
     const calculatePosition = useCallback(() => {
         let top = 0;
@@ -123,12 +128,15 @@ function TKIndicator({editor, rootElement, parentKey, nodeKeys}) {
         }
 
         nodeKeys.forEach((key) => {
+            const element = editor.getElementByKey(key);
+            if (!element) return;
+
             if (isHighlighted) {
-                editor.getElementByKey(key).classList.remove(...tkClasses);
-                editor.getElementByKey(key).classList.add(...tkHighlightClasses);
+                element.classList.remove(...tkClasses);
+                element.classList.add(...tkHighlightClasses);
             } else {
-                editor.getElementByKey(key).classList.add(...tkClasses);
-                editor.getElementByKey(key).classList.remove(...tkHighlightClasses);
+                element.classList.add(...tkClasses);
+                element.classList.remove(...tkHighlightClasses);
             }
         });
     };
@@ -288,7 +296,7 @@ export default function TKPlugin() {
         const parentContainer = editor.getElementByKey(parentKey);
 
         if (!parentContainer) {
-            return false;
+            return null;
         }
 
         return (

--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -60,12 +60,10 @@ function TKIndicator({editor, rootElement, parentKey, nodeKeys}) {
 
         const rootElementRect = rootElement.getBoundingClientRect();
 
-        let positioningElement = containingElement.querySelector('[data-kg-card]') || containingElement;
-
-        // For list items, use more precise positioning
-        if (containingElement.nodeName === 'LI') {
-            positioningElement = containingElement;
-        }
+        // Determine positioning element based on container type
+        const positioningElement = containingElement.nodeName === NODE_TYPES.LIST_ITEM
+            ? containingElement
+            : containingElement.querySelector('[data-kg-card]') || containingElement;
 
         const positioningElementRect = positioningElement.getBoundingClientRect();
 

--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -21,6 +21,21 @@ const NODE_TYPES = {
     LIST_ITEM: 'LI'
 };
 
+// Positioning helper functions
+function getPositioningElement(containingElement) {
+    return containingElement.nodeName === NODE_TYPES.LIST_ITEM
+        ? containingElement
+        : containingElement.querySelector('[data-kg-card]') || containingElement;
+}
+
+function calculateRightOffset(elementRect, rootRect) {
+    let right = INDICATOR_OFFSET_RIGHT;
+    if (elementRect.right > rootRect.right) {
+        right = right - (elementRect.right - rootRect.right);
+    }
+    return right;
+}
+
 // Helper function to get effective top-level element, treating list items as containers
 function getEffectiveTopLevelElement(node) {
     const topLevel = node.getTopLevelElement();
@@ -53,25 +68,14 @@ function TKIndicator({editor, rootElement, parentKey, nodeKeys}) {
 
     const containingElement = editor.getElementByKey(parentKey);
 
-    // position element relative to the TK Node containing element
+    // Calculate indicator position relative to the root element
     const calculatePosition = useCallback(() => {
-        let top = 0;
-        let right = INDICATOR_OFFSET_RIGHT;
+        const rootRect = rootElement.getBoundingClientRect();
+        const positioningElement = getPositioningElement(containingElement);
+        const elementRect = positioningElement.getBoundingClientRect();
 
-        const rootElementRect = rootElement.getBoundingClientRect();
-
-        // Determine positioning element based on container type
-        const positioningElement = containingElement.nodeName === NODE_TYPES.LIST_ITEM
-            ? containingElement
-            : containingElement.querySelector('[data-kg-card]') || containingElement;
-
-        const positioningElementRect = positioningElement.getBoundingClientRect();
-
-        top = positioningElementRect.top - rootElementRect.top + INDICATOR_OFFSET_TOP;
-
-        if (positioningElementRect.right > rootElementRect.right) {
-            right = right - (positioningElementRect.right - rootElementRect.right);
-        }
+        const top = elementRect.top - rootRect.top + INDICATOR_OFFSET_TOP;
+        const right = calculateRightOffset(elementRect, rootRect);
 
         return {top, right};
     }, [rootElement, containingElement]);

--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -29,17 +29,21 @@ function getEffectiveTopLevelElement(node) {
         return null;
     }
 
-    // If the top-level element is a list, find the containing list item instead
-    if ($isListNode(topLevel)) {
-        let currentNode = node;
-        while (currentNode && currentNode.getParent() !== null) {
-            if ($isListItemNode(currentNode)) {
-                return currentNode;
-            }
-            currentNode = currentNode.getParent();
-        }
+    // If the top-level element is not a list, return it directly
+    if (!$isListNode(topLevel)) {
+        return topLevel;
     }
 
+    // Find the containing list item for list nodes
+    let currentNode = node;
+    while (currentNode?.getParent()) {
+        if ($isListItemNode(currentNode)) {
+            return currentNode;
+        }
+        currentNode = currentNode.getParent();
+    }
+
+    // Fallback to top-level element if no list item found
     return topLevel;
 }
 

--- a/packages/koenig-lexical/src/plugins/TKPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/TKPlugin.jsx
@@ -1,6 +1,7 @@
 import CardContext from '../context/CardContext';
 import {$createTKNode, $isTKNode, ExtendedTextNode, TKNode} from '@tryghost/kg-default-nodes';
 import {$getNodeByKey, $getSelection, $isDecoratorNode, $isRangeSelection, TextNode} from 'lexical';
+import {$isListItemNode, $isListNode} from '@lexical/list';
 import {SELECT_CARD_COMMAND} from './KoenigBehaviourPlugin';
 import {createPortal} from 'react-dom';
 import {useCallback, useContext, useEffect, useState} from 'react';
@@ -19,15 +20,11 @@ function getEffectiveTopLevelElement(node) {
         return null;
     }
 
-    // Get the DOM element to check if it's a list
-    const domElement = topLevel.getDOMNode?.() || topLevel.__domNode;
-
-    if (domElement && (domElement.nodeName === 'UL' || domElement.nodeName === 'OL')) {
-        // For lists, find the containing list item instead
+    // If the top-level element is a list, find the containing list item instead
+    if ($isListNode(topLevel)) {
         let currentNode = node;
-        while (currentNode && !currentNode.isRoot()) {
-            const domNode = currentNode.getDOMNode?.() || currentNode.__domNode;
-            if (domNode && domNode.nodeName === 'LI') {
+        while (currentNode && currentNode.getParent() !== null) {
+            if ($isListItemNode(currentNode)) {
                 return currentNode;
             }
             currentNode = currentNode.getParent();

--- a/packages/koenig-lexical/test/e2e/plugins/TKPlugin.test.js
+++ b/packages/koenig-lexical/test/e2e/plugins/TKPlugin.test.js
@@ -115,6 +115,42 @@ test.describe('TK Plugin', async function () {
             await expect(page.getByTestId('tk-indicator')).toHaveCount(3);
         });
 
+        test('creates separate TK indicators for each list item containing TK', async function () {
+            await focusEditor(page);
+
+            await page.keyboard.type('- First item with TK');
+            await page.keyboard.press('Enter');
+            await page.keyboard.type('Second item with TK');
+            await page.keyboard.press('Enter');
+            await page.keyboard.type('Third item without placeholder');
+            await page.keyboard.press('Enter');
+            await page.keyboard.type('Fourth item with TK');
+
+            // Should have 3 separate TK indicators, one for each list item containing TK
+            await expect(page.getByTestId('tk-indicator')).toHaveCount(3);
+        });
+
+        test('positions TK indicators correctly for individual list items', async function () {
+            await focusEditor(page);
+
+            await page.keyboard.type('- First TK item');
+            await page.keyboard.press('Enter');
+            await page.keyboard.type('Second TK item');
+
+            const indicators = page.getByTestId('tk-indicator');
+            await expect(indicators).toHaveCount(2);
+
+            // Get positions to verify they're different (one per list item)
+            const firstIndicator = indicators.first();
+            const secondIndicator = indicators.last();
+
+            const firstBox = await firstIndicator.boundingBox();
+            const secondBox = await secondIndicator.boundingBox();
+
+            // The indicators should have different vertical positions
+            expect(Math.abs(firstBox.y - secondBox.y)).toBeGreaterThan(10);
+        });
+
         test('clicking the indicator selects the first TK node in the parent', async function () {
             await focusEditor(page);
             await page.keyboard.type('TK and TK and TK');


### PR DESCRIPTION
  Previously, TK monikers in bulleted lists were tracked at the `<ul>` level,
  making it difficult for authors to identify which specific list items
  contained incomplete content. This change implements list-aware TK detection
  that treats each <li> element as an individual container.

  - Added getEffectiveTopLevelElement() to recognize list items as containers
  - Updated mutation listener to use list-aware detection logic
  - Enhanced positioning calculations for precise list item indicator placement
  - Added comprehensive test coverage for list-specific TK behavior

  This provides authors with granular visibility into which list items need
  completion, consistent with how TK tracking works for paragraph elements.

  Fixes PROD-2389