### PR TITLE
Add file extensions to deep dependency imports for ESM consumers

### DIFF
--- a/packages/html-to-mobiledoc/src/converter.ts
+++ b/packages/html-to-mobiledoc/src/converter.ts
@@ -1,6 +1,6 @@
-import DOMParserModule from '@tryghost/mobiledoc-kit/dist/commonjs/mobiledoc-kit/parsers/dom';
-import BuilderModule from '@tryghost/mobiledoc-kit/dist/commonjs/mobiledoc-kit/models/post-node-builder';
-import mobiledocRendererModule from '@tryghost/mobiledoc-kit/dist/commonjs/mobiledoc-kit/renderers/mobiledoc';
+import DOMParserModule from '@tryghost/mobiledoc-kit/dist/commonjs/mobiledoc-kit/parsers/dom.js';
+import BuilderModule from '@tryghost/mobiledoc-kit/dist/commonjs/mobiledoc-kit/models/post-node-builder.js';
+import mobiledocRendererModule from '@tryghost/mobiledoc-kit/dist/commonjs/mobiledoc-kit/renderers/mobiledoc/index.js';
 import {createParserPlugins} from '@tryghost/kg-parser-plugins';
 import {JSDOM} from 'jsdom';
 

--- a/packages/html-to-mobiledoc/src/types.d.ts
+++ b/packages/html-to-mobiledoc/src/types.d.ts
@@ -1,4 +1,4 @@
-declare module '@tryghost/mobiledoc-kit/dist/commonjs/mobiledoc-kit/parsers/dom' {
+declare module '@tryghost/mobiledoc-kit/dist/commonjs/mobiledoc-kit/parsers/dom.js' {
     class DOMParser {
         constructor(builder: unknown, options: unknown);
         parse(element: unknown): unknown;
@@ -6,14 +6,14 @@ declare module '@tryghost/mobiledoc-kit/dist/commonjs/mobiledoc-kit/parsers/dom'
     export default DOMParser;
 }
 
-declare module '@tryghost/mobiledoc-kit/dist/commonjs/mobiledoc-kit/models/post-node-builder' {
+declare module '@tryghost/mobiledoc-kit/dist/commonjs/mobiledoc-kit/models/post-node-builder.js' {
     class Builder {
         constructor();
     }
     export default Builder;
 }
 
-declare module '@tryghost/mobiledoc-kit/dist/commonjs/mobiledoc-kit/renderers/mobiledoc' {
+declare module '@tryghost/mobiledoc-kit/dist/commonjs/mobiledoc-kit/renderers/mobiledoc/index.js' {
     const mobiledocRenderer: {
         render(post: unknown, version: string): unknown;
     };

--- a/packages/kg-default-cards/src/ambient.d.ts
+++ b/packages/kg-default-cards/src/ambient.d.ts
@@ -31,7 +31,7 @@ declare module '@tryghost/string' {
     export function escapeHtml(str: string): string;
 }
 
-declare module '@tryghost/url-utils/lib/utils' {
+declare module '@tryghost/url-utils/lib/utils/index.js' {
     export function absoluteToRelative(url: string, siteUrl: string, options?: unknown): string;
     export function relativeToAbsolute(url: string, siteUrl: string, itemUrl: string, options?: unknown): string;
     export function toTransformReady(url: string, siteUrl: string, ...args: unknown[]): string;

--- a/packages/kg-default-cards/src/cards/audio.ts
+++ b/packages/kg-default-cards/src/cards/audio.ts
@@ -5,7 +5,7 @@ import {
     htmlRelativeToAbsolute,
     htmlToTransformReady,
     toTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import {
     hbs,
     dedent

--- a/packages/kg-default-cards/src/cards/before-after.ts
+++ b/packages/kg-default-cards/src/cards/before-after.ts
@@ -2,7 +2,7 @@ import {
     htmlAbsoluteToRelative,
     htmlRelativeToAbsolute,
     htmlToTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import type {Card} from '../types.js';
 
 interface BeforeAfterImage {

--- a/packages/kg-default-cards/src/cards/bookmark.ts
+++ b/packages/kg-default-cards/src/cards/bookmark.ts
@@ -6,7 +6,7 @@ import {
     htmlRelativeToAbsolute,
     htmlToTransformReady,
     toTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import {hbs, dedent} from '../utils/index.js';
 import type {Card} from '../types.js';
 

--- a/packages/kg-default-cards/src/cards/button.ts
+++ b/packages/kg-default-cards/src/cards/button.ts
@@ -2,7 +2,7 @@ import {
     absoluteToRelative,
     relativeToAbsolute,
     toTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import {hbs, dedent} from '../utils/index.js';
 import type {Card} from '../types.js';
 

--- a/packages/kg-default-cards/src/cards/callout.ts
+++ b/packages/kg-default-cards/src/cards/callout.ts
@@ -2,7 +2,7 @@ import {
     htmlAbsoluteToRelative,
     htmlRelativeToAbsolute,
     htmlToTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import {hbs, dedent} from '../utils/index.js';
 import type {Card} from '../types.js';
 

--- a/packages/kg-default-cards/src/cards/code.ts
+++ b/packages/kg-default-cards/src/cards/code.ts
@@ -2,7 +2,7 @@ import {
     htmlAbsoluteToRelative,
     htmlRelativeToAbsolute,
     htmlToTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import type {Card} from '../types.js';
 
 const codeCard: Card = {

--- a/packages/kg-default-cards/src/cards/email-cta.ts
+++ b/packages/kg-default-cards/src/cards/email-cta.ts
@@ -6,7 +6,7 @@ import {
     htmlAbsoluteToRelative,
     htmlRelativeToAbsolute,
     htmlToTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import type {Card} from '../types.js';
 
 const emailCtaCard: Card = {

--- a/packages/kg-default-cards/src/cards/email.ts
+++ b/packages/kg-default-cards/src/cards/email.ts
@@ -2,7 +2,7 @@ import {
     htmlAbsoluteToRelative,
     htmlRelativeToAbsolute,
     htmlToTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import type {Card} from '../types.js';
 
 const emailCard: Card = {

--- a/packages/kg-default-cards/src/cards/embed.ts
+++ b/packages/kg-default-cards/src/cards/embed.ts
@@ -2,7 +2,7 @@ import {
     htmlAbsoluteToRelative,
     htmlRelativeToAbsolute,
     htmlToTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import nftCard from './embed/nft.js';
 import twitterCard from './embed/twitter.js';
 import type {Card} from '../types.js';

--- a/packages/kg-default-cards/src/cards/file.ts
+++ b/packages/kg-default-cards/src/cards/file.ts
@@ -2,7 +2,7 @@ import {
     absoluteToRelative,
     relativeToAbsolute,
     toTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import {
     escapeHtml
 } from '@tryghost/string';

--- a/packages/kg-default-cards/src/cards/gallery.ts
+++ b/packages/kg-default-cards/src/cards/gallery.ts
@@ -12,7 +12,7 @@ import {
     htmlRelativeToAbsolute,
     htmlToTransformReady,
     toTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import type {Card} from '../types.js';
 
 interface GalleryPayload {

--- a/packages/kg-default-cards/src/cards/header.ts
+++ b/packages/kg-default-cards/src/cards/header.ts
@@ -5,7 +5,7 @@ import {
     htmlRelativeToAbsolute,
     toTransformReady,
     htmlToTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import {
     slugify
 } from '@tryghost/kg-utils';

--- a/packages/kg-default-cards/src/cards/html.ts
+++ b/packages/kg-default-cards/src/cards/html.ts
@@ -2,7 +2,7 @@ import {
     htmlAbsoluteToRelative,
     htmlRelativeToAbsolute,
     htmlToTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import type {Card} from '../types.js';
 
 const htmlCard: Card = {

--- a/packages/kg-default-cards/src/cards/image.ts
+++ b/packages/kg-default-cards/src/cards/image.ts
@@ -12,7 +12,7 @@ import {
     htmlRelativeToAbsolute,
     htmlToTransformReady,
     toTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import type {Card} from '../types.js';
 
 interface ImagePayload {

--- a/packages/kg-default-cards/src/cards/markdown.ts
+++ b/packages/kg-default-cards/src/cards/markdown.ts
@@ -3,7 +3,7 @@ import {
     markdownRelativeToAbsolute,
     markdownAbsoluteToRelative,
     markdownToTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import type {Card} from '../types.js';
 
 const markdownCard: Card = {

--- a/packages/kg-default-cards/src/cards/product.ts
+++ b/packages/kg-default-cards/src/cards/product.ts
@@ -5,7 +5,7 @@ import {
     absoluteToRelative,
     relativeToAbsolute,
     toTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import {
     hbs,
     dedent,

--- a/packages/kg-default-cards/src/cards/toggle.ts
+++ b/packages/kg-default-cards/src/cards/toggle.ts
@@ -2,7 +2,7 @@ import {
     htmlToTransformReady,
     htmlAbsoluteToRelative,
     htmlRelativeToAbsolute
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import {hbs, dedent} from '../utils/index.js';
 import type {Card} from '../types.js';
 

--- a/packages/kg-default-cards/src/cards/video.ts
+++ b/packages/kg-default-cards/src/cards/video.ts
@@ -5,7 +5,7 @@ import {
     htmlRelativeToAbsolute,
     toTransformReady,
     htmlToTransformReady
-} from '@tryghost/url-utils/lib/utils';
+} from '@tryghost/url-utils/lib/utils/index.js';
 import {
     hbs,
     dedent

--- a/packages/kg-default-nodes/src/nodes/transistor/TransistorNode.ts
+++ b/packages/kg-default-nodes/src/nodes/transistor/TransistorNode.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep';
+import cloneDeep from 'lodash/cloneDeep.js';
 import {generateDecoratorNode, type DecoratorNodeProperty} from '../../generate-decorator-node.js';
 import {renderTransistorNode} from './transistor-renderer.js';
 import {ALL_MEMBERS_SEGMENT} from '../../utils/visibility.js';


### PR DESCRIPTION
Deep dependency imports in `kg-default-cards`, `html-to-mobiledoc`, and `kg-default-nodes` lacked file extensions, so the published ESM builds failed to resolve under Node's native ESM and TypeScript