### PR TITLE
Add CI job timeout and concurrency guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,15 @@ on:
     branches:
       - main
       - 'renovate/*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
       matrix:


### PR DESCRIPTION
## Why

Preventative hardening after the 2026-07-06 org-wide Actions runner starvation (root cause was in express-hbs, see that repo's PR). Koenig has the same two latent gaps that let a single stuck job squat shared GitHub-hosted runners: no per-job timeout (default 6h) and no concurrency guard (rebases stack). Koenig runs Playwright and had queued runs during the incident.

## Changes

- **`timeout-minutes: 60`** on the `test` job — generous headroom over the normal ~5–6 min run (and the occasional ~50 min outlier), but bounds a hang to 1h instead of GitHub's 6h default.
- **`concurrency` with `cancel-in-progress: true`**, keyed to PR number / ref — repeated pushes/rebases supersede the previous run instead of stacking.

Triggers are intentionally left unchanged: the existing `if:` guard already skips the duplicate `pull_request` run for `renovate/*` branches, so Koenig does not double-fire.