### PR TITLE
Fixed local E2E shortcut handling

### DIFF
--- a/packages/koenig-lexical/test/e2e/card-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/card-behaviour.test.js
@@ -1323,9 +1323,9 @@ test.describe('Card behaviour', async () => {
         test('at start of formatted text in paragraph before card', async function () {
             await focusEditor(page);
             await page.keyboard.type('Before ');
-            await page.keyboard.press(`${ctrlOrCmd()}+i`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+i`);
             await page.keyboard.type('italic');
-            await page.keyboard.press(`${ctrlOrCmd()}+i`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+i`);
             await page.keyboard.type(' after');
             await page.keyboard.press('Enter');
             await page.keyboard.type('---');
@@ -1376,7 +1376,7 @@ test.describe('Card behaviour', async () => {
             await page.keyboard.type('---');
             await page.keyboard.type('Some content');
 
-            await page.keyboard.press(`${ctrlOrCmd()}+Backspace`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+Backspace`);
 
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
@@ -1397,7 +1397,7 @@ test.describe('Card behaviour', async () => {
             await page.keyboard.press('ArrowUp');
             await page.keyboard.press('ArrowUp');
 
-            await page.keyboard.press(`${ctrlOrCmd()}+Backspace`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+Backspace`);
 
             await assertHTML(page, html`
                 <div data-lexical-decorator="true" contenteditable="false">
@@ -1859,8 +1859,6 @@ test.describe('Card behaviour', async () => {
         test.describe('codemirror', function () {
             // Skipped because CodeMirror does not pick up the copy/paste properly inside Playwright - manual testing is working
             test.skip('can copy/paste', async function () {
-                const ctrlOrCmdKey = ctrlOrCmd();
-
                 await focusEditor(page);
                 await insertCard(page, {cardName: 'html'});
 
@@ -1869,13 +1867,13 @@ test.describe('Card behaviour', async () => {
 
                 await page.keyboard.type('Testing', {delay: 10});
                 await page.waitForTimeout(100);
-                await page.keyboard.press(`${ctrlOrCmdKey}+KeyA`, {delay: 10});
+                await page.keyboard.press(`${ctrlOrCmd(page)}+KeyA`);
                 await page.waitForTimeout(100);
-                await page.keyboard.press(`${ctrlOrCmdKey}+KeyC`, {delay: 10});
+                await page.keyboard.press(`${ctrlOrCmd(page)}+KeyC`);
                 await page.waitForTimeout(100);
-                await page.keyboard.press(`${ctrlOrCmdKey}+KeyV`, {delay: 10});
+                await page.keyboard.press(`${ctrlOrCmd(page)}+KeyV`);
                 await page.waitForTimeout(100);
-                await page.keyboard.press(`${ctrlOrCmdKey}+KeyV`, {delay: 10});
+                await page.keyboard.press(`${ctrlOrCmd(page)}+KeyV`);
                 await page.waitForTimeout(100);
 
                 await assertHTML(page, html`

--- a/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/code-block-card.test.js
@@ -1,14 +1,6 @@
 import {assertHTML, ctrlOrCmd, focusEditor, html, initialize, pasteText, selectBackwards} from '../../utils/e2e';
 import {expect, test} from '@playwright/test';
 
-async function pressCodeEditorShortcut(page, key) {
-    const modifier = await page.evaluate(() => {
-        return navigator.platform.includes('Mac') ? 'Meta' : 'Control';
-    });
-
-    await page.keyboard.press(`${modifier}+${key}`);
-}
-
 test.describe('Code Block card', async () => {
     let page;
 
@@ -185,7 +177,7 @@ test.describe('Code Block card', async () => {
         await page.keyboard.press('Enter');
         await page.keyboard.press('Backspace');
         await page.keyboard.press('Backspace');
-        await pressCodeEditorShortcut(page, 'z');
+        await page.keyboard.press(`${ctrlOrCmd(page)}+z`);
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
@@ -226,13 +218,13 @@ test.describe('Code Block card', async () => {
         await expect(page.getByText('Here are some words')).toBeVisible();
         await page.keyboard.press('Backspace');
         await expect(page.getByText('Here are some word')).toBeVisible();
-        await pressCodeEditorShortcut(page, 'z');
+        await page.keyboard.press(`${ctrlOrCmd(page)}+z`);
         await expect(page.getByText('Here are some words')).toBeVisible();
         await page.keyboard.press('Escape');
         await page.click('[data-testid="codeblock-caption"]');
         await page.keyboard.type('My caption');
         await page.keyboard.press('Backspace');
-        await pressCodeEditorShortcut(page, 'z');
+        await page.keyboard.press(`${ctrlOrCmd(page)}+z`);
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">

--- a/packages/koenig-lexical/test/e2e/cards/email-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/email-card.test.js
@@ -1,4 +1,4 @@
-import {assertHTML, createSnippet, focusEditor, html, initialize} from '../../utils/e2e';
+import {assertHTML, createSnippet, ctrlOrCmd, focusEditor, html, initialize} from '../../utils/e2e';
 import {expect, test} from '@playwright/test';
 
 async function insertEmailCard(page) {
@@ -20,14 +20,6 @@ async function insertEmailCard(page) {
     await page.waitForSelector('[data-kg-card-menu-item="Email content"]', {state: 'visible'});
     await page.locator('[data-kg-card-menu-item="Email content"]').click();
     await page.waitForSelector('[data-kg-card="email"]');
-}
-
-async function pressEmailEditorShortcut(page, key) {
-    const modifier = await page.evaluate(() => {
-        return navigator.platform.includes('Mac') ? 'Meta' : 'Control';
-    });
-
-    await page.keyboard.press(`${modifier}+${key}`);
 }
 
 test.describe('Email card', async () => {
@@ -152,7 +144,7 @@ test.describe('Email card', async () => {
         await insertEmailCard(page);
 
         // Remove all existing content
-        await pressEmailEditorShortcut(page, 'A');
+        await page.keyboard.press(`${ctrlOrCmd(page)}+A`);
         await page.keyboard.press('Backspace');
 
         // Shift focus away from email card
@@ -200,7 +192,7 @@ test.describe('Email card', async () => {
         await page.keyboard.press('Enter');
         await page.keyboard.press('Escape');
         await page.keyboard.press('Backspace');
-        await pressEmailEditorShortcut(page, 'z');
+        await page.keyboard.press(`${ctrlOrCmd(page)}+z`);
 
         const emailCard = page.locator('[data-kg-card="email"] [data-kg="editor"] ul > li:first-child');
         await expect(emailCard).toHaveText('List item 1');

--- a/packages/koenig-lexical/test/e2e/cards/gallery-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/gallery-card.test.js
@@ -371,8 +371,8 @@ test.describe('Gallery card', async () => {
         // Second Backspace: deletes the selected gallery card
         await page.keyboard.press('Backspace');
         await expect(page.locator('[data-testid="gallery-image"]')).toHaveCount(0);
-        await page.keyboard.press(`${ctrlOrCmd()}+z`);
-        await page.keyboard.press(`${ctrlOrCmd()}+z`);
+        await page.keyboard.press(`${ctrlOrCmd(page)}+z`);
+        await page.keyboard.press(`${ctrlOrCmd(page)}+z`);
         await expect(page.locator('[data-kg-card="gallery"]')).toBeVisible();
 
         // verify the gallery content is preserved after undo

--- a/packages/koenig-lexical/test/e2e/cards/html-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/html-card.test.js
@@ -141,7 +141,7 @@ test.describe('Html card', async () => {
         await page.waitForTimeout(600);
         await page.keyboard.press('Backspace');
         await expect(page.getByText('Here are some word')).toBeVisible();
-        await page.keyboard.press(`${ctrlOrCmd()}+z`);
+        await page.keyboard.press(`${ctrlOrCmd(page)}+z`);
         await expect(page.getByText('Here are some words')).toBeVisible();
         await page.keyboard.press('Escape');
         await expect(page.getByText('Here are some words')).toBeVisible();

--- a/packages/koenig-lexical/test/e2e/cards/image-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/image-card.test.js
@@ -1124,7 +1124,7 @@ test.describe('Image card', async () => {
             await page.waitForSelector('[data-kg-card="image"][data-kg-card-selected="true"]');
             await page.keyboard.press('Backspace');
             await expect(page.locator('[data-kg-card="image"]')).not.toBeVisible();
-            await page.keyboard.press(`${ctrlOrCmd()}+z`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+z`);
 
             await expect(page.getByTestId('image-caption-editor')).toHaveText('This is a caption');
         });

--- a/packages/koenig-lexical/test/e2e/cards/signup-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/signup-card.test.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import {assertHTML, focusEditor, html, initialize, insertCard} from '../../utils/e2e';
+import {assertHTML, ctrlOrCmd, focusEditor, html, initialize, insertCard} from '../../utils/e2e';
 import {expect, test} from '@playwright/test';
 import {fileURLToPath} from 'url';
 import {selectCustomColor, selectTitledColor} from '../../utils/color-select-helper';
@@ -721,7 +721,7 @@ test.describe('Signup card', async () => {
 
         await page.keyboard.press('Escape');
         await page.keyboard.press('Backspace');
-        await page.keyboard.press(`${ctrlOrCmd()}+z`);
+        await page.keyboard.press(`${ctrlOrCmd(page)}+z`);
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">

--- a/packages/koenig-lexical/test/e2e/cards/toggle-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/toggle-card.test.js
@@ -271,7 +271,7 @@ test.describe('Toggle card', async () => {
         await page.keyboard.press('Enter');
         await page.keyboard.press('Backspace');
         await page.keyboard.press('Backspace');
-        await page.keyboard.press(`${ctrlOrCmd()}+z`);
+        await page.keyboard.press(`${ctrlOrCmd(page)}+z`);
 
         // verify the card is restored and selected after undo
         await expect(page.locator('[data-kg-card="toggle"]')).toBeVisible();

--- a/packages/koenig-lexical/test/e2e/cards/video-card.firefox.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/video-card.firefox.test.js
@@ -405,7 +405,7 @@ test.describe('Video card', async () => {
         await page.keyboard.type('Test caption');
         await page.keyboard.press('Escape');
         await page.keyboard.press('Backspace');
-        await page.keyboard.press(`${ctrlOrCmd()}+z`);
+        await page.keyboard.press(`${ctrlOrCmd(page)}+z`);
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">

--- a/packages/koenig-lexical/test/e2e/floating-toolbar.test.js
+++ b/packages/koenig-lexical/test/e2e/floating-toolbar.test.js
@@ -7,7 +7,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 test.describe('Floating format toolbar', async () => {
-    const ctrlOrCmdKey = ctrlOrCmd();
     let page;
 
     test.beforeAll(async ({browser}) => {
@@ -285,7 +284,7 @@ test.describe('Floating format toolbar', async () => {
             await page.keyboard.press('Enter');
             await insertCard(page, {cardName: 'divider'});
             await page.keyboard.type('Second paragraph');
-            await page.keyboard.press(`${ctrlOrCmdKey}+A`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+A`);
 
             const buttonSelector = `[data-kg-floating-toolbar] [data-kg-toolbar-button="h2"] button`;
             await page.click(buttonSelector);
@@ -317,7 +316,7 @@ test.describe('Floating format toolbar', async () => {
 
             await page.keyboard.press('ArrowDown');
             await page.keyboard.type('Second paragraph');
-            await page.keyboard.press(`${ctrlOrCmdKey}+A`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+A`);
 
             const buttonSelector = `[data-kg-floating-toolbar] [data-kg-toolbar-button="h2"] button`;
             await page.click(buttonSelector);
@@ -347,7 +346,7 @@ test.describe('Floating format toolbar', async () => {
 
             await page.keyboard.press('ArrowDown');
             await page.keyboard.type('Second paragraph');
-            await page.keyboard.press(`${ctrlOrCmdKey}+A`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+A`);
 
             const buttonSelector = `[data-kg-floating-toolbar] [data-kg-toolbar-button="h2"] button`;
             await page.click(buttonSelector);

--- a/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
+++ b/packages/koenig-lexical/test/e2e/format-shortcuts.test.js
@@ -2,7 +2,6 @@ import {assertHTML, ctrlOrCmd, focusEditor, html, initialize, selectBackwards} f
 import {test} from '@playwright/test';
 
 test.describe('Editor keyboard shortcuts', async () => {
-    const ctrlOrCmdKey = ctrlOrCmd();
     let page;
 
     test.beforeAll(async ({browser}) => {
@@ -25,7 +24,7 @@ test.describe('Editor keyboard shortcuts', async () => {
 
             await selectBackwards(page, 4);
 
-            await page.keyboard.press(`${ctrlOrCmdKey}+B`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+B`);
 
             await assertHTML(page, html`<p dir="ltr"><strong data-lexical-text="true">test</strong></p>`);
         });
@@ -37,7 +36,7 @@ test.describe('Editor keyboard shortcuts', async () => {
 
             await selectBackwards(page, 4);
 
-            await page.keyboard.press(`${ctrlOrCmdKey}+I`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+I`);
 
             await assertHTML(page, html`<p dir="ltr"><em data-lexical-text="true">test</em></p>`);
         });
@@ -49,7 +48,7 @@ test.describe('Editor keyboard shortcuts', async () => {
 
             await selectBackwards(page, 4);
 
-            await page.keyboard.press(`${ctrlOrCmdKey}+Alt+U`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+Alt+U`);
 
             await assertHTML(page, html`<p dir="ltr"><span data-lexical-text="true" class="line-through">test</span></p>`);
         });
@@ -61,7 +60,7 @@ test.describe('Editor keyboard shortcuts', async () => {
 
             await selectBackwards(page, 4);
 
-            await page.keyboard.press(`${ctrlOrCmdKey}+K`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+K`);
 
             await page.waitForSelector('[data-testid="link-input"]');
             await page.getByTestId('link-input').fill('https://example.com');
@@ -94,7 +93,7 @@ test.describe('Editor keyboard shortcuts', async () => {
 
             await selectBackwards(page, 4);
 
-            await page.keyboard.press(`${ctrlOrCmdKey}+Alt+H`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+Alt+H`);
 
             await assertHTML(page, html`<p dir="ltr"><mark data-lexical-text="true"><span>test</span></mark></p>`);
         });

--- a/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
+++ b/packages/koenig-lexical/test/e2e/paste-behaviour.test.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import {assertHTML, ctrlOrCmd, focusEditor,html, initialize, insertCard, paste, pasteFiles, pasteFilesWithText, pasteHtml, pasteText, selectBackwards} from '../utils/e2e';
+import {assertHTML, ctrlOrCmd, focusEditor, html, initialize, insertCard, paste, pasteFiles, pasteFilesWithText, pasteHtml, pasteText, selectBackwards} from '../utils/e2e';
 import {expect, test} from '@playwright/test';
 import {fileURLToPath} from 'url';
 const __filename = fileURLToPath(import.meta.url);
@@ -109,13 +109,13 @@ test.describe('Paste behaviour', async () => {
         test('pasted on selected text containing formats converts to link', async function () {
             await focusEditor(page);
             await page.keyboard.type('Text with ');
-            await page.keyboard.press(`${ctrlOrCmd()}+B`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+B`);
             await page.keyboard.type('bold');
-            await page.keyboard.press(`${ctrlOrCmd()}+B`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+B`);
             await page.keyboard.type(' and ');
-            await page.keyboard.press(`${ctrlOrCmd()}+I`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+I`);
             await page.keyboard.type('italic');
-            await page.keyboard.press(`${ctrlOrCmd()}+I`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+I`);
             await page.keyboard.type(' text.');
 
             await assertHTML(page, html`
@@ -128,7 +128,7 @@ test.describe('Paste behaviour', async () => {
                 </p>
             `);
 
-            await page.keyboard.press(`${ctrlOrCmd()}+A`);
+            await page.keyboard.press(`${ctrlOrCmd(page)}+A`);
             await pasteText(page, 'https://ghost.org');
 
             await assertHTML(page, html`
@@ -151,7 +151,7 @@ test.describe('Paste behaviour', async () => {
             await page.keyboard.type('1 test');
             await selectBackwards(page, 4);
             await pasteText(page, 'https://ghost.org');
-            await page.keyboard.press(`${ctrlOrCmd()}+Enter`); // exit edit mode
+            await page.keyboard.press(`${ctrlOrCmd(page)}+Enter`); // exit edit mode
 
             await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">

--- a/packages/koenig-lexical/test/e2e/plugins/EmojiPickerPlugin.test.js
+++ b/packages/koenig-lexical/test/e2e/plugins/EmojiPickerPlugin.test.js
@@ -175,7 +175,7 @@ test.describe('Emoji Picker Plugin', async function () {
         await page.keyboard.press('Enter');
         await page.keyboard.type('s for all', {delay: 10});
 
-        await page.keyboard.press(`${ctrlOrCmd()}+Enter`); // exit edit mode
+        await page.keyboard.press(`${ctrlOrCmd(page)}+Enter`); // exit edit mode
 
         await assertHTML(page, `
         <div data-lexical-decorator="true" contenteditable="false">
@@ -235,7 +235,7 @@ test.describe('Emoji Picker Plugin', async function () {
 
         await page.keyboard.type('```js ', {delay: 10});
         await page.keyboard.type(`sample code`, {delay: 10});
-        await page.keyboard.press(`${ctrlOrCmd()}+Enter`);
+        await page.keyboard.press(`${ctrlOrCmd(page)}+Enter`);
         await page.keyboard.type('enjoy :ta', {delay: 10});
         await page.keyboard.press('ArrowDown'); // make sure we test arrow key use
         await page.keyboard.press('ArrowDown');

--- a/packages/koenig-lexical/test/e2e/selection.test.js
+++ b/packages/koenig-lexical/test/e2e/selection.test.js
@@ -1,8 +1,6 @@
 import {assertHTML, assertSelection, ctrlOrCmd, dragMouse, focusEditor, html, initialize} from '../utils/e2e';
 import {test} from '@playwright/test';
 
-const ctrlOrCmdKey = ctrlOrCmd();
-
 test.describe('Selection behaviour', async () => {
     let page;
 
@@ -72,9 +70,10 @@ test.describe('Selection behaviour', async () => {
             await page.keyboard.type('---');
             await page.keyboard.type('Second paragraph');
 
-            await page.keyboard.down(ctrlOrCmdKey);
+            const modifier = ctrlOrCmd(page);
+            await page.keyboard.down(modifier);
             await page.keyboard.press('a');
-            await page.keyboard.up(ctrlOrCmdKey);
+            await page.keyboard.up(modifier);
 
             await assertSelection(page, {
                 anchorPath: [0, 0, 0],
@@ -89,9 +88,10 @@ test.describe('Selection behaviour', async () => {
             await page.keyboard.press('Enter');
             await page.keyboard.type('---');
 
-            await page.keyboard.down(ctrlOrCmdKey);
+            const modifier = ctrlOrCmd(page);
+            await page.keyboard.down(modifier);
             await page.keyboard.press('a');
-            await page.keyboard.up(ctrlOrCmdKey);
+            await page.keyboard.up(modifier);
 
             await assertSelection(page, {
                 anchorPath: [0],

--- a/packages/koenig-lexical/test/utils/e2e.js
+++ b/packages/koenig-lexical/test/utils/e2e.js
@@ -6,6 +6,7 @@ import {E2E_PORT} from '../../playwright.config';
 import {expect} from '@playwright/test';
 
 const {JSDOM} = jsdom;
+const browserCtrlOrCmdMap = new WeakMap();
 
 export async function initialize({page, uri = '/#/?content=false'}) {
     const url = `http://localhost:${E2E_PORT}${uri}`;
@@ -45,6 +46,10 @@ export async function initialize({page, uri = '/#/?content=false'}) {
         }, [uri.slice(2), currentUrl === url]);
         await exposeLexicalEditor(page);
     }
+
+    browserCtrlOrCmdMap.set(page, await page.evaluate(() => {
+        return navigator.platform.includes('Mac') ? 'Meta' : 'Control';
+    }));
 }
 
 async function exposeLexicalEditor(page) {
@@ -397,8 +402,18 @@ export function isMac() {
     return process.platform === 'darwin';
 }
 
-export function ctrlOrCmd() {
-    return isMac() ? 'Meta' : 'Control';
+export function ctrlOrCmd(page) {
+    if (!page) {
+        return isMac() ? 'Meta' : 'Control';
+    }
+
+    const modifier = browserCtrlOrCmdMap.get(page);
+
+    if (!modifier) {
+        throw new Error('ctrlOrCmd(page) requires initialize({page}) before use');
+    }
+
+    return modifier;
 }
 
 // note: we always use lowercase for the cardName but we use start case for the menu item attribute


### PR DESCRIPTION
## Summary
- cache the browser-reported ctrl/cmd modifier during test initialization and expose it via ctrlOrCmd(page)
- replace duplicated browser shortcut helpers across the E2E suite with explicit page.keyboard.press calls using ctrlOrCmd(page)
- keep the CodeMirror cut test on the host-side shortcut path while preserving the local image, code block, and email fixes