### PR TITLE
fix: Centered search icon in editor's GIF selector

### DIFF
--- a/packages/koenig-lexical/src/styles/index.css
+++ b/packages/koenig-lexical/src/styles/index.css
@@ -43,6 +43,10 @@
         translate: none;
     }
 
+    .-translate-y-2 {
+        translate: none;
+    }
+
     .-translate-y-full {
         translate: none;
     }


### PR DESCRIPTION
## Describe the problem you are solving

The search icon in the editor's GIF selector appears misaligned, sitting roughly 8px above the vertical center of the input.

Same root cause as #1863 (which introduced the `translate: none` reset block at `packages/koenig-lexical/src/styles/index.css` lines 36-49): when Koenig (built with `tailwindcss@3.4.19`) renders inside a host on Tailwind v4 (e.g. Ghost admin on `tailwindcss@4.2.2`), classes that v3 emits as a `transform: translate(...)` shorthand are *also* emitted by v4 as the independent CSS `translate` property. Both apply to the same element and compose additively, doubling the vertical shift.

#1863 fixed this for `-translate-x-1/2` and `-translate-y-full`. The search-icon markup in `TenorSelector` (and `UnsplashSelector`) uses `-translate-y-2`, which the original fix did not cover. This PR extends the same one-line reset pattern to that class, scoped to `.koenig-lexical`. No call site needs to change.

The reset is a no-op for consumers still on Tailwind v3 (the `translate` CSS property is never set in that environment, so `translate: none` resets nothing).

## Changelog for devs

* Added `.-translate-y-2 { translate: none; }` to the existing Tailwind v4 translate reset in `packages/koenig-lexical/src/styles/index.css`, alongside the existing entries for `.-translate-x-1/2` and `.-translate-y-full`

## Changelog for customers

* Fixed search icon alignment in the editor's GIF selector

## Notes

* Direct follow-up to #1863 — same root cause, same file, same pattern, just one more class added to the reset list.
* `-translate-y-1/2` is also used in the codebase (CallToActionCard's "no background color" swatch slash at `src/components/ui/cards/CallToActionCard.jsx:29`) and is technically subject to the same doubling. The rendered slash is 1px tall and rotated 45°, so the doubled offset is not visually perceptible; verified manually in the editor and left untouched to keep this PR minimal and focused on the user-reported bug.
* Verified manually in the local Ghost editor: search icon now sits at the input's vertical center; nothing else regressed visually.

## Technical debt

* A more comprehensive fix would normalize all Tailwind v3 `transform`-based translate utilities used in Koenig against the host's v4 `translate` property in one go (e.g. a single CSS rule covering all `[class*="-translate-"]` matches inside `.koenig-lexical`), instead of allow-listing each affected class as it's discovered. Not done here to keep this PR aligned with the existing reset pattern from #1863.

## PR Scope (mark all that apply)

- [x] Improves the user experience
- [ ] Enhances the readability of our code
- [ ] Simplifies the maintenance of our software
- [x] Fixes a bug
- [ ] Provide a core layer to allow one of the points above

## Checklist before requesting a review (mark all that apply)

- [x] I have performed a self-review of my code
- [x] It's simple enough
- [x] The PR is not extensive
- [ ] It includes documentation
- [ ] I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.

## Merge instructions

- **Requires approval from Renato**
- **Use squash and merge**
