### PR TITLE
Disable Renovate Lexical upgrades

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,7 +24,8 @@
       "packagePatterns": [
         "^lexical",
         "^@lexical"
-      ]
+      ],
+      "enabled": false
     },
     {
       "groupName": "vitest",


### PR DESCRIPTION
## Summary
- Disable the existing Renovate rule for `lexical` and `@lexical/*`
- Stop automatic Lexical upgrade PRs until manual upgrade work is planned and validated
- Leave all other Renovate dependency rules unchanged