### PR TITLE
Fix product card rating clicks being swallowed after sibling card focus change

### DIFF
--- a/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
+++ b/packages/koenig-lexical/src/components/KoenigCardWrapper.jsx
@@ -111,6 +111,22 @@ const KoenigCardWrapper = ({nodeKey, width, wrapperStyle, IndicatorIcon, childre
 
         function handleMousedown(event) {
             if (!isSelected && !isEditing) {
+                const targetTagName = event.target.tagName;
+                const allowedTagNames = ['INPUT', 'TEXTAREA'];
+                const allowClickthrough = !!event.target.closest('[data-kg-allow-clickthrough]');
+
+                // For clickthrough controls (interactive widgets that should
+                // act on first click), skip SELECT_CARD_COMMAND on mousedown
+                // entirely. Dispatching it here causes other cards to lose
+                // their editing state synchronously, and the resulting layout
+                // shift can land mouseup on a different element than mousedown
+                // — the click event then fires on a common ancestor instead
+                // of the intended button. The control's own React onClick is
+                // expected to call setEditing(true) itself.
+                if (allowClickthrough) {
+                    return;
+                }
+
                 editor.dispatchCommand(SELECT_CARD_COMMAND, {cardKey: nodeKey});
 
                 // skip CLICK_COMMAND behaviour otherwise we'll immediately enter edit mode
@@ -120,11 +136,7 @@ const KoenigCardWrapper = ({nodeKey, width, wrapperStyle, IndicatorIcon, childre
                 // can cause an underlying cursor position change but inputs and
                 // textareas are different and we want the focus to move to them
                 // immediately when clicked
-                const targetTagName = event.target.tagName;
-                const allowedTagNames = ['INPUT', 'TEXTAREA'];
-                const allowClickthrough = !!event.target.closest('[data-kg-allow-clickthrough]');
-
-                if (!allowedTagNames.includes(targetTagName) && !allowClickthrough) {
+                if (!allowedTagNames.includes(targetTagName)) {
                     event.preventDefault();
                 }
             }

--- a/packages/koenig-lexical/src/components/ui/cards/ProductCard/RatingButton.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/ProductCard/RatingButton.jsx
@@ -18,9 +18,14 @@ export function RatingButton({rating, onRatingChange}) {
     };
 
     return (
+        // The rating widget sits above the card's ReadOnlyOverlay (z-10) and
+        // opts out of the wrapper's mousedown preventDefault via
+        // `data-kg-allow-clickthrough`, so clicking a star always reaches the
+        // button regardless of the card's editing state.
         <div
-            className="not-kg-prose ml-auto flex transition-all duration-75"
+            className="not-kg-prose relative z-20 ml-auto flex transition-all duration-75"
             data-testid="product-stars"
+            data-kg-allow-clickthrough
             onMouseLeave={resetHoveredStarIndex}
         >
             {

--- a/packages/koenig-lexical/src/nodes/ProductNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/ProductNodeComponent.jsx
@@ -105,6 +105,9 @@ export function ProductNodeComponent({
     };
 
     const handleRatingToggle = (event) => {
+        // Mutating any control on the card should move it into EDITING state —
+        // toggling the rating is an edit, the card should reflect that.
+        setEditing(true);
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
             node.productRatingEnabled = event.target.checked;
@@ -112,6 +115,9 @@ export function ProductNodeComponent({
     };
 
     const handleRatingChange = (rating) => {
+        // Same principle: clicking a star is a real edit. Promote the card
+        // into EDITING so the affordance the user just acted on is honoured.
+        setEditing(true);
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
             node.productStarRating = rating;

--- a/packages/koenig-lexical/test/e2e/cards/file-card-overlay.test.ts
+++ b/packages/koenig-lexical/test/e2e/cards/file-card-overlay.test.ts
@@ -1,0 +1,91 @@
+import path from 'path';
+import {focusEditor, initialize, insertCard} from '../../utils/e2e';
+import {expect, test} from '@playwright/test';
+import {fileURLToPath} from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// BER-3595 — original report (TryGhost/Product#4114, 2023):
+//   1. Add a file card, leave empty
+//   2. Add a product card, try to set the rating — see that it works
+//   3. Add a file to the file card
+//   4. Try to set the rating on the product card — see it no longer works
+//
+// Root cause: uploading the file moves Lexical selection to the file card,
+// dropping the product card out of editing state. The product card's
+// ReadOnlyOverlay then sits over the rating widget. The rating widget still
+// looks interactive because RatingButton always renders <button>s, so the
+// user clicks a star expecting it to work — and the click is silently
+// swallowed.
+//
+// The fix:
+//   - The rating widget stacks above the ReadOnlyOverlay (z-20) and opts out
+//     of the wrapper's mousedown promotion via `data-kg-allow-clickthrough`.
+//   - KoenigCardWrapper's mousedown handler now early-returns for clickthrough
+//     elements rather than dispatching SELECT_CARD_COMMAND on mousedown. That
+//     dispatch was causing a synchronous re-render (sibling card losing
+//     editing state, placeholder inputs unmounting, vertical layout shift)
+//     between mousedown and mouseup, so the click event landed on a common
+//     ancestor instead of the button.
+//   - handleRatingChange (and handleRatingToggle) now call setEditing(true)
+//     so the very act of changing the rating focuses the card — the
+//     affordance the user just acted on is honoured in a single gesture.
+
+test.describe('BER-3595: clicking a product card rating star promotes the card to editing', async () => {
+    let page: import('@playwright/test').Page;
+
+    test.beforeAll(async ({browser}) => {
+        page = await browser.newPage();
+    });
+
+    test.beforeEach(async () => {
+        await initialize({page});
+    });
+
+    test.afterAll(async () => {
+        await page.close();
+    });
+
+    test('clicking a star after the card has lost focus updates the rating AND re-enters editing in one gesture', async () => {
+        await focusEditor(page);
+
+        // Add an empty file card. Cancel the chooser so it stays empty.
+        const initialChooser = page.waitForEvent('filechooser');
+        await insertCard(page, {cardName: 'file'});
+        await (await initialChooser).setFiles([]);
+
+        // Add a product card below it and enable rating.
+        await page.keyboard.press('Escape');
+        await page.keyboard.press('ArrowDown');
+        await insertCard(page, {cardName: 'product'});
+        await page.getByTestId('product-rating-toggle').check();
+
+        const productCard = page.locator('[data-kg-card="product"]');
+        const productStars = page.getByTestId('product-stars');
+        const starButtons = productStars.locator('button');
+        const activeStars = productStars.locator('button.fill-grey-900.dark\\:fill-white');
+
+        // Pre-condition: the rating works while the product card is editing.
+        await starButtons.nth(4).click();
+        await expect(activeStars).toHaveCount(5);
+        await expect(productCard).toHaveAttribute('data-kg-card-editing', 'true');
+
+        // Click the empty file card. This matches the user flow ("add a file
+        // to the file card") and transfers selection to the file card; the
+        // product card silently leaves editing state.
+        await page.locator('[data-kg-card="file"]').click();
+        const fileInput = page.locator('[data-kg-card="file"] input[type="file"]');
+        await fileInput.setInputFiles(path.relative(process.cwd(), __dirname + '/../fixtures/large-image-0.png'));
+        await expect(page.locator('[data-kg-card="file"]').first()).toContainText('large-image-0');
+        await expect(productCard).toHaveAttribute('data-kg-card-editing', 'false');
+
+        // The actual regression: a single click on a star both applies the
+        // rating change AND puts the product card back into editing state.
+        // Pre-fix, this click was absorbed by the layout shift caused by
+        // the wrapper's mousedown SELECT command.
+        await starButtons.nth(2).click();
+        await expect(activeStars).toHaveCount(3);
+        await expect(productCard).toHaveAttribute('data-kg-card-editing', 'true');
+    });
+});

--- a/packages/koenig-lexical/test/e2e/cards/product-card.test.js
+++ b/packages/koenig-lexical/test/e2e/cards/product-card.test.js
@@ -76,7 +76,7 @@ test.describe('Product card', async () => {
                                     </div>
                                 </div>
                             </div>
-                            <div>
+                            <div data-kg-allow-clickthrough="true">
                                 <button type="button"><svg></svg></button>
                                 <button type="button"><svg></svg></button>
                                 <button type="button"><svg></svg></button>
@@ -469,7 +469,7 @@ test.describe('Product card', async () => {
                                     </div>
                                 </div>
                             </div>
-                            <div>
+                            <div data-kg-allow-clickthrough="true">
                                 <button type="button"><svg></svg></button>
                                 <button type="button"><svg></svg></button>
                                 <button type="button"><svg></svg></button>
@@ -562,7 +562,7 @@ test.describe('Product card', async () => {
                                     </div>
                                 </div>
                             </div>
-                            <div>
+                            <div data-kg-allow-clickthrough="true">
                                 <button type="button"><svg></svg></button>
                                 <button type="button"><svg></svg></button>
                                 <button type="button"><svg></svg></button>


### PR DESCRIPTION
## Problem

When a product card with rating enabled is no longer the editing card — typically because focus has just moved to a sibling card (e.g. uploading a file to an adjacent file card) — clicking a rating star does nothing. The user is looking at a still-green, apparently-interactive card with rating buttons, but clicks are silently swallowed and the rating doesn't change.

This was reported in TryGhost/Product#4114 in 2023.

## Root cause

Two things conspire:

1. The rating widget always renders as \`<button>\`s regardless of editing state, so the affordance promises interactivity even when the card has silently lost editing focus.

2. \`KoenigCardWrapper\`'s mousedown handler dispatches \`SELECT_CARD_COMMAND\` for any non-input target. That dispatch synchronously deselects whichever sibling card was previously editing, which causes its placeholder inputs to unmount and the layout to shift vertically. By the time mouseup lands, the rating button has moved — the click event then fires on the common ancestor (the card wrapper div), not on the button.

## Solution

- Add \`data-kg-allow-clickthrough\` and \`relative z-20\` to the rating widget so clicks reach the button without being intercepted by \`ReadOnlyOverlay\`.
- Update \`KoenigCardWrapper\`'s mousedown handler to early-return for clickthrough elements rather than dispatching \`SELECT_CARD_COMMAND\`. **The contract is now: controls marked with \`data-kg-allow-clickthrough\` are responsible for promoting their own card to EDITING via \`setEditing(true)\`.**
- \`handleRatingChange\` and \`handleRatingToggle\` in \`ProductNodeComponent\` now call \`setEditing(true)\` before mutating, so the very act of changing the rating focuses the card.

The existing \`INPUT\`/\`TEXTAREA\` whitelist is unchanged — those controls survived the same class of layout-shift bug because the browser commits focus at mousedown rather than on the click event.

## Scope of the wrapper change

The wrapper change affects every card. Today only \`RatingButton\` opts into \`data-kg-allow-clickthrough\`, so the practical blast radius is limited and the existing chromium e2e suite (765+ tests) still passes. The principle generalises cleanly to any future card-internal \`<button>\` that should act on first click.

## Tests

- New \`test/e2e/cards/file-card-overlay.test.ts\` reproduces the original ticket flow and asserts that a single click on a rating star both updates the rating and promotes the card to editing state.
- Three existing import-snapshot tests in \`product-card.test.js\` updated to include the new \`data-kg-allow-clickthrough\` attribute on the rating wrapper.
- Confirmed the regression test fails when the wrapper change is reverted (click event lands on common ancestor, not the button).