### PR TITLE
🚧 Prototype: editable paywall card (customizable paywalls shaping)

### DIFF
--- a/packages/kg-default-nodes/src/nodes/paywall/PaywallNode.ts
+++ b/packages/kg-default-nodes/src/nodes/paywall/PaywallNode.ts
@@ -7,6 +7,7 @@ const paywallProperties = [
     {name: 'heading', default: ''},
     {name: 'description', default: ''},
     {name: 'buttonText', default: ''},
+    {name: 'emailButtonText', default: ''},
     {name: 'offerId', default: ''}
 ] as const satisfies readonly DecoratorNodeProperty[];
 

--- a/packages/kg-default-nodes/src/nodes/paywall/PaywallNode.ts
+++ b/packages/kg-default-nodes/src/nodes/paywall/PaywallNode.ts
@@ -2,7 +2,11 @@ import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropert
 import {parsePaywallNode} from './paywall-parser.js';
 import {renderPaywallNode} from './paywall-renderer.js';
 
-const paywallProperties = [] as const satisfies readonly DecoratorNodeProperty[];
+const paywallProperties = [
+    {name: 'heading', default: ''},
+    {name: 'description', default: ''},
+    {name: 'buttonText', default: ''}
+] as const satisfies readonly DecoratorNodeProperty[];
 
 export type PaywallData = DecoratorNodeData<typeof paywallProperties>;
 

--- a/packages/kg-default-nodes/src/nodes/paywall/PaywallNode.ts
+++ b/packages/kg-default-nodes/src/nodes/paywall/PaywallNode.ts
@@ -7,6 +7,8 @@ const paywallProperties = [
     {name: 'heading', default: ''},
     {name: 'description', default: ''},
     {name: 'buttonText', default: ''},
+    {name: 'emailHeading', default: ''},
+    {name: 'emailDescription', default: ''},
     {name: 'emailButtonText', default: ''},
     {name: 'offerId', default: ''}
 ] as const satisfies readonly DecoratorNodeProperty[];

