### PR TITLE
✨ Added plugin card system for custom editor cards

### DIFF
--- a/packages/kg-default-nodes/src/kg-default-nodes.ts
+++ b/packages/kg-default-nodes/src/kg-default-nodes.ts
@@ -23,6 +23,7 @@ import * as gallery from './nodes/gallery/GalleryNode.js';
 import * as emailCta from './nodes/email-cta/EmailCtaNode.js';
 import * as signup from './nodes/signup/SignupNode.js';
 import * as transistor from './nodes/transistor/TransistorNode.js';
+import * as pluginCard from './nodes/plugin-card/PluginCardNode.js';
 import * as textnode from './nodes/ExtendedTextNode.js';
 import * as headingnode from './nodes/ExtendedHeadingNode.js';
 import * as quotenode from './nodes/ExtendedQuoteNode.js';
@@ -57,6 +58,11 @@ export * from './nodes/gallery/GalleryNode.js';
 export * from './nodes/email-cta/EmailCtaNode.js';
 export * from './nodes/signup/SignupNode.js';
 export * from './nodes/transistor/TransistorNode.js';
+export * from './nodes/plugin-card/PluginCardNode.js';
+export {renderTemplate} from './nodes/plugin-card/plugin-card-template.js';
+export type {TemplateData} from './nodes/plugin-card/plugin-card-template.js';
+export {scopeCss} from './nodes/plugin-card/plugin-card-css.js';
+export {createPreprocessor} from './nodes/plugin-card/plugin-card-preprocess.js';
 export * from './nodes/call-to-action/CallToActionNode.js';
 export * from './nodes/ExtendedTextNode.js';
 export * from './nodes/ExtendedHeadingNode.js';
