### PR TITLE
Remove redundant devDependencies automerge override

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,14 +6,7 @@
     "codecov/codecov-action"
   ],
   "packageRules": [
-    {
-      "depTypeList": [
-        "devDependencies"
-      ],
-      "automerge": true,
-      "automergeType": "branch"
-    },
-    {
+{
       "groupName": "rollup + plugins",
       "packagePatterns": [
         "^rollup"


### PR DESCRIPTION
## Summary
- Removes the repo-local Renovate rule that overrides automergeType to branch for devDependencies
- The org-wide config (tryghost/renovate-config) already automerges all dependency types using automergeType pr, making this local override redundant
- Aligning with the org default simplifies the config and ensures consistent behaviour across repos

## Test plan
- [ ] Verify Renovate still automerges devDependency updates (now via PR instead of branch)
- [ ] Monitor that dependency update behaviour remains as expected