### PR TITLE
Fixed email card unfocus timing test

### DIFF
--- a/packages/koenig-lexical/test/e2e/cards/email-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/email-card.test.js
@@ -126,11 +126,11 @@ test.describe('Email card', async () => {
         await focusEditor(page);
         await insertEmailCard(page);
 
-        // Wait for card to be in editing mode before moving away
         const emailCard = page.locator('[data-kg-card="email"]');
         await expect(emailCard).toHaveAttribute('data-kg-card-editing', 'true');
 
-        // Shift focus away from email card
+        // Match real-world pacing and avoid local selection timing flake.
+        await page.waitForTimeout(25);
         await page.keyboard.press('ArrowDown');
 
         await expect(emailCard).toHaveAttribute('data-kg-card-editing', 'false');


### PR DESCRIPTION
## What
- add a short delay before ArrowDown in the email-card unfocus E2E test
 
## Why
- local Playwright runs can hit a nested-editor selection timing issue when the key event fires immediately after autofocus
- the small delay matches real-world pacing without changing product behavior