### PR TITLE
Fixed CodeQL security alerts in koenig-lexical

### DIFF
--- a/packages/koenig-lexical/src/utils/dataSrcToFile.js
+++ b/packages/koenig-lexical/src/utils/dataSrcToFile.js
@@ -10,7 +10,7 @@ export async function dataSrcToFile(src, fileName) {
         try {
             uuid = window.crypto.randomUUID();
         } catch (e) {
-            uuid = Math.random().toString(36).substring(2, 15);
+            uuid = Array.from(window.crypto.getRandomValues(new Uint8Array(8)), byte => byte.toString(16).padStart(2, '0')).join('');
         }
         const extension = mimeType.split('/')[1];
         fileName = `data-src-image-${uuid}.${extension}`;

--- a/packages/koenig-lexical/src/utils/sanitize-html.js
+++ b/packages/koenig-lexical/src/utils/sanitize-html.js
@@ -8,9 +8,9 @@ export function sanitizeHtml(html = '', options = {}) {
 
     // replace script and iFrame
     if (options.replaceJS) {
-        html = html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+        html = html.replace(/<script\b[^<]*(?:(?!<\/script\b)<[^<]*)*<\/script\b[^>]*>/gi,
             '<pre class="js-embed-placeholder">Embedded JavaScript</pre>');
-        html = html.replace(/<iframe\b[^<]*(?:(?!<\/iframe>)<[^<]*)*<\/iframe>/gi,
+        html = html.replace(/<iframe\b[^<]*(?:(?!<\/iframe\b)<[^<]*)*<\/iframe\b[^>]*>/gi,
             '<pre class="iframe-embed-placeholder">Embedded iFrame</pre>');
     }
 

--- a/packages/koenig-lexical/test/unit/utils/sanitize-html.test.js
+++ b/packages/koenig-lexical/test/unit/utils/sanitize-html.test.js
@@ -7,6 +7,15 @@ describe('Utils: sanitize-html', () => {
         expect(sanitizedHtml).toEqual('<span>Hey</span><pre class="js-embed-placeholder">Embedded JavaScript</pre>');
     });
 
+    test.each([
+        '</script >',
+        '</script\t\n bar>',
+        '</script/foo>'
+    ])('can replace scripts with lax end tags: %j', function (endTag) {
+        const sanitizedHtml = sanitizeHtml(`<span>Hey</span><script>alert("hello");${endTag}`);
+        expect(sanitizedHtml).toEqual('<span>Hey</span><pre class="js-embed-placeholder">Embedded JavaScript</pre>');
+    });
+
     it('can render html', function () {
         const sanitizedHtml = sanitizeHtml('<strong>bold</strong>');
         expect(sanitizedHtml).toEqual('<strong>bold</strong>');


### PR DESCRIPTION
no issue

CodeQL flagged two issues on #2046; the code is long-standing but the mechanical `.js`→`.ts` rename surfaced it as "new" code. Fixing separately so the rename PR stays purely mechanical — once this merges, #2046 will be rebased and its CodeQL check should go green.

- `sanitizeHtml()`'s script/iframe placeholder regexes only matched strict `</script>`/`</iframe>` end tags, so markup using the browser-accepted `</script >` form skipped placeholder replacement. Not exploitable — DOMPurify still strips the elements afterwards — but the regexes now accept whitespace before `>`, with a unit test covering the lax end-tag form.
- `dataSrcToFile()` fell back to `Math.random()` for pasted-image filename generation when `crypto.randomUUID()` is unavailable (non-secure contexts); it now uses `crypto.getRandomValues()`.