### PR TITLE
Fix Unsplash mock no-op and scroll listener cleanup

### DIFF
--- a/packages/kg-default-nodes/test/nodes/transistor.test.js
+++ b/packages/kg-default-nodes/test/nodes/transistor.test.js
@@ -36,31 +36,31 @@ describe('TransistorNode', function () {
 
     it('matches node with $isTransistorNode', editorTest(function () {
         const transistorNode = new TransistorNode(dataset);
-        assert.strictEqual($isTransistorNode(transistorNode), true);
+        assert.equal($isTransistorNode(transistorNode), true);
     }));
 
     describe('data access', function () {
         it('has getters for all properties', editorTest(function () {
             const transistorNode = new TransistorNode(dataset);
 
-            assert.strictEqual(transistorNode.accentColor, dataset.accentColor);
-            assert.strictEqual(transistorNode.backgroundColor, dataset.backgroundColor);
+            assert.equal(transistorNode.accentColor, dataset.accentColor);
+            assert.equal(transistorNode.backgroundColor, dataset.backgroundColor);
             // Default visibility should be members-only (nonMember: false)
-            assert.strictEqual(transistorNode.visibility.web.nonMember, false);
-            assert.strictEqual(transistorNode.visibility.web.memberSegment, 'status:free,status:-free');
-            assert.strictEqual(transistorNode.visibility.email.memberSegment, 'status:free,status:-free');
+            assert.equal(transistorNode.visibility.web.nonMember, false);
+            assert.equal(transistorNode.visibility.web.memberSegment, 'status:free,status:-free');
+            assert.equal(transistorNode.visibility.email.memberSegment, 'status:free,status:-free');
         }));
 
         it('has setters for all properties', editorTest(function () {
             const transistorNode = new TransistorNode();
 
-            assert.strictEqual(transistorNode.accentColor, '');
+            assert.equal(transistorNode.accentColor, '');
             transistorNode.accentColor = '#FF0000';
-            assert.strictEqual(transistorNode.accentColor, '#FF0000');
+            assert.equal(transistorNode.accentColor, '#FF0000');
 
-            assert.strictEqual(transistorNode.backgroundColor, '');
+            assert.equal(transistorNode.backgroundColor, '');
             transistorNode.backgroundColor = '#000000';
-            assert.strictEqual(transistorNode.backgroundColor, '#000000');
+            assert.equal(transistorNode.backgroundColor, '#000000');
 
             transistorNode.visibility = {
                 web: {
@@ -71,7 +71,7 @@ describe('TransistorNode', function () {
                     memberSegment: 'status:free'
                 }
             };
-            assert.deepStrictEqual(transistorNode.visibility, {
+            assert.deepEqual(transistorNode.visibility, {
                 web: {
                     nonMember: false,
                     memberSegment: 'status:free'
@@ -86,15 +86,15 @@ describe('TransistorNode', function () {
             const transistorNode = new TransistorNode(dataset);
             const transistorNodeDataset = transistorNode.getDataset();
 
-            assert.strictEqual(transistorNodeDataset.accentColor, dataset.accentColor);
-            assert.strictEqual(transistorNodeDataset.backgroundColor, dataset.backgroundColor);
-            assert.strictEqual(transistorNodeDataset.visibility.web.nonMember, false);
+            assert.equal(transistorNodeDataset.accentColor, dataset.accentColor);
+            assert.equal(transistorNodeDataset.backgroundColor, dataset.backgroundColor);
+            assert.equal(transistorNodeDataset.visibility.web.nonMember, false);
         }));
     });
 
     describe('getType', function () {
         it('returns the correct node type', editorTest(function () {
-            assert.strictEqual(TransistorNode.getType(), 'transistor');
+            assert.equal(TransistorNode.getType(), 'transistor');
         }));
     });
 
@@ -105,30 +105,30 @@ describe('TransistorNode', function () {
             const clone = TransistorNode.clone(transistorNode);
             const cloneDataset = clone.getDataset();
 
-            assert.deepStrictEqual(cloneDataset, {...transistorNodeDataset});
+            assert.deepEqual(cloneDataset, {...transistorNodeDataset});
         }));
     });
 
     describe('hasEditMode', function () {
         it('returns true', editorTest(function () {
             const transistorNode = new TransistorNode(dataset);
-            assert.strictEqual(transistorNode.hasEditMode(), true);
+            assert.equal(transistorNode.hasEditMode(), true);
         }));
     });
 
     describe('isEmpty', function () {
         it('returns false', editorTest(function () {
             const transistorNode = new TransistorNode(dataset);
-            assert.strictEqual(transistorNode.isEmpty(), false);
+            assert.equal(transistorNode.isEmpty(), false);
         }));
     });
 
     describe('default visibility', function () {
         it('defaults to members-only (nonMember: false)', editorTest(function () {
             const transistorNode = new TransistorNode();
-            assert.strictEqual(transistorNode.visibility.web.nonMember, false);
-            assert.strictEqual(transistorNode.visibility.web.memberSegment, 'status:free,status:-free');
-            assert.strictEqual(transistorNode.visibility.email.memberSegment, 'status:free,status:-free');
+            assert.equal(transistorNode.visibility.web.nonMember, false);
+            assert.equal(transistorNode.visibility.web.memberSegment, 'status:free,status:-free');
+            assert.equal(transistorNode.visibility.email.memberSegment, 'status:free,status:-free');
         }));
 
         it('preserves custom visibility when provided', editorTest(function () {
@@ -142,7 +142,7 @@ describe('TransistorNode', function () {
                 }
             };
             const transistorNode = new TransistorNode({visibility: customVisibility});
-            assert.deepStrictEqual(transistorNode.visibility, customVisibility);
+            assert.deepEqual(transistorNode.visibility, customVisibility);
         }));
     });
 
@@ -162,18 +162,18 @@ describe('TransistorNode', function () {
             const transistorNode = new TransistorNode({visibility: publicVisibility});
             const {element} = transistorNode.exportDOM(exportOptions);
 
-            assert.strictEqual(element.tagName, 'FIGURE');
-            assert.strictEqual(element.classList.contains('kg-card'), true);
-            assert.strictEqual(element.classList.contains('kg-transistor-card'), true);
+            assert.equal(element.tagName, 'FIGURE');
+            assert.equal(element.classList.contains('kg-card'), true);
+            assert.equal(element.classList.contains('kg-transistor-card'), true);
 
             const iframe = element.querySelector('iframe');
             assert.ok(iframe);
-            assert.strictEqual(iframe.getAttribute('src'), 'https://partner.transistor.fm/ghost/embed/{uuid}');
-            assert.strictEqual(iframe.getAttribute('width'), '100%');
-            assert.strictEqual(iframe.getAttribute('height'), '180');
-            assert.strictEqual(iframe.getAttribute('frameborder'), 'no');
-            assert.strictEqual(iframe.getAttribute('scrolling'), 'no');
-            assert.strictEqual(iframe.hasAttribute('seamless'), true);
+            assert.equal(iframe.getAttribute('src'), 'https://partner.transistor.fm/ghost/embed/{uuid}');
+            assert.equal(iframe.getAttribute('width'), '100%');
+            assert.equal(iframe.getAttribute('height'), '180');
+            assert.equal(iframe.getAttribute('frameborder'), 'no');
+            assert.equal(iframe.getAttribute('scrolling'), 'no');
+            assert.equal(iframe.hasAttribute('seamless'), true);
         }));
 
         it('includes color param when accentColor is set', editorTest(function () {
@@ -181,7 +181,7 @@ describe('TransistorNode', function () {
             const {element} = transistorNode.exportDOM(exportOptions);
 
             const iframe = element.querySelector('iframe');
-            assert.strictEqual(iframe.getAttribute('src'), 'https://partner.transistor.fm/ghost/embed/{uuid}?color=8B5CF6');
+            assert.equal(iframe.getAttribute('src'), 'https://partner.transistor.fm/ghost/embed/{uuid}?color=8B5CF6');
         }));
 
         it('includes background param when backgroundColor is set', editorTest(function () {
@@ -189,7 +189,7 @@ describe('TransistorNode', function () {
             const {element} = transistorNode.exportDOM(exportOptions);
 
             const iframe = element.querySelector('iframe');
-            assert.strictEqual(iframe.getAttribute('src'), 'https://partner.transistor.fm/ghost/embed/{uuid}?background=FFFFFF');
+            assert.equal(iframe.getAttribute('src'), 'https://partner.transistor.fm/ghost/embed/{uuid}?background=FFFFFF');
         }));
 
         it('includes both color params when both are set', editorTest(function () {
@@ -201,7 +201,7 @@ describe('TransistorNode', function () {
             const {element} = transistorNode.exportDOM(exportOptions);
 
             const iframe = element.querySelector('iframe');
-            assert.strictEqual(iframe.getAttribute('src'), 'https://partner.transistor.fm/ghost/embed/{uuid}?color=8B5CF6&background=1F2937');
+            assert.equal(iframe.getAttribute('src'), 'https://partner.transistor.fm/ghost/embed/{uuid}?color=8B5CF6&background=1F2937');
         }));
 
         it('strips # from color values', editorTest(function () {
@@ -226,7 +226,7 @@ describe('TransistorNode', function () {
             const {element} = transistorNode.exportDOM(exportOptions);
 
             // Should be wrapped in visibility gating
-            assert.strictEqual(element.tagName, 'TEXTAREA');
+            assert.equal(element.tagName, 'TEXTAREA');
             assert.match(element.value, /<!--kg-gated-block:begin nonMember:false memberSegment:"status:free,status:-free" -->/);
         }));
 
@@ -240,9 +240,9 @@ describe('TransistorNode', function () {
             });
             const {element, type} = transistorNode.exportDOM(exportOptions);
 
-            assert.strictEqual(type, 'html');
-            assert.strictEqual(element.tagName, 'DIV');
-            assert.strictEqual(element.dataset.ghSegment, 'status:-free');
+            assert.equal(type, 'html');
+            assert.equal(element.tagName, 'DIV');
+            assert.equal(element.dataset.ghSegment, 'status:-free');
         }));
     });
 
@@ -251,7 +251,7 @@ describe('TransistorNode', function () {
             const transistorNode = new TransistorNode(dataset);
             const json = transistorNode.exportJSON();
 
-            assert.deepStrictEqual(json, {
+            assert.deepEqual(json, {
                 type: 'transistor',
                 version: 1,
                 accentColor: '#8B5CF6',
@@ -272,8 +272,8 @@ describe('TransistorNode', function () {
             const transistorNode = new TransistorNode({});
             const json = transistorNode.exportJSON();
 
-            assert.strictEqual(json.accentColor, '');
-            assert.strictEqual(json.backgroundColor, '');
+            assert.equal(json.accentColor, '');
+            assert.equal(json.backgroundColor, '');
         }));
     });
 
@@ -310,11 +310,11 @@ describe('TransistorNode', function () {
             editor.getEditorState().read(() => {
                 try {
                     const [transistorNode] = $getRoot().getChildren();
-                    assert.strictEqual($isTransistorNode(transistorNode), true);
-                    assert.strictEqual(transistorNode.accentColor, '#FF5500');
-                    assert.strictEqual(transistorNode.backgroundColor, '#000000');
-                    assert.strictEqual(transistorNode.visibility.web.nonMember, false);
-                    assert.strictEqual(transistorNode.visibility.web.memberSegment, 'status:-free');
+                    assert.equal($isTransistorNode(transistorNode), true);
+                    assert.equal(transistorNode.accentColor, '#FF5500');
+                    assert.equal(transistorNode.backgroundColor, '#000000');
+                    assert.equal(transistorNode.visibility.web.nonMember, false);
+                    assert.equal(transistorNode.visibility.web.memberSegment, 'status:-free');
 
                     done();
                 } catch (e) {
@@ -327,7 +327,7 @@ describe('TransistorNode', function () {
     describe('getTextContent', function () {
         it('returns empty string', editorTest(function () {
             const transistorNode = new TransistorNode(dataset);
-            assert.strictEqual(transistorNode.getTextContent(), '');
+            assert.equal(transistorNode.getTextContent(), '');
         }));
     });
 });

--- a/packages/kg-unsplash-selector/src/UnsplashSearchModal.tsx
+++ b/packages/kg-unsplash-selector/src/UnsplashSearchModal.tsx
@@ -56,19 +56,15 @@ export const UnsplashSearchModal : React.FC<UnsplashModalProps> = ({onClose, onI
 
     React.useEffect(() => {
         const ref = galleryRef.current;
-        if (!zoomedImg) {
-            if (ref) {
-                ref.addEventListener('scroll', () => {
-                    setScrollPos(ref.scrollTop);
-                });
-            }
-            // unmount
+        if (!zoomedImg && ref) {
+            const handleScrollPosition = () => {
+                setScrollPos(ref.scrollTop);
+            };
+
+            ref.addEventListener('scroll', handleScrollPosition);
+
             return () => {
-                if (ref) {
-                    ref.removeEventListener('scroll', () => {
-                        setScrollPos(ref.scrollTop);
-                    });
-                }
+                ref.removeEventListener('scroll', handleScrollPosition);
             };
         }
     }, [galleryRef, zoomedImg]);
@@ -154,7 +150,7 @@ export const UnsplashSearchModal : React.FC<UnsplashModalProps> = ({onClose, onI
         }
     }, [galleryRef, loadMorePhotos, zoomedImg]);
 
-    const selectImg = (payload:Photo) => {
+    const selectImg = (payload: Photo | null) => {
         if (payload) {
             setZoomedImg(payload);
             setLastScrollPos(scrollPos);

--- a/packages/kg-unsplash-selector/src/api/InMemoryUnsplashProvider.ts
+++ b/packages/kg-unsplash-selector/src/api/InMemoryUnsplashProvider.ts
@@ -47,9 +47,8 @@ export class InMemoryUnsplashProvider implements IUnsplashProvider {
         return this.SEARCH_IS_RUNNING;
     }
 
-    triggerDownload(photo: Photo): void {
-        () => {
-            photo;
-        };
+    triggerDownload(_photo: Photo): void {
+        // Intentionally a no-op in the in-memory test provider.
+        void _photo;
     }
 }


### PR DESCRIPTION
## Summary\n- fix no-op implementation in in-memory Unsplash provider\n- fix scroll listener cleanup in Unsplash search modal to prevent leaked handlers\n- normalize assert usage in transistor tests for node:assert/strict lint rule\n\n## Validation\n- yarn workspace @tryghost/kg-unsplash-selector lint\n- yarn workspace @tryghost/kg-unsplash-selector build\n- yarn workspace @tryghost/kg-default-nodes lint\n- yarn workspace @tryghost/kg-default-nodes test:no-coverage -- ./test/nodes/transistor.test.js

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to UI event listener management and test/mock code with minimal behavior impact beyond preventing leaked handlers.
> 
> **Overview**
> Fixes a scroll event listener leak in `UnsplashSearchModal` by registering a stable handler and removing the same function during effect cleanup.
> 
> Clarifies `InMemoryUnsplashProvider.triggerDownload` as an explicit no-op (and avoids unused-var linting), and updates `TransistorNode` tests to use `assert.equal`/`assert.deepEqual` instead of strict variants for `node:assert/strict` lint compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41ae16b763a26c369aa5f2e27a0b6c728a5d77da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->