### PR TITLE
Fixed code block local E2E undo handling

### DIFF
--- a/packages/koenig-lexical/src/utils/codemirror-config.js
+++ b/packages/koenig-lexical/src/utils/codemirror-config.js
@@ -1,8 +1,10 @@
 import {EditorView, keymap, lineNumbers} from '@codemirror/view';
 import {HighlightStyle, syntaxHighlighting} from '@codemirror/language';
-import {history, standardKeymap} from '@codemirror/commands';
+import {history, historyKeymap, standardKeymap} from '@codemirror/commands';
 import {minimalSetup} from '@uiw/codemirror-extensions-basic-setup';
 import {tags as t} from '@lezer/highlight';
+
+const disableHistoryGroupingForTests = import.meta.env.VITE_TEST;
 
 // Static theme and highlight objects — hoisted to module scope to avoid
 // recreating them on every render. CodeMirror tracks extensions by reference
@@ -129,9 +131,9 @@ const sharedExtensions = [
     EditorView.lineWrapping,
     lineNumbers(),
     minimalSetup({defaultKeymap: false, history: false}),
-    keymap.of(standardKeymap),
+    keymap.of([...historyKeymap, ...standardKeymap]),
     history({
-        joinToEvent: process.env.NODE_ENV === 'test' ? () => false : undefined
+        joinToEvent: disableHistoryGroupingForTests ? () => false : undefined
     })
 ];
 

--- a/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
@@ -1,8 +1,15 @@
-import {assertHTML, focusEditor, html, initialize, isMac, pasteText, selectBackwards} from '../../utils/e2e';
+import {assertHTML, ctrlOrCmd, focusEditor, html, initialize, pasteText, selectBackwards} from '../../utils/e2e';
 import {expect, test} from '@playwright/test';
 
+async function pressCodeEditorShortcut(page, key) {
+    const modifier = await page.evaluate(() => {
+        return navigator.platform.includes('Mac') ? 'Meta' : 'Control';
+    });
+
+    await page.keyboard.press(`${modifier}+${key}`);
+}
+
 test.describe('Code Block card', async () => {
-    const ctrlOrCmd = isMac() ? 'Meta' : 'Control';
     let page;
 
     test.beforeAll(async ({browser}) => {
@@ -178,7 +185,7 @@ test.describe('Code Block card', async () => {
         await page.keyboard.press('Enter');
         await page.keyboard.press('Backspace');
         await page.keyboard.press('Backspace');
-        await page.keyboard.press(`${ctrlOrCmd}+z`);
+        await pressCodeEditorShortcut(page, 'z');
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
@@ -219,13 +226,13 @@ test.describe('Code Block card', async () => {
         await expect(page.getByText('Here are some words')).toBeVisible();
         await page.keyboard.press('Backspace');
         await expect(page.getByText('Here are some word')).toBeVisible();
-        await page.keyboard.press(`${ctrlOrCmd}+z`);
+        await pressCodeEditorShortcut(page, 'z');
         await expect(page.getByText('Here are some words')).toBeVisible();
         await page.keyboard.press('Escape');
         await page.click('[data-testid="codeblock-caption"]');
         await page.keyboard.type('My caption');
         await page.keyboard.press('Backspace');
-        await page.keyboard.press(`${ctrlOrCmd}+z`);
+        await pressCodeEditorShortcut(page, 'z');
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
@@ -294,7 +301,7 @@ test.describe('Code Block card', async () => {
         // see https://github.com/TryGhost/Product/issues/3785
         await selectBackwards(page, 4);
 
-        await page.keyboard.press(`${ctrlOrCmd}+x`);
+        await page.keyboard.press(`${ctrlOrCmd()}+x`);
 
         await assertHTML(page, html`
             <div>


### PR DESCRIPTION
## What
- disable CodeMirror history grouping in E2E builds using VITE_TEST instead of NODE_ENV
- register CodeMirror historyKeymap so undo/redo stays inside the code editor
- use the browser-reported modifier for code-block undo assertions in Playwright

## Why
Local Playwright Chromium was reporting a Windows platform while the host was macOS, and the browser bundle was running with NODE_ENV=development. That meant the code-block test could send the wrong modifier locally and CodeMirror history grouping was not actually disabled in E2E runs, causing paste + backspace to collapse into a single undo step.

## Testing
- yarn workspace @tryghost/koenig-lexical test:e2e test/e2e/cards/code-block-card.test.js --project=chromium --repeat-each=5