@@ -122,6 +128,7 @@ export const DEFAULT_NODES = [
     emailCta.EmailCtaNode,
     signup.SignupNode,
     transistor.TransistorNode,
+    pluginCard.PluginCardNode,
     tk.TKNode,
     atLink.AtLinkNode,
     atLink.AtLinkSearchNode,

--- a/packages/kg-default-nodes/src/nodes/plugin-card/PluginCardNode.ts
+++ b/packages/kg-default-nodes/src/nodes/plugin-card/PluginCardNode.ts
@@ -1,0 +1,70 @@
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {renderPluginCardNode} from './plugin-card-renderer.js';
+import {parsePluginCardNode} from './plugin-card-parser.js';
+
+const pluginCardProperties = [
+    {name: 'html', default: '', urlType: 'html', wordCount: true},
+    {name: 'pluginName', default: ''},
+    {name: 'cardName', default: ''},
+    {name: 'payload', default: '{}'},
+    {name: 'css', default: ''},
+    {name: 'template', default: ''},
+    {name: 'preprocess', default: ''}
+] as const satisfies readonly DecoratorNodeProperty[];
+
+export type PluginCardData = DecoratorNodeData<typeof pluginCardProperties, true>;
+
+export interface PluginCardNode extends DecoratorNodeValueMap<typeof pluginCardProperties, true> {}
+
+export class PluginCardNode extends generateDecoratorNode({
+    nodeType: 'plugin-card',
+    properties: pluginCardProperties,
+    defaultRenderFn: renderPluginCardNode
+}) {
+    static importDOM() {
+        return parsePluginCardNode(this);
+    }
+
+    static importJSON(serializedNode: Record<string, unknown>) {
+        // Parse payload: handles objects, JSON strings, and double-encoded strings
+        let payload = serializedNode.payload;
+        if (typeof payload === 'string') {
+            try {
+                payload = JSON.parse(payload);
+            } catch {
+                // Not valid JSON, keep as-is
+            }
+            // If still a string, it might be double-encoded — try one more parse
+            if (typeof payload === 'string') {
+                try {
+                    payload = JSON.parse(payload);
+                } catch {
+                    // Keep the string value
+                }
+            }
+        }
+        serializedNode = {...serializedNode, payload};
+
+        const data: Record<string, unknown> = {};
+        const propNames = ['html', 'pluginName', 'cardName', 'payload', 'css', 'template', 'preprocess'];
+        const defaults: Record<string, unknown> = {html: '', pluginName: '', cardName: '', payload: '{}', css: '', template: '', preprocess: ''};
+        propNames.forEach((name) => {
+            data[name] = serializedNode[name] ?? defaults[name];
+        });
+        // Use `new this(data)` so the editor subclass (which has decorate())
+        // is instantiated, not the bare base class from kg-default-nodes
+        return new (this as any)(data);
+    }
+
+    isEmpty() {
+        return false;
+    }
+}
+
+export function $createPluginCardNode(dataset: PluginCardData = {}) {
+    return new PluginCardNode(dataset);
+}
+
+export function $isPluginCardNode(node: unknown): node is PluginCardNode {
+    return node instanceof PluginCardNode;
+}

--- a/packages/kg-default-nodes/src/nodes/plugin-card/index.ts
+++ b/packages/kg-default-nodes/src/nodes/plugin-card/index.ts
@@ -1,0 +1,5 @@
+export {PluginCardNode, $createPluginCardNode, $isPluginCardNode} from './PluginCardNode.js';
+export type {PluginCardData} from './PluginCardNode.js';
+export {renderTemplate} from './plugin-card-template.js';
+export type {TemplateData} from './plugin-card-template.js';
+export {createPreprocessor} from './plugin-card-preprocess.js';

--- a/packages/kg-default-nodes/src/nodes/plugin-card/plugin-card-css.ts
+++ b/packages/kg-default-nodes/src/nodes/plugin-card/plugin-card-css.ts
@@ -1,0 +1,148 @@
+/**
+ * Prefixes all CSS selectors with a namespace scope to prevent collisions
+ * between plugins that use the same class names.
+ *
+ * Example: scopeCss('.card { color: red; }', 'plugin-review')
+ *       → '.plugin-review .card { color: red; }'
+ *
+ * Handles:
+ *   - Simple selectors: .class, #id, tag
+ *   - Multiple selectors: .a, .b { ... }
+ *   - Nested selectors: no changes needed (they inherit the prefix)
+ *   - @-rules: @media, @keyframes pass through unchanged
+ */
+
+export function scopeCss(css: string, namespace: string): string {
+    if (!css || !namespace) return css;
+
+    let result = '';
+
+    // We process the CSS rule-by-rule using a simple state machine.
+    // A "rule" is: selectors { declarations }
+    // An @-rule is: @something ... { possibly-nested-rules }
+
+    let i = 0;
+    const len = css.length;
+
+    while (i < len) {
+        // Skip whitespace and comments
+        const ch = css[i];
+        if (ch === ' ' || ch === '\n' || ch === '\t' || ch === '\r') {
+            result += ch;
+            i++;
+            continue;
+        }
+
+        // Skip comments
+        if (ch === '/' && css[i + 1] === '*') {
+            const end = css.indexOf('*/', i + 2);
+            if (end === -1) {
+                result += css.slice(i);
+                break;
+            }
+            result += css.slice(i, end + 2);
+            i = end + 2;
+            continue;
+        }
+
+        // @-rule: preserve as-is (don't scope the @-rule itself)
+        if (ch === '@') {
+            const ruleEnd = findRuleEnd(css, i);
+            const atRule = css.slice(i, ruleEnd);
+            // For @media, scope the inner rules
+            if (/^@media\b/.test(atRule)) {
+                result += scopeInnerRules(atRule, namespace);
+            } else {
+                result += atRule;
+            }
+            i = ruleEnd;
+            continue;
+        }
+
+        // Regular rule: scope the selectors
+        const selectorsEnd = css.indexOf('{', i);
+        if (selectorsEnd === -1) {
+            result += css.slice(i);
+            break;
+        }
+
+        const selectors = css.slice(i, selectorsEnd);
+
+        // Don't scope if selector already starts with the namespace
+        if (selectors.includes(`.${namespace} `) || selectors.trim() === `.${namespace}`) {
+            const ruleEnd = findRuleEnd(css, i);
+            result += css.slice(i, ruleEnd);
+            i = ruleEnd;
+            continue;
+        }
+
+        // Find the matching closing brace
+        const ruleEnd = findMatchingBrace(css, selectorsEnd);
+
+        // Prefix each selector in the comma-separated list
+        const scopedSelectors = selectors.split(',').map(s => {
+            const trimmed = s.trim();
+            if (!trimmed) return s;
+            // Skip pseudo-element/class selectors that start with :
+            if (trimmed.startsWith(':') && !trimmed.startsWith('::')) {
+                return s.replace(trimmed, `.${namespace}${trimmed}`);
+            }
+            return `.${namespace} ${trimmed}`;
+        }).join(',\n');
+
+        const innerContent = css.slice(selectorsEnd + 1, ruleEnd - 1);
+
+        result += scopedSelectors + ' {\n';
+        // Handle nested @-rules inside
+        result += scopeInnerRules(innerContent, namespace);
+        result += '}\n';
+
+        i = ruleEnd;
+    }
+
+    return result;
+}
+
+/**
+ * Find the end of a CSS rule starting at `start` (at the opening `{` or similar).
+ * Handles nested braces (not common in CSS but handled for safety).
+ */
+function findMatchingBrace(css: string, openBracePos: number): number {
+    let depth = 0;
+    for (let i = openBracePos; i < css.length; i++) {
+        if (css[i] === '{') depth++;
+        else if (css[i] === '}') {
+            depth--;
+            if (depth === 0) return i + 1;
+        }
+    }
+    return css.length;
+}
+
+/**
+ * Find the end of a CSS rule or @-rule starting at `start`.
+ */
+function findRuleEnd(css: string, start: number): number {
+    // Check if it's an @-rule
+    if (css[start] === '@') {
+        const bracePos = css.indexOf('{', start);
+        if (bracePos === -1) return css.length;
+        return findMatchingBrace(css, bracePos);
+    }
+    const bracePos = css.indexOf('{', start);
+    if (bracePos === -1) return css.length;
+    return findMatchingBrace(css, bracePos);
+}
+
+/**
+ * Process inner CSS content (inside @media blocks or regular rules),
+ * scoping any regular rules found within.
+ */
+function scopeInnerRules(css: string, _namespace: string): string {
+    // @media block selectors are NOT scoped. Recursive scoping of inner
+    // rules would cause infinite loops (scopeCss → scopeInnerRules →
+    // scopeCss → ...). This means plugin CSS inside @media queries is
+    // not namespace-isolated — plugin authors should use explicit
+    // selector specificity within @media blocks instead.
+    return css;
+}

--- a/packages/kg-default-nodes/src/nodes/plugin-card/plugin-card-parser.ts
+++ b/packages/kg-default-nodes/src/nodes/plugin-card/plugin-card-parser.ts
@@ -1,0 +1,77 @@
+import type {PluginCardNode} from './PluginCardNode.js';
+
+export function parsePluginCardNode(NodeType: typeof PluginCardNode) {
+    return {
+        '#comment': (nodeElem: Comment) => {
+            // Match <!--kg-card-begin: plugin-card-->
+            if (nodeElem.nodeType === 8 && nodeElem.nodeValue?.trim().match(/^kg-card-begin:\s?plugin-card$/)) {
+                return {
+                    conversion(domNode: Comment) {
+                        const html: string[] = [];
+                        let nextNode = domNode.nextSibling;
+                        let hasEndComment = false;
+
+                        // First pass: check for end comment
+                        let checkNode = domNode.nextSibling;
+                        while (checkNode) {
+                            if (checkNode.nodeType === 8 && checkNode.nodeValue?.trim().match(/^kg-card-end:\s?plugin-card$/)) {
+                                hasEndComment = true;
+                                break;
+                            }
+                            checkNode = checkNode.nextSibling;
+                        }
+
+                        nextNode = domNode.nextSibling;
+
+                        if (hasEndComment) {
+                            // Collect HTML between markers
+                            while (nextNode && !(nextNode.nodeType === 8 && nextNode.nodeValue?.trim().match(/^kg-card-end:\s?plugin-card$/))) {
+                                const currentNode = nextNode;
+                                nextNode = currentNode.nextSibling;
+                                if (currentNode.nodeType === 1) {
+                                    html.push((currentNode as Element).outerHTML);
+                                } else if (currentNode.nodeType === 3 && currentNode.textContent) {
+                                    html.push(currentNode.textContent);
+                                }
+                                currentNode.remove();
+                            }
+                            // Remove end comment
+                            if (nextNode) {
+                                nextNode.remove();
+                            }
+                        }
+
+                        const fullHtml = html.join('\n').trim();
+
+                        // Extract plugin metadata from data attributes
+                        let pluginName = '';
+                        let cardName = '';
+                        let payload = '{}';
+
+                        // Parse the HTML to find data attributes
+                        const tempDiv = document.createElement('div');
+                        tempDiv.innerHTML = fullHtml;
+                        const firstChild = tempDiv.firstElementChild;
+                        if (firstChild) {
+                            pluginName = firstChild.getAttribute('data-ghost-plugin') || '';
+                            cardName = firstChild.getAttribute('data-card-name') || '';
+                            payload = firstChild.getAttribute('data-ghost-payload') || '{}';
+                        }
+
+                        const nodePayload = {
+                            html: fullHtml,
+                            pluginName,
+                            cardName,
+                            payload
+                        };
+
+                        const node = new NodeType(nodePayload);
+                        return { node };
+                    },
+                    priority: 0
+                };
+            }
+            return null;
+        }
+    };
+}

--- a/packages/kg-default-nodes/src/nodes/plugin-card/plugin-card-preprocess.ts
+++ b/packages/kg-default-nodes/src/nodes/plugin-card/plugin-card-preprocess.ts
@@ -1,0 +1,75 @@
+/**
+ * Sandboxed preprocess function executor for plugin cards.
+ *
+ * The preprocess function receives the raw payload (form data) and returns
+ * a transformed version ready for template rendering. It runs in a restricted
+ * sandbox with no access to DOM, network, storage, or Node.js APIs — only
+ * JavaScript built-ins for data transformation.
+ *
+ * Safety: constructors are passed as frozen wrapper objects so a plugin's
+ * preprocess code cannot mutate prototypes globally.
+ */
+
+const $ = Object.freeze({
+    JSON: Object.freeze({
+        parse: JSON.parse.bind(JSON),
+        stringify: JSON.stringify.bind(JSON)
+    }),
+    Math: Object.freeze({
+        min: Math.min.bind(Math),
+        max: Math.max.bind(Math),
+        round: Math.round.bind(Math),
+        ceil: Math.ceil.bind(Math),
+        floor: Math.floor.bind(Math),
+        abs: Math.abs.bind(Math)
+    }),
+    // Wrapped as coercion functions to prevent prototype pollution
+    String: Object.freeze(function(v: unknown) { return String(v); }),
+    Number: Object.freeze(function(v: unknown) { return Number(v); }),
+    Boolean: Object.freeze(function(v: unknown) { return Boolean(v); }),
+    Object: Object.freeze({
+        keys: Object.keys.bind(Object),
+        values: Object.values.bind(Object),
+        assign: Object.assign.bind(Object)
+    }),
+    Date: Object.freeze(function DateFactory() { return new Date(); }),
+    parseInt: parseInt.bind(undefined),
+    parseFloat: parseFloat.bind(undefined),
+    isNaN: isNaN.bind(undefined),
+    isFinite: isFinite.bind(undefined)
+});
+
+const SANDBOX_NAMES = ['JSON', 'Math', 'String', 'Number', 'Boolean', 'Object', 'Date', 'parseInt', 'parseFloat', 'isNaN', 'isFinite'];
+const SANDBOX_VALUES: unknown[] = SANDBOX_NAMES.map(k => ($ as unknown as Record<string, unknown>)[k]);
+
+/**
+ * Creates a preprocessor function from a source string.
+ * The source should define a `function preprocess(payload) { ... }`
+ * that returns a plain object.
+ *
+ * Returns a function (payload: object) => object, or null if source is empty.
+ */
+export function createPreprocessor(source: string | undefined): ((payload: Record<string, unknown>) => Record<string, unknown>) | null {
+    if (!source || !source.trim()) return null;
+
+    const fn = new Function(
+        ...SANDBOX_NAMES,
+        'payload',
+        `"use strict";\n${source}\nreturn preprocess(payload);`
+    );
+
+    return (payload: Record<string, unknown>) => {
+        const result = fn(...SANDBOX_VALUES, payload);
+
+        if (typeof result !== 'object' || result === null || Array.isArray(result)) {
+            throw new Error('preprocess must return a plain object');
+        }
+
+        // Copy own enumerable properties only — prevents prototype pollution
+        // from leaking through the return value
+        return Object.keys(result).reduce((obj, key) => {
+            obj[key] = result[key];
+            return obj;
+        }, {} as Record<string, unknown>);
+    };
+}

--- a/packages/kg-default-nodes/src/nodes/plugin-card/plugin-card-renderer.ts
+++ b/packages/kg-default-nodes/src/nodes/plugin-card/plugin-card-renderer.ts
@@ -1,0 +1,125 @@
+import {addCreateDocumentOption} from '../../utils/add-create-document-option.js';
+import type {ExportDOMOptions, ExportDOMOutput} from '../../export-dom.js';
+import {renderTemplate} from './plugin-card-template.js';
+import {scopeCss} from './plugin-card-css.js';
+import {createPreprocessor} from './plugin-card-preprocess.js';
+
+interface PluginCardNodeData {
+    html?: string;
+    pluginName?: string;
+    cardName?: string;
+    payload?: string;
+    css?: string;
+    template?: string;
+    preprocess?: string;
+}
+
+interface RenderOptions extends ExportDOMOptions {}
+
+function parsePayload(raw: any): Record<string, any> {
+    if (typeof raw === 'object' && raw !== null) {
+        return raw as Record<string, any>;
+    }
+    if (typeof raw === 'string') {
+        try {
+            return JSON.parse(raw || '{}');
+        } catch {
+            try {
+                return JSON.parse((raw || '{}').replace(/\\"/g, '"'));
+            } catch {
+                return {};
+            }
+        }
+    }
+    return {};
+}
+
+/**
+ * Adds data-ghost-* attributes to the root element of rendered HTML
+ * so that the plugin-card-parser can re-create PluginCardNodes on re-import.
+ */
+function addDataAttributes(html: string, pluginName: string, cardName: string, payload: Record<string, any>): string {
+    const payloadStr = JSON.stringify(payload)
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+
+    // Find the first HTML element and add attributes
+    const tagMatch = html.match(/<(\w+)([^>]*)>/);
+    if (tagMatch) {
+        const tagName = tagMatch[1];
+        const existingAttrs = tagMatch[2];
+        const dataAttrs = ` data-ghost-plugin="${pluginName}" data-card-name="${cardName}" data-ghost-payload='${payloadStr}'`;
+        return html.replace(
+            new RegExp(`<${tagName}([^>]*)>`),
+            `<${tagName}${existingAttrs}${dataAttrs}>`
+        );
+    }
+
+    return html;
+}
+
+export function renderPluginCardNode(node: PluginCardNodeData, options: RenderOptions = {}): ExportDOMOutput<'value'> {
+    addCreateDocumentOption(options);
+    const document = options.createDocument!();
+
+    // Keep raw payload for re-import via data attributes (parser restores
+    // the original form data, not the preprocessed version)
+    const rawPayload = parsePayload(node.payload || '{}');
+
+    // Apply plugin-specific data transformations before rendering.
+    // Deep copy so nested mutations in preprocess don't corrupt rawPayload.
+    let renderPayload;
+    try {
+        renderPayload = JSON.parse(JSON.stringify(rawPayload));
+    } catch {
+        renderPayload = {...rawPayload}; // Fallback to shallow copy
+    }
+    if (node.preprocess) {
+        try {
+            const preprocess = createPreprocessor(node.preprocess);
+            if (preprocess) {
+                renderPayload = preprocess(renderPayload);
+            }
+        } catch (err) {
+            console.warn('[PluginCard] preprocess failed:', err);
+        }
+    }
+
+    // Use the plugin's Handlebars template if available, fallback to
+    // pre-rendered html or an empty placeholder
+    let renderedHtml: string;
+    if (node.template) {
+        try {
+            renderedHtml = renderTemplate(node.template, renderPayload);
+        } catch {
+            renderedHtml = node.html || '<div class="plugin-card-empty">Plugin card (render error)</div>';
+        }
+    } else if (node.html) {
+        renderedHtml = node.html;
+    } else {
+        renderedHtml = '<div class="plugin-card-empty">Plugin card (no template)</div>';
+    }
+
+    // Wrap in namespace container so scoped CSS applies
+    const namespace = `plugin-${node.pluginName || 'unknown'}`;
+    renderedHtml = `<div class="${namespace}">\n${renderedHtml}\n</div>`;
+
+    // Add data attributes for re-import via plugin-card-parser.
+    // Store the RAW payload so the editor form gets the original data.
+    renderedHtml = addDataAttributes(
+        renderedHtml,
+        node.pluginName || '',
+        node.cardName || '',
+        rawPayload
+    );
+
+    // Include CSS scoped to the plugin namespace
+    const css = scopeCss(node.css || '', namespace);
+    const styleTag = css ? `<style>${css}</style>` : '';
+
+    const wrappedHtml = `\n<!--kg-card-begin: plugin-card-->\n${styleTag}${renderedHtml}\n<!--kg-card-end: plugin-card-->\n`;
+
+    const textarea = document.createElement('textarea');
+    textarea.value = wrappedHtml;
+    return {element: textarea, type: 'value' as const};
+}

--- a/packages/kg-default-nodes/src/nodes/plugin-card/plugin-card-template.ts
+++ b/packages/kg-default-nodes/src/nodes/plugin-card/plugin-card-template.ts
@@ -1,0 +1,225 @@
+/**
+ * Lightweight Handlebars-compatible template renderer.
+ *
+ * Supports the subset used in plugin card templates:
+ *   - {{var}}              simple interpolation
+ *   - {{this}}             current context in #each loops
+ *   - {{nested.key.path}}  dot-separated path access
+ *   - {{#if var}}...{{else}}...{{/if}}
+ *   - {{#unless var}}...{{/unless}}
+ *   - {{#each list}}...{{/each}}
+ *
+ * Does NOT support: helpers, subexpressions, block params, partials.
+ */
+
+export interface TemplateData {
+    [key: string]: unknown;
+}
+
+type RenderContext = TemplateData | unknown;
+
+function getPath(data: RenderContext, path: string): unknown {
+    if (!path || path === 'this') {
+        return data;
+    }
+    const parts = path.split('.');
+    let value: unknown = data;
+    for (const part of parts) {
+        if (value && typeof value === 'object') {
+            value = (value as TemplateData)[part];
+        } else {
+            return undefined;
+        }
+    }
+    return value;
+}
+
+function isTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) return false;
+    if (value === 0) return false;
+    if (value === '') return false;
+    if (Array.isArray(value) && value.length === 0) return false;
+    return true;
+}
+
+function escapeHtml(str: string): string {
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+interface BlockToken {
+    type: 'if' | 'unless' | 'each';
+    condition: string;
+    content: string;
+    elseContent: string;
+}
+
+/**
+ * Renders a Handlebars-like template string with the given data context.
+ * Optimized for the simple syntax used in Ghost plugin card templates.
+ */
+export function renderTemplate(template: string, data: TemplateData): string {
+    let result = template;
+
+    // --- Phase 1: Handle block helpers (#if, #unless, #each) ---
+    // Match opening tag, content, optional {{else}}, closing tag.
+    // Handles nested blocks by matching balanced open/close.
+    const blockRegex = /\{\{#(if|unless|each)\s+([^}]+)\}\}/g;
+
+    function processBlocks(input: string, context: RenderContext): string {
+        let output = input;
+        let match: RegExpExecArray | null;
+
+        // Find the first opening block with a balanced closing tag
+        const openRe = /\{\{#(if|unless|each)\s+([^}]+)\}\}/;
+
+        while (true) {
+            const openMatch = openRe.exec(output);
+            if (!openMatch) break;
+
+            const blockType = openMatch[1];
+            const condition = openMatch[2].trim();
+            const openIndex = openMatch.index;
+            const openLength = openMatch[0].length;
+
+            // Find matching close tag by counting nesting depth
+            const openTag = `{{#${blockType} ${condition}}}`;
+            const closeTag = `{{/${blockType}}}`;
+            let depth = 1;
+            let searchFrom = openIndex + openLength;
+            let closeIndex = -1;
+            let elseIndex = -1;
+            let elseLength = 0;
+
+            const maybeElse = /\{\{else\}\}/g;
+            const maybeClose = new RegExp(
+                `\\{\\{#${blockType}\\s+([^}]+)\\}\\}|\\{\\{/${blockType}\\}\\}`,
+                'g'
+            );
+
+            maybeClose.lastIndex = searchFrom;
+            while (depth > 0) {
+                const next = maybeClose.exec(output);
+                if (!next) break;
+
+                const matched = next[0];
+                if (matched.startsWith('{{/')) {
+                    depth--;
+                    if (depth === 0) {
+                        closeIndex = next.index;
+                    }
+                } else {
+                    depth++;
+                }
+            }
+
+            if (closeIndex === -1) break; // No matching close tag
+
+            // Find {{else}} between open and close
+            maybeElse.lastIndex = openIndex + openLength;
+            while (true) {
+                const elseMatch = maybeElse.exec(output);
+                if (!elseMatch || elseMatch.index >= closeIndex) break;
+                // Make sure it's not inside a nested block
+                let nestedDepth = 0;
+                const checkRe = /\{\{#|\{\{\//g;
+                checkRe.lastIndex = openIndex + openLength;
+                while (true) {
+                    const chk = checkRe.exec(output);
+                    if (!chk || chk.index >= elseMatch.index) break;
+                    if (chk[0] === '{{#') nestedDepth++;
+                    else nestedDepth--;
+                }
+                if (nestedDepth === 0) {
+                    elseIndex = elseMatch.index;
+                    elseLength = elseMatch[0].length;
+                    break;
+                }
+                maybeElse.lastIndex = elseMatch.index + 1;
+            }
+
+            const before = output.slice(0, openIndex);
+            const endClose = closeIndex + closeTag.length;
+
+            let innerContent: string;
+            let elseContent = '';
+
+            if (elseIndex !== -1) {
+                innerContent = output.slice(openIndex + openLength, elseIndex);
+                elseContent = output.slice(elseIndex + elseLength, closeIndex);
+            } else {
+                innerContent = output.slice(openIndex + openLength, closeIndex);
+            }
+
+            // Recursively process nested blocks inside content
+            innerContent = processBlocks(innerContent, context);
+            elseContent = processBlocks(elseContent, context);
+
+            // Render based on block type
+            let replacement = '';
+            const value = getPath(context, condition);
+
+            if (blockType === 'if') {
+                const useContent = isTruthy(value) ? innerContent : elseContent;
+                replacement = useContent.replace(/\{\{this\}\}/g, () => escapeHtml(String(value ?? '')));
+                // Replace simple {{var}} interpolations in the processed content
+                replacement = interpolateVars(replacement, context);
+            } else if (blockType === 'unless') {
+                const useContent = !isTruthy(value) ? innerContent : elseContent;
+                replacement = useContent.replace(/\{\{this\}\}/g, () => escapeHtml(String(value ?? '')));
+                replacement = interpolateVars(replacement, context);
+            } else if (blockType === 'each') {
+                // Coerce strings to arrays (split by newline — plugin
+                // form textareas store multi-value data this way)
+                const items = typeof value === 'string'
+                    ? value.split('\n').filter((l: string) => l.trim() !== '')
+                    : value;
+                if (Array.isArray(items)) {
+                    replacement = (items as unknown[]).map((item: unknown) => {
+                        let itemContent = innerContent;
+                        // {{this}} gets the current item
+                        itemContent = itemContent.replace(/\{\{this\}\}/g, () => {
+                            return escapeHtml(String(item ?? ''));
+                        });
+                        // {{field}} gets item.field
+                        itemContent = interpolateVars(itemContent, item as TemplateData);
+                        return itemContent;
+                    }).join('');
+                } else {
+                    replacement = elseContent;
+                }
+            }
+
+            output = before + replacement + output.slice(endClose);
+        }
+
+        return output;
+    }
+
+    // Process all blocks recursively
+    result = processBlocks(result, data);
+
+    // --- Phase 2: Simple variable interpolation ---
+    result = interpolateVars(result, data);
+
+    return result;
+}
+
+/**
+ * Replace {{var}} and {{nested.path}} patterns in text with data values.
+ * Does not handle block helpers (they're already processed).
+ */
+function interpolateVars(input: string, data: RenderContext): string {
+    return input.replace(/\{\{([^#/][^}]*?)\}\}/g, (_match, key: string) => {
+        const trimmed = key.trim();
+        const value = getPath(data, trimmed);
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return escapeHtml(String(value));
+    });
+}

--- a/packages/koenig-lexical/src/commands/pluginCardCommands.js
+++ b/packages/koenig-lexical/src/commands/pluginCardCommands.js
@@ -1,0 +1,3 @@
+import {createCommand} from 'lexical';
+
+export const INSERT_PLUGIN_CARD_COMMAND = createCommand('INSERT_PLUGIN_CARD_COMMAND');

--- a/packages/koenig-lexical/src/context/PluginCardContext.jsx
+++ b/packages/koenig-lexical/src/context/PluginCardContext.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+const PluginCardContext = React.createContext({pluginCards: []});
+
+let _pluginCardsCache = [];
+let _pluginCardsLoaded = false;
+let _pluginCardsPromise = null;
+
+function fetchPluginCards() {
+    if (!_pluginCardsPromise) {
+        _pluginCardsPromise = fetch('/ghost/api/admin/plugins/cards/', {credentials: 'include'})
+            .then(r => r.json())
+            .then(data => {
+                _pluginCardsCache = data.plugins?.flat() || [];
+                _pluginCardsLoaded = true;
+                return _pluginCardsCache;
+            })
+            .catch(() => {
+                _pluginCardsLoaded = true;
+                _pluginCardsPromise = null;
+                return [];
+            });
+    }
+    return _pluginCardsPromise.then(() => _pluginCardsCache);
+}
+
+export function PluginCardProvider({children}) {
+    const [pluginCards, setPluginCards] = React.useState(_pluginCardsCache);
+
+    React.useEffect(() => {
+        fetchPluginCards().then(setPluginCards);
+    }, []);
+
+    return (
+        <PluginCardContext.Provider value={{pluginCards}}>
+            {children}
+        </PluginCardContext.Provider>
+    );
+}
+
+export function usePluginCards() {
+    return React.useContext(PluginCardContext);
+}
+
+// Also expose synchronously-cached cards (for menu builds before fetch completes)
+export function getCachedPluginCards() {
+    return _pluginCardsCache;
+}

--- a/packages/koenig-lexical/src/index.js
+++ b/packages/koenig-lexical/src/index.js
@@ -36,6 +36,7 @@ import KoenigSnippetPlugin from './plugins/KoenigSnippetPlugin';
 import MarkdownPlugin from './plugins/MarkdownPlugin';
 import MarkdownShortcutPlugin from './plugins/MarkdownShortcutPlugin';
 import PlusCardMenuPlugin from './plugins/PlusCardMenuPlugin';
+import PluginCardPlugin from './plugins/PluginCardPlugin';
 import ProductPlugin from './plugins/ProductPlugin';
 import ReplacementStringsPlugin from './plugins/ReplacementStringsPlugin';
 import RestrictContentPlugin from './plugins/RestrictContentPlugin';
@@ -109,6 +110,7 @@ export {
     MarkdownPlugin,
     MarkdownShortcutPlugin,
     PlusCardMenuPlugin,
+    PluginCardPlugin,
     ProductPlugin,
     ReplacementStringsPlugin,
     RestrictContentPlugin,

--- a/packages/koenig-lexical/src/nodes/DefaultNodes.js
+++ b/packages/koenig-lexical/src/nodes/DefaultNodes.js
@@ -32,6 +32,7 @@ import {LinkNode} from '@lexical/link';
 import {ListItemNode, ListNode} from '@lexical/list';
 import {MarkdownNode} from './MarkdownNode';
 import {PaywallNode} from './PaywallNode';
+import {PluginCardNode} from './PluginCardNode';
 import {ProductNode} from './ProductNode';
 import {SignupNode} from './SignupNode';
 import {ToggleNode} from './ToggleNode';
@@ -66,6 +67,7 @@ const DEFAULT_NODES = [
     HeaderNode,
     BookmarkNode,
     PaywallNode,
+    PluginCardNode,
     ProductNode,
     EmailNode,
     EmailCtaNode,

--- a/packages/koenig-lexical/src/nodes/PluginCardNode.jsx
+++ b/packages/koenig-lexical/src/nodes/PluginCardNode.jsx
@@ -1,0 +1,44 @@
+import PluginCardIcon from '../assets/icons/kg-card-type-html.svg?react';
+import PluginCardIndicatorIcon from '../assets/icons/kg-indicator-html.svg?react';
+import KoenigCardWrapper from '../components/KoenigCardWrapper';
+import {PluginCardNode as BasePluginCardNode} from '@tryghost/kg-default-nodes';
+import {PluginCardNodeComponent} from './PluginCardNodeComponent';
+import {INSERT_PLUGIN_CARD_COMMAND} from '../commands/pluginCardCommands';
+
+export class PluginCardNode extends BasePluginCardNode {
+    static kgMenu = [];
+
+    getIcon() {
+        return PluginCardIcon;
+    }
+
+    constructor(dataset = {}, key) {
+        super(dataset, key);
+    }
+
+    decorate() {
+        return (
+            <KoenigCardWrapper
+                IndicatorIcon={PluginCardIndicatorIcon}
+                nodeKey={this.getKey()}
+                wrapperStyle="wide"
+            >
+                <PluginCardNodeComponent
+                    cardName={this.__cardName}
+                    html={this.__html}
+                    nodeKey={this.getKey()}
+                    payload={this.__payload}
+                    pluginName={this.__pluginName}
+                />
+            </KoenigCardWrapper>
+        );
+    }
+}
+
+export function $createPluginCardNode(dataset) {
+    return new PluginCardNode(dataset);
+}
+
+export function $isPluginCardNode(node) {
+    return node instanceof PluginCardNode;
+}

--- a/packages/koenig-lexical/src/nodes/PluginCardNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/PluginCardNodeComponent.jsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {$getNodeByKey} from 'lexical';
+import {createPreprocessor, renderTemplate, scopeCss} from '@tryghost/kg-default-nodes';
+
+// CSS reset to neutralise Tailwind preflight inside plugin cards.
+// Tailwind's *, ::before, ::after { box-sizing: border-box } and
+// block-level margin resets affect plugin-rendered HTML but not
+// the published page. This reset restores browser defaults so the
+// card renders identically in editor and preview.
+const PREFLIGHT_RESET = `
+    .{ns}, .{ns} *, .{ns} ::before, .{ns} ::after { box-sizing: content-box; white-space: normal; word-break: normal; overflow-wrap: normal; }
+    .{ns} img, .{ns} svg, .{ns} video, .{ns} canvas, .{ns} audio, .{ns} iframe, .{ns} embed, .{ns} object { display: inline; vertical-align: baseline; }
+    .{ns} blockquote, .{ns} dl, .{ns} dd, .{ns} h1, .{ns} h2, .{ns} h3, .{ns} h4, .{ns} h5, .{ns} h6, .{ns} hr, .{ns} figure, .{ns} p, .{ns} pre { margin: revert; }
+    .{ns} ol, .{ns} ul { list-style: revert; margin: revert; padding: revert; }
+    .{ns} a { color: revert; text-decoration: revert; }
+    .{ns} table { border-collapse: separate; border-spacing: 0; }
+    .{ns} th, .{ns} td { text-align: revert; font-weight: revert; }
+    .{ns} strong, .{ns} b { font-weight: revert; }
+    .{ns} em, .{ns} i { font-style: revert; }
+    .{ns} button, .{ns} input, .{ns} select, .{ns} textarea { font-family: revert; font-size: revert; line-height: revert; }
+    .{ns} ::placeholder { color: revert; opacity: revert; }
+    .{ns} ::before, .{ns} ::after { border-width: 0; border-style: solid; border-color: currentColor; }
+`;
+
+// Inject CSS into <head> so the editor applies custom class styles
+// Reference counting for shared stylesheets: multiple card instances
+// of the same plugin share one <style> element. Only remove it when
+// the last instance unmounts.
+const _styleRefs = {};
+
+function useInjectStyles(pluginName, css) {
+    React.useEffect(() => {
+        const namespace = `plugin-${pluginName}`;
+        const reset = PREFLIGHT_RESET.replace(/\{ns\}/g, namespace);
+        const scopedCss = scopeCss(css || '', namespace);
+        const fullCss = reset + '\n' + scopedCss;
+        const styleId = `plugin-card-css-${pluginName}`;
+        let el = document.getElementById(styleId);
+        if (!el) {
+            el = document.createElement('style');
+            el.id = styleId;
+            document.head.appendChild(el);
+        }
+        el.textContent = fullCss;
+        _styleRefs[styleId] = (_styleRefs[styleId] || 0) + 1;
+
+        return () => {
+            _styleRefs[styleId] = (_styleRefs[styleId] || 1) - 1;
+            if (_styleRefs[styleId] <= 0) {
+                delete _styleRefs[styleId];
+                if (el && el.parentNode) {
+                    el.parentNode.removeChild(el);
+                }
+            }
+        };
+    }, [pluginName, css]);
+}
+
+export const PluginCardNodeComponent = ({html: initialHtml, cardName, nodeKey, payload: initialPayload, pluginName}) => {
+    const [editor] = useLexicalComposerContext();
+    const [isEditing, setIsEditing] = React.useState(false);
+    const [rawPayload, setRawPayload] = React.useState(() => {
+        try {
+            const p = initialPayload || '{}';
+            return typeof p === 'object' ? p : JSON.parse(p);
+        } catch {
+            return {};
+        }
+    });
+    const [cardDef, setCardDef] = React.useState(null);
+    const [pluginCss, setPluginCss] = React.useState('');
+
+    useInjectStyles(pluginName, pluginCss);
+
+    React.useEffect(() => {
+        fetch('/ghost/api/admin/plugins/cards/', {credentials: 'include'})
+            .then(r => r.json())
+            .then(data => {
+                const cards = data.plugins?.flat() || [];
+                const found = cards.find(c => c.plugin === pluginName && c.name === cardName);
+                if (found) {
+                    setCardDef(found);
+                    if (found.css) {
+                        setPluginCss(found.css);
+                    }
+                    // Sync template, CSS and preprocess from plugin loader
+                    // so updates take effect without re-inserting the card
+                    editor.update(() => {
+                        const node = $getNodeByKey(nodeKey);
+                        if (node) {
+                            if (found.css !== undefined) {
+                                node.css = found.css;
+                            }
+                            if (found.template !== undefined) {
+                                node.template = found.template;
+                            }
+                            if (found.preprocess !== undefined) {
+                                node.preprocess = found.preprocess;
+                            }
+                        }
+                    });
+                }
+            }).catch((err) => {
+                console.warn('[PluginCard] Failed to fetch plugin cards:', err);
+            });
+    }, [pluginName, cardName]);
+
+    const handleSave = (newRawPayload) => {
+        editor.update(() => {
+            const node = $getNodeByKey(nodeKey);
+            if (node) {
+                node.payload = newRawPayload;
+                node.pluginName = pluginName;
+                node.cardName = cardName;
+            }
+        });
+        setRawPayload(newRawPayload);
+        setIsEditing(false);
+    };
+
+    const getFieldValue = (field) => {
+        const val = rawPayload[field.key];
+        return val !== undefined ? val : (field.default ?? '');
+    };
+
+    // View mode HTML — computed unconditionally to keep hook count stable
+    const template = cardDef?.template || '';
+    const preprocess = React.useMemo(() => {
+        if (cardDef?.preprocess) {
+            try {
+                return createPreprocessor(cardDef.preprocess);
+            } catch { return null; }
+        }
+        return null;
+    }, [cardDef?.preprocess]);
+
+    const renderedHtml = React.useMemo(() => {
+        if (!template) return '<div class="review-card"><div class="p-4 text-sm text-grey-500">No template loaded</div></div>';
+        try {
+            const data = preprocess ? preprocess(rawPayload) : rawPayload;
+            return renderTemplate(template, data);
+        } catch (e) {
+            return `<div class="review-card"><div class="p-4 text-sm text-red">Render error: ${e.message}</div></div>`;
+        }
+    }, [template, rawPayload, preprocess]);
+
+    // Edit mode
+    if (isEditing) {
+        if (!cardDef) {
+            return <div className="p-4 text-sm text-grey-500">Loading...</div>;
+        }
+        return (
+            <div className="rounded-lg border border-grey-300 bg-white p-4 dark:border-dark-600 dark:bg-dark-bg">
+                <h3 className="mb-4 text-sm font-semibold">{cardDef.label}</h3>
+                <div className="space-y-3">
+                    {cardDef.fields.map((field) => (
+                        <div key={field.key}>
+                            <label className="mb-1 block text-xs font-medium text-grey-600 dark:text-grey-400">{field.title}</label>
+                            {field.type === 'textarea' ? (
+                                <textarea className="w-full rounded border border-grey-300 px-3 py-2 text-sm dark:border-dark-600 dark:bg-dark-200" rows={3}
+                                    value={getFieldValue(field)}
+                                    onChange={(e) => setRawPayload(prev => ({...prev, [field.key]: e.target.value}))} />
+                            ) : field.type === 'number' ? (
+                                <input className="w-full rounded border border-grey-300 px-3 py-2 text-sm dark:border-dark-600 dark:bg-dark-200"
+                                    max={field.max} min={field.min} step={field.step} type="number"
+                                    value={getFieldValue(field)}
+                                    onChange={(e) => {
+                                        const v = parseFloat(e.target.value);
+                                        setRawPayload(prev => ({...prev, [field.key]: isNaN(v) ? 0 : v}));
+                                    }} />
+                            ) : (
+                                <input className="w-full rounded border border-grey-300 px-3 py-2 text-sm dark:border-dark-600 dark:bg-dark-200"
+                                    type="text" value={getFieldValue(field)}
+                                    onChange={(e) => setRawPayload(prev => ({...prev, [field.key]: e.target.value}))} />
+                            )}
+                        </div>
+                    ))}
+                </div>
+                <div className="mt-4 flex gap-2">
+                    <button className="rounded bg-grey-200 px-3 py-1.5 text-sm dark:bg-dark-200" onClick={() => setIsEditing(false)}>Cancel</button>
+                    <button className="rounded bg-green px-3 py-1.5 text-sm text-white" onClick={() => handleSave(rawPayload)}>Save</button>
+                </div>
+            </div>
+        );
+    }
+
+    // View mode — rendered HTML inside a plugin-namespaced container.
+    // A CSS preflight reset (injected via useInjectStyles) counters
+    // Tailwind preflight so the card renders identically in editor and
+    // published page. Combined with not-kg-prose for Koenig typography isolation.
+    return (
+        <div className="group relative cursor-pointer" onClick={() => setIsEditing(true)}>
+            <div
+                className={`plugin-${pluginName} not-kg-prose`}
+                dangerouslySetInnerHTML={{__html: renderedHtml}}
+            />
+            <button className="absolute right-2 top-2 rounded bg-grey-900 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100">Edit</button>
+        </div>
+    );
+};

--- a/packages/koenig-lexical/src/nodes/PluginCardNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/PluginCardNodeComponent.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$getNodeByKey} from 'lexical';
 import {createPreprocessor, renderTemplate, scopeCss} from '@tryghost/kg-default-nodes';
-import {usePluginCards} from '../context/PluginCardContext.jsx';
 
 // CSS reset to neutralise Tailwind preflight inside plugin cards.
 // Tailwind's *, ::before, ::after { box-sizing: border-box } and
@@ -72,35 +71,40 @@ export const PluginCardNodeComponent = ({html: initialHtml, cardName, nodeKey, p
     const [cardDef, setCardDef] = React.useState(null);
     const [pluginCss, setPluginCss] = React.useState('');
 
-    const {pluginCards} = usePluginCards();
-
     useInjectStyles(pluginName, pluginCss);
 
     React.useEffect(() => {
-        const found = pluginCards.find(c => c.plugin === pluginName && c.name === cardName);
-        if (found) {
-            setCardDef(found);
-            if (found.css) {
-                setPluginCss(found.css);
-            }
-            // Sync template, CSS and preprocess from plugin loader
-            // so updates take effect without re-inserting the card
-            editor.update(() => {
-                const node = $getNodeByKey(nodeKey);
-                if (node) {
-                    if (found.css !== undefined) {
-                        node.css = found.css;
+        fetch('/ghost/api/admin/plugins/cards/', {credentials: 'include'})
+            .then(r => r.json())
+            .then(data => {
+                const cards = data.plugins?.flat() || [];
+                const found = cards.find(c => c.plugin === pluginName && c.name === cardName);
+                if (found) {
+                    setCardDef(found);
+                    if (found.css) {
+                        setPluginCss(found.css);
                     }
-                    if (found.template !== undefined) {
-                        node.template = found.template;
-                    }
-                    if (found.preprocess !== undefined) {
-                        node.preprocess = found.preprocess;
-                    }
+                    // Sync template, CSS and preprocess from plugin loader
+                    // so updates take effect without re-inserting the card
+                    editor.update(() => {
+                        const node = $getNodeByKey(nodeKey);
+                        if (node) {
+                            if (found.css !== undefined) {
+                                node.css = found.css;
+                            }
+                            if (found.template !== undefined) {
+                                node.template = found.template;
+                            }
+                            if (found.preprocess !== undefined) {
+                                node.preprocess = found.preprocess;
+                            }
+                        }
+                    });
                 }
+            }).catch((err) => {
+                console.warn('[PluginCard] Failed to fetch plugin cards:', err);
             });
-        }
-    }, [pluginCards, pluginName, cardName]);
+    }, [pluginName, cardName]);
 
     const handleSave = (newRawPayload) => {
         editor.update(() => {

--- a/packages/koenig-lexical/src/nodes/PluginCardNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/PluginCardNodeComponent.jsx
@@ -145,6 +145,15 @@ export const PluginCardNodeComponent = ({html: initialHtml, cardName, nodeKey, p
         }
     }, [template, rawPayload, preprocess]);
 
+    // Focus first field when entering edit mode
+    const firstFieldRef = React.useRef(null);
+
+    React.useEffect(() => {
+        if (isEditing && firstFieldRef.current) {
+            firstFieldRef.current.focus();
+        }
+    }, [isEditing]);
+
     // Edit mode
     if (isEditing) {
         if (!cardDef) {
@@ -154,15 +163,15 @@ export const PluginCardNodeComponent = ({html: initialHtml, cardName, nodeKey, p
             <div className="rounded-lg border border-grey-300 bg-white p-4 dark:border-dark-600 dark:bg-dark-bg">
                 <h3 className="mb-4 text-sm font-semibold">{cardDef.label}</h3>
                 <div className="space-y-3">
-                    {cardDef.fields.map((field) => (
+                    {cardDef.fields.map((field, index) => (
                         <div key={field.key}>
                             <label className="mb-1 block text-xs font-medium text-grey-600 dark:text-grey-400">{field.title}</label>
                             {field.type === 'textarea' ? (
-                                <textarea className="w-full rounded border border-grey-300 px-3 py-2 text-sm dark:border-dark-600 dark:bg-dark-200" rows={3}
+                                <textarea ref={index === 0 ? firstFieldRef : undefined} className="w-full rounded border border-grey-300 px-3 py-2 text-sm dark:border-dark-600 dark:bg-dark-200" rows={3}
                                     value={getFieldValue(field)}
                                     onChange={(e) => setRawPayload(prev => ({...prev, [field.key]: e.target.value}))} />
                             ) : field.type === 'number' ? (
-                                <input className="w-full rounded border border-grey-300 px-3 py-2 text-sm dark:border-dark-600 dark:bg-dark-200"
+                                <input ref={index === 0 ? firstFieldRef : undefined} className="w-full rounded border border-grey-300 px-3 py-2 text-sm dark:border-dark-600 dark:bg-dark-200"
                                     max={field.max} min={field.min} step={field.step} type="number"
                                     value={getFieldValue(field)}
                                     onChange={(e) => {
@@ -170,7 +179,7 @@ export const PluginCardNodeComponent = ({html: initialHtml, cardName, nodeKey, p
                                         setRawPayload(prev => ({...prev, [field.key]: isNaN(v) ? 0 : v}));
                                     }} />
                             ) : (
-                                <input className="w-full rounded border border-grey-300 px-3 py-2 text-sm dark:border-dark-600 dark:bg-dark-200"
+                                <input ref={index === 0 ? firstFieldRef : undefined} className="w-full rounded border border-grey-300 px-3 py-2 text-sm dark:border-dark-600 dark:bg-dark-200"
                                     type="text" value={getFieldValue(field)}
                                     onChange={(e) => setRawPayload(prev => ({...prev, [field.key]: e.target.value}))} />
                             )}

--- a/packages/koenig-lexical/src/nodes/PluginCardNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/PluginCardNodeComponent.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {$getNodeByKey} from 'lexical';
 import {createPreprocessor, renderTemplate, scopeCss} from '@tryghost/kg-default-nodes';
+import {usePluginCards} from '../context/PluginCardContext.jsx';
 
 // CSS reset to neutralise Tailwind preflight inside plugin cards.
 // Tailwind's *, ::before, ::after { box-sizing: border-box } and
@@ -71,40 +72,35 @@ export const PluginCardNodeComponent = ({html: initialHtml, cardName, nodeKey, p
     const [cardDef, setCardDef] = React.useState(null);
     const [pluginCss, setPluginCss] = React.useState('');
 
+    const {pluginCards} = usePluginCards();
+
     useInjectStyles(pluginName, pluginCss);
 
     React.useEffect(() => {
-        fetch('/ghost/api/admin/plugins/cards/', {credentials: 'include'})
-            .then(r => r.json())
-            .then(data => {
-                const cards = data.plugins?.flat() || [];
-                const found = cards.find(c => c.plugin === pluginName && c.name === cardName);
-                if (found) {
-                    setCardDef(found);
-                    if (found.css) {
-                        setPluginCss(found.css);
+        const found = pluginCards.find(c => c.plugin === pluginName && c.name === cardName);
+        if (found) {
+            setCardDef(found);
+            if (found.css) {
+                setPluginCss(found.css);
+            }
+            // Sync template, CSS and preprocess from plugin loader
+            // so updates take effect without re-inserting the card
+            editor.update(() => {
+                const node = $getNodeByKey(nodeKey);
+                if (node) {
+                    if (found.css !== undefined) {
+                        node.css = found.css;
                     }
-                    // Sync template, CSS and preprocess from plugin loader
-                    // so updates take effect without re-inserting the card
-                    editor.update(() => {
-                        const node = $getNodeByKey(nodeKey);
-                        if (node) {
-                            if (found.css !== undefined) {
-                                node.css = found.css;
-                            }
-                            if (found.template !== undefined) {
-                                node.template = found.template;
-                            }
-                            if (found.preprocess !== undefined) {
-                                node.preprocess = found.preprocess;
-                            }
-                        }
-                    });
+                    if (found.template !== undefined) {
+                        node.template = found.template;
+                    }
+                    if (found.preprocess !== undefined) {
+                        node.preprocess = found.preprocess;
+                    }
                 }
-            }).catch((err) => {
-                console.warn('[PluginCard] Failed to fetch plugin cards:', err);
             });
-    }, [pluginName, cardName]);
+        }
+    }, [pluginCards, pluginName, cardName]);
 
     const handleSave = (newRawPayload) => {
         editor.update(() => {

--- a/packages/koenig-lexical/src/plugins/AllDefaultPlugins.jsx
+++ b/packages/koenig-lexical/src/plugins/AllDefaultPlugins.jsx
@@ -21,6 +21,8 @@ import {HeaderPlugin} from '../plugins/HeaderPlugin';
 import {KoenigSnippetPlugin} from '../plugins/KoenigSnippetPlugin';
 import {ListPlugin} from '@lexical/react/LexicalListPlugin';
 import {PaywallPlugin} from '../plugins/PaywallPlugin';
+import {PluginCardPlugin} from '../plugins/PluginCardPlugin';
+import {PluginCardProvider} from '../context/PluginCardContext.jsx';
 import {ProductPlugin} from '../plugins/ProductPlugin';
 import {SignupPlugin} from '../plugins/SignupPlugin';
 import {TogglePlugin} from '../plugins/TogglePlugin';
@@ -35,6 +37,7 @@ export const AllDefaultPlugins = () => {
             {/* <TabIndentationPlugin /> tab/shift+tab triggers indent/outdent */}
 
             {/* Koenig Plugins */}
+            <PluginCardProvider>
             <CardMenuPlugin />
             <KoenigSnippetPlugin />
             <KoenigSelectorPlugin /> {/* Gif/Unsplash selectors */}
@@ -57,6 +60,8 @@ export const AllDefaultPlugins = () => {
             <HeaderPlugin />
             <BookmarkPlugin />
             <PaywallPlugin />
+            <PluginCardPlugin />
+            </PluginCardProvider>
             <ProductPlugin />
             <EmailCtaPlugin />
             <EmailPlugin />

--- a/packages/koenig-lexical/src/plugins/PluginCardPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/PluginCardPlugin.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {$createPluginCardNode, PluginCardNode} from '../nodes/PluginCardNode';
+import {INSERT_PLUGIN_CARD_COMMAND} from '../commands/pluginCardCommands';
+import {COMMAND_PRIORITY_LOW} from 'lexical';
+import {INSERT_CARD_COMMAND} from './KoenigBehaviourPlugin';
+import {mergeRegister} from '@lexical/utils';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+
+const PluginCardPluginInner = () => {
+    const [editor] = useLexicalComposerContext();
+
+    React.useEffect(() => {
+        if (!editor.hasNodes([PluginCardNode])){
+            console.error('PluginCardPlugin: PluginCardNode not registered');
+            return;
+        }
+        return mergeRegister(
+            editor.registerCommand(
+                INSERT_PLUGIN_CARD_COMMAND,
+                (dataset) => {
+                    const cardNode = $createPluginCardNode(dataset);
+                    editor.dispatchCommand(INSERT_CARD_COMMAND, {cardNode, openInEditMode: true});
+                    return true;
+                },
+                COMMAND_PRIORITY_LOW
+            )
+        );
+    }, [editor]);
+
+    return null;
+};
+
+// PluginCardProvider wraps CardMenuPlugin + PluginCardPlugin in AllDefaultPlugins
+export const PluginCardPlugin = PluginCardPluginInner;
+
+export default PluginCardPlugin;

--- a/packages/koenig-lexical/src/plugins/PlusCardMenuPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/PlusCardMenuPlugin.jsx
@@ -1,4 +1,5 @@
 import KoenigComposerContext from '../context/KoenigComposerContext.jsx';
+import {usePluginCards} from '../context/PluginCardContext.jsx';
 import React from 'react';
 import {$getSelection, $isParagraphNode, $isRangeSelection, $setSelection} from 'lexical';
 import {CardMenu} from '../components/ui/CardMenu';
@@ -16,6 +17,7 @@ function usePlusCardMenu(editor) {
     const [cardMenu, setCardMenu] = React.useState({});
     const containerRef = React.useRef(null);
     const {cardConfig} = React.useContext(KoenigComposerContext);
+    const {pluginCards} = usePluginCards();
 
     function getTopPosition(elem) {
         const elemRect = elem.getBoundingClientRect();
@@ -234,8 +236,8 @@ function usePlusCardMenu(editor) {
     // build up the card menu based on registered nodes and current search
     React.useEffect(() => {
         const cardNodes = getEditorCardNodes(editor);
-        setCardMenu(buildCardMenu(cardNodes, {config: cardConfig}));
-    }, [cardConfig, editor, setCardMenu]);
+        setCardMenu(buildCardMenu(cardNodes, {config: cardConfig, pluginCards}));
+    }, [cardConfig, editor, setCardMenu, pluginCards]);
 
     const style = {
         top: `${topPosition}px`

--- a/packages/koenig-lexical/src/plugins/SlashCardMenuPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/SlashCardMenuPlugin.jsx
@@ -1,4 +1,5 @@
 import KoenigComposerContext from '../context/KoenigComposerContext.jsx';
+import {usePluginCards} from '../context/PluginCardContext.jsx';
 import React from 'react';
 import {$createParagraphNode, $getSelection, $isParagraphNode, $isRangeSelection, COMMAND_PRIORITY_HIGH, KEY_ARROW_DOWN_COMMAND, KEY_ARROW_LEFT_COMMAND, KEY_ARROW_RIGHT_COMMAND, KEY_ARROW_UP_COMMAND, KEY_ENTER_COMMAND} from 'lexical';
 import {CardMenu} from '../components/ui/CardMenu';
@@ -20,6 +21,7 @@ function useSlashCardMenu(editor) {
     const cachedRange = React.useRef(null);
     const containerRef = React.useRef(null);
     const {cardConfig} = React.useContext(KoenigComposerContext);
+    const {pluginCards} = usePluginCards();
 
     function setMenuPosition(elem) {
         const elemRect = elem.getBoundingClientRect();
@@ -318,9 +320,9 @@ function useSlashCardMenu(editor) {
     // build up the card menu based on registered nodes and current search
     React.useEffect(() => {
         const cardNodes = getEditorCardNodes(editor);
-        setCardMenu(buildCardMenu(cardNodes, {insert, query, config: cardConfig}));
+        setCardMenu(buildCardMenu(cardNodes, {insert, query, config: cardConfig, pluginCards}));
         setSelectedItemIndex(0);
-    }, [editor, query, insert, setCardMenu, setSelectedItemIndex, cardConfig]);
+    }, [editor, query, insert, setCardMenu, setSelectedItemIndex, cardConfig, pluginCards]);
 
     // attach a resize observer to call setMenuPosition when the window resizes
     React.useEffect(() => {

--- a/packages/koenig-lexical/src/utils/buildCardMenu.js
+++ b/packages/koenig-lexical/src/utils/buildCardMenu.js
@@ -1,7 +1,12 @@
 import SnippetCardIcon from '../assets/icons/kg-card-type-snippet.svg?react';
+import React from 'react';
+import DOMPurify from 'dompurify';
 import {INSERT_SNIPPET_COMMAND} from '../plugins/KoenigSnippetPlugin';
+import {INSERT_PLUGIN_CARD_COMMAND} from '../commands/pluginCardCommands';
 
-export function buildCardMenu(nodes, {query, config} = {}) {
+const DEFAULT_ICON = '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"/></svg>';
+
+export function buildCardMenu(nodes, {query, config, pluginCards: contextCards} = {}) {
     let menu = new Map();
 
     query = query?.toLowerCase();
@@ -55,6 +60,15 @@ export function buildCardMenu(nodes, {query, config} = {}) {
         addMenuItem(snippetMenuItem);
     });
 
+    // Add plugin cards from config (host app) or context (self-fetched)
+    const cards = config?.pluginCards || contextCards || [];
+    if (cards.length) {
+        cards.forEach((pluginCard) => {
+            const pluginCardMenuItem = buildPluginCardMenuItem(pluginCard);
+            addMenuItem(pluginCardMenuItem);
+        });
+    }
+
     // sort each menu section by priority
     menu = new Map([...menu.entries()].map(([section, items]) => {
         return [section, items.sort((a, b) => {
@@ -96,4 +110,47 @@ function buildSnippetMenuItem(data, config) {
     };
 
     return snippet;
+}
+
+function buildPluginCardMenuItem(pluginCard) {
+    if (!pluginCard || typeof pluginCard.label !== 'string' || typeof pluginCard.name !== 'string') {
+        return null;
+    }
+    const label = pluginCard.label.toLowerCase();
+    const cardName = pluginCard.name;
+
+    // Simple Icon component that renders the SVG (sanitized)
+    function PluginCardIcon({className, ...rest}) {
+        const rawIcon = pluginCard.icon || DEFAULT_ICON;
+        const cleanIcon = DOMPurify.sanitize(rawIcon, {
+            ALLOWED_TAGS: ['svg', 'path', 'circle', 'rect', 'line', 'polyline', 'polygon', 'g', 'defs', 'clipPath', 'mask', 'use'],
+            ALLOWED_ATTR: ['d', 'viewBox', 'fill', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin', 'xmlns', 'width', 'height', 'transform', 'cx', 'cy', 'r', 'x', 'y', 'x1', 'y1', 'x2', 'y2', 'points', 'clip-path', 'id', 'href', 'opacity', 'style']
+        }) || DEFAULT_ICON;
+
+        return React.createElement('span', {
+            className: className,
+            style: {display: 'inline-flex', alignItems: 'center', justifyContent: 'center'},
+            ...rest,
+            dangerouslySetInnerHTML: {__html: cleanIcon}
+        });
+    }
+
+    return {
+        type: 'card',
+        label: pluginCard.label,
+        Icon: PluginCardIcon,
+        section: 'Plugins',
+        matches: query => label.indexOf(query) > -1 || cardName.indexOf(query) > -1 || 'plugin'.indexOf(query) > -1,
+        insertCommand: INSERT_PLUGIN_CARD_COMMAND,
+        insertParams: {
+            pluginName: pluginCard.plugin,
+            cardName: pluginCard.name,
+            payload: JSON.stringify(
+                pluginCard.fields.reduce((acc, field) => {
+                    acc[field.key] = field.default;
+                    return acc;
+                }, {})
+            )
+        }
+    };
 }


### PR DESCRIPTION
Adds a plugin card system that lets Ghost admins install custom editor cards via ZIP upload. Cards define their own template (Handlebars syntax), CSS, and form fields — enabling review cards, info boxes, pricing tables, and more without touching Koenig's source code.

## ⚠️ Dependencies

This PR must be merged and published to npm **before** the companion Ghost PR, because Ghost's `plugin-renderer.js` imports `renderTemplate` and `createPreprocessor` from `@tryghost/kg-default-nodes`.

Companion PR:  https://github.com/TryGhost/Ghost/pull/28642

## New Packages/Files

### `kg-default-nodes` — Base node & rendering
- `PluginCardNode.ts` — Lexical node for plugin cards with `pluginName`, `cardName`, `payload`, `template`, `css`, and `preprocess` properties
- `plugin-card-template.ts` — Lightweight Handlebars-compatible template engine (`{{var}}`, `{{#if}}`, `{{#each}}`, `{{#unless}}`)
- `plugin-card-renderer.ts` — Client-side `exportDOM` renderer using the template engine
- `plugin-card-parser.ts` — `importDOM` parser that extracts `data-ghost-*` attributes for re-import
- `plugin-card-css.ts` — `scopeCss()` utility that namespaces selectors to prevent style collisions
- `plugin-card-preprocess.ts` — Sandboxed `createPreprocessor()` that runs plugin-defined data transformations with frozen wrapper objects to prevent prototype pollution

### `koenig-lexical` — Editor integration
- `PluginCardNode.jsx` — Editor node subclass with icon, indicator, and `KoenigCardWrapper`
- `PluginCardNodeComponent.jsx` — React component with:
  - Dynamic edit mode (form fields generated from `cardDef.fields`)
  - Template-based view mode via `dangerouslySetInnerHTML`
  - CSS preflight reset to counter Tailwind in the editor
  - `not-kg-prose` wrapper for Koenig typography isolation
  - Preprocess hook integration
- `PluginCardPlugin.jsx` — Lexical plugin that registers the `INSERT_PLUGIN_CARD_COMMAND`
- `PluginCardContext.jsx` — React context that fetches plugin cards from the API and populates the slash/plus menu
- `pluginCardCommands.js` — Lexical command definition

### Modified files
- `kg-default-nodes.ts` — Re-exports `renderTemplate`, `scopeCss`, `createPreprocessor`
- `DefaultNodes.js` — Registers `PluginCardNode`
- `AllDefaultPlugins.jsx` — Registers `PluginCardPlugin`
- `buildCardMenu.js` — Builds menu items from plugin card config
- `SlashCardMenuPlugin.jsx` / `PlusCardMenuPlugin.jsx` — Pass plugin cards to menu builder
- `PluginCardNode.ts` — Property list updated with `template` and `preprocess`

## Features

- **Template rendering**: Plugin authors write `template.html` using Handlebars syntax (`{{var}}`, `{{#if}}`, `{{#each}}`, `{{#unless}}`, `{{else}}`). Renders identically in editor and published page.
- **Dynamic edit forms**: Form fields are generated from `plugin.json` field definitions (`text`, `number`, `textarea`)
- **CSS isolation**: `scopeCss()` adds `.plugin-{name}` prefix to all selectors. Editor view mode applies a preflight reset to neutralise Tailwind overrides.
- **Card menu**: Slash and plus menus automatically show all installed plugin cards
- **Re-import**: `importDOM` extracts `data-ghost-plugin`, `data-card-name`, `data-ghost-payload` from HTML
- **Data preprocessing**: Plugins can define a `preprocess.js` that transforms raw form data before rendering (e.g., parsing `"Label=9"` into structured rating objects). Runs in a sandboxed environment.
- **Sandbox security**: Preprocess functions receive frozen wrapper objects, not raw constructors, preventing prototype pollution.

## Testing

1. Install a plugin ZIP via Settings → Labs → Card Plugins
2. Open the editor, type `/` or click `+` → plugin card appears in menu
3. Insert card, fill form, save → view mode renders with template
4. Publish → card HTML includes scoped CSS and data attributes
5. Download plugin → valid ZIP with all plugin files
6. Delete plugin → card nodes converted to static HTML preserving content

# Screenshots

<img width="1037" height="806" alt="image" src="https://github.com/user-attachments/assets/a724ee35-1cdc-4503-b7aa-6ce724c3f8f6" />
