### PR TITLE
Removed stale mobiledoc-kit renovate rule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,10 +28,6 @@
       ]
     },
     {
-      "matchPackageNames": ["@tryghost/mobiledoc-kit"],
-      "enabled": false
-    },
-    {
       "groupName": "react",
       "matchPackageNames": [
         "react",


### PR DESCRIPTION
Follow-up to #2028: `@tryghost/mobiledoc-kit` is no longer a dependency of any package in this repo, so the renovate rule disabling its updates is dead config.