--- a/packages/kg-default-nodes/src/nodes/paywall/PaywallNode.ts
+++ b/packages/kg-default-nodes/src/nodes/paywall/PaywallNode.ts
@@ -3,6 +3,7 @@ import {parsePaywallNode} from './paywall-parser.js';
 import {renderPaywallNode} from './paywall-renderer.js';
 
 const paywallProperties = [
+    {name: 'gate', default: 'paid'},
     {name: 'heading', default: ''},
     {name: 'description', default: ''},
     {name: 'buttonText', default: ''},

--- a/packages/kg-default-nodes/src/nodes/paywall/PaywallNode.ts
+++ b/packages/kg-default-nodes/src/nodes/paywall/PaywallNode.ts
@@ -5,7 +5,8 @@ import {renderPaywallNode} from './paywall-renderer.js';
 const paywallProperties = [
     {name: 'heading', default: ''},
     {name: 'description', default: ''},
-    {name: 'buttonText', default: ''}
+    {name: 'buttonText', default: ''},
+    {name: 'offerId', default: ''}
 ] as const satisfies readonly DecoratorNodeProperty[];
 
 export type PaywallData = DecoratorNodeData<typeof paywallProperties>;

--- a/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import {InputSetting} from '../SettingsPanel';
+import {DropdownSetting, InputSetting} from '../SettingsPanel';
 
 function Divider() {
     return (
@@ -13,24 +13,33 @@ function Divider() {
     );
 }
 
+const NO_OFFER_OPTION = {label: 'None — default signup', name: ''};
+
 export function PaywallCard({
     isEditing,
     heading,
     description,
     buttonText,
+    offerId,
+    offers = [],
+    selectedOfferName,
     updateHeading,
     updateDescription,
-    updateButtonText
+    updateButtonText,
+    updateOfferId
 }) {
-    const hasCustomCta = heading || description || buttonText;
+    const hasCustomCta = heading || description || buttonText || offerId;
 
     if (isEditing) {
+        const offerOptions = [NO_OFFER_OPTION, ...offers.map(offer => ({label: offer.name, name: offer.id}))];
+
         return (
             <div>
                 <Divider />
-                <div className="mt-3 rounded border border-grey-200 bg-grey-50 p-4 font-sans dark:border-grey-900 dark:bg-grey-950" data-testid="paywall-cta-editor">
-                    <div className="mb-3 text-2xs font-semibold uppercase tracking-wide text-grey-500">
-                        Upgrade message &mdash; emailed to free subscribers in place of the paid content
+                <div className="not-kg-prose mt-3 rounded border border-grey-200 bg-grey-50 p-4 font-sans dark:border-grey-900 dark:bg-grey-950" data-testid="paywall-cta-editor">
+                    <div className="mb-3 flex items-baseline justify-between">
+                        <span className="text-sm font-semibold text-grey-900 dark:text-grey-300">Email preview message</span>
+                        <span className="text-xs font-normal text-grey-600 dark:text-grey-500">Shown to free subscribers in place of the paid content</span>
                     </div>
                     <div className="flex flex-col gap-3">
                         <InputSetting
@@ -54,6 +63,14 @@ export function PaywallCard({
                             value={buttonText}
                             onChange={updateButtonText}
                         />
+                        <DropdownSetting
+                            dataTestId="paywall-offer-dropdown"
+                            description="Send readers to an offer instead of the standard signup"
+                            label="Offer"
+                            menu={offerOptions}
+                            value={offerId || ''}
+                            onChange={updateOfferId}
+                        />
                     </div>
                     <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500" data-testid="paywall-web-note">
                         On your website, visitors see your site-wide paywall instead &mdash; customize it under Settings &rarr; Membership &rarr; Paywall.
@@ -67,11 +84,14 @@ export function PaywallCard({
         <div>
             <Divider />
             {hasCustomCta &&
-                <div className="mt-3 rounded border border-grey-200 p-4 text-center font-sans dark:border-grey-900" data-testid="paywall-cta-preview">
-                    <div className="mb-1 text-2xs font-semibold uppercase tracking-wide text-grey-400">Free subscribers see</div>
+                <div className="not-kg-prose mt-3 rounded border border-grey-200 p-4 text-center font-sans dark:border-grey-900" data-testid="paywall-cta-preview">
+                    <div className="mb-1 text-2xs font-semibold uppercase tracking-wide text-grey-400">Email preview &mdash; free subscribers see</div>
                     <div className="text-lg font-bold text-black dark:text-grey-100">{heading || 'Upgrade to continue reading.'}</div>
                     <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">{description || 'Become a paid member to get access to all premium content.'}</div>
                     <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{buttonText || 'Upgrade'}</div>
+                    {offerId &&
+                        <div className="mt-2 text-xs font-normal text-grey-600 dark:text-grey-500" data-testid="paywall-offer-note">Button links to offer{selectedOfferName ? `: ${selectedOfferName}` : ''}</div>
+                    }
                 </div>
             }
         </div>
@@ -83,7 +103,11 @@ PaywallCard.propTypes = {
     heading: PropTypes.string,
     description: PropTypes.string,
     buttonText: PropTypes.string,
+    offerId: PropTypes.string,
+    offers: PropTypes.array,
+    selectedOfferName: PropTypes.string,
     updateHeading: PropTypes.func,
     updateDescription: PropTypes.func,
-    updateButtonText: PropTypes.func
+    updateButtonText: PropTypes.func,
+    updateOfferId: PropTypes.func
 };

--- a/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
@@ -178,6 +178,9 @@ export function PaywallCard({
                     {offerId && !isMembersGate &&
                         <div className="mt-2 text-xs font-normal text-grey-600 dark:text-grey-500" data-testid="paywall-offer-note">Button links to offer{selectedOfferName ? `: ${selectedOfferName}` : ''}</div>
                     }
+                    {offerId && isMembersGate &&
+                        <div className="mt-2 text-xs font-normal text-grey-500" data-testid="paywall-dormant-offer-note">An attached offer{selectedOfferName ? ` (${selectedOfferName})` : ''} is dormant &mdash; sign-up walls don&rsquo;t use offers; it returns if the gate switches back to paid</div>
+                    }
                     {sitePaywallCopy?.isCustomised && (heading || description || buttonText) ?
                         <div className="mt-2 text-xs font-normal text-grey-500" data-testid="paywall-override-note">Replaces your site-wide paywall message</div> : null
                     }

--- a/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
@@ -46,6 +46,8 @@ export function PaywallCard({
     heading,
     description,
     buttonText,
+    emailHeading,
+    emailDescription,
     emailButtonText,
     offerId,
     offers = [],
@@ -54,11 +56,14 @@ export function PaywallCard({
     updateHeading,
     updateDescription,
     updateButtonText,
+    updateEmailHeading,
+    updateEmailDescription,
     updateEmailButtonText,
     updateOfferId
 }) {
     const isMembersGate = !isTiersPost && gate === 'members';
-    const hasCustomCta = heading || description || buttonText || offerId;
+    const hasEmailVariant = Boolean(emailHeading || emailDescription || emailButtonText);
+    const hasCustomCta = heading || description || buttonText || offerId || hasEmailVariant;
 
     // Site-wide fallback copy for whichever wall this post renders
     const siteWall = (isMembersGate ? sitePaywallCopy?.signup : sitePaywallCopy?.payment) || {};
@@ -155,14 +160,6 @@ export function PaywallCard({
                                     value={buttonText}
                                     onChange={updateButtonText}
                                 />
-                                <InputSetting
-                                    dataTestId="paywall-email-button-input"
-                                    description="Email readers are already free members — an upgrade-flavoured CTA usually converts better there. Blank uses the button above."
-                                    label="Button — email"
-                                    placeholder={buttonText || siteWall.emailButtonText || siteWall.buttonText || 'Upgrade'}
-                                    value={emailButtonText}
-                                    onChange={updateEmailButtonText}
-                                />
                                 <DropdownSetting
                                     dataTestId="paywall-offer-dropdown"
                                     description="Send readers to an offer instead of the standard signup"
@@ -170,6 +167,33 @@ export function PaywallCard({
                                     menu={offerOptions}
                                     value={offerId || ''}
                                     onChange={updateOfferId}
+                                />
+                            </div>
+                            <div className="mb-3 mt-4 flex items-baseline justify-between border-t border-grey-200 pt-3 dark:border-grey-900">
+                                <span className="text-sm font-semibold text-grey-900 dark:text-grey-300">Email version <span className="font-normal text-grey-600 dark:text-grey-500">(optional)</span></span>
+                                <span className="text-xs font-normal text-grey-600 dark:text-grey-500">Email readers are already free members &mdash; speak to them directly. Blank fields use the message above</span>
+                            </div>
+                            <div className="flex flex-col gap-3">
+                                <InputSetting
+                                    dataTestId="paywall-email-heading-input"
+                                    label="Heading — email"
+                                    placeholder={heading || sitePaywallCopy?.payment?.emailHeading || siteHeading || 'Upgrade to continue reading.'}
+                                    value={emailHeading}
+                                    onChange={updateEmailHeading}
+                                />
+                                <InputSetting
+                                    dataTestId="paywall-email-description-input"
+                                    label="Description — email"
+                                    placeholder={description || sitePaywallCopy?.payment?.emailDescription || siteWall.description || 'Become a paid member to get access to all premium content.'}
+                                    value={emailDescription}
+                                    onChange={updateEmailDescription}
+                                />
+                                <InputSetting
+                                    dataTestId="paywall-email-button-input"
+                                    label="Button — email"
+                                    placeholder={buttonText || siteWall.emailButtonText || siteWall.buttonText || 'Upgrade'}
+                                    value={emailButtonText}
+                                    onChange={updateEmailButtonText}
                                 />
                             </div>
                             <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500" data-testid="paywall-web-note">
@@ -189,12 +213,17 @@ export function PaywallCard({
             <Divider gate={gate} isTiersPost={isTiersPost} />
             {hasCustomCta &&
                 <div className="not-kg-prose mt-3 rounded border border-grey-200 p-4 text-center font-sans dark:border-grey-900" data-testid="paywall-cta-preview">
-                    <div className="mb-1 text-2xs font-semibold uppercase tracking-wide text-grey-400">{isMembersGate ? 'Sign-up message — site visitors see' : 'Upgrade message — shown at the paywall (site & email)'}</div>
+                    <div className="mb-1 text-2xs font-semibold uppercase tracking-wide text-grey-400">{isMembersGate ? 'Sign-up message — site visitors see' : (hasEmailVariant ? 'Website — visitors see' : 'Upgrade message — shown at the paywall (site & email)')}</div>
                     <div className="text-lg font-bold text-black dark:text-grey-100">{heading || siteHeading}</div>
                     {(description || siteWall.description) && <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">{description || siteWall.description}</div>}
                     <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{buttonText || siteWall.buttonText}</div>
-                    {emailButtonText && !isMembersGate &&
-                        <div className="mt-2 text-xs font-normal text-grey-600 dark:text-grey-500" data-testid="paywall-email-button-note">Email button: &ldquo;{emailButtonText}&rdquo;</div>
+                    {hasEmailVariant && !isMembersGate &&
+                        <div className="mt-3 border-t border-grey-200 pt-3 dark:border-grey-900" data-testid="paywall-email-variant-preview">
+                            <div className="mb-1 text-2xs font-semibold uppercase tracking-wide text-grey-400">Email — free subscribers see</div>
+                            <div className="text-lg font-bold text-black dark:text-grey-100">{emailHeading || heading || siteHeading}</div>
+                            {(emailDescription || description || siteWall.description) && <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">{emailDescription || description || siteWall.description}</div>}
+                            <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{emailButtonText || buttonText || siteWall.emailButtonText || siteWall.buttonText}</div>
+                        </div>
                     }
                     {offerId && !isMembersGate && !sitePaywallCopy?.campaign &&
                         <div className="mt-2 text-xs font-normal text-grey-600 dark:text-grey-500" data-testid="paywall-offer-note">Button links to offer{selectedOfferName ? `: ${selectedOfferName}` : ''}</div>
@@ -222,6 +251,8 @@ PaywallCard.propTypes = {
     heading: PropTypes.string,
     description: PropTypes.string,
     buttonText: PropTypes.string,
+    emailHeading: PropTypes.string,
+    emailDescription: PropTypes.string,
     emailButtonText: PropTypes.string,
     offerId: PropTypes.string,
     offers: PropTypes.array,
@@ -230,6 +261,8 @@ PaywallCard.propTypes = {
     updateHeading: PropTypes.func,
     updateDescription: PropTypes.func,
     updateButtonText: PropTypes.func,
+    updateEmailHeading: PropTypes.func,
+    updateEmailDescription: PropTypes.func,
     updateEmailButtonText: PropTypes.func,
     updateOfferId: PropTypes.func
 };

--- a/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
@@ -64,7 +64,7 @@ export function PaywallCard({
     updateOfferId
 }) {
     const isMembersGate = gate === 'members';
-    const hasCustomCta = !isMembersGate && (heading || description || buttonText || offerId);
+    const hasCustomCta = heading || description || buttonText || offerId;
 
     if (isEditing) {
         const offerOptions = [NO_OFFER_OPTION, ...offers.map(offer => ({label: offer.name, name: offer.id}))];
@@ -85,22 +85,42 @@ export function PaywallCard({
                     </div>
                     {isMembersGate ? (
                         <div data-testid="paywall-members-note">
-                            {sitePaywallCopy &&
-                                <WebWallPreview
-                                    buttonText={sitePaywallCopy.buttonText}
-                                    description={sitePaywallCopy.description}
-                                    heading={sitePaywallCopy.membersHeading}
+                            <div className="mb-3 mt-4 flex items-baseline justify-between">
+                                <span className="text-sm font-semibold text-grey-900 dark:text-grey-300">Sign-up message</span>
+                                <span className="text-xs font-normal text-grey-600 dark:text-grey-500">Shown to visitors on your site &mdash; your email list already has full access</span>
+                            </div>
+                            <div className="flex flex-col gap-3">
+                                <InputSetting
+                                    dataTestId="paywall-heading-input"
+                                    label="Heading"
+                                    placeholder={sitePaywallCopy?.membersHeading || 'This post is for subscribers only'}
+                                    value={heading}
+                                    onChange={updateHeading}
                                 />
-                            }
+                                <InputSetting
+                                    dataTestId="paywall-description-input"
+                                    label="Description"
+                                    placeholder={sitePaywallCopy?.description || 'Optional supporting line'}
+                                    value={description}
+                                    onChange={updateDescription}
+                                />
+                                <InputSetting
+                                    dataTestId="paywall-button-input"
+                                    label="Button"
+                                    placeholder={sitePaywallCopy?.buttonText || 'Subscribe now'}
+                                    value={buttonText}
+                                    onChange={updateButtonText}
+                                />
+                            </div>
                             <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500">
-                                Everyone on your email list is a member, so newsletters include the full post. Visitors on your website see the message above and can sign up free &mdash; customize it in <SettingsLink />.
+                                Blank fields use your site-wide message &mdash; edit it in <SettingsLink />.
                             </div>
                         </div>
                     ) : (
                         <>
                             <div className="mb-3 mt-4 flex items-baseline justify-between">
-                                <span className="text-sm font-semibold text-grey-900 dark:text-grey-300">Email preview message</span>
-                                <span className="text-xs font-normal text-grey-600 dark:text-grey-500">Shown to free subscribers in place of the paid content</span>
+                                <span className="text-sm font-semibold text-grey-900 dark:text-grey-300">Upgrade message</span>
+                                <span className="text-xs font-normal text-grey-600 dark:text-grey-500">Shown wherever readers hit this paywall &mdash; on your site and in email</span>
                             </div>
                             <div className="flex flex-col gap-3">
                                 <InputSetting
@@ -134,7 +154,7 @@ export function PaywallCard({
                                 />
                             </div>
                             <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500" data-testid="paywall-web-note">
-                                On your website, visitors see your site-wide paywall instead &mdash; customize it in <SettingsLink />.
+                                Blank fields use your site-wide message &mdash; edit it in <SettingsLink />. The offer applies to the email button.
                             </div>
                         </>
                     )}
@@ -148,10 +168,10 @@ export function PaywallCard({
             <Divider gate={gate} />
             {hasCustomCta &&
                 <div className="not-kg-prose mt-3 rounded border border-grey-200 p-4 text-center font-sans dark:border-grey-900" data-testid="paywall-cta-preview">
-                    <div className="mb-1 text-2xs font-semibold uppercase tracking-wide text-grey-400">Email preview &mdash; free subscribers see</div>
-                    <div className="text-lg font-bold text-black dark:text-grey-100">{heading || 'Upgrade to continue reading.'}</div>
-                    <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">{description || 'Become a paid member to get access to all premium content.'}</div>
-                    <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{buttonText || 'Upgrade'}</div>
+                    <div className="mb-1 text-2xs font-semibold uppercase tracking-wide text-grey-400">{isMembersGate ? 'Sign-up message — site visitors see' : 'Upgrade message — shown at the paywall (site & email)'}</div>
+                    <div className="text-lg font-bold text-black dark:text-grey-100">{heading || (isMembersGate ? (sitePaywallCopy?.membersHeading || 'This post is for subscribers only') : 'Upgrade to continue reading.')}</div>
+                    <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">{description || (isMembersGate ? sitePaywallCopy?.description : 'Become a paid member to get access to all premium content.')}</div>
+                    <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{buttonText || (isMembersGate ? (sitePaywallCopy?.buttonText || 'Subscribe now') : 'Upgrade')}</div>
                     {offerId &&
                         <div className="mt-2 text-xs font-normal text-grey-600 dark:text-grey-500" data-testid="paywall-offer-note">Button links to offer{selectedOfferName ? `: ${selectedOfferName}` : ''}</div>
                     }

--- a/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
@@ -1,4 +1,7 @@
-export function PaywallCard() {
+import PropTypes from 'prop-types';
+import {InputSetting} from '../SettingsPanel';
+
+function Divider() {
     return (
         <div className="flex h-3 items-center whitespace-pre text-center font-sans text-2xs font-semibold uppercase text-grey-500 before:mr-2 before:flex-1 before:border-t before:border-grey-300 before:content-[''] after:ml-2 after:flex-1 after:border-t after:border-grey-300 dark:text-grey-800">
             Free public preview
@@ -9,3 +12,75 @@ export function PaywallCard() {
         </div>
     );
 }
+
+export function PaywallCard({
+    isEditing,
+    heading,
+    description,
+    buttonText,
+    updateHeading,
+    updateDescription,
+    updateButtonText
+}) {
+    const hasCustomCta = heading || description || buttonText;
+
+    if (isEditing) {
+        return (
+            <div>
+                <Divider />
+                <div className="mt-3 rounded border border-grey-200 bg-grey-50 p-4 font-sans dark:border-grey-900 dark:bg-grey-950" data-testid="paywall-cta-editor">
+                    <div className="mb-3 text-2xs font-semibold uppercase tracking-wide text-grey-500">
+                        Upgrade message &mdash; emailed to free subscribers in place of the paid content
+                    </div>
+                    <div className="flex flex-col gap-3">
+                        <InputSetting
+                            dataTestId="paywall-heading-input"
+                            label="Heading"
+                            placeholder="Upgrade to continue reading."
+                            value={heading}
+                            onChange={updateHeading}
+                        />
+                        <InputSetting
+                            dataTestId="paywall-description-input"
+                            label="Description"
+                            placeholder="Become a paid member to get access to all premium content."
+                            value={description}
+                            onChange={updateDescription}
+                        />
+                        <InputSetting
+                            dataTestId="paywall-button-input"
+                            label="Button"
+                            placeholder="Upgrade"
+                            value={buttonText}
+                            onChange={updateButtonText}
+                        />
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <Divider />
+            {hasCustomCta &&
+                <div className="mt-3 rounded border border-grey-200 p-4 text-center font-sans dark:border-grey-900" data-testid="paywall-cta-preview">
+                    <div className="mb-1 text-2xs font-semibold uppercase tracking-wide text-grey-400">Free subscribers see</div>
+                    <div className="text-lg font-bold text-black dark:text-grey-100">{heading || 'Upgrade to continue reading.'}</div>
+                    <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">{description || 'Become a paid member to get access to all premium content.'}</div>
+                    <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{buttonText || 'Upgrade'}</div>
+                </div>
+            }
+        </div>
+    );
+}
+
+PaywallCard.propTypes = {
+    isEditing: PropTypes.bool,
+    heading: PropTypes.string,
+    description: PropTypes.string,
+    buttonText: PropTypes.string,
+    updateHeading: PropTypes.func,
+    updateDescription: PropTypes.func,
+    updateButtonText: PropTypes.func
+};

--- a/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
@@ -46,6 +46,7 @@ export function PaywallCard({
     heading,
     description,
     buttonText,
+    emailButtonText,
     offerId,
     offers = [],
     selectedOfferName,
@@ -53,6 +54,7 @@ export function PaywallCard({
     updateHeading,
     updateDescription,
     updateButtonText,
+    updateEmailButtonText,
     updateOfferId
 }) {
     const isMembersGate = !isTiersPost && gate === 'members';
@@ -153,6 +155,14 @@ export function PaywallCard({
                                     value={buttonText}
                                     onChange={updateButtonText}
                                 />
+                                <InputSetting
+                                    dataTestId="paywall-email-button-input"
+                                    description="Email readers are already free members — an upgrade-flavoured CTA usually converts better there. Blank uses the button above."
+                                    label="Button — email"
+                                    placeholder={buttonText || siteWall.emailButtonText || siteWall.buttonText || 'Upgrade'}
+                                    value={emailButtonText}
+                                    onChange={updateEmailButtonText}
+                                />
                                 <DropdownSetting
                                     dataTestId="paywall-offer-dropdown"
                                     description="Send readers to an offer instead of the standard signup"
@@ -183,6 +193,9 @@ export function PaywallCard({
                     <div className="text-lg font-bold text-black dark:text-grey-100">{heading || siteHeading}</div>
                     {(description || siteWall.description) && <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">{description || siteWall.description}</div>}
                     <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{buttonText || siteWall.buttonText}</div>
+                    {emailButtonText && !isMembersGate &&
+                        <div className="mt-2 text-xs font-normal text-grey-600 dark:text-grey-500" data-testid="paywall-email-button-note">Email button: &ldquo;{emailButtonText}&rdquo;</div>
+                    }
                     {offerId && !isMembersGate && !sitePaywallCopy?.campaign &&
                         <div className="mt-2 text-xs font-normal text-grey-600 dark:text-grey-500" data-testid="paywall-offer-note">Button links to offer{selectedOfferName ? `: ${selectedOfferName}` : ''}</div>
                     }
@@ -209,6 +222,7 @@ PaywallCard.propTypes = {
     heading: PropTypes.string,
     description: PropTypes.string,
     buttonText: PropTypes.string,
+    emailButtonText: PropTypes.string,
     offerId: PropTypes.string,
     offers: PropTypes.array,
     selectedOfferName: PropTypes.string,
@@ -216,5 +230,6 @@ PaywallCard.propTypes = {
     updateHeading: PropTypes.func,
     updateDescription: PropTypes.func,
     updateButtonText: PropTypes.func,
+    updateEmailButtonText: PropTypes.func,
     updateOfferId: PropTypes.func
 };

--- a/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
@@ -1,20 +1,28 @@
 import PropTypes from 'prop-types';
 import {DropdownSetting, InputSetting} from '../SettingsPanel';
 
-function Divider({gate}) {
+function Divider({gate, isTiersPost}) {
+    let audience = 'Only visible to paid members';
+    if (isTiersPost) {
+        audience = 'Only visible to selected tiers';
+    } else if (gate === 'members') {
+        audience = 'Only visible to members';
+    }
+
     return (
         <div className="flex h-3 items-center whitespace-pre text-center font-sans text-2xs font-semibold uppercase text-grey-500 before:mr-2 before:flex-1 before:border-t before:border-grey-300 before:content-[''] after:ml-2 after:flex-1 after:border-t after:border-grey-300 dark:text-grey-800">
             Free public preview
             <span className="mx-2 text-green">↑</span>
             /
             <span className="mx-2 text-green">↓</span>
-            {gate === 'members' ? 'Only visible to members' : 'Only visible to paid members'}
+            {audience}
         </div>
     );
 }
 
 Divider.propTypes = {
-    gate: PropTypes.string
+    gate: PropTypes.string,
+    isTiersPost: PropTypes.bool
 };
 
 const NO_OFFER_OPTION = {label: 'None — default signup', name: ''};
@@ -30,25 +38,9 @@ function SettingsLink() {
     );
 }
 
-function WebWallPreview({heading, description, buttonText}) {
-    return (
-        <div className="mt-3 rounded border border-grey-200 p-4 text-center dark:border-grey-900" data-testid="paywall-web-preview">
-            <div className="mb-1 text-2xs font-semibold uppercase tracking-wide text-grey-400">Website &mdash; visitors see</div>
-            <div className="text-lg font-bold text-black dark:text-grey-100">{heading}</div>
-            {description && <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">{description}</div>}
-            <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{buttonText}</div>
-        </div>
-    );
-}
-
-WebWallPreview.propTypes = {
-    heading: PropTypes.string,
-    description: PropTypes.string,
-    buttonText: PropTypes.string
-};
-
 export function PaywallCard({
     isEditing,
+    isTiersPost,
     gate = 'paid',
     sitePaywallCopy,
     heading,
@@ -63,25 +55,40 @@ export function PaywallCard({
     updateButtonText,
     updateOfferId
 }) {
-    const isMembersGate = gate === 'members';
+    const isMembersGate = !isTiersPost && gate === 'members';
     const hasCustomCta = heading || description || buttonText || offerId;
+
+    // Site-wide fallback copy for whichever wall this post renders
+    const siteWall = (isMembersGate ? sitePaywallCopy?.signup : sitePaywallCopy?.payment) || {};
+    // Tier walls have their own headline (the paid headline never renders
+    // there); the built-in default lists the selected tier names
+    const siteHeading = isTiersPost
+        ? (sitePaywallCopy?.payment?.tiersHeading || 'This post is for subscribers on selected tiers only')
+        : siteWall.heading;
 
     if (isEditing) {
         const offerOptions = [NO_OFFER_OPTION, ...offers.map(offer => ({label: offer.name, name: offer.id}))];
 
         return (
             <div>
-                <Divider gate={gate} />
+                <Divider gate={gate} isTiersPost={isTiersPost} />
                 <div className="not-kg-prose mt-3 rounded border border-grey-200 bg-grey-50 p-4 font-sans dark:border-grey-900 dark:bg-grey-950" data-testid="paywall-cta-editor">
                     <div className="flex flex-col gap-3">
-                        <DropdownSetting
-                            dataTestId="paywall-gate-dropdown"
-                            description={isMembersGate ? 'Anyone can sign up for free to keep reading' : 'A paid subscription is required to keep reading'}
-                            label="Who can read past this point?"
-                            menu={GATE_OPTIONS}
-                            value={gate || 'paid'}
-                            onChange={updateGate}
-                        />
+                        {isTiersPost ? (
+                            <div data-testid="paywall-tiers-gate-note">
+                                <div className="text-sm font-medium tracking-normal text-grey-900 dark:text-grey-300">Who can read past this point?</div>
+                                <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">Members of the selected tiers &mdash; manage tiers in the post settings menu</div>
+                            </div>
+                        ) : (
+                            <DropdownSetting
+                                dataTestId="paywall-gate-dropdown"
+                                description={isMembersGate ? 'Anyone can sign up for free to keep reading' : 'A paid subscription is required to keep reading'}
+                                label="Who can read past this point?"
+                                menu={GATE_OPTIONS}
+                                value={gate || 'paid'}
+                                onChange={updateGate}
+                            />
+                        )}
                     </div>
                     {isMembersGate ? (
                         <div data-testid="paywall-members-note">
@@ -93,27 +100,27 @@ export function PaywallCard({
                                 <InputSetting
                                     dataTestId="paywall-heading-input"
                                     label="Heading"
-                                    placeholder={sitePaywallCopy?.membersHeading || 'This post is for subscribers only'}
+                                    placeholder={siteHeading || 'This post is for subscribers only'}
                                     value={heading}
                                     onChange={updateHeading}
                                 />
                                 <InputSetting
                                     dataTestId="paywall-description-input"
                                     label="Description"
-                                    placeholder={sitePaywallCopy?.description || 'Optional supporting line'}
+                                    placeholder={siteWall.description || 'Optional supporting line'}
                                     value={description}
                                     onChange={updateDescription}
                                 />
                                 <InputSetting
                                     dataTestId="paywall-button-input"
                                     label="Button"
-                                    placeholder={sitePaywallCopy?.buttonText || 'Subscribe now'}
+                                    placeholder={siteWall.buttonText || 'Subscribe now'}
                                     value={buttonText}
                                     onChange={updateButtonText}
                                 />
                             </div>
                             <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500">
-                                Blank fields use your site-wide message &mdash; edit it in <SettingsLink />.
+                                Blank fields use your site-wide sign-up wall message &mdash; edit it in <SettingsLink />.
                                 {offerId ? <span className="mt-1 block" data-testid="paywall-inactive-offer-note">The attached offer{selectedOfferName ? ` (${selectedOfferName})` : ''} doesn&rsquo;t apply to sign-up walls &mdash; the button is a plain free signup. It returns if you switch back to paid.</span> : null}
                                 {sitePaywallCopy?.isCustomised && (heading || description || buttonText) ? <span className="mt-1 block font-medium text-yellow-600" data-testid="paywall-override-warning">This post&rsquo;s message replaces your site-wide paywall message.</span> : null}
                             </div>
@@ -128,21 +135,21 @@ export function PaywallCard({
                                 <InputSetting
                                     dataTestId="paywall-heading-input"
                                     label="Heading"
-                                    placeholder={sitePaywallCopy?.paidHeading || 'Upgrade to continue reading.'}
+                                    placeholder={siteHeading || 'Upgrade to continue reading.'}
                                     value={heading}
                                     onChange={updateHeading}
                                 />
                                 <InputSetting
                                     dataTestId="paywall-description-input"
                                     label="Description"
-                                    placeholder={sitePaywallCopy?.description || 'Become a paid member to get access to all premium content.'}
+                                    placeholder={siteWall.description || 'Become a paid member to get access to all premium content.'}
                                     value={description}
                                     onChange={updateDescription}
                                 />
                                 <InputSetting
                                     dataTestId="paywall-button-input"
                                     label="Button"
-                                    placeholder={sitePaywallCopy?.buttonText || 'Upgrade'}
+                                    placeholder={siteWall.buttonText || 'Upgrade'}
                                     value={buttonText}
                                     onChange={updateButtonText}
                                 />
@@ -156,7 +163,7 @@ export function PaywallCard({
                                 />
                             </div>
                             <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500" data-testid="paywall-web-note">
-                                Blank fields use your site-wide message &mdash; edit it in <SettingsLink />. The offer applies wherever this message shows, on your site and in email.
+                                Blank fields use your site-wide payment wall message &mdash; edit it in <SettingsLink />. The offer applies wherever this message shows, on your site and in email.
                                 {sitePaywallCopy?.isCustomised && (heading || description || buttonText) ? <span className="mt-1 block font-medium text-yellow-600" data-testid="paywall-override-warning">This post&rsquo;s message replaces your site-wide paywall message.</span> : null}
                             </div>
                         </>
@@ -168,13 +175,13 @@ export function PaywallCard({
 
     return (
         <div>
-            <Divider gate={gate} />
+            <Divider gate={gate} isTiersPost={isTiersPost} />
             {hasCustomCta &&
                 <div className="not-kg-prose mt-3 rounded border border-grey-200 p-4 text-center font-sans dark:border-grey-900" data-testid="paywall-cta-preview">
                     <div className="mb-1 text-2xs font-semibold uppercase tracking-wide text-grey-400">{isMembersGate ? 'Sign-up message — site visitors see' : 'Upgrade message — shown at the paywall (site & email)'}</div>
-                    <div className="text-lg font-bold text-black dark:text-grey-100">{heading || (isMembersGate ? (sitePaywallCopy?.membersHeading || 'This post is for subscribers only') : 'Upgrade to continue reading.')}</div>
-                    <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">{description || (isMembersGate ? sitePaywallCopy?.description : 'Become a paid member to get access to all premium content.')}</div>
-                    <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{buttonText || (isMembersGate ? (sitePaywallCopy?.buttonText || 'Subscribe now') : 'Upgrade')}</div>
+                    <div className="text-lg font-bold text-black dark:text-grey-100">{heading || siteHeading}</div>
+                    {(description || siteWall.description) && <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">{description || siteWall.description}</div>}
+                    <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{buttonText || siteWall.buttonText}</div>
                     {offerId && !isMembersGate &&
                         <div className="mt-2 text-xs font-normal text-grey-600 dark:text-grey-500" data-testid="paywall-offer-note">Button links to offer{selectedOfferName ? `: ${selectedOfferName}` : ''}</div>
                     }
@@ -192,6 +199,7 @@ export function PaywallCard({
 
 PaywallCard.propTypes = {
     isEditing: PropTypes.bool,
+    isTiersPost: PropTypes.bool,
     gate: PropTypes.string,
     sitePaywallCopy: PropTypes.object,
     heading: PropTypes.string,

--- a/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
@@ -164,6 +164,7 @@ export function PaywallCard({
                             </div>
                             <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500" data-testid="paywall-web-note">
                                 Blank fields use your site-wide payment wall message &mdash; edit it in <SettingsLink />. The offer applies wherever this message shows, on your site and in email.
+                                {sitePaywallCopy?.campaign && offerId ? <span className="mt-1 block font-medium text-yellow-600" data-testid="paywall-campaign-takeover-warning">Your site-wide campaign offer is currently shown on this wall instead of {selectedOfferName ? `"${selectedOfferName}"` : 'this post\u2019s offer'} &mdash; it returns when the campaign ends.</span> : null}
                                 {sitePaywallCopy?.isCustomised && (heading || description || buttonText) ? <span className="mt-1 block font-medium text-yellow-600" data-testid="paywall-override-warning">This post&rsquo;s message replaces your site-wide paywall message.</span> : null}
                             </div>
                         </>
@@ -182,8 +183,11 @@ export function PaywallCard({
                     <div className="text-lg font-bold text-black dark:text-grey-100">{heading || siteHeading}</div>
                     {(description || siteWall.description) && <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">{description || siteWall.description}</div>}
                     <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{buttonText || siteWall.buttonText}</div>
-                    {offerId && !isMembersGate &&
+                    {offerId && !isMembersGate && !sitePaywallCopy?.campaign &&
                         <div className="mt-2 text-xs font-normal text-grey-600 dark:text-grey-500" data-testid="paywall-offer-note">Button links to offer{selectedOfferName ? `: ${selectedOfferName}` : ''}</div>
+                    }
+                    {offerId && !isMembersGate && sitePaywallCopy?.campaign &&
+                        <div className="mt-2 text-xs font-normal text-yellow-600" data-testid="paywall-campaign-takeover-note">Site-wide campaign offer showing instead of {selectedOfferName ? `"${selectedOfferName}"` : 'this post\u2019s offer'}</div>
                     }
                     {offerId && isMembersGate &&
                         <div className="mt-2 text-xs font-normal text-grey-500" data-testid="paywall-dormant-offer-note">An attached offer{selectedOfferName ? ` (${selectedOfferName})` : ''} is dormant &mdash; sign-up walls don&rsquo;t use offers; it returns if the gate switches back to paid</div>

--- a/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
@@ -24,9 +24,33 @@ const GATE_OPTIONS = [
     {label: 'Free members — grow your list', name: 'members'}
 ];
 
+function SettingsLink() {
+    return (
+        <a className="font-medium text-green-600 hover:underline" href="#/settings/paywall" onMouseDown={e => e.stopPropagation()}>Settings &rarr; Membership &rarr; Paywall</a>
+    );
+}
+
+function WebWallPreview({heading, description, buttonText}) {
+    return (
+        <div className="mt-3 rounded border border-grey-200 p-4 text-center dark:border-grey-900" data-testid="paywall-web-preview">
+            <div className="mb-1 text-2xs font-semibold uppercase tracking-wide text-grey-400">Website &mdash; visitors see</div>
+            <div className="text-lg font-bold text-black dark:text-grey-100">{heading}</div>
+            {description && <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">{description}</div>}
+            <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{buttonText}</div>
+        </div>
+    );
+}
+
+WebWallPreview.propTypes = {
+    heading: PropTypes.string,
+    description: PropTypes.string,
+    buttonText: PropTypes.string
+};
+
 export function PaywallCard({
     isEditing,
     gate = 'paid',
+    sitePaywallCopy,
     heading,
     description,
     buttonText,
@@ -60,8 +84,17 @@ export function PaywallCard({
                         />
                     </div>
                     {isMembersGate ? (
-                        <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500" data-testid="paywall-members-note">
-                            Everyone on your email list is a member, so newsletters include the full post. On your website, visitors hit your site-wide paywall and can sign up free &mdash; customize it under Settings &rarr; Membership &rarr; Paywall.
+                        <div data-testid="paywall-members-note">
+                            {sitePaywallCopy &&
+                                <WebWallPreview
+                                    buttonText={sitePaywallCopy.buttonText}
+                                    description={sitePaywallCopy.description}
+                                    heading={sitePaywallCopy.membersHeading}
+                                />
+                            }
+                            <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500">
+                                Everyone on your email list is a member, so newsletters include the full post. Visitors on your website see the message above and can sign up free &mdash; customize it in <SettingsLink />.
+                            </div>
                         </div>
                     ) : (
                         <>
@@ -101,7 +134,7 @@ export function PaywallCard({
                                 />
                             </div>
                             <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500" data-testid="paywall-web-note">
-                                On your website, visitors see your site-wide paywall instead &mdash; customize it under Settings &rarr; Membership &rarr; Paywall.
+                                On your website, visitors see your site-wide paywall instead &mdash; customize it in <SettingsLink />.
                             </div>
                         </>
                     )}
@@ -131,6 +164,7 @@ export function PaywallCard({
 PaywallCard.propTypes = {
     isEditing: PropTypes.bool,
     gate: PropTypes.string,
+    sitePaywallCopy: PropTypes.object,
     heading: PropTypes.string,
     description: PropTypes.string,
     buttonText: PropTypes.string,

--- a/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
@@ -10,7 +10,7 @@ function Divider({gate, isTiersPost}) {
     }
 
     return (
-        <div className="flex h-3 items-center whitespace-pre text-center font-sans text-2xs font-semibold uppercase text-grey-500 before:mr-2 before:flex-1 before:border-t before:border-grey-300 before:content-[''] after:ml-2 after:flex-1 after:border-t after:border-grey-300 dark:text-grey-800">
+        <div className="flex h-3 items-center whitespace-pre text-center font-sans text-2xs font-semibold uppercase text-grey-500 before:mr-2 before:flex-1 before:border-t before:border-grey-300 before:content-[''] after:ml-2 after:flex-1 after:border-t after:border-grey-300 dark:text-grey-600">
             Free public preview
             <span className="mx-2 text-green">↑</span>
             /
@@ -29,7 +29,7 @@ const NO_OFFER_OPTION = {label: 'None — default signup', name: ''};
 
 const GATE_OPTIONS = [
     {label: 'Paid members', name: 'paid'},
-    {label: 'Free members — grow your list', name: 'members'}
+    {label: 'Free members', name: 'members'}
 ];
 
 function SettingsLink() {
@@ -89,7 +89,7 @@ export function PaywallCard({
                         ) : (
                             <DropdownSetting
                                 dataTestId="paywall-gate-dropdown"
-                                description={isMembersGate ? 'Anyone can sign up for free to keep reading' : 'A paid subscription is required to keep reading'}
+                                description={isMembersGate ? 'Anyone can sign up for free to keep reading — a sign-up wall grows your list' : 'A paid subscription is required to keep reading'}
                                 label="Who can read past this point?"
                                 menu={GATE_OPTIONS}
                                 value={gate || 'paid'}
@@ -101,7 +101,7 @@ export function PaywallCard({
                         <div data-testid="paywall-members-note">
                             <div className="mb-3 mt-4 flex items-baseline justify-between">
                                 <span className="text-sm font-semibold text-grey-900 dark:text-grey-300">Sign-up message</span>
-                                <span className="text-xs font-normal text-grey-600 dark:text-grey-500">Shown to visitors on your site &mdash; your email list already has full access</span>
+                                <span className="text-xs font-normal text-grey-600 dark:text-grey-500">Shown to visitors on your site &mdash; everyone subscribed to your emails already has full access</span>
                             </div>
                             <div className="flex flex-col gap-3">
                                 <InputSetting
@@ -129,7 +129,7 @@ export function PaywallCard({
                             <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500">
                                 Blank fields use your site-wide sign-up wall message &mdash; edit it in <SettingsLink />.
                                 {offerId ? <span className="mt-1 block" data-testid="paywall-inactive-offer-note">The attached offer{selectedOfferName ? ` (${selectedOfferName})` : ''} doesn&rsquo;t apply to sign-up walls &mdash; the button is a plain free signup. It returns if you switch back to paid.</span> : null}
-                                {sitePaywallCopy?.isCustomised && (heading || description || buttonText) ? <span className="mt-1 block font-medium text-yellow-600" data-testid="paywall-override-warning">This post&rsquo;s message replaces your site-wide paywall message.</span> : null}
+                                {sitePaywallCopy?.isCustomised && (heading || description || buttonText) ? <span className="mt-1 block font-medium text-yellow-600" data-testid="paywall-override-warning">This post&rsquo;s message replaces your site-wide sign-up wall message.</span> : null}
                             </div>
                         </div>
                     ) : (
@@ -198,8 +198,9 @@ export function PaywallCard({
                             </div>
                             <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500" data-testid="paywall-web-note">
                                 Blank fields use your site-wide payment wall message &mdash; edit it in <SettingsLink />. The offer applies wherever this message shows, on your site and in email.
+                                {isTiersPost && offerId ? <span className="mt-1 block font-medium text-yellow-600" data-testid="paywall-tiers-offer-caution">Check the offer unlocks the right tier &mdash; an offer for a different tier won&rsquo;t give buyers access to this post.</span> : null}
                                 {sitePaywallCopy?.campaign && offerId ? <span className="mt-1 block font-medium text-yellow-600" data-testid="paywall-campaign-takeover-warning">Your site-wide campaign offer is currently shown on this wall instead of {selectedOfferName ? `"${selectedOfferName}"` : 'this post\u2019s offer'} &mdash; it returns when the campaign ends.</span> : null}
-                                {sitePaywallCopy?.isCustomised && (heading || description || buttonText) ? <span className="mt-1 block font-medium text-yellow-600" data-testid="paywall-override-warning">This post&rsquo;s message replaces your site-wide paywall message.</span> : null}
+                                {sitePaywallCopy?.isCustomised && (heading || description || buttonText) ? <span className="mt-1 block font-medium text-yellow-600" data-testid="paywall-override-warning">This post&rsquo;s message replaces your site-wide payment wall message.</span> : null}
                             </div>
                         </>
                     )}
@@ -216,13 +217,13 @@ export function PaywallCard({
                     <div className="mb-1 text-2xs font-semibold uppercase tracking-wide text-grey-400">{isMembersGate ? 'Sign-up message — site visitors see' : (hasEmailVariant ? 'Website — visitors see' : 'Upgrade message — shown at the paywall (site & email)')}</div>
                     <div className="text-lg font-bold text-black dark:text-grey-100">{heading || siteHeading}</div>
                     {(description || siteWall.description) && <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">{description || siteWall.description}</div>}
-                    <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{buttonText || siteWall.buttonText}</div>
+                    <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white" style={sitePaywallCopy?.accentColor ? {backgroundColor: sitePaywallCopy.accentColor} : undefined}>{buttonText || siteWall.buttonText}</div>
                     {hasEmailVariant && !isMembersGate &&
                         <div className="mt-3 border-t border-grey-200 pt-3 dark:border-grey-900" data-testid="paywall-email-variant-preview">
                             <div className="mb-1 text-2xs font-semibold uppercase tracking-wide text-grey-400">Email — free subscribers see</div>
                             <div className="text-lg font-bold text-black dark:text-grey-100">{emailHeading || heading || siteHeading}</div>
                             {(emailDescription || description || siteWall.description) && <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">{emailDescription || description || siteWall.description}</div>}
-                            <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{emailButtonText || buttonText || siteWall.emailButtonText || siteWall.buttonText}</div>
+                            <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white" style={sitePaywallCopy?.accentColor ? {backgroundColor: sitePaywallCopy.accentColor} : undefined}>{emailButtonText || buttonText || siteWall.emailButtonText || siteWall.buttonText}</div>
                         </div>
                     }
                     {offerId && !isMembersGate && !sitePaywallCopy?.campaign &&
@@ -235,7 +236,7 @@ export function PaywallCard({
                         <div className="mt-2 text-xs font-normal text-grey-500" data-testid="paywall-dormant-offer-note">An attached offer{selectedOfferName ? ` (${selectedOfferName})` : ''} is dormant &mdash; sign-up walls don&rsquo;t use offers; it returns if the gate switches back to paid</div>
                     }
                     {sitePaywallCopy?.isCustomised && (heading || description || buttonText) ?
-                        <div className="mt-2 text-xs font-normal text-grey-500" data-testid="paywall-override-note">Replaces your site-wide paywall message</div> : null
+                        <div className="mt-2 text-xs font-normal text-grey-500" data-testid="paywall-override-note">Replaces your site-wide wall message</div> : null
                     }
                 </div>
             }

--- a/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
@@ -55,6 +55,9 @@ export function PaywallCard({
                             onChange={updateButtonText}
                         />
                     </div>
+                    <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500" data-testid="paywall-web-note">
+                        On your website, visitors see your site-wide paywall instead &mdash; customize it under Settings &rarr; Membership &rarr; Paywall.
+                    </div>
                 </div>
             </div>
         );

--- a/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
@@ -1,80 +1,110 @@
 import PropTypes from 'prop-types';
 import {DropdownSetting, InputSetting} from '../SettingsPanel';
 
-function Divider() {
+function Divider({gate}) {
     return (
         <div className="flex h-3 items-center whitespace-pre text-center font-sans text-2xs font-semibold uppercase text-grey-500 before:mr-2 before:flex-1 before:border-t before:border-grey-300 before:content-[''] after:ml-2 after:flex-1 after:border-t after:border-grey-300 dark:text-grey-800">
             Free public preview
             <span className="mx-2 text-green">↑</span>
             /
             <span className="mx-2 text-green">↓</span>
-            Only visible to members
+            {gate === 'members' ? 'Only visible to members' : 'Only visible to paid members'}
         </div>
     );
 }
 
+Divider.propTypes = {
+    gate: PropTypes.string
+};
+
 const NO_OFFER_OPTION = {label: 'None — default signup', name: ''};
+
+const GATE_OPTIONS = [
+    {label: 'Paid members', name: 'paid'},
+    {label: 'Free members — grow your list', name: 'members'}
+];
 
 export function PaywallCard({
     isEditing,
+    gate = 'paid',
     heading,
     description,
     buttonText,
     offerId,
     offers = [],
     selectedOfferName,
+    updateGate,
     updateHeading,
     updateDescription,
     updateButtonText,
     updateOfferId
 }) {
-    const hasCustomCta = heading || description || buttonText || offerId;
+    const isMembersGate = gate === 'members';
+    const hasCustomCta = !isMembersGate && (heading || description || buttonText || offerId);
 
     if (isEditing) {
         const offerOptions = [NO_OFFER_OPTION, ...offers.map(offer => ({label: offer.name, name: offer.id}))];
 
         return (
             <div>
-                <Divider />
+                <Divider gate={gate} />
                 <div className="not-kg-prose mt-3 rounded border border-grey-200 bg-grey-50 p-4 font-sans dark:border-grey-900 dark:bg-grey-950" data-testid="paywall-cta-editor">
-                    <div className="mb-3 flex items-baseline justify-between">
-                        <span className="text-sm font-semibold text-grey-900 dark:text-grey-300">Email preview message</span>
-                        <span className="text-xs font-normal text-grey-600 dark:text-grey-500">Shown to free subscribers in place of the paid content</span>
-                    </div>
                     <div className="flex flex-col gap-3">
-                        <InputSetting
-                            dataTestId="paywall-heading-input"
-                            label="Heading"
-                            placeholder="Upgrade to continue reading."
-                            value={heading}
-                            onChange={updateHeading}
-                        />
-                        <InputSetting
-                            dataTestId="paywall-description-input"
-                            label="Description"
-                            placeholder="Become a paid member to get access to all premium content."
-                            value={description}
-                            onChange={updateDescription}
-                        />
-                        <InputSetting
-                            dataTestId="paywall-button-input"
-                            label="Button"
-                            placeholder="Upgrade"
-                            value={buttonText}
-                            onChange={updateButtonText}
-                        />
                         <DropdownSetting
-                            dataTestId="paywall-offer-dropdown"
-                            description="Send readers to an offer instead of the standard signup"
-                            label="Offer"
-                            menu={offerOptions}
-                            value={offerId || ''}
-                            onChange={updateOfferId}
+                            dataTestId="paywall-gate-dropdown"
+                            description={isMembersGate ? 'Anyone can sign up for free to keep reading' : 'A paid subscription is required to keep reading'}
+                            label="Who can read past this point?"
+                            menu={GATE_OPTIONS}
+                            value={gate || 'paid'}
+                            onChange={updateGate}
                         />
                     </div>
-                    <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500" data-testid="paywall-web-note">
-                        On your website, visitors see your site-wide paywall instead &mdash; customize it under Settings &rarr; Membership &rarr; Paywall.
-                    </div>
+                    {isMembersGate ? (
+                        <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500" data-testid="paywall-members-note">
+                            Everyone on your email list is a member, so newsletters include the full post. On your website, visitors hit your site-wide paywall and can sign up free &mdash; customize it under Settings &rarr; Membership &rarr; Paywall.
+                        </div>
+                    ) : (
+                        <>
+                            <div className="mb-3 mt-4 flex items-baseline justify-between">
+                                <span className="text-sm font-semibold text-grey-900 dark:text-grey-300">Email preview message</span>
+                                <span className="text-xs font-normal text-grey-600 dark:text-grey-500">Shown to free subscribers in place of the paid content</span>
+                            </div>
+                            <div className="flex flex-col gap-3">
+                                <InputSetting
+                                    dataTestId="paywall-heading-input"
+                                    label="Heading"
+                                    placeholder="Upgrade to continue reading."
+                                    value={heading}
+                                    onChange={updateHeading}
+                                />
+                                <InputSetting
+                                    dataTestId="paywall-description-input"
+                                    label="Description"
+                                    placeholder="Become a paid member to get access to all premium content."
+                                    value={description}
+                                    onChange={updateDescription}
+                                />
+                                <InputSetting
+                                    dataTestId="paywall-button-input"
+                                    label="Button"
+                                    placeholder="Upgrade"
+                                    value={buttonText}
+                                    onChange={updateButtonText}
+                                />
+                                <DropdownSetting
+                                    dataTestId="paywall-offer-dropdown"
+                                    description="Send readers to an offer instead of the standard signup"
+                                    label="Offer"
+                                    menu={offerOptions}
+                                    value={offerId || ''}
+                                    onChange={updateOfferId}
+                                />
+                            </div>
+                            <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500" data-testid="paywall-web-note">
+                                On your website, visitors see your site-wide paywall instead &mdash; customize it under Settings &rarr; Membership &rarr; Paywall.
+                            </div>
+                        </>
+                    )}
                 </div>
             </div>
         );
@@ -82,7 +112,7 @@ export function PaywallCard({
 
     return (
         <div>
-            <Divider />
+            <Divider gate={gate} />
             {hasCustomCta &&
                 <div className="not-kg-prose mt-3 rounded border border-grey-200 p-4 text-center font-sans dark:border-grey-900" data-testid="paywall-cta-preview">
                     <div className="mb-1 text-2xs font-semibold uppercase tracking-wide text-grey-400">Email preview &mdash; free subscribers see</div>
@@ -100,12 +130,14 @@ export function PaywallCard({
 
 PaywallCard.propTypes = {
     isEditing: PropTypes.bool,
+    gate: PropTypes.string,
     heading: PropTypes.string,
     description: PropTypes.string,
     buttonText: PropTypes.string,
     offerId: PropTypes.string,
     offers: PropTypes.array,
     selectedOfferName: PropTypes.string,
+    updateGate: PropTypes.func,
     updateHeading: PropTypes.func,
     updateDescription: PropTypes.func,
     updateButtonText: PropTypes.func,

--- a/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
@@ -114,6 +114,7 @@ export function PaywallCard({
                             </div>
                             <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500">
                                 Blank fields use your site-wide message &mdash; edit it in <SettingsLink />.
+                                {sitePaywallCopy?.isCustomised && (heading || description || buttonText) ? <span className="mt-1 block font-medium text-yellow-600" data-testid="paywall-override-warning">This post&rsquo;s message replaces your site-wide paywall message.</span> : null}
                             </div>
                         </div>
                     ) : (
@@ -154,7 +155,8 @@ export function PaywallCard({
                                 />
                             </div>
                             <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500" data-testid="paywall-web-note">
-                                Blank fields use your site-wide message &mdash; edit it in <SettingsLink />. The offer applies to the email button.
+                                Blank fields use your site-wide message &mdash; edit it in <SettingsLink />. The offer applies wherever this message shows, on your site and in email.
+                                {sitePaywallCopy?.isCustomised && (heading || description || buttonText) ? <span className="mt-1 block font-medium text-yellow-600" data-testid="paywall-override-warning">This post&rsquo;s message replaces your site-wide paywall message.</span> : null}
                             </div>
                         </>
                     )}
@@ -174,6 +176,9 @@ export function PaywallCard({
                     <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{buttonText || (isMembersGate ? (sitePaywallCopy?.buttonText || 'Subscribe now') : 'Upgrade')}</div>
                     {offerId &&
                         <div className="mt-2 text-xs font-normal text-grey-600 dark:text-grey-500" data-testid="paywall-offer-note">Button links to offer{selectedOfferName ? `: ${selectedOfferName}` : ''}</div>
+                    }
+                    {sitePaywallCopy?.isCustomised && (heading || description || buttonText) ?
+                        <div className="mt-2 text-xs font-normal text-grey-500" data-testid="paywall-override-note">Replaces your site-wide paywall message</div> : null
                     }
                 </div>
             }

--- a/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
@@ -127,21 +127,21 @@ export function PaywallCard({
                                 <InputSetting
                                     dataTestId="paywall-heading-input"
                                     label="Heading"
-                                    placeholder="Upgrade to continue reading."
+                                    placeholder={sitePaywallCopy?.paidHeading || 'Upgrade to continue reading.'}
                                     value={heading}
                                     onChange={updateHeading}
                                 />
                                 <InputSetting
                                     dataTestId="paywall-description-input"
                                     label="Description"
-                                    placeholder="Become a paid member to get access to all premium content."
+                                    placeholder={sitePaywallCopy?.description || 'Become a paid member to get access to all premium content.'}
                                     value={description}
                                     onChange={updateDescription}
                                 />
                                 <InputSetting
                                     dataTestId="paywall-button-input"
                                     label="Button"
-                                    placeholder="Upgrade"
+                                    placeholder={sitePaywallCopy?.buttonText || 'Upgrade'}
                                     value={buttonText}
                                     onChange={updateButtonText}
                                 />

--- a/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
+++ b/packages/koenig-lexical/src/components/ui/cards/PaywallCard.jsx
@@ -114,6 +114,7 @@ export function PaywallCard({
                             </div>
                             <div className="mt-3 border-t border-grey-200 pt-3 text-xs font-normal text-grey-600 dark:border-grey-900 dark:text-grey-500">
                                 Blank fields use your site-wide message &mdash; edit it in <SettingsLink />.
+                                {offerId ? <span className="mt-1 block" data-testid="paywall-inactive-offer-note">The attached offer{selectedOfferName ? ` (${selectedOfferName})` : ''} doesn&rsquo;t apply to sign-up walls &mdash; the button is a plain free signup. It returns if you switch back to paid.</span> : null}
                                 {sitePaywallCopy?.isCustomised && (heading || description || buttonText) ? <span className="mt-1 block font-medium text-yellow-600" data-testid="paywall-override-warning">This post&rsquo;s message replaces your site-wide paywall message.</span> : null}
                             </div>
                         </div>
@@ -174,7 +175,7 @@ export function PaywallCard({
                     <div className="text-lg font-bold text-black dark:text-grey-100">{heading || (isMembersGate ? (sitePaywallCopy?.membersHeading || 'This post is for subscribers only') : 'Upgrade to continue reading.')}</div>
                     <div className="mt-1 text-sm text-grey-700 dark:text-grey-500">{description || (isMembersGate ? sitePaywallCopy?.description : 'Become a paid member to get access to all premium content.')}</div>
                     <div className="mt-3 inline-block rounded bg-green px-4 py-2 text-sm font-semibold text-white">{buttonText || (isMembersGate ? (sitePaywallCopy?.buttonText || 'Subscribe now') : 'Upgrade')}</div>
-                    {offerId &&
+                    {offerId && !isMembersGate &&
                         <div className="mt-2 text-xs font-normal text-grey-600 dark:text-grey-500" data-testid="paywall-offer-note">Button links to offer{selectedOfferName ? `: ${selectedOfferName}` : ''}</div>
                     }
                     {sitePaywallCopy?.isCustomised && (heading || description || buttonText) ?

--- a/packages/koenig-lexical/src/nodes/PaywallNode.jsx
+++ b/packages/koenig-lexical/src/nodes/PaywallNode.jsx
@@ -27,6 +27,7 @@ export class PaywallNode extends BasePaywallNode {
                 <PaywallNodeComponent
                     buttonText={this.buttonText}
                     description={this.description}
+                    gate={this.gate}
                     heading={this.heading}
                     nodeKey={this.getKey()}
                     offerId={this.offerId}

--- a/packages/koenig-lexical/src/nodes/PaywallNode.jsx
+++ b/packages/koenig-lexical/src/nodes/PaywallNode.jsx
@@ -9,10 +9,10 @@ export const INSERT_PAYWALL_COMMAND = createCommand();
 export class PaywallNode extends BasePaywallNode {
     static kgMenu = {
         label: 'Paywall',
-        desc: 'Free preview above, paid-only below — free subscribers get the preview by email',
+        desc: 'Free preview above, members or paid-only below — grows your list or sells subscriptions',
         Icon: DividerCardIcon,
         insertCommand: INSERT_PAYWALL_COMMAND,
-        matches: ['paywall', 'public preview', 'preview', 'public intro', 'members only', 'upgrade', 'premium', 'gate', 'paid'],
+        matches: ['paywall', 'wall', 'public preview', 'preview', 'public intro', 'members only', 'upgrade', 'premium', 'gate', 'paid', 'signup', 'sign up', 'free signup'],
         priority: 6,
         shortcut: '/paywall'
     };
@@ -40,8 +40,8 @@ export class PaywallNode extends BasePaywallNode {
     }
 }
 
-export function $createPaywallNode() {
-    return new PaywallNode();
+export function $createPaywallNode(dataset) {
+    return new PaywallNode(dataset);
 }
 
 export function $isPaywallNode(node) {

--- a/packages/koenig-lexical/src/nodes/PaywallNode.jsx
+++ b/packages/koenig-lexical/src/nodes/PaywallNode.jsx
@@ -1,18 +1,18 @@
 import DividerCardIcon from '../assets/icons/kg-card-type-preview.svg?react';
 import KoenigCardWrapper from '../components/KoenigCardWrapper';
 import {PaywallNode as BasePaywallNode} from '@tryghost/kg-default-nodes';
-import {PaywallCard} from '../components/ui/cards/PaywallCard';
+import {PaywallNodeComponent} from './PaywallNodeComponent';
 import {createCommand} from 'lexical';
 
 export const INSERT_PAYWALL_COMMAND = createCommand();
 
 export class PaywallNode extends BasePaywallNode {
     static kgMenu = {
-        label: 'Public preview',
-        desc: 'Attract signups with a public intro',
+        label: 'Paywall',
+        desc: 'Free preview above, paid-only below — free subscribers get the preview by email',
         Icon: DividerCardIcon,
         insertCommand: INSERT_PAYWALL_COMMAND,
-        matches: ['public preview','preview', 'public intro', 'members only', 'paywall'],
+        matches: ['paywall', 'public preview', 'preview', 'public intro', 'members only', 'upgrade', 'premium', 'gate', 'paid'],
         priority: 6,
         shortcut: '/paywall'
     };
@@ -24,7 +24,12 @@ export class PaywallNode extends BasePaywallNode {
     decorate() {
         return (
             <KoenigCardWrapper className="inline-block" nodeKey={this.getKey()}>
-                <PaywallCard />
+                <PaywallNodeComponent
+                    buttonText={this.buttonText}
+                    description={this.description}
+                    heading={this.heading}
+                    nodeKey={this.getKey()}
+                />
             </KoenigCardWrapper>
         );
     }

--- a/packages/koenig-lexical/src/nodes/PaywallNode.jsx
+++ b/packages/koenig-lexical/src/nodes/PaywallNode.jsx
@@ -29,6 +29,7 @@ export class PaywallNode extends BasePaywallNode {
                     description={this.description}
                     heading={this.heading}
                     nodeKey={this.getKey()}
+                    offerId={this.offerId}
                 />
             </KoenigCardWrapper>
         );

--- a/packages/koenig-lexical/src/nodes/PaywallNode.jsx
+++ b/packages/koenig-lexical/src/nodes/PaywallNode.jsx
@@ -28,6 +28,8 @@ export class PaywallNode extends BasePaywallNode {
                     buttonText={this.buttonText}
                     description={this.description}
                     emailButtonText={this.emailButtonText}
+                    emailDescription={this.emailDescription}
+                    emailHeading={this.emailHeading}
                     gate={this.gate}
                     heading={this.heading}
                     nodeKey={this.getKey()}

--- a/packages/koenig-lexical/src/nodes/PaywallNode.jsx
+++ b/packages/koenig-lexical/src/nodes/PaywallNode.jsx
@@ -27,6 +27,7 @@ export class PaywallNode extends BasePaywallNode {
                 <PaywallNodeComponent
                     buttonText={this.buttonText}
                     description={this.description}
+                    emailButtonText={this.emailButtonText}
                     gate={this.gate}
                     heading={this.heading}
                     nodeKey={this.getKey()}

--- a/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
@@ -48,6 +48,7 @@ export function PaywallNodeComponent({nodeKey, gate, heading, description, butto
     };
 
     const selectedOffer = offers.find(offer => offer.id === offerId);
+    const isTiersPost = cardConfig?.post?.visibility === 'tiers';
 
     return (
         <>
@@ -57,6 +58,7 @@ export function PaywallNodeComponent({nodeKey, gate, heading, description, butto
                 gate={gate}
                 heading={heading}
                 isEditing={isEditing}
+                isTiersPost={isTiersPost}
                 offerId={offerId}
                 offers={offers}
                 selectedOfferName={selectedOffer?.name}

--- a/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
@@ -1,0 +1,49 @@
+import CardContext from '../context/CardContext';
+import React from 'react';
+import {$getNodeByKey} from 'lexical';
+import {ActionToolbar} from '../components/ui/ActionToolbar';
+import {EDIT_CARD_COMMAND} from '../plugins/KoenigBehaviourPlugin';
+import {PaywallCard} from '../components/ui/cards/PaywallCard';
+import {ToolbarMenu, ToolbarMenuItem} from '../components/ui/ToolbarMenu';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+
+export function PaywallNodeComponent({nodeKey, heading, description, buttonText}) {
+    const [editor] = useLexicalComposerContext();
+    const {isEditing, isSelected} = React.useContext(CardContext);
+
+    const handleToolbarEdit = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        editor.dispatchCommand(EDIT_CARD_COMMAND, {cardKey: nodeKey, focusEditor: false});
+    };
+
+    const updateProperty = propertyName => (event) => {
+        editor.update(() => {
+            const node = $getNodeByKey(nodeKey);
+            node[propertyName] = event.target.value;
+        });
+    };
+
+    return (
+        <>
+            <PaywallCard
+                buttonText={buttonText}
+                description={description}
+                heading={heading}
+                isEditing={isEditing}
+                updateButtonText={updateProperty('buttonText')}
+                updateDescription={updateProperty('description')}
+                updateHeading={updateProperty('heading')}
+            />
+
+            <ActionToolbar
+                data-kg-card-toolbar="paywall"
+                isVisible={isSelected && !isEditing}
+            >
+                <ToolbarMenu>
+                    <ToolbarMenuItem dataTestId="edit-paywall-cta" icon="edit" isActive={false} label="Customize upgrade message" onClick={handleToolbarEdit} />
+                </ToolbarMenu>
+            </ActionToolbar>
+        </>
+    );
+}

--- a/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
@@ -8,7 +8,7 @@ import {PaywallCard} from '../components/ui/cards/PaywallCard';
 import {ToolbarMenu, ToolbarMenuItem} from '../components/ui/ToolbarMenu';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
-export function PaywallNodeComponent({nodeKey, heading, description, buttonText, offerId}) {
+export function PaywallNodeComponent({nodeKey, gate, heading, description, buttonText, offerId}) {
     const [editor] = useLexicalComposerContext();
     const {isEditing, isSelected} = React.useContext(CardContext);
     const {cardConfig} = React.useContext(KoenigComposerContext);
@@ -40,6 +40,13 @@ export function PaywallNodeComponent({nodeKey, heading, description, buttonText,
         });
     };
 
+    const updateGate = (value) => {
+        editor.update(() => {
+            const node = $getNodeByKey(nodeKey);
+            node.gate = value;
+        });
+    };
+
     const selectedOffer = offers.find(offer => offer.id === offerId);
 
     return (
@@ -47,6 +54,7 @@ export function PaywallNodeComponent({nodeKey, heading, description, buttonText,
             <PaywallCard
                 buttonText={buttonText}
                 description={description}
+                gate={gate}
                 heading={heading}
                 isEditing={isEditing}
                 offerId={offerId}
@@ -54,6 +62,7 @@ export function PaywallNodeComponent({nodeKey, heading, description, buttonText,
                 selectedOfferName={selectedOffer?.name}
                 updateButtonText={updateProperty('buttonText')}
                 updateDescription={updateProperty('description')}
+                updateGate={updateGate}
                 updateHeading={updateProperty('heading')}
                 updateOfferId={updateOfferId}
             />

--- a/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
@@ -15,10 +15,11 @@ export function PaywallNodeComponent({nodeKey, gate, heading, description, butto
     const [offers, setOffers] = React.useState([]);
 
     React.useEffect(() => {
-        if (isEditing && cardConfig?.fetchOffers) {
+        // the read view needs offer names too ("Button links to offer: X")
+        if ((isEditing || offerId) && cardConfig?.fetchOffers) {
             cardConfig.fetchOffers().then(setOffers).catch(() => setOffers([]));
         }
-    }, [isEditing, cardConfig]);
+    }, [isEditing, offerId, cardConfig]);
 
     const handleToolbarEdit = (event) => {
         event.preventDefault();

--- a/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
@@ -8,7 +8,7 @@ import {PaywallCard} from '../components/ui/cards/PaywallCard';
 import {ToolbarMenu, ToolbarMenuItem} from '../components/ui/ToolbarMenu';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
-export function PaywallNodeComponent({nodeKey, gate, heading, description, buttonText, emailButtonText, offerId}) {
+export function PaywallNodeComponent({nodeKey, gate, heading, description, buttonText, emailHeading, emailDescription, emailButtonText, offerId}) {
     const [editor] = useLexicalComposerContext();
     const {isEditing, isSelected} = React.useContext(CardContext);
     const {cardConfig} = React.useContext(KoenigComposerContext);
@@ -56,6 +56,8 @@ export function PaywallNodeComponent({nodeKey, gate, heading, description, butto
                 buttonText={buttonText}
                 description={description}
                 emailButtonText={emailButtonText}
+                emailDescription={emailDescription}
+                emailHeading={emailHeading}
                 gate={gate}
                 heading={heading}
                 isEditing={isEditing}
@@ -67,6 +69,8 @@ export function PaywallNodeComponent({nodeKey, gate, heading, description, butto
                 updateButtonText={updateProperty('buttonText')}
                 updateDescription={updateProperty('description')}
                 updateEmailButtonText={updateProperty('emailButtonText')}
+                updateEmailDescription={updateProperty('emailDescription')}
+                updateEmailHeading={updateProperty('emailHeading')}
                 updateGate={updateGate}
                 updateHeading={updateProperty('heading')}
                 updateOfferId={updateOfferId}

--- a/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
@@ -73,7 +73,7 @@ export function PaywallNodeComponent({nodeKey, gate, heading, description, butto
                 isVisible={isSelected && !isEditing}
             >
                 <ToolbarMenu>
-                    <ToolbarMenuItem dataTestId="edit-paywall-cta" icon="edit" isActive={false} label="Customize email preview message" onClick={handleToolbarEdit} />
+                    <ToolbarMenuItem dataTestId="edit-paywall-cta" icon="edit" isActive={false} label="Edit paywall" onClick={handleToolbarEdit} />
                 </ToolbarMenu>
             </ActionToolbar>
         </>

--- a/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
@@ -1,4 +1,5 @@
 import CardContext from '../context/CardContext';
+import KoenigComposerContext from '../context/KoenigComposerContext.jsx';
 import React from 'react';
 import {$getNodeByKey} from 'lexical';
 import {ActionToolbar} from '../components/ui/ActionToolbar';
@@ -7,9 +8,17 @@ import {PaywallCard} from '../components/ui/cards/PaywallCard';
 import {ToolbarMenu, ToolbarMenuItem} from '../components/ui/ToolbarMenu';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
-export function PaywallNodeComponent({nodeKey, heading, description, buttonText}) {
+export function PaywallNodeComponent({nodeKey, heading, description, buttonText, offerId}) {
     const [editor] = useLexicalComposerContext();
     const {isEditing, isSelected} = React.useContext(CardContext);
+    const {cardConfig} = React.useContext(KoenigComposerContext);
+    const [offers, setOffers] = React.useState([]);
+
+    React.useEffect(() => {
+        if (isEditing && cardConfig?.fetchOffers) {
+            cardConfig.fetchOffers().then(setOffers).catch(() => setOffers([]));
+        }
+    }, [isEditing, cardConfig]);
 
     const handleToolbarEdit = (event) => {
         event.preventDefault();
@@ -24,6 +33,15 @@ export function PaywallNodeComponent({nodeKey, heading, description, buttonText}
         });
     };
 
+    const updateOfferId = (value) => {
+        editor.update(() => {
+            const node = $getNodeByKey(nodeKey);
+            node.offerId = value;
+        });
+    };
+
+    const selectedOffer = offers.find(offer => offer.id === offerId);
+
     return (
         <>
             <PaywallCard
@@ -31,9 +49,13 @@ export function PaywallNodeComponent({nodeKey, heading, description, buttonText}
                 description={description}
                 heading={heading}
                 isEditing={isEditing}
+                offerId={offerId}
+                offers={offers}
+                selectedOfferName={selectedOffer?.name}
                 updateButtonText={updateProperty('buttonText')}
                 updateDescription={updateProperty('description')}
                 updateHeading={updateProperty('heading')}
+                updateOfferId={updateOfferId}
             />
 
             <ActionToolbar
@@ -41,7 +63,7 @@ export function PaywallNodeComponent({nodeKey, heading, description, buttonText}
                 isVisible={isSelected && !isEditing}
             >
                 <ToolbarMenu>
-                    <ToolbarMenuItem dataTestId="edit-paywall-cta" icon="edit" isActive={false} label="Customize upgrade message" onClick={handleToolbarEdit} />
+                    <ToolbarMenuItem dataTestId="edit-paywall-cta" icon="edit" isActive={false} label="Customize email preview message" onClick={handleToolbarEdit} />
                 </ToolbarMenu>
             </ActionToolbar>
         </>

--- a/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
@@ -60,6 +60,7 @@ export function PaywallNodeComponent({nodeKey, gate, heading, description, butto
                 offerId={offerId}
                 offers={offers}
                 selectedOfferName={selectedOffer?.name}
+                sitePaywallCopy={cardConfig?.sitePaywallCopy}
                 updateButtonText={updateProperty('buttonText')}
                 updateDescription={updateProperty('description')}
                 updateGate={updateGate}

--- a/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
+++ b/packages/koenig-lexical/src/nodes/PaywallNodeComponent.jsx
@@ -8,7 +8,7 @@ import {PaywallCard} from '../components/ui/cards/PaywallCard';
 import {ToolbarMenu, ToolbarMenuItem} from '../components/ui/ToolbarMenu';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
-export function PaywallNodeComponent({nodeKey, gate, heading, description, buttonText, offerId}) {
+export function PaywallNodeComponent({nodeKey, gate, heading, description, buttonText, emailButtonText, offerId}) {
     const [editor] = useLexicalComposerContext();
     const {isEditing, isSelected} = React.useContext(CardContext);
     const {cardConfig} = React.useContext(KoenigComposerContext);
@@ -55,6 +55,7 @@ export function PaywallNodeComponent({nodeKey, gate, heading, description, butto
             <PaywallCard
                 buttonText={buttonText}
                 description={description}
+                emailButtonText={emailButtonText}
                 gate={gate}
                 heading={heading}
                 isEditing={isEditing}
@@ -65,6 +66,7 @@ export function PaywallNodeComponent({nodeKey, gate, heading, description, butto
                 sitePaywallCopy={cardConfig?.sitePaywallCopy}
                 updateButtonText={updateProperty('buttonText')}
                 updateDescription={updateProperty('description')}
+                updateEmailButtonText={updateProperty('emailButtonText')}
                 updateGate={updateGate}
                 updateHeading={updateProperty('heading')}
                 updateOfferId={updateOfferId}

--- a/packages/koenig-lexical/src/plugins/PaywallPlugin.jsx
+++ b/packages/koenig-lexical/src/plugins/PaywallPlugin.jsx
@@ -1,11 +1,15 @@
+import KoenigComposerContext from '../context/KoenigComposerContext.jsx';
 import {$createParagraphNode, $getSelection, $isParagraphNode, $isRangeSelection, COMMAND_PRIORITY_EDITOR} from 'lexical';
 import {$createPaywallNode, INSERT_PAYWALL_COMMAND} from '../nodes/PaywallNode';
 import {getSelectedNode} from '../utils/getSelectedNode';
-import {useEffect} from 'react';
+import {useContext, useEffect} from 'react';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
 export const PaywallPlugin = () => {
     const [editor] = useLexicalComposerContext();
+    const {cardConfig} = useContext(KoenigComposerContext);
+    // free-membership sites gate for members by default; everyone else paid
+    const defaultGate = cardConfig?.defaultPaywallGate === 'members' ? 'members' : 'paid';
 
     useEffect(() => {
         if (!editor.hasNodes([])) {
@@ -24,7 +28,7 @@ export const PaywallPlugin = () => {
                 const focusNode = selection.focus.getNode();
 
                 if (focusNode !== null) {
-                    const paywallNode = $createPaywallNode();
+                    const paywallNode = $createPaywallNode({gate: defaultGate});
 
                     // insert a paragraph unless we're already on a blank paragraph
                     const selectedNode = selection.focus.getNode();
@@ -44,7 +48,7 @@ export const PaywallPlugin = () => {
             },
             COMMAND_PRIORITY_EDITOR
         );
-    }, [editor]);
+    }, [editor, defaultGate]);
 
     // add markdown shortcut '==='
     useEffect(() => {
@@ -74,7 +78,7 @@ export const PaywallPlugin = () => {
                     return;
                 }
 
-                const line = $createPaywallNode();
+                const line = $createPaywallNode({gate: defaultGate});
                 const parentNode = node.getTopLevelElement();
 
                 if (parentNode.getNextSibling()) {
@@ -87,7 +91,7 @@ export const PaywallPlugin = () => {
                 line.selectNext();
             });
         });
-    }, [editor]);
+    }, [editor, defaultGate]);
 
     return null;
 };


### PR DESCRIPTION
## What this is

**Shaping prototype — for discussion, not merge.** The Koenig half of the [Customizable paywalls](https://linear.app/ghost/project/customizable-paywalls-40cff85610f1) exploration: the paywall card becomes the single control for a post's gate, message, and offer.

## What's in it

- **PaywallNode properties** (`kg-default-nodes`): `gate` (paid|members), `heading`, `description`, `buttonText`, `emailHeading`, `emailDescription`, `emailButtonText`, `offerId`
- **Editable card UI**: gate dropdown ("Who can read past this point?"), inline wall message editing with live site-default placeholders, optional email variant, offer picker (fed via `cardConfig.fetchOffers`, stored by id)
- **Read view**: dual "Website — visitors see" / "Email — free subscribers see" previews in the site accent colour, with offer / override / campaign-takeover notes — divergence is never invisible
- **Tier-gated posts**: honest read-only gate state pointing at post settings; offer-tier caution
- **Menu**: renamed "Paywall" with broad aliases (wall, signup, upgrade, premium…); gate default follows the host app's `defaultPaywallGate`

## How it was validated

Built through 4 sequential usability cycles + a 10-persona fleet test against a live Ghost sandbox. Final fleet round found zero divergence between what the card claims and what renders on web/email.

## Caveats

Prototype-grade: no new unit tests; `cardConfig` contract additions (`fetchOffers`, `sitePaywallCopy`, `defaultPaywallGate`) need design review; requires the companion Ghost PR (renderers, sync, settings) to function end to end — linked in the first comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)