### PR TITLE
Fixed doubled positioning when host app uses Tailwind v4

### DIFF
--- a/packages/koenig-lexical/src/styles/index.css
+++ b/packages/koenig-lexical/src/styles/index.css
@@ -32,4 +32,18 @@
     --green: #30CF43;
 
     --kg-breakout-adjustment-with-fallback: var(--kg-breakout-adjustment, 0px);
+
+    /*
+        Tailwind v4 "translate" classes use `translate` rather than `transform`,
+        if Koenig renders inside a TW v4 app we get doubled positioning through
+        transform+translate. Reset `translate` for the .koenig-lexical classes.
+    */
+
+    .-translate-x-1\/2 {
+        translate: none;
+    }
+
+    .-translate-y-full {
+        translate: none;
+    }
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/DES-1355/
ref https://linear.app/ghost/issue/DES-1354/

Tailwind v4's "translate" utilities apply translation via the `translate` property rather than `transform`. When Koenig (built against Tailwind v3) renders inside a host app on Tailwind v4, an element carrying `-translate-x-1/2` or `-translate-y-full` ends up with both Koenig's `transform: translate(...)` and the host's `translate: ...` rules — compounding the positioning on tooltips, dropdowns, the URL search input, etc.

Reset `translate` to `none` for these classes inside `.koenig-lexical` so the host's v4 contribution is neutralised and Koenig's v3 transform continues to position correctly on its own.