### PR TITLE
Align kg-default-nodes exportDOM signature with Lexical

### DIFF
--- a/packages/kg-default-nodes/src/KoenigDecoratorNode.ts
+++ b/packages/kg-default-nodes/src/KoenigDecoratorNode.ts
@@ -1,5 +1,6 @@
 /* c8 ignore start */
 import {DecoratorNode} from 'lexical';
+import type {LexicalEditor} from 'lexical';
 import type {ExportDOMOptions, ExportDOMOutput} from './export-dom.js';
 
 export class KoenigDecoratorNode extends DecoratorNode<unknown> {
@@ -14,7 +15,7 @@ export class KoenigDecoratorNode extends DecoratorNode<unknown> {
 
 export type KoenigCard = KoenigDecoratorNode & {
     isKoenigCard(): true;
-    exportDOM(options: ExportDOMOptions): ExportDOMOutput;
+    exportDOM(editor: LexicalEditor, options?: ExportDOMOptions): ExportDOMOutput;
     hasDynamicData(): boolean;
     getDynamicData?(options: ExportDOMOptions): Promise<{key: number; data: unknown}>;
 };

--- a/packages/kg-default-nodes/src/generate-decorator-node.ts
+++ b/packages/kg-default-nodes/src/generate-decorator-node.ts
@@ -2,6 +2,7 @@ import {KoenigDecoratorNode} from './KoenigDecoratorNode.js';
 import type {ExportDOMOptions, ExportDOMOutput} from './export-dom.js';
 import readTextContent from './utils/read-text-content.js';
 import {buildDefaultVisibility, isVisibilityRestricted, migrateOldVisibilityFormat} from './utils/visibility.js';
+import type {LexicalEditor} from 'lexical';
 import type {Visibility} from './utils/visibility.js';
 
 type RenderFn<TOutput extends ExportDOMOutput = ExportDOMOutput> = (node: any, options: ExportDOMOptions) => TOutput;
@@ -66,7 +67,7 @@ export type DecoratorNodeValueMap<Props extends readonly DecoratorNodeProperty[]
 export type DecoratorNodeData<Props extends readonly DecoratorNodeProperty[], HasVisibility extends boolean = false> = Partial<DecoratorNodeValueMap<Props, HasVisibility>>;
 
 type GeneratedDecoratorNodeInstance<TDataset extends Record<string, unknown>, TOutput extends ExportDOMOutput = ExportDOMOutput> = GeneratedDecoratorNodeBase<TDataset> & TDataset & {
-    exportDOM(options?: ExportDOMOptions): TOutput;
+    exportDOM(editor: LexicalEditor, options?: ExportDOMOptions): TOutput;
 };
 
 export interface GeneratedDecoratorNodeClass<TDataset extends Record<string, unknown>, TOutput extends ExportDOMOutput = ExportDOMOutput> {
@@ -292,8 +293,7 @@ export function generateDecoratorNode<
             return dataset;
         }
 
-        // @ts-expect-error - custom exportDOM signature for Ghost rendering
-        exportDOM(options: ExportDOMOptions = {}): TOutput {
+        exportDOM(_editor: LexicalEditor, options: ExportDOMOptions = {}): TOutput {
             // this.__version is used when a node has a version property which
             // means it's set from the serialized version data at runtime
             const nodeVersion = this.__version || version;

--- a/packages/kg-default-nodes/test/generate-decorator-node.test.ts
+++ b/packages/kg-default-nodes/test/generate-decorator-node.test.ts
@@ -9,7 +9,7 @@ const defaultVisibility = utils.visibility.buildDefaultVisibility();
 type GeneratedNodeClass = ReturnType<typeof utils.generateDecoratorNode>;
 
 interface GeneratedNodeInstance {
-    exportDOM(options?: ExportDOMOptions): ExportDOMOutput;
+    exportDOM(editor: LexicalEditor, options?: ExportDOMOptions): ExportDOMOutput;
     exportJSON(): Record<string, unknown>;
     getDataset(): Record<string, unknown>;
     visibility: Record<string, unknown>;
@@ -72,7 +72,7 @@ describe('Utils: generateDecoratorNode', function () {
 
         it('uses default renderer when no custom renderer is provided', editorTest(function () {
             const node = $createNodeWithRender();
-            const result = node.exportDOM();
+            const result = node.exportDOM(editor);
 
             result.type.should.equal('inner');
             expectHtmlElement(result).outerHTML.should.equal('<div>default render</div>');
@@ -90,7 +90,7 @@ describe('Utils: generateDecoratorNode', function () {
             });
 
             const node = new VersionedNode() as unknown as GeneratedNodeInstance;
-            const result = node.exportDOM();
+            const result = node.exportDOM(editor);
 
             result.type.should.equal('inner');
             expectHtmlElement(result).outerHTML.should.equal('<div>version 2</div>');
@@ -108,7 +108,7 @@ describe('Utils: generateDecoratorNode', function () {
             });
 
             const node = new VersionedNode({version: 2}) as unknown as GeneratedNodeInstance;
-            const result = node.exportDOM();
+            const result = node.exportDOM(editor);
 
             result.type.should.equal('inner');
             expectHtmlElement(result).outerHTML.should.equal('<div>version 2</div>');
@@ -121,7 +121,7 @@ describe('Utils: generateDecoratorNode', function () {
             });
 
             const node = new NodeWithoutRender() as unknown as GeneratedNodeInstance;
-            (() => node.exportDOM()).should.throw('[generateDecoratorNode] no-render-test: "defaultRenderFn" is required');
+            (() => node.exportDOM(editor)).should.throw('[generateDecoratorNode] no-render-test: "defaultRenderFn" is required');
         }));
 
         it('throws error when default versioned renderer is missing for node version', editorTest(function () {
@@ -135,7 +135,7 @@ describe('Utils: generateDecoratorNode', function () {
             });
 
             const node = new VersionedNode() as unknown as GeneratedNodeInstance;
-            (() => node.exportDOM()).should.throw('[generateDecoratorNode] versioned-render-test: "defaultRenderFn" for version 2 is required');
+            (() => node.exportDOM(editor)).should.throw('[generateDecoratorNode] versioned-render-test: "defaultRenderFn" for version 2 is required');
         }));
 
         ['emailCustomizationAlpha', 'emailCustomization'].forEach((feature) => {
@@ -146,7 +146,7 @@ describe('Utils: generateDecoratorNode', function () {
                 const featureOption: Record<string, boolean> = {};
                 featureOption[feature] = true;
 
-                const result = node.exportDOM({
+                const result = node.exportDOM(editor, {
                     feature: featureOption,
                     nodeRenderers: {
                         'render-test': customRenderer
@@ -171,7 +171,7 @@ describe('Utils: generateDecoratorNode', function () {
 
             const node = new VersionedNode({version: 2}) as unknown as GeneratedNodeInstance;
 
-            (() => node.exportDOM({
+            (() => node.exportDOM(editor, {
                 feature: {
                     emailCustomizationAlpha: true
                 },

--- a/packages/kg-default-nodes/test/nodes/audio.test.ts
+++ b/packages/kg-default-nodes/test/nodes/audio.test.ts
@@ -202,21 +202,21 @@ describe('AudioNode', function () {
     describe('exportDOM', function () {
         it('creates an audio card', editorTest(function () {
             const audioNode = $createAudioNode(dataset);
-            const {element} = audioNode.exportDOM(exportOptions);
+            const {element} = audioNode.exportDOM(editor, exportOptions);
 
             getHTMLElement(element).outerHTML.should.prettifyTo(html`<div class="kg-card kg-audio-card"><img src="/content/images/2022/11/koenig-audio-lexical.jpg" alt="audio-thumbnail" class="kg-audio-thumbnail"><div class="kg-audio-thumbnail placeholder kg-audio-hide"><svg width="24" height="24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.5 15.33a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0ZM15 13.83a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0Z"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M14.486 6.81A2.25 2.25 0 0 1 17.25 9v5.579a.75.75 0 0 1-1.5 0v-5.58a.75.75 0 0 0-.932-.727.755.755 0 0 1-.059.013l-4.465.744a.75.75 0 0 0-.544.72v6.33a.75.75 0 0 1-1.5 0v-6.33a2.25 2.25 0 0 1 1.763-2.194l4.473-.746Z"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M3 1.5a.75.75 0 0 0-.75.75v19.5a.75.75 0 0 0 .75.75h18a.75.75 0 0 0 .75-.75V5.133a.75.75 0 0 0-.225-.535l-.002-.002-3-2.883A.75.75 0 0 0 18 1.5H3ZM1.409.659A2.25 2.25 0 0 1 3 0h15a2.25 2.25 0 0 1 1.568.637l.003.002 3 2.883a2.25 2.25 0 0 1 .679 1.61V21.75A2.25 2.25 0 0 1 21 24H3a2.25 2.25 0 0 1-2.25-2.25V2.25c0-.597.237-1.169.659-1.591Z"></path></svg></div><div class="kg-audio-player-container"><audio src="/content/audio/2022/11/koenig-lexical.mp3" preload="metadata"></audio><div class="kg-audio-title">Test Audio</div><div class="kg-audio-player"><button class="kg-audio-play-icon" aria-label="Play audio"><svg viewBox="0 0 24 24"><path d="M23.14 10.608 2.253.164A1.559 1.559 0 0 0 0 1.557v20.887a1.558 1.558 0 0 0 2.253 1.392L23.14 13.393a1.557 1.557 0 0 0 0-2.785Z"></path></svg></button><button class="kg-audio-pause-icon kg-audio-hide" aria-label="Pause audio"><svg viewBox="0 0 24 24"><rect x="3" y="1" width="7" height="22" rx="1.5" ry="1.5"></rect><rect x="14" y="1" width="7" height="22" rx="1.5" ry="1.5"></rect></svg></button><span class="kg-audio-current-time">0:00</span><div class="kg-audio-time">/<span class="kg-audio-duration">60</span></div><input type="range" class="kg-audio-seek-slider" max="100" value="0"><button class="kg-audio-playback-rate" aria-label="Adjust playback speed">1×</button><button class="kg-audio-unmute-icon" aria-label="Unmute"><svg viewBox="0 0 24 24"><path d="M15.189 2.021a9.728 9.728 0 0 0-7.924 4.85.249.249 0 0 1-.221.133H5.25a3 3 0 0 0-3 3v2a3 3 0 0 0 3 3h1.794a.249.249 0 0 1 .221.133 9.73 9.73 0 0 0 7.924 4.85h.06a1 1 0 0 0 1-1V3.02a1 1 0 0 0-1.06-.998Z"></path></svg></button><button class="kg-audio-mute-icon kg-audio-hide" aria-label="Mute"><svg viewBox="0 0 24 24"><path d="M16.177 4.3a.248.248 0 0 0 .073-.176v-1.1a1 1 0 0 0-1.061-1 9.728 9.728 0 0 0-7.924 4.85.249.249 0 0 1-.221.133H5.25a3 3 0 0 0-3 3v2a3 3 0 0 0 3 3h.114a.251.251 0 0 0 .177-.073ZM23.707 1.706A1 1 0 0 0 22.293.292l-22 22a1 1 0 0 0 0 1.414l.009.009a1 1 0 0 0 1.405-.009l6.63-6.631A.251.251 0 0 1 8.515 17a.245.245 0 0 1 .177.075 10.081 10.081 0 0 0 6.5 2.92 1 1 0 0 0 1.061-1V9.266a.247.247 0 0 1 .073-.176Z"></path></svg></button><input type="range" class="kg-audio-volume-slider" max="100" value="100"></div></div></div>`);
         }));
 
         it('renders an empty span with a missing src', editorTest(function () {
             const audioNode = $createAudioNode({});
-            const {element} = audioNode.exportDOM(exportOptions);
+            const {element} = audioNode.exportDOM(editor, exportOptions);
 
             getHTMLElement(element).outerHTML.should.equal('<span></span>');
         }));
 
         it('renders email links with postUrl', editorTest(function () {
             const audioNode = $createAudioNode(dataset);
-            const {element} = audioNode.exportDOM({...exportOptions, target: 'email', postUrl: 'https://example.com/posts/test-audio'});
+            const {element} = audioNode.exportDOM(editor, {...exportOptions, target: 'email', postUrl: 'https://example.com/posts/test-audio'});
 
             const output = getHTMLElement(element).outerHTML;
             output.should.containEql('href="https://example.com/posts/test-audio"');
@@ -226,7 +226,7 @@ describe('AudioNode', function () {
         it('throws when rendering email without postUrl', editorTest(function () {
             const audioNode = $createAudioNode(dataset);
 
-            (() => audioNode.exportDOM({...exportOptions, target: 'email'})).should.throw('renderAudioNode requires options.postUrl when options.target is "email"');
+            (() => audioNode.exportDOM(editor, {...exportOptions, target: 'email'})).should.throw('renderAudioNode requires options.postUrl when options.target is "email"');
         }));
     });
 

--- a/packages/kg-default-nodes/test/nodes/bookmark.test.ts
+++ b/packages/kg-default-nodes/test/nodes/bookmark.test.ts
@@ -163,7 +163,7 @@ describe('BookmarkNode', function () {
     describe('exportDOM', function () {
         it('creates an bookmark card', editorTest(function () {
             const bookmarkNode = $createBookmarkNode(dataset);
-            const result = bookmarkNode.exportDOM(exportOptions);
+            const result = bookmarkNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             const metadata = dataset.metadata as Record<string, unknown>;
 
@@ -197,7 +197,7 @@ describe('BookmarkNode', function () {
                 target: 'email'
             };
             const bookmarkNode = $createBookmarkNode(dataset);
-            const result = bookmarkNode.exportDOM({...exportOptions, ...options});
+            const result = bookmarkNode.exportDOM(editor, {...exportOptions, ...options});
             const element = result.element as HTMLElement;
 
             element.innerHTML.should.containEql('<!--[if !mso !vml]-->');
@@ -208,7 +208,7 @@ describe('BookmarkNode', function () {
 
         it('renders an empty span with a missing src', editorTest(function () {
             const bookmarkNode = $createBookmarkNode();
-            const result = bookmarkNode.exportDOM(exportOptions);
+            const result = bookmarkNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.equal('<span></span>');
@@ -228,7 +228,7 @@ describe('BookmarkNode', function () {
                 caption: '<p dir="ltr"><span style="white-space: pre-wrap;">This is a </span><b><strong style="white-space: pre-wrap;">caption</strong></b></p>'
             };
             const bookmarkNode = $createBookmarkNode(dataset);
-            const result = bookmarkNode.exportDOM(exportOptions);
+            const result = bookmarkNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             // Check that text fields are escaped
@@ -258,7 +258,7 @@ describe('BookmarkNode', function () {
                 caption: '<p dir="ltr"><span style="white-space: pre-wrap;">This is a </span><b><strong style="white-space: pre-wrap;">caption</strong></b></p>'
             };
             const bookmarkNode = $createBookmarkNode(dataset);
-            const result = bookmarkNode.exportDOM({...exportOptions, ...options});
+            const result = bookmarkNode.exportDOM(editor, {...exportOptions, ...options});
             const element = result.element as HTMLElement;
 
             // Check that email template is used

--- a/packages/kg-default-nodes/test/nodes/button.test.ts
+++ b/packages/kg-default-nodes/test/nodes/button.test.ts
@@ -114,7 +114,7 @@ describe('ButtonNode', function () {
     describe('exportDOM', function () {
         it('creates a button card', editorTest(function () {
             const buttonNode = $createButtonNode(dataset);
-            const result = buttonNode.exportDOM(exportOptions);
+            const result = buttonNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(html`<div class="kg-card kg-button-card kg-align-center"><a href="http://blog.com/post1" class="kg-btn kg-btn-accent">click me</a></div>`);
@@ -125,7 +125,7 @@ describe('ButtonNode', function () {
             const options = {
                 target: 'email'
             };
-            const result = buttonNode.exportDOM({...exportOptions, ...options});
+            const result = buttonNode.exportDOM(editor, {...exportOptions, ...options});
             const element = result.element as HTMLElement;
             const output = element.outerHTML;
 
@@ -143,7 +143,7 @@ describe('ButtonNode', function () {
                     emailCustomization: true
                 }
             };
-            const result = buttonNode.exportDOM({...exportOptions, ...options});
+            const result = buttonNode.exportDOM(editor, {...exportOptions, ...options});
             const element = result.element as HTMLElement;
             const output = element.innerHTML;
 
@@ -176,7 +176,7 @@ describe('ButtonNode', function () {
                     emailCustomizationAlpha: true
                 }
             };
-            const result = buttonNode.exportDOM({...exportOptions, ...options});
+            const result = buttonNode.exportDOM(editor, {...exportOptions, ...options});
             const element = result.element as HTMLElement;
             const output = element.innerHTML;
 
@@ -203,7 +203,7 @@ describe('ButtonNode', function () {
 
         it('renders an empty span with a missing buttonUrl', editorTest(function () {
             const buttonNode = $createButtonNode();
-            const result = buttonNode.exportDOM(exportOptions);
+            const result = buttonNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.equal('<span></span>');

--- a/packages/kg-default-nodes/test/nodes/call-to-action.test.ts
+++ b/packages/kg-default-nodes/test/nodes/call-to-action.test.ts
@@ -232,7 +232,7 @@ describe('CallToActionNode', function () {
     describe('exportDOM', function () {
         const testRender = (assertFn: (result: {element: HTMLElement; type: ExportDOMOutputType; html: string}) => void) => {
             const callToActionNode = new CallToActionNode(dataset);
-            const result = callToActionNode.exportDOM(exportOptions);
+            const result = callToActionNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             const {type} = result;
 
@@ -459,7 +459,7 @@ describe('CallToActionNode', function () {
                     (callToActionNode as unknown as Record<string, unknown>)[prop] = '';
                 });
 
-                const result = callToActionNode.exportDOM(exportOptions);
+                const result = callToActionNode.exportDOM(editor, exportOptions);
                 const element = result.element as HTMLElement;
                 const html = element.outerHTML.toString();
 
@@ -749,7 +749,7 @@ describe('CallToActionNode', function () {
     describe('importDom', function () {
         const generateCallToActionNodes = (nodeDataset: Record<string, unknown>) => {
             const callToActionNode = new CallToActionNode(nodeDataset);
-            const result = callToActionNode.exportDOM(exportOptions);
+            const result = callToActionNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             const docuement = createDocument(htmlTemplate`${element.outerHTML.toString()}`);
             const nodes = $generateNodesFromDOM(editor, docuement) as CallToActionNode[];

--- a/packages/kg-default-nodes/test/nodes/callout.test.ts
+++ b/packages/kg-default-nodes/test/nodes/callout.test.ts
@@ -118,7 +118,7 @@ describe('CalloutNode', function () {
     describe('exportDOM', function () {
         it('can render to HTML', editorTest(function () {
             const node = $createCalloutNode(dataset);
-            const result = node.exportDOM(exportOptions);
+            const result = node.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-callout-card kg-callout-card-blue">
@@ -139,7 +139,7 @@ describe('CalloutNode', function () {
                 backgroundColor: 'blue'
             };
             const node = $createCalloutNode(dataset2);
-            const result = node.exportDOM(exportOptions);
+            const result = node.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-callout-card kg-callout-card-blue">
@@ -156,7 +156,7 @@ describe('CalloutNode', function () {
             dataset.backgroundColor = 'rgba(124, 139, 154, 0.13)';
 
             const node = $createCalloutNode(dataset);
-            const result = node.exportDOM(exportOptions);
+            const result = node.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(html`
@@ -175,7 +175,7 @@ describe('CalloutNode', function () {
             dataset.calloutText = '<p><span style="white-space: pre-wrap;">Does </span><code spellcheck="false" style="white-space: pre-wrap;"><span>inline code</span></code><span style="white-space: pre-wrap;"> render properly?</span></p>';
 
             const node = $createCalloutNode(dataset);
-            const result = node.exportDOM(exportOptions);
+            const result = node.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(html`

--- a/packages/kg-default-nodes/test/nodes/codeblock.test.ts
+++ b/packages/kg-default-nodes/test/nodes/codeblock.test.ts
@@ -198,7 +198,7 @@ describe('CodeBlockNode', function () {
     describe('exportDOM', function () {
         it('renders and escapes', editorTest(function () {
             const codeBlockNode = $createCodeBlockNode({code});
-            const {element} = codeBlockNode.exportDOM(exportOptions);
+            const {element} = codeBlockNode.exportDOM(editor, exportOptions);
             const el = element as HTMLElement;
 
             el.outerHTML.should.prettifyTo(html`
@@ -208,7 +208,7 @@ describe('CodeBlockNode', function () {
 
         it('renders language class if provided', editorTest(function () {
             const codeBlockNode = $createCodeBlockNode({language, code});
-            const {element} = codeBlockNode.exportDOM(exportOptions);
+            const {element} = codeBlockNode.exportDOM(editor, exportOptions);
             const el = element as HTMLElement;
 
             el.outerHTML.should.prettifyTo(html`
@@ -218,7 +218,7 @@ describe('CodeBlockNode', function () {
 
         it('renders empty span when code is undefined or empty', editorTest(function () {
             const codeBlockNode = $createCodeBlockNode({code: ''});
-            const {element} = codeBlockNode.exportDOM(exportOptions);
+            const {element} = codeBlockNode.exportDOM(editor, exportOptions);
             const el = element as HTMLElement;
 
             el.outerHTML.should.equal('<span></span>');
@@ -226,7 +226,7 @@ describe('CodeBlockNode', function () {
 
         it('renders a figure if a caption is provided', editorTest(function () {
             const codeBlockNode = $createCodeBlockNode({language, code, caption});
-            const {element} = codeBlockNode.exportDOM(exportOptions);
+            const {element} = codeBlockNode.exportDOM(editor, exportOptions);
             const el = element as HTMLElement;
 
             el.outerHTML.should.prettifyTo(html`

--- a/packages/kg-default-nodes/test/nodes/email-cta.test.ts
+++ b/packages/kg-default-nodes/test/nodes/email-cta.test.ts
@@ -210,7 +210,7 @@ describe('EmailCtaNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailCtaNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.outerHTML.should.prettifyTo(html`
@@ -237,7 +237,7 @@ describe('EmailCtaNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailCtaNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.outerHTML.should.equal('<span></span>');
@@ -259,7 +259,7 @@ describe('EmailCtaNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailCtaNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.outerHTML.should.equal('<span></span>');
@@ -281,7 +281,7 @@ describe('EmailCtaNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailCtaNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.outerHTML.should.equal('<span></span>');
@@ -303,7 +303,7 @@ describe('EmailCtaNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailCtaNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.outerHTML.should.prettifyTo(html`
@@ -331,7 +331,7 @@ describe('EmailCtaNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailCtaNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.outerHTML.should.prettifyTo(html`
@@ -359,7 +359,7 @@ describe('EmailCtaNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailCtaNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.outerHTML.should.prettifyTo(html`
@@ -399,7 +399,7 @@ describe('EmailCtaNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailCtaNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.outerHTML.should.prettifyTo(html`
@@ -437,7 +437,7 @@ describe('EmailCtaNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailCtaNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.outerHTML.should.prettifyTo(html`
@@ -474,7 +474,7 @@ describe('EmailCtaNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailCtaNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.outerHTML.should.prettifyTo(html`

--- a/packages/kg-default-nodes/test/nodes/email.test.ts
+++ b/packages/kg-default-nodes/test/nodes/email.test.ts
@@ -155,7 +155,7 @@ describe('EmailNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.innerHTML.should.prettifyTo(html`
@@ -168,7 +168,7 @@ describe('EmailNode', function () {
                 html: '<p>Hello World</p>'
             };
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM(exportOptions);
+            const {element} = emailNode.exportDOM(editor, exportOptions);
 
             (element as HTMLElement).innerHTML.should.equal('');
         }));
@@ -183,7 +183,7 @@ describe('EmailNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
 
             (element as HTMLElement).innerHTML.should.equal('');
         }));
@@ -198,7 +198,7 @@ describe('EmailNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.innerHTML.should.prettifyTo(html`
@@ -216,7 +216,7 @@ describe('EmailNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.innerHTML.should.prettifyTo(html`
@@ -234,7 +234,7 @@ describe('EmailNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.innerHTML.should.prettifyTo(html`
@@ -252,7 +252,7 @@ describe('EmailNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.innerHTML.should.prettifyTo(html`
@@ -270,7 +270,7 @@ describe('EmailNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.innerHTML.should.prettifyTo(html`
@@ -288,7 +288,7 @@ describe('EmailNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.innerHTML.should.prettifyTo(html`
@@ -306,7 +306,7 @@ describe('EmailNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.innerHTML.should.prettifyTo(html`
@@ -324,7 +324,7 @@ describe('EmailNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.innerHTML.should.prettifyTo(html`
@@ -342,7 +342,7 @@ describe('EmailNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.innerHTML.should.prettifyTo(html`
@@ -360,7 +360,7 @@ describe('EmailNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.innerHTML.should.prettifyTo(html`
@@ -378,7 +378,7 @@ describe('EmailNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.innerHTML.should.prettifyTo(html`
@@ -399,7 +399,7 @@ describe('EmailNode', function () {
             };
 
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.innerHTML.should.prettifyTo(html`
@@ -420,7 +420,7 @@ describe('EmailNode', function () {
             };
 
             const emailNode = $createEmailNode(payload);
-            const {element} = emailNode.exportDOM({...exportOptions, ...options});
+            const {element} = emailNode.exportDOM(editor, {...exportOptions, ...options});
             const el = element as HTMLElement;
 
             el.innerHTML.should.prettifyTo(html`

--- a/packages/kg-default-nodes/test/nodes/embed.test.ts
+++ b/packages/kg-default-nodes/test/nodes/embed.test.ts
@@ -172,7 +172,7 @@ describe('EmbedNode', function () {
     describe('exportDOM', function () {
         it('renders embed html with no metadata', editorTest(function () {
             const embedNode = $createEmbedNode(dataset);
-            const {element} = embedNode.exportDOM(exportOptions);
+            const {element} = embedNode.exportDOM(editor, exportOptions);
 
             const expectedHtml = `
                 <figure class="kg-card kg-embed-card kg-card-hascaption">
@@ -205,7 +205,7 @@ describe('EmbedNode', function () {
                 },
                 caption: 'caption text'
             });
-            const {element} = embedNode.exportDOM(exportOptions);
+            const {element} = embedNode.exportDOM(editor, exportOptions);
 
             const expectedHtml = `
                 <figure class="kg-card kg-embed-card kg-card-hascaption">
@@ -262,7 +262,7 @@ describe('EmbedNode', function () {
                 },
                 caption: 'caption text'
             });
-            const {element} = embedNode.exportDOM(exportOptions);
+            const {element} = embedNode.exportDOM(editor, exportOptions);
 
             (element as HTMLElement).outerHTML.should.containEql('<blockquote class="twitter-tweet"');
         }));
@@ -334,7 +334,7 @@ describe('EmbedNode', function () {
                 },
                 caption: 'caption text'
             });
-            const {element} = embedNode.exportDOM({...exportOptions, ...options});
+            const {element} = embedNode.exportDOM(editor, {...exportOptions, ...options});
 
             (element as HTMLElement).outerHTML.should.containEql('<table cellspacing="0" cellpadding="0" border="0" class="kg-twitter-card">');
             (element as HTMLElement).outerHTML.should.containEql(`<a href="https://twitter.com/twitter/status/${tweetData.id}"`);
@@ -357,7 +357,7 @@ describe('EmbedNode', function () {
                 },
                 caption: 'caption text'
             });
-            const {element} = embedNode.exportDOM({...exportOptions, ...options});
+            const {element} = embedNode.exportDOM(editor, {...exportOptions, ...options});
             const output = (element as HTMLElement).outerHTML;
 
             output.should.containEql('<blockquote class="twitter-tweet">');
@@ -370,7 +370,7 @@ describe('EmbedNode', function () {
                 target: 'email'
             };
             const embedNode = $createEmbedNode(youtubeEmbed);
-            const {element} = embedNode.exportDOM({...exportOptions, ...options});
+            const {element} = embedNode.exportDOM(editor, {...exportOptions, ...options});
 
             (element as HTMLElement).outerHTML.should.containEql('<!--[if !mso !vml]-->');
             (element as HTMLElement).outerHTML.should.containEql('<a class="kg-video-preview"');
@@ -380,7 +380,7 @@ describe('EmbedNode', function () {
 
         it('renders empty span with missing data', editorTest(function () {
             const embedNode = $createEmbedNode({} as Record<string, unknown>);
-            const {element} = embedNode.exportDOM(exportOptions);
+            const {element} = embedNode.exportDOM(editor, exportOptions);
 
             (element as HTMLElement).outerHTML.should.equal('<span></span>');
         }));

--- a/packages/kg-default-nodes/test/nodes/file.test.ts
+++ b/packages/kg-default-nodes/test/nodes/file.test.ts
@@ -83,7 +83,7 @@ describe('FileNode', function () {
     describe('exportDOM', function () {
         it('creates a file card', editorTest(function () {
             const fileNode = $createFileNode(dataset);
-            const {element} = fileNode.exportDOM(exportOptions);
+            const {element} = fileNode.exportDOM(editor, exportOptions);
             (element as HTMLElement).outerHTML.should.equal(`<div class="kg-card kg-file-card"><a class="kg-file-card-container" href="/content/files/2023/03/IMG_0196.jpeg" title="Download" download=""><div class="kg-file-card-contents"><div class="kg-file-card-title">Cool image to download</div><div class="kg-file-card-caption">This is a description</div><div class="kg-file-card-metadata"><div class="kg-file-card-filename">IMG_0196.jpeg</div><div class="kg-file-card-filesize">121 KB</div></div></div><div class="kg-file-card-icon"><svg viewBox="0 0 24 24"><defs><style>.a{fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5px;}</style></defs><title>download-circle</title><polyline class="a" points="8.25 14.25 12 18 15.75 14.25"></polyline><line class="a" x1="12" y1="6.75" x2="12" y2="18"></line><circle class="a" cx="12" cy="12" r="11.25"></circle></svg></div></a></div>`);
         }));
 
@@ -95,7 +95,7 @@ describe('FileNode', function () {
 
             it('renders complete email template with all fields', editorTest(function () {
                 const fileNode = $createFileNode(dataset);
-                const {element} = fileNode.exportDOM(exportOptions);
+                const {element} = fileNode.exportDOM(editor, exportOptions);
                 const el = element as HTMLElement;
 
                 // Check basic structure
@@ -130,7 +130,7 @@ describe('FileNode', function () {
                     fileSize: 123456
                 };
                 const fileNode = $createFileNode(minimalDataset);
-                const {element} = fileNode.exportDOM(exportOptions);
+                const {element} = fileNode.exportDOM(editor, exportOptions);
                 const el = element as HTMLElement;
 
                 // Should not have title
@@ -152,7 +152,7 @@ describe('FileNode', function () {
                     fileName: 'file<.html'
                 };
                 const fileNode = $createFileNode(datasetWithHtml);
-                const {element} = fileNode.exportDOM(exportOptions);
+                const {element} = fileNode.exportDOM(editor, exportOptions);
                 const el = element as HTMLElement;
 
                 const elHtml = el.innerHTML;

--- a/packages/kg-default-nodes/test/nodes/gallery.test.ts
+++ b/packages/kg-default-nodes/test/nodes/gallery.test.ts
@@ -642,21 +642,21 @@ describe('GalleryNode', function () {
     describe('exportDOM', function () {
         it('renders empty span with no images', editorTest(function () {
             const galleryNode = $createGalleryNode({images: [], caption: null as unknown as string});
-            const {element} = galleryNode.exportDOM(exportOptions);
+            const {element} = galleryNode.exportDOM(editor, exportOptions);
 
             (element as HTMLElement).outerHTML.should.equal('<span></span>');
         }));
 
         it('renders empty span no valid images', editorTest(function () {
             const galleryNode = $createGalleryNode({images: [{src: 'undefined'}], caption: null as unknown as string});
-            const {element} = galleryNode.exportDOM(exportOptions);
+            const {element} = galleryNode.exportDOM(editor, exportOptions);
 
             (element as HTMLElement).outerHTML.should.equal('<span></span>');
         }));
 
         it('renders', editorTest(function () {
             const galleryNode = $createGalleryNode(dataset);
-            const {element} = galleryNode.exportDOM({...exportOptions, canTransformImage: () => false});
+            const {element} = galleryNode.exportDOM(editor, {...exportOptions, canTransformImage: () => false});
 
             (element as HTMLElement).outerHTML.should.prettifyTo(html`
                 <figure class="kg-card kg-gallery-card kg-width-wide kg-card-hascaption">
@@ -697,7 +697,7 @@ describe('GalleryNode', function () {
                 ],
                 caption: 'Test caption'
             });
-            const {element} = galleryNode.exportDOM({...exportOptions, canTransformImage: () => false});
+            const {element} = galleryNode.exportDOM(editor, {...exportOptions, canTransformImage: () => false});
 
             (element as HTMLElement).outerHTML.should.prettifyTo(html`
                 <figure class="kg-card kg-gallery-card kg-width-wide kg-card-hascaption">
@@ -724,7 +724,7 @@ describe('GalleryNode', function () {
                 ],
                 caption: 'Test caption'
             });
-            const {element} = galleryNode.exportDOM({...exportOptions, canTransformImage: () => false});
+            const {element} = galleryNode.exportDOM(editor, {...exportOptions, canTransformImage: () => false});
 
             (element as HTMLElement).outerHTML.should.prettifyTo(html`
                 <figure class="kg-card kg-gallery-card kg-width-wide kg-card-hascaption">
@@ -807,7 +807,7 @@ describe('GalleryNode', function () {
                 ],
                 caption: 'Test caption'
             });
-            const {element} = galleryNode.exportDOM({...exportOptions, canTransformImage: () => false});
+            const {element} = galleryNode.exportDOM(editor, {...exportOptions, canTransformImage: () => false});
 
             (element as HTMLElement).outerHTML.should.prettifyTo(html`
                 <figure class="kg-card kg-gallery-card kg-width-wide kg-card-hascaption">
@@ -842,7 +842,7 @@ describe('GalleryNode', function () {
                 ]
             });
 
-            const {element} = galleryNode.exportDOM(exportOptions);
+            const {element} = galleryNode.exportDOM(editor, exportOptions);
 
             const output = (element as HTMLElement).outerHTML;
 
@@ -929,7 +929,7 @@ describe('GalleryNode', function () {
 
             // skip srcset
             delete (exportOptions.imageOptimization as Record<string, unknown>).contentImageSizes;
-            const {element} = galleryNode.exportDOM(exportOptions);
+            const {element} = galleryNode.exportDOM(editor, exportOptions);
 
             (element as HTMLElement).outerHTML.should.prettifyTo(html`
                 <figure class="kg-card kg-gallery-card kg-width-wide">
@@ -979,7 +979,7 @@ describe('GalleryNode', function () {
                 });
 
                 delete (exportOptions.imageOptimization as Record<string, unknown>).defaultMaxWidth;
-                const {element} = galleryNode.exportDOM(exportOptions);
+                const {element} = galleryNode.exportDOM(editor, exportOptions);
 
                 (element as HTMLElement).outerHTML.should.prettifyTo(html`
                     <figure class="kg-card kg-gallery-card kg-width-wide">
@@ -1013,7 +1013,7 @@ describe('GalleryNode', function () {
 
                 delete (exportOptions.imageOptimization as Record<string, unknown>).defaultMaxWidth;
                 exportOptions.siteUrl = 'https://localhost:2368';
-                const {element} = galleryNode.exportDOM(exportOptions);
+                const {element} = galleryNode.exportDOM(editor, exportOptions);
 
                 (element as HTMLElement).outerHTML.should.prettifyTo(html`
                     <figure class="kg-card kg-gallery-card kg-width-wide">
@@ -1040,7 +1040,7 @@ describe('GalleryNode', function () {
 
                 delete (exportOptions.imageOptimization as Record<string, unknown>).defaultMaxWidth;
                 exportOptions.target = 'email';
-                const {element} = galleryNode.exportDOM(exportOptions);
+                const {element} = galleryNode.exportDOM(editor, exportOptions);
 
                 (element as HTMLElement).outerHTML.should.not.containEql('srcset=');
             }));
@@ -1057,7 +1057,7 @@ describe('GalleryNode', function () {
                 });
 
                 delete (exportOptions.imageOptimization as Record<string, unknown>).contentImageSizes;
-                const {element} = galleryNode.exportDOM(exportOptions);
+                const {element} = galleryNode.exportDOM(editor, exportOptions);
 
                 (element as HTMLElement).outerHTML.should.not.containEql('srcset=');
             }));
@@ -1074,7 +1074,7 @@ describe('GalleryNode', function () {
                 });
 
                 (exportOptions.imageOptimization as Record<string, unknown>).srcsets = false;
-                const {element} = galleryNode.exportDOM(exportOptions);
+                const {element} = galleryNode.exportDOM(editor, exportOptions);
 
                 (element as HTMLElement).outerHTML.should.not.containEql('srcset=');
             }));
@@ -1104,7 +1104,7 @@ describe('GalleryNode', function () {
                     }]
                 });
 
-                const {element} = galleryNode.exportDOM(exportOptions);
+                const {element} = galleryNode.exportDOM(editor, exportOptions);
 
                 const output = (element as HTMLElement).outerHTML;
                 const sizes = output.match(/sizes="(.*?)"/g);
@@ -1126,7 +1126,7 @@ describe('GalleryNode', function () {
                     }]
                 });
 
-                const {element} = galleryNode.exportDOM(exportOptions);
+                const {element} = galleryNode.exportDOM(editor, exportOptions);
 
                 (element as HTMLElement).outerHTML.should.match(/standard\.jpg 2000w" sizes="\(min-width: 1200px\) 1200px"/);
             }));
@@ -1142,7 +1142,7 @@ describe('GalleryNode', function () {
                     }]
                 });
 
-                const {element} = galleryNode.exportDOM(exportOptions);
+                const {element} = galleryNode.exportDOM(editor, exportOptions);
 
                 (element as HTMLElement).outerHTML.should.match(/standard\.jpg 1000w" sizes="\(min-width: 720px\) 720px"/);
             }));
@@ -1171,7 +1171,7 @@ describe('GalleryNode', function () {
                 });
 
                 (exportOptions.imageOptimization as Record<string, unknown>).srcsets = false;
-                const {element} = galleryNode.exportDOM(exportOptions);
+                const {element} = galleryNode.exportDOM(editor, exportOptions);
 
                 const output = (element as HTMLElement).outerHTML;
                 const sizes = output.match(/sizes="(.*?)"/g);
@@ -1214,7 +1214,7 @@ describe('GalleryNode', function () {
                     }]
                 });
 
-                const {element} = galleryNode.exportDOM(exportOptions);
+                const {element} = galleryNode.exportDOM(editor, exportOptions);
                 const output = (element as HTMLElement).outerHTML;
 
                 // 3 images wider than 600px template width resized to fit
@@ -1249,7 +1249,7 @@ describe('GalleryNode', function () {
 
                 exportOptions.canTransformImage = () => false;
 
-                const {element} = galleryNode.exportDOM(exportOptions);
+                const {element} = galleryNode.exportDOM(editor, exportOptions);
                 const output = (element as HTMLElement).outerHTML;
 
                 output.should.not.match(/width="3000"/);

--- a/packages/kg-default-nodes/test/nodes/header.test.ts
+++ b/packages/kg-default-nodes/test/nodes/header.test.ts
@@ -137,7 +137,7 @@ describe('HeaderNode', function () {
         describe('exportDOM', function () {
             it('can render to HTML', editorTest(function () {
                 const headerNode = $createHeaderNode(dataset);
-                const {element} = headerNode.exportDOM(exportOptions);
+                const {element} = headerNode.exportDOM(editor, exportOptions);
                 const expectedElement = html`
                 <div class="kg-card kg-header-card kg-width-full kg-size-small kg-style-image" data-kg-background-image="https://example.com/image.jpg" style="background-image: url(https://example.com/image.jpg)">
                     <h2 class="kg-header-card-header" id="this-is-the-header-card">This is the header card</h2>
@@ -153,7 +153,7 @@ describe('HeaderNode', function () {
                 node.header = null as unknown as string;
                 node.subheader = null as unknown as string;
                 node.buttonEnabled = false;
-                const result = node.exportDOM(exportOptions);
+                const result = node.exportDOM(editor, exportOptions);
                 should.equal((result as unknown as {type?: string}).type, 'inner');
                 (result.element as HTMLElement).innerHTML.should.equal('');
             }));
@@ -172,7 +172,7 @@ describe('HeaderNode', function () {
                 };
                 const node = $createHeaderNode(payload);
 
-                const {element} = node.exportDOM(exportOptions);
+                const {element} = node.exportDOM(editor, exportOptions);
                 const expectedElement = `<div class="kg-card kg-header-card kg-width-full kg-size-small kg-style-dark" data-kg-background-image="" style=""><h2 class="kg-header-card-header" id="hello-world">hello world</h2><h3 class="kg-header-card-subheader" id="hello-sub-world">hello sub world</h3></div>`;
                 (element as HTMLElement).outerHTML.should.equal(expectedElement);
             }));
@@ -191,7 +191,7 @@ describe('HeaderNode', function () {
                 };
                 const node = $createHeaderNode(payload);
 
-                const {element} = node.exportDOM(exportOptions);
+                const {element} = node.exportDOM(editor, exportOptions);
                 const expectedElement = `<div class="kg-card kg-header-card kg-width-full kg-size-small kg-style-dark" data-kg-background-image="" style=""><h2 class="kg-header-card-header" id="hello-world">hello world</h2></div>`;
                 (element as HTMLElement).outerHTML.should.equal(expectedElement);
             }));
@@ -210,7 +210,7 @@ describe('HeaderNode', function () {
                 };
                 const node = $createHeaderNode(payload);
 
-                const {element} = node.exportDOM(exportOptions);
+                const {element} = node.exportDOM(editor, exportOptions);
                 const expectedElement = `<div class="kg-card kg-header-card kg-width-full kg-size-small kg-style-dark" data-kg-background-image="" style=""><h2 class="kg-header-card-header" id="hello-world">hello world</h2></div>`;
                 (element as HTMLElement).outerHTML.should.equal(expectedElement);
             }));
@@ -462,7 +462,7 @@ describe('HeaderNode', function () {
         describe('exportDOM', function () {
             it('renders version 2 html', editorTest(function () {
                 const headerNode = $createHeaderNode(dataset);
-                const {element} = headerNode.exportDOM(exportOptions);
+                const {element} = headerNode.exportDOM(editor, exportOptions);
                 const el = element as HTMLElement;
 
                 // Assuming outerHTML gets the full HTML string of the element
@@ -488,7 +488,7 @@ describe('HeaderNode', function () {
                 node.header = null as unknown as string;
                 node.subheader = null as unknown as string;
                 node.buttonEnabled = false;
-                const {element} = node.exportDOM(exportOptions);
+                const {element} = node.exportDOM(editor, exportOptions);
                 // v2 renderer has no empty check — it always returns a card element
                 should.exist(element);
                 should.not.exist((element as HTMLElement).querySelector('.kg-header-card-heading'));
@@ -510,7 +510,7 @@ describe('HeaderNode', function () {
                 };
                 const node = $createHeaderNode(payload);
 
-                const {element} = node.exportDOM(exportOptions);
+                const {element} = node.exportDOM(editor, exportOptions);
                 const el = element as HTMLElement;
                 const renderedHtml = _.replace(el.outerHTML, /\s/g, '');
                 const expectedHtml = `
@@ -543,7 +543,7 @@ describe('HeaderNode', function () {
                 };
                 const node = $createHeaderNode(payload);
 
-                const {element} = node.exportDOM(exportOptions);
+                const {element} = node.exportDOM(editor, exportOptions);
                 const el = element as HTMLElement;
                 const renderedHtml = _.replace(el.outerHTML, /\s/g, '');
                 const expectedHtml = `

--- a/packages/kg-default-nodes/test/nodes/horizontalrule.test.ts
+++ b/packages/kg-default-nodes/test/nodes/horizontalrule.test.ts
@@ -44,7 +44,7 @@ describe('HorizontalNode', function () {
     describe('exportDOM', function () {
         it('creates hr element', editorTest(function () {
             const hrNode = $createHorizontalRuleNode();
-            const {element} = hrNode.exportDOM(exportOptions);
+            const {element} = hrNode.exportDOM(editor, exportOptions);
 
             (element as HTMLElement).outerHTML.should.prettifyTo(html`
                 <hr />

--- a/packages/kg-default-nodes/test/nodes/html.test.ts
+++ b/packages/kg-default-nodes/test/nodes/html.test.ts
@@ -152,7 +152,7 @@ describe('HtmlNode', function () {
     describe('exportDOM', function () {
         it('creates a html card', editorTest(function () {
             const htmlNode = $createHtmlNode(dataset);
-            const result = htmlNode.exportDOM(exportOptions);
+            const result = htmlNode.exportDOM(editor, exportOptions);
             result.type.should.equal('value');
             const element = result.element as HTMLTextAreaElement;
             element.value.should.prettifyTo(html`
@@ -168,7 +168,7 @@ describe('HtmlNode', function () {
 
         it('renders an empty span with missing html', editorTest(function () {
             const htmlNode = $createHtmlNode();
-            const result = htmlNode.exportDOM(exportOptions);
+            const result = htmlNode.exportDOM(editor, exportOptions);
             result.type.should.equal('inner');
             const element = result.element as HTMLElement;
 
@@ -177,7 +177,7 @@ describe('HtmlNode', function () {
 
         it('renders unclosed tags', editorTest(function () {
             const htmlNode = $createHtmlNode({html: '<div style="color:red">'});
-            const result = htmlNode.exportDOM(exportOptions);
+            const result = htmlNode.exportDOM(editor, exportOptions);
             result.type.should.equal('value');
             const element = result.element as HTMLTextAreaElement;
 
@@ -187,7 +187,7 @@ describe('HtmlNode', function () {
 
         it('renders html entities', editorTest(function () {
             const htmlNode = $createHtmlNode({html: '<p>&lt;pre&gt;Test&lt;/pre&gt;</p>'});
-            const result = htmlNode.exportDOM(exportOptions);
+            const result = htmlNode.exportDOM(editor, exportOptions);
             result.type.should.equal('value');
             const element = result.element as HTMLTextAreaElement;
 
@@ -196,7 +196,7 @@ describe('HtmlNode', function () {
 
         it('handles single-quote attributes', editorTest(function () {
             const htmlNode = $createHtmlNode({html: '<div data-graph-name=\'The "all-in" cost of a grant\'>Test</div>'});
-            const result = htmlNode.exportDOM(exportOptions);
+            const result = htmlNode.exportDOM(editor, exportOptions);
             result.type.should.equal('value');
             const element = result.element as HTMLTextAreaElement;
 
@@ -207,7 +207,7 @@ describe('HtmlNode', function () {
             describe('with old visibility settings', function () {
                 function testWebRender(visibility: Record<string, unknown>) {
                     const htmlNode = $createHtmlNode({html: '<div>Test</div>', visibility});
-                    const result = htmlNode.exportDOM(exportOptions);
+                    const result = htmlNode.exportDOM(editor, exportOptions);
                     result.type.should.equal('value');
                     const element = result.element as HTMLTextAreaElement;
                     element.value.should.equal('\n<!--kg-card-begin: html-->\n<div>Test</div>\n<!--kg-card-end: html-->\n');
@@ -215,7 +215,7 @@ describe('HtmlNode', function () {
 
                 function testEmailRender(visibility: Record<string, unknown>) {
                     const htmlNode = $createHtmlNode({html: '<div>Test</div>', visibility});
-                    const result = htmlNode.exportDOM({...exportOptions, target: 'email'});
+                    const result = htmlNode.exportDOM(editor, {...exportOptions, target: 'email'});
                     const expectedContents = '<!--kg-card-begin: html-->\n<div>Test</div>\n<!--kg-card-end: html-->';
 
                     if (visibility.segment) {
@@ -231,7 +231,7 @@ describe('HtmlNode', function () {
 
                 function testBlankRender(visibility: Record<string, unknown>, target: string) {
                     const htmlNode = $createHtmlNode({html: '<div>Test</div>', visibility});
-                    const result = htmlNode.exportDOM({...exportOptions, target});
+                    const result = htmlNode.exportDOM(editor, {...exportOptions, target});
                     result.type.should.equal('inner');
                     const element = result.element as HTMLElement;
                     element.innerHTML.should.equal('');
@@ -259,7 +259,7 @@ describe('HtmlNode', function () {
             describe('with new visibility settings', function () {
                 function testWebRender(visibility: Record<string, unknown>, expectedGateParams?: string | null) {
                     const htmlNode = $createHtmlNode({html: '<div>Test</div>', visibility});
-                    const result = htmlNode.exportDOM(exportOptions);
+                    const result = htmlNode.exportDOM(editor, exportOptions);
                     result.type.should.equal('value');
                     const element = result.element as HTMLTextAreaElement;
                     const baseExpectedContents = '\n<!--kg-card-begin: html-->\n<div>Test</div>\n<!--kg-card-end: html-->\n';
@@ -268,7 +268,7 @@ describe('HtmlNode', function () {
 
                 function testEmailRender(visibility: Record<string, unknown>, expectedSegment: string) {
                     const htmlNode = $createHtmlNode({html: '<div>Test</div>', visibility});
-                    const result = htmlNode.exportDOM({...exportOptions, target: 'email'});
+                    const result = htmlNode.exportDOM(editor, {...exportOptions, target: 'email'});
                     const expectedContents = '<!--kg-card-begin: html-->\n<div>Test</div>\n<!--kg-card-end: html-->';
 
                     if (!expectedSegment) {
@@ -284,7 +284,7 @@ describe('HtmlNode', function () {
 
                 function testBlankRender(visibility: Record<string, unknown>, target: string) {
                     const htmlNode = $createHtmlNode({html: '<div>Test</div>', visibility});
-                    const result = htmlNode.exportDOM({...exportOptions, target});
+                    const result = htmlNode.exportDOM(editor, {...exportOptions, target});
                     result.type.should.equal('inner');
                     const element = result.element as HTMLElement;
                     element.innerHTML.should.equal('');

--- a/packages/kg-default-nodes/test/nodes/image.test.ts
+++ b/packages/kg-default-nodes/test/nodes/image.test.ts
@@ -139,7 +139,7 @@ describe('ImageNode', function () {
     describe('exportDOM', function () {
         it('creates a full-featured image card', editorTest(function () {
             const imageNode = $createImageNode(dataset);
-            const {element} = imageNode.exportDOM(exportOptions);
+            const {element} = imageNode.exportDOM(editor, exportOptions);
 
             (element as HTMLElement).outerHTML.should.prettifyTo(html`
                 <figure class="kg-card kg-image-card kg-card-hascaption">
@@ -163,7 +163,7 @@ describe('ImageNode', function () {
                 ...dataset,
                 href: 'https://example.com'
             });
-            const {element} = imageNode.exportDOM(exportOptions);
+            const {element} = imageNode.exportDOM(editor, exportOptions);
 
             (element as HTMLElement).outerHTML.should.prettifyTo(html`
                 <figure class="kg-card kg-image-card kg-card-hascaption">
@@ -191,7 +191,7 @@ describe('ImageNode', function () {
 
         it('creates a minimal image card', editorTest(function () {
             const imageNode = $createImageNode({src: '/image.png'});
-            const {element} = imageNode.exportDOM(exportOptions);
+            const {element} = imageNode.exportDOM(editor, exportOptions);
 
             (element as HTMLElement).outerHTML.should.prettifyTo(html`
                 <figure class="kg-card kg-image-card">
@@ -202,7 +202,7 @@ describe('ImageNode', function () {
 
         it('renders an empty span with a missing src', editorTest(function () {
             const imageNode = $createImageNode({} as Record<string, unknown>);
-            const {element} = imageNode.exportDOM(exportOptions);
+            const {element} = imageNode.exportDOM(editor, exportOptions);
 
             (element as HTMLElement).outerHTML.should.equal('<span></span>');
         }));
@@ -210,7 +210,7 @@ describe('ImageNode', function () {
         it('renders a wide image', editorTest(function () {
             dataset.cardWidth = 'wide';
             const imageNode = $createImageNode(dataset);
-            const {element} = imageNode.exportDOM(exportOptions);
+            const {element} = imageNode.exportDOM(editor, exportOptions);
 
             (element as HTMLElement).classList.contains('kg-width-wide').should.be.true();
         }));
@@ -223,7 +223,7 @@ describe('ImageNode', function () {
             exportOptions.canTransformImage = () => true;
 
             const imageNode = $createImageNode(dataset);
-            const {element} = imageNode.exportDOM(exportOptions);
+            const {element} = imageNode.exportDOM(editor, exportOptions);
             const output = (element as HTMLElement).outerHTML;
 
             output.should.containEql('width="2000"');
@@ -236,7 +236,7 @@ describe('ImageNode', function () {
             exportOptions.canTransformImage = () => false;
 
             const imageNode = $createImageNode(dataset);
-            const {element} = imageNode.exportDOM(exportOptions);
+            const {element} = imageNode.exportDOM(editor, exportOptions);
             const output = (element as HTMLElement).outerHTML;
 
             output.should.containEql('width="3000" height="6000"');
@@ -249,7 +249,7 @@ describe('ImageNode', function () {
                 dataset.src = 'https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=2000&fit=max&ixid=eyJhcHBfaWQiOjExNzczfQ';
 
                 const imageNode = $createImageNode(dataset);
-                const {element} = imageNode.exportDOM(exportOptions);
+                const {element} = imageNode.exportDOM(editor, exportOptions);
                 const output = (element as HTMLElement).outerHTML;
 
                 output.should.containEql('https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=600&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 600w, https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=1000&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 1000w, https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=1600&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 1600w, https://images.unsplash.com/photo-1591672299888-e16a08b6c7ce?ixlib=rb-1.2.1&amp;q=80&amp;fm=jpg&amp;crop=entropy&amp;cs=tinysrgb&amp;w=2400&amp;fit=max&amp;ixid=eyJhcHBfaWQiOjExNzczfQ 2400w');
@@ -259,7 +259,7 @@ describe('ImageNode', function () {
                 exportOptions.target = 'email';
 
                 const imageNode = $createImageNode(dataset);
-                const {element} = imageNode.exportDOM(exportOptions);
+                const {element} = imageNode.exportDOM(editor, exportOptions);
                 const output = (element as HTMLElement).outerHTML;
 
                 output.should.not.containEql('srcset');
@@ -284,7 +284,7 @@ describe('ImageNode', function () {
                 dataset.height = 6000;
 
                 const imageNode = $createImageNode(dataset);
-                const {element} = imageNode.exportDOM(exportOptions);
+                const {element} = imageNode.exportDOM(editor, exportOptions);
                 const output = (element as HTMLElement).outerHTML;
 
                 output.should.containEql('sizes="(min-width: 720px) 720px"');
@@ -296,7 +296,7 @@ describe('ImageNode', function () {
                 dataset.cardWidth = 'wide';
 
                 const imageNode = $createImageNode(dataset);
-                const {element} = imageNode.exportDOM(exportOptions);
+                const {element} = imageNode.exportDOM(editor, exportOptions);
                 const output = (element as HTMLElement).outerHTML;
 
                 output.should.containEql('sizes="(min-width: 1200px) 1200px"');

--- a/packages/kg-default-nodes/test/nodes/markdown.test.ts
+++ b/packages/kg-default-nodes/test/nodes/markdown.test.ts
@@ -112,7 +112,7 @@ describe('MarkdownNode', function () {
     describe('exportDOM', function () {
         it('creates a markdown card', editorTest(function () {
             const markdownNode = $createMarkdownNode(dataset);
-            const result = markdownNode.exportDOM(exportOptions);
+            const result = markdownNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             result.type.should.equal('inner');
@@ -127,7 +127,7 @@ describe('MarkdownNode', function () {
 
         it('renders an empty div with a missing src', editorTest(function () {
             const markdownNode = $createMarkdownNode();
-            const result = markdownNode.exportDOM(exportOptions);
+            const result = markdownNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.equal('<div></div>');
@@ -136,7 +136,7 @@ describe('MarkdownNode', function () {
         it('throws a clear error when createDocument is not callable', editorTest(function () {
             const markdownNode = $createMarkdownNode(dataset);
 
-            (() => markdownNode.exportDOM({createDocument: true as unknown as () => Document})).should.throw(
+            (() => markdownNode.exportDOM(editor, {createDocument: true as unknown as () => Document})).should.throw(
                 'renderMarkdownNode requires options.createDocument to be a function'
             );
         }));

--- a/packages/kg-default-nodes/test/nodes/paywall.test.ts
+++ b/packages/kg-default-nodes/test/nodes/paywall.test.ts
@@ -96,7 +96,7 @@ describe('PaywallNode', function () {
     describe('exportDOM', function () {
         it('renders a paywall node', editorTest(function () {
             const paywallNode = $createPaywallNode(dataset);
-            const {element, type} = paywallNode.exportDOM(exportOptions);
+            const {element, type} = paywallNode.exportDOM(editor, exportOptions);
 
             type.should.equal('inner');
             getHTMLElement(element).innerHTML.should.equal('<!--members-only-->');

--- a/packages/kg-default-nodes/test/nodes/product.test.ts
+++ b/packages/kg-default-nodes/test/nodes/product.test.ts
@@ -243,7 +243,7 @@ describe('ProductNode', function () {
                 productUrl: 'https://example.com/product/ok'
             };
             const productNode = $createProductNode(payload);
-            const result = productNode.exportDOM(exportOptions);
+            const result = productNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(`
@@ -265,7 +265,7 @@ describe('ProductNode', function () {
                 productUrl: 'https://example.com/product/ok'
             };
             const productNode = $createProductNode(payload);
-            const result = productNode.exportDOM(exportOptions);
+            const result = productNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(`
@@ -279,7 +279,7 @@ describe('ProductNode', function () {
                 productDescription: ''
             };
             const productNode = $createProductNode(payload);
-            const result = productNode.exportDOM(exportOptions);
+            const result = productNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.equal('<span></span>');
@@ -290,7 +290,7 @@ describe('ProductNode', function () {
                 productTitle: 'Just a title'
             };
             const productNode = $createProductNode(payload);
-            const result = productNode.exportDOM(exportOptions);
+            const result = productNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(`
@@ -303,7 +303,7 @@ describe('ProductNode', function () {
                 productDescription: 'Just a description'
             };
             const productNode = $createProductNode(payload);
-            const result = productNode.exportDOM(exportOptions);
+            const result = productNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(`
@@ -318,7 +318,7 @@ describe('ProductNode', function () {
                 productUrl: 'https://example.com/product/ok'
             };
             const productNode = $createProductNode(payload);
-            const result = productNode.exportDOM(exportOptions);
+            const result = productNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(`
@@ -343,7 +343,7 @@ describe('ProductNode', function () {
             };
 
             const productNode = $createProductNode(payload);
-            const result = productNode.exportDOM({...exportOptions, ...options});
+            const result = productNode.exportDOM(editor, {...exportOptions, ...options});
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(`
@@ -371,7 +371,7 @@ describe('ProductNode', function () {
             };
 
             const productNode = $createProductNode(payload);
-            const result = productNode.exportDOM({...exportOptions, ...options});
+            const result = productNode.exportDOM(editor, {...exportOptions, ...options});
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(`
@@ -448,7 +448,7 @@ describe('ProductNode', function () {
             };
 
             const productNode = $createProductNode(payload);
-            const result = productNode.exportDOM({...exportOptions, ...options});
+            const result = productNode.exportDOM(editor, {...exportOptions, ...options});
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(`
@@ -472,7 +472,7 @@ describe('ProductNode', function () {
             };
 
             const productNode = $createProductNode(payload);
-            const result = productNode.exportDOM({...exportOptions, ...options});
+            const result = productNode.exportDOM(editor, {...exportOptions, ...options});
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(`
@@ -496,7 +496,7 @@ describe('ProductNode', function () {
             };
 
             const productNode = $createProductNode(payload);
-            const result = productNode.exportDOM({...exportOptions, ...options});
+            const result = productNode.exportDOM(editor, {...exportOptions, ...options});
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(`
@@ -519,7 +519,7 @@ describe('ProductNode', function () {
             };
 
             const productNode = $createProductNode(payload);
-            const result = productNode.exportDOM({...exportOptions, ...options});
+            const result = productNode.exportDOM(editor, {...exportOptions, ...options});
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(`
@@ -543,7 +543,7 @@ describe('ProductNode', function () {
             };
 
             const productNode = $createProductNode(payload);
-            const result = productNode.exportDOM({...exportOptions, ...options});
+            const result = productNode.exportDOM(editor, {...exportOptions, ...options});
             const element = result.element as HTMLElement;
 
             return element.outerHTML;

--- a/packages/kg-default-nodes/test/nodes/signup.test.ts
+++ b/packages/kg-default-nodes/test/nodes/signup.test.ts
@@ -205,7 +205,7 @@ describe('SignupNode', function () {
 
         it('creates signup element', editorTest(function () {
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-signup-card kg-width-regular" data-lexical-signup-form=""  style="display: none;">
@@ -239,7 +239,7 @@ describe('SignupNode', function () {
             dataset.subheader = '';
             dataset.disclaimer = '';
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-signup-card kg-width-regular" data-lexical-signup-form="" style="display:none">
@@ -271,7 +271,7 @@ describe('SignupNode', function () {
             dataset.backgroundImageSrc = '';
 
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-signup-card kg-width-regular kg-style-accent" data-lexical-signup-form="" style="display:none">
@@ -303,7 +303,7 @@ describe('SignupNode', function () {
             dataset.layout = 'split';
 
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-signup-card kg-layout-split kg-width-full" data-lexical-signup-form="" style="background-color: transparent; display:none">
@@ -337,7 +337,7 @@ describe('SignupNode', function () {
             dataset.swapped = true;
 
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-signup-card kg-layout-split kg-width-full kg-swapped" data-lexical-signup-form="" style="background-color: transparent; display:none">
@@ -371,7 +371,7 @@ describe('SignupNode', function () {
             dataset.backgroundSize = 'contain';
 
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-signup-card kg-layout-split kg-width-full kg-content-wide" data-lexical-signup-form="" style="background-color: transparent; display:none">
@@ -404,7 +404,7 @@ describe('SignupNode', function () {
             dataset.backgroundColor = '#ffffff';
 
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-signup-card kg-width-regular" data-lexical-signup-form="" style="display:none">
@@ -438,7 +438,7 @@ describe('SignupNode', function () {
             dataset.backgroundImageSrc = '';
 
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-signup-card kg-width-regular" data-lexical-signup-form="" style="background-color: transparent; display:none">
@@ -471,7 +471,7 @@ describe('SignupNode', function () {
             dataset.backgroundImageSrc = '';
 
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-signup-card kg-width-regular kg-style-accent" data-lexical-signup-form="" style="display:none">
@@ -504,7 +504,7 @@ describe('SignupNode', function () {
             dataset.layout = 'split';
 
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-signup-card kg-layout-split kg-width-full kg-style-accent" data-lexical-signup-form="" style="display:none">
@@ -538,7 +538,7 @@ describe('SignupNode', function () {
             dataset.backgroundImageSrc = 'https://example.com/image.jpg';
 
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.prettifyTo(html`
                 <div class="kg-card kg-signup-card kg-width-regular" data-lexical-signup-form="" style="display:none">
@@ -576,7 +576,7 @@ describe('SignupNode', function () {
         it('returns empty element if target is email', editorTest(function () {
             exportOptions.target = 'email';
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.equal('<div></div>');
         }));
@@ -586,7 +586,7 @@ describe('SignupNode', function () {
             dataset.backgroundColor = '#ffffff';
 
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             const document = createDocument(element.outerHTML);
@@ -598,7 +598,7 @@ describe('SignupNode', function () {
             dataset.layout = 'split';
 
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             const document = createDocument(element.outerHTML);
@@ -610,7 +610,7 @@ describe('SignupNode', function () {
             dataset.layout = 'split';
             dataset.swapped = true;
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             const document = createDocument(element.outerHTML);
             const nodes = $generateNodesFromDOM(editor, document);
@@ -621,7 +621,7 @@ describe('SignupNode', function () {
             dataset.layout = 'split';
             dataset.backgroundSize = 'contain';
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             const document = createDocument(element.outerHTML);
             const nodes = $generateNodesFromDOM(editor, document);
@@ -632,7 +632,7 @@ describe('SignupNode', function () {
             dataset.layout = 'split';
             dataset.backgroundSize = 'cover';
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             const document = createDocument(element.outerHTML);
             const nodes = $generateNodesFromDOM(editor, document);
@@ -646,7 +646,7 @@ describe('SignupNode', function () {
             dataset.backgroundColor = '#ffffff';
 
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             const document = createDocument(element.outerHTML);
@@ -660,7 +660,7 @@ describe('SignupNode', function () {
             dataset.backgroundImageSrc = '';
 
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             const document = createDocument(element.outerHTML);
@@ -674,7 +674,7 @@ describe('SignupNode', function () {
             dataset.buttonTextColor = '#ffffff';
 
             const signupNode = $createSignupNode(dataset);
-            const result = signupNode.exportDOM(exportOptions);
+            const result = signupNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             const document = createDocument(element.outerHTML);

--- a/packages/kg-default-nodes/test/nodes/toggle.test.ts
+++ b/packages/kg-default-nodes/test/nodes/toggle.test.ts
@@ -165,7 +165,7 @@ describe('ToggleNode', function () {
                 content: 'Content'
             };
             const toggleNode = $createToggleNode(payload);
-            const result = toggleNode.exportDOM(exportOptions);
+            const result = toggleNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(html`
@@ -194,7 +194,7 @@ describe('ToggleNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const toggleNode = $createToggleNode(payload);
-            const result = toggleNode.exportDOM({...exportOptions, ...options});
+            const result = toggleNode.exportDOM(editor, {...exportOptions, ...options});
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(html`
@@ -220,7 +220,7 @@ describe('ToggleNode', function () {
                 }
             };
             const toggleNode = $createToggleNode(payload);
-            const result = toggleNode.exportDOM({...exportOptions, ...options});
+            const result = toggleNode.exportDOM(editor, {...exportOptions, ...options});
             const element = result.element as HTMLElement;
 
             element.outerHTML.should.prettifyTo(html`
@@ -248,7 +248,7 @@ describe('ToggleNode', function () {
             };
 
             const toggleNode = $createToggleNode(payload);
-            const result = toggleNode.exportDOM(exportOptions);
+            const result = toggleNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.containEql('<h4 class="kg-toggle-heading-text">Heading</h4>');
         }));
@@ -260,7 +260,7 @@ describe('ToggleNode', function () {
             };
 
             const toggleNode = $createToggleNode(payload);
-            const result = toggleNode.exportDOM(exportOptions);
+            const result = toggleNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             element.outerHTML.should.containEql('<div class="kg-toggle-content">Content</div>');
         }));

--- a/packages/kg-default-nodes/test/nodes/transistor.test.ts
+++ b/packages/kg-default-nodes/test/nodes/transistor.test.ts
@@ -171,7 +171,7 @@ describe('TransistorNode', function () {
 
         it('renders an iframe with the correct base URL', editorTest(function () {
             const transistorNode = new TransistorNode({visibility: publicVisibility});
-            const {element} = transistorNode.exportDOM(exportOptions);
+            const {element} = transistorNode.exportDOM(editor, exportOptions);
             const el = element as HTMLElement;
 
             assert.equal(el.tagName, 'FIGURE');
@@ -197,7 +197,7 @@ describe('TransistorNode', function () {
 
         it('includes ctx param when siteUuid is in options', editorTest(function () {
             const transistorNode = new TransistorNode({visibility: publicVisibility});
-            const {element} = transistorNode.exportDOM({...exportOptions, siteUuid: 'abc123'});
+            const {element} = transistorNode.exportDOM(editor, {...exportOptions, siteUuid: 'abc123'});
             const el = element as HTMLElement;
 
             const iframe = el.querySelector('iframe');
@@ -206,7 +206,7 @@ describe('TransistorNode', function () {
 
         it('does not include ctx param when siteUuid is not provided', editorTest(function () {
             const transistorNode = new TransistorNode({visibility: publicVisibility});
-            const {element} = transistorNode.exportDOM(exportOptions);
+            const {element} = transistorNode.exportDOM(editor, exportOptions);
             const el = element as HTMLElement;
 
             const iframe = el.querySelector('iframe');
@@ -215,7 +215,7 @@ describe('TransistorNode', function () {
 
         it('includes background detection script that reads data-src', editorTest(function () {
             const transistorNode = new TransistorNode({visibility: publicVisibility});
-            const {element} = transistorNode.exportDOM(exportOptions);
+            const {element} = transistorNode.exportDOM(editor, exportOptions);
             const el = element as HTMLElement;
 
             const script = el.querySelector('script');
@@ -227,7 +227,7 @@ describe('TransistorNode', function () {
 
         it('includes noscript fallback with src', editorTest(function () {
             const transistorNode = new TransistorNode({visibility: publicVisibility});
-            const {element} = transistorNode.exportDOM(exportOptions);
+            const {element} = transistorNode.exportDOM(editor, exportOptions);
             const el = element as HTMLElement;
 
             const noscript = el.querySelector('noscript');
@@ -241,7 +241,7 @@ describe('TransistorNode', function () {
             exportOptions.target = 'web';
             // Default visibility has nonMember: false
             const transistorNode = new TransistorNode({});
-            const {element} = transistorNode.exportDOM(exportOptions);
+            const {element} = transistorNode.exportDOM(editor, exportOptions);
             const el = element as HTMLTextAreaElement;
 
             // Should be wrapped in visibility gating
@@ -257,7 +257,7 @@ describe('TransistorNode', function () {
                     email: {memberSegment: 'status:-free'} // paid only
                 }
             });
-            const result = transistorNode.exportDOM(exportOptions);
+            const result = transistorNode.exportDOM(editor, exportOptions);
             const element = result.element as HTMLElement;
             const type = result.type;
 

--- a/packages/kg-default-nodes/test/nodes/video.test.ts
+++ b/packages/kg-default-nodes/test/nodes/video.test.ts
@@ -262,7 +262,7 @@ describe('VideoNode', function () {
                 thumbnailSrc: '/content/images/2022/11/koenig-lexical.jpg'
             };
             const videoNode = $createVideoNode(payload);
-            const {element} = videoNode.exportDOM(exportOptions);
+            const {element} = videoNode.exportDOM(editor, exportOptions);
 
             (element as HTMLElement).outerHTML.should.prettifyTo(html`
                 <figure class="kg-card kg-video-card kg-width-regular" data-kg-thumbnail="/content/images/2022/11/koenig-lexical.jpg" data-kg-custom-thumbnail="">
@@ -334,7 +334,7 @@ describe('VideoNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const videoNode = $createVideoNode(payload);
-            const {element} = videoNode.exportDOM({...exportOptions, ...options});
+            const {element} = videoNode.exportDOM(editor, {...exportOptions, ...options});
             const output = (element as HTMLElement).outerHTML;
 
             output.should.not.containEql('<video');
@@ -354,7 +354,7 @@ describe('VideoNode', function () {
 
             const videoNode = $createVideoNode(payload);
 
-            (() => videoNode.exportDOM({...exportOptions, target: 'email'})).should.throw('renderVideoNode requires options.postUrl when options.target is "email"');
+            (() => videoNode.exportDOM(editor, {...exportOptions, target: 'email'})).should.throw('renderVideoNode requires options.postUrl when options.target is "email"');
         }));
 
         it('renders without invalid dimensions when width and height are null', editorTest(function () {
@@ -367,7 +367,7 @@ describe('VideoNode', function () {
             };
 
             const videoNode = $createVideoNode(payload);
-            const {element} = videoNode.exportDOM(exportOptions);
+            const {element} = videoNode.exportDOM(editor, exportOptions);
             const output = (element as HTMLElement).outerHTML;
 
             output.should.not.containEql('nullxnull');
@@ -390,7 +390,7 @@ describe('VideoNode', function () {
                 postUrl: 'https://example.com/my-post'
             };
             const videoNode = $createVideoNode(payload);
-            const {element} = videoNode.exportDOM({...exportOptions, ...options});
+            const {element} = videoNode.exportDOM(editor, {...exportOptions, ...options});
             const output = (element as HTMLElement).outerHTML;
 
             output.should.not.containEql('NaN');
@@ -409,7 +409,7 @@ describe('VideoNode', function () {
             };
 
             const videoNode = $createVideoNode(payload);
-            const {element} = videoNode.exportDOM(exportOptions);
+            const {element} = videoNode.exportDOM(editor, exportOptions);
             const output = (element as HTMLElement).outerHTML;
             output.should.containEql('kg-card kg-video-card kg-width-wide');
         }));
@@ -425,7 +425,7 @@ describe('VideoNode', function () {
             };
 
             const videoNode = $createVideoNode(payload);
-            const {element} = videoNode.exportDOM(exportOptions);
+            const {element} = videoNode.exportDOM(editor, exportOptions);
             const output = (element as HTMLElement).outerHTML;
             output.should.containEql('loop');
         }));
@@ -441,7 +441,7 @@ describe('VideoNode', function () {
             };
 
             const videoNode = $createVideoNode(payload);
-            const {element} = videoNode.exportDOM(exportOptions);
+            const {element} = videoNode.exportDOM(editor, exportOptions);
             const output = (element as HTMLElement).outerHTML;
             output.should.containEql('<figure class="kg-card kg-video-card kg-width-regular kg-card-hascaption"');
             output.should.containEql('<figcaption><strong>Caption</strong></figcaption>');

--- a/packages/kg-lexical-html-renderer/src/LexicalHTMLRenderer.ts
+++ b/packages/kg-lexical-html-renderer/src/LexicalHTMLRenderer.ts
@@ -80,7 +80,7 @@ export default class LexicalHTMLRenderer {
         // render
         let html = '';
         editor.update(async () => {
-            html = $convertToHtmlString(options);
+            html = $convertToHtmlString(editor, options);
         });
 
         return html;

--- a/packages/kg-lexical-html-renderer/src/convert-to-html-string.ts
+++ b/packages/kg-lexical-html-renderer/src/convert-to-html-string.ts
@@ -3,17 +3,17 @@ import {$isLinkNode} from '@lexical/link';
 import {$isKoenigCard} from '@tryghost/kg-default-nodes';
 import TextContent from './utils/TextContent.js';
 import elementTransformers from './transformers/index.js';
-import type {ElementNode, LexicalNode} from 'lexical';
+import type {ElementNode, LexicalEditor, LexicalNode} from 'lexical';
 import type {RendererOptions} from './types.js';
 
-export default function $convertToHtmlString(options: RendererOptions = {}): string {
+export default function $convertToHtmlString(editor: LexicalEditor, options: RendererOptions = {}): string {
     const output: string[] = [];
     const children: LexicalNode[] = $getRoot().getChildren();
 
     options.usedIdAttributes = options.usedIdAttributes || {};
 
     for (const child of children) {
-        const result = exportTopLevelElementOrDecorator(child, options);
+        const result = exportTopLevelElementOrDecorator(child, editor, options);
 
         if (result !== null) {
             output.push(result);
@@ -30,9 +30,9 @@ export default function $convertToHtmlString(options: RendererOptions = {}): str
     return output.join('');
 }
 
-function exportTopLevelElementOrDecorator(node: LexicalNode, options: RendererOptions): string | null {
+function exportTopLevelElementOrDecorator(node: LexicalNode, editor: LexicalEditor, options: RendererOptions): string | null {
     if ($isKoenigCard(node)) {
-        const {element, type} = node.exportDOM(options);
+        const {element, type} = node.exportDOM(editor, options);
 
         switch (type) {
         case 'inner':


### PR DESCRIPTION
closes https://github.com/TryGhost/Koenig/issues/1837

## What changed
- updated Koenig card `exportDOM()` typing to match Lexical's `exportDOM(editor)` contract
- threaded the headless `editor` through `kg-lexical-html-renderer` so card rendering now calls `node.exportDOM(editor, options)`
- updated the `kg-default-nodes` tests to pass the editor as the first argument when exporting card nodes

## Why
The TypeScript migration exposed that generated card nodes still used a Ghost-specific `exportDOM(options)` signature even though Lexical defines `exportDOM(editor)`. That mismatch forced custom typing and `@ts-expect-error` escape hatches around generated node typing.

This aligns the override shape with Lexical while keeping Ghost-specific export options as the optional second argument.

## Impact
- removes the custom `exportDOM()` signature mismatch for generated Koenig cards
- keeps existing Ghost rendering options available to card renderers
- makes the HTML renderer use the same call shape Lexical expects