### PR TITLE
Fix markdown card blockquote spacing in read-only mode

### DIFF
--- a/packages/koenig-lexical/src/styles/components/kg-prose.css
+++ b/packages/koenig-lexical/src/styles/components/kg-prose.css
@@ -549,9 +549,16 @@
         /* -------------------------------------------------------------------- */
 
         :where(
-            blockquote p
+            blockquote > *
         ):not(:where(.not-kg-prose, [class~='not-kg-prose'] *)) {
-            margin: 0;
+            margin-top: 0;
+            margin-bottom: 0;
+        }
+
+        :where(
+            blockquote > * + *
+        ):not(:where(.not-kg-prose, [class~='not-kg-prose'] *)) {
+            margin-top: 1em;
         }
 
         :where(

--- a/packages/koenig-lexical/test/e2e/cards/markdown-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/markdown-card.test.js
@@ -73,6 +73,73 @@ test.describe('Markdown card', async () => {
         `);
     });
 
+    test('preserves multi-paragraph and nested blockquote spacing in read-only mode', async function () {
+        await page.evaluate(() => {
+            const markdown = [
+                '> First paragraph',
+                '>',
+                '> Second paragraph',
+                '>',
+                '> > Nested one',
+                '> >',
+                '> > Nested two'
+            ].join('\n');
+
+            const serializedState = JSON.stringify({
+                root: {
+                    children: [{
+                        type: 'markdown',
+                        version: 1,
+                        markdown
+                    }],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            });
+            const editor = window.lexicalEditor;
+            const editorState = editor.parseEditorState(serializedState);
+            editor.setEditorState(editorState);
+        });
+
+        await assertHTML(page, html`
+            <div data-lexical-decorator="true" contenteditable="false">
+                <div><svg></svg></div>
+                <div data-kg-card-editing="false" data-kg-card-selected="false" data-kg-card="markdown">
+                    <div>
+                        <div>
+                            <blockquote>
+                                <p>First paragraph</p>
+                                <p>Second paragraph</p>
+                                <blockquote>
+                                    <p>Nested one</p>
+                                    <p>Nested two</p>
+                                </blockquote>
+                            </blockquote>
+                        </div>
+                        <div></div>
+                    </div>
+                </div>
+            </div>
+        `);
+
+        const quoteStyles = await page.evaluate(() => {
+            const card = document.querySelector('[data-kg-card="markdown"]');
+            const secondParagraph = card.querySelector('blockquote > p + p');
+            const nestedQuote = card.querySelector('blockquote > blockquote');
+
+            return {
+                secondParagraphMarginTop: getComputedStyle(secondParagraph).marginTop,
+                nestedQuoteBorderLeftWidth: getComputedStyle(nestedQuote).borderLeftWidth
+            };
+        });
+
+        expect(parseFloat(quoteStyles.secondParagraphMarginTop)).toBeGreaterThan(0);
+        expect(parseFloat(quoteStyles.nestedQuoteBorderLeftWidth)).toBeGreaterThan(0);
+    });
+
     test('renders markdown card node', async function () {
         await focusEditor(page);
         await page.keyboard.type('/');


### PR DESCRIPTION
Summary

This fixes a Markdown card display issue where multi-paragraph and nested blockquotes lose their visual separation in read-only mode.

The underlying markdown HTML is correct, but the shared prose styles currently reset blockquote paragraph margins too aggressively. That causes sibling paragraphs inside a blockquote to collapse together, and nested blockquotes can appear visually cramped.

What changed

The fix updates the shared blockquote spacing rules in `packages/koenig-lexical/src/styles/components/kg-prose.css` to style direct blockquote children instead of only `blockquote p`:

- `blockquote > *` now resets top and bottom margins
- `blockquote > * + *` restores spacing between adjacent children

This preserves separate paragraphs and nested blockquotes without changing markdown parsing or card serialization.

Why the change is in shared prose styles

Markdown card read-only rendering goes through the shared `.kg-prose` layer, so the problem is in the prose blockquote styles rather than in the Markdown renderer or card component itself.

Testing

I added a focused e2e regression in `packages/koenig-lexical/test/e2e/cards/markdown-card.test.js` that:

- loads a Markdown card containing multi-paragraph blockquotes
- includes nested blockquotes
- verifies the rendered HTML structure
- verifies that sibling blockquote children have non-zero spacing
- verifies that nested blockquotes still render with a left border

I also ran the targeted e2e case locally.

Risk / side effects

This is a small CSS-only change plus a regression test.

It does not change:

- Markdown parsing
- card editing behavior
- serialized editor state
- frontend theme rendering

The only behavioral impact should be that blockquotes rendered through the shared prose layer preserve spacing between direct children more reliably, which is the expected result for multi-paragraph and nested quotes.

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS tweak in shared prose styles plus an e2e regression test; potential impact is limited to blockquote spacing across `.kg-prose` content.
> 
> **Overview**
> Fixes Markdown card read-only rendering so multi-paragraph and nested blockquotes keep visible separation.
> 
> Updates `.kg-prose` blockquote rules in `kg-prose.css` to reset margins for all direct blockquote children (`blockquote > *`) and reintroduce spacing between adjacent children (`blockquote > * + *`). Adds a Playwright e2e regression asserting the expected HTML structure and non-zero spacing/border for nested quotes in `markdown-card.test.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7d91a1f145117bb03dc10a8520412acf9f31653. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